### PR TITLE
Add Raid Reloader Plugin

### DIFF
--- a/plugins/raid-reloader
+++ b/plugins/raid-reloader
@@ -1,0 +1,2 @@
+repository=https://github.com/Trevor159/runelite-raid-reloader.git
+commit=9678ceac5b687bd1a537aee31787e6a005246ecc


### PR DESCRIPTION
This works nicely with https://github.com/runelite/runelite/pull/7981 so I will take this chance to plug that for review. It only shows the panel when you are in the raid lobby or in a raid. You can only use the button while in a raid.