### PR TITLE
region-locker: Add GPU service support

### DIFF
--- a/plugins/region-locker
+++ b/plugins/region-locker
@@ -1,2 +1,2 @@
 repository=https://github.com/slaytostay/region-locker.git
-commit=70d8a31a4d4ef450f1be04357596e6601bcf49b5
+commit=4e98a38d83b61137f4b2eeb17b99db0c76a150ae

--- a/plugins/region-locker
+++ b/plugins/region-locker
@@ -1,2 +1,2 @@
 repository=https://github.com/slaytostay/region-locker.git
-commit=4e98a38d83b61137f4b2eeb17b99db0c76a150ae
+commit=5e5d879f587ff135456118cb64bed0b711f01153

--- a/plugins/region-locker
+++ b/plugins/region-locker
@@ -1,2 +1,2 @@
 repository=https://github.com/slaytostay/region-locker.git
-commit=5e5d879f587ff135456118cb64bed0b711f01153
+commit=fd16d579b868613cb9a57aeb0a871a041330c17a


### PR DESCRIPTION
Same changes as in https://github.com/runelite/plugin-hub/pull/29
Add goaltracker plugin for regions
Add GPU support for custom locked region shaders
Instead of using the GPU subclass implementation it depends on the GPU service from https://github.com/runelite/runelite/pull/10532