### PR TITLE
Add Party Panel plugin

### DIFF
--- a/plugins/party-panel
+++ b/plugins/party-panel
@@ -1,0 +1,2 @@
+repository=https://github.com/TheStonedTurtle/party-panel.git
+commit=e5c35d13c9ce58902c3506c591204339fe9eb149


### PR DESCRIPTION
Adds a side panel that displays useful information about your discord party members who are also using this plugin.

![eL0EvwkxU4](https://user-images.githubusercontent.com/29030969/71756611-878ce380-2e45-11ea-9b73-0093838f8e42.gif)

Thanks to @Trevor159 for helping me test the UI