### PR TITLE
Create osrs-wiki-crowdsourcing

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=ac5e666899f6f81937d6625a62ed26b9d8ffe920
+commit=bb778ab2b4e403572f8185c8e37b766517501a0f

--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=f1f925d02c606ca0d2c1ffa2c4e1de5908a9d7dc
+commit=ac5e666899f6f81937d6625a62ed26b9d8ffe920

--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,0 +1,2 @@
+repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
+commit=f659ca57de4f17f895907a3dbbf68fc254d60f52

--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=f659ca57de4f17f895907a3dbbf68fc254d60f52
+commit=f1f925d02c606ca0d2c1ffa2c4e1de5908a9d7dc

--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=33e5a426f681c5f79c8730590544a40fba1c3452
+commit=71ffc3baee38a747d25fba8e2d93ceafa770b671

--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=bb778ab2b4e403572f8185c8e37b766517501a0f
+commit=33e5a426f681c5f79c8730590544a40fba1c3452


### PR DESCRIPTION
This plugin gathers data to figure out Cooking success rates, for use on the wiki. In the future it will be used for other skilling success rates.

This hits a crowdsource.runescape.wiki endpoint, which I've discussed prior with abex and Adam. Please note the comment on the frequency of requests to the endpoint – this will be dramatically reduced before we start actually advertising it.