### PR TITLE
Master Farmer Plugin

### DIFF
--- a/plugins/master-farmer
+++ b/plugins/master-farmer
@@ -1,0 +1,2 @@
+repository=https://github.com/ConradicalMel/master-farmer.git
+commit=0836763af9e9786f8b5225c7f576e8a2594084b8


### PR DESCRIPTION
Used for tracking the amount of time a master farmer has stood still on a tile.