### PR TITLE
Add loot logger plugin

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/TheStonedTurtle/Loot-Logger.git
+commit=76ad2fcaab3e178761ec2bf54a101708e28fa382


### PR DESCRIPTION
Adds a plugin that logs Loot Tracker data locally and adds a new side-panel UI for viewing it.

Depends on the LootReceived event being added from runelite/runelite#10484

![https://i.imgur.com/iYEkvAv.png](https://i.imgur.com/iYEkvAv.png)