### PR TITLE
leftclickdropper: trim white space

### DIFF
--- a/plugins/custom-leftclick-dropper
+++ b/plugins/custom-leftclick-dropper
@@ -1,2 +1,0 @@
-repository=https://github.com/JZomerlei/red-external-plugins.git
-commit=5c4890fc006895144f4f2a14ac5f0ea5fe77ea1c

--- a/plugins/custom-leftclick-dropper
+++ b/plugins/custom-leftclick-dropper
@@ -1,0 +1,2 @@
+repository=https://github.com/JZomerlei/red-external-plugins.git
+commit=5c4890fc006895144f4f2a14ac5f0ea5fe77ea1c

--- a/plugins/zom-leftclick-dropper
+++ b/plugins/zom-leftclick-dropper
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomerlei/zom-external-plugins.git
-commit=80ee75c310f868597af3b1bb7fe7e419ff62fe44
+commit=5e3e1f84a9a01133195427a70b457afdf8ef04cd


### PR DESCRIPTION
I've had users ask how the typed in list works and I tell them it's item1,item2 and every time they've had issues they've been typing in item1, item2 with a space. This will trim the leading and trailing white spaces between comas when making the compare list. 

The white space removal only happens on config change and on start up.