### PR TITLE
Create orb-hider

### DIFF
--- a/plugins/orb-hider
+++ b/plugins/orb-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/wizguin/runelite-orb-hider.git
+commit=14eadd1e878c676c74029c263efb86cd7473551d


### PR DESCRIPTION
This plugin allows for hiding of individual minimap orbs, e.g hiding the special attack orb.