### PR TITLE
Add Hiscore killcount plugin

### DIFF
--- a/plugins/hiscorekc
+++ b/plugins/hiscorekc
@@ -1,0 +1,2 @@
+repository=https://github.com/melkypie/Hiscorekc.git
+commit=8af6bfc9e02bb1f2a2305f4158019ace3a3f4b65


### PR DESCRIPTION
A rendered down version of the Hiscore plugin that looks up players killcounts.
Looking at the wiki this would not make it into the client as an official plugin because of the possibility of spoofing the data. But with user taking full responsibility with external plugins, I hope it can be merged as an external plugin.

I think it would be really useful for people doing raids and trying to see if they are bringing along someone inexperienced or with decent amount of experience.