### PR TITLE
leftclick dropper: Fix description and set version

### DIFF
--- a/plugins/custom-leftclick-dropper
+++ b/plugins/custom-leftclick-dropper
@@ -1,2 +1,0 @@
-repository=https://github.com/JZomerlei/red-external-plugins.git
-commit=5c4890fc006895144f4f2a14ac5f0ea5fe77ea1c

--- a/plugins/custom-leftclick-dropper
+++ b/plugins/custom-leftclick-dropper
@@ -1,0 +1,2 @@
+repository=https://github.com/JZomerlei/red-external-plugins.git
+commit=5c4890fc006895144f4f2a14ac5f0ea5fe77ea1c

--- a/plugins/zom-leftclick-dropper
+++ b/plugins/zom-leftclick-dropper
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomerlei/zom-external-plugins.git
-commit=5111d6b20dac497e48f822f6baea528bf8c1bbca
+commit=a161abfcc9c7a301268f4311819f166755effcb8


### PR DESCRIPTION
purely beautification PR.

Fixed the html for the description of the plugin in the hub.
Version set to 1.0
group set to com.zom.leftclickdrop

not sure it matters but runeliteversion updated to 1.6.0.1