### PR TITLE
Add profiles plugin

### DIFF
--- a/plugins/profiles-panel
+++ b/plugins/profiles-panel
@@ -1,0 +1,2 @@
+repository=https://github.com/mlgudi/profiles.git
+commit=304ae672effdb266c61b3682c605053082767e1d

--- a/plugins/profiles-panel
+++ b/plugins/profiles-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/mlgudi/profiles.git
-commit=304ae672effdb266c61b3682c605053082767e1d
+commit=e2515649c86f641448f7c826ea0be2a4af7afcb6


### PR DESCRIPTION
This is the profiles panel plugin created by Spedwards. He gave his blessing for it to be submitted to the plugin hub.

It adds a panel where usernames/log in emails can be stored. Clicking a user in the panel enters it into the user field on the log in screen.

It does not store passwords. Only usernames.