### PR TITLE
add bats-locator plugin

### DIFF
--- a/plugins/bats-locator
+++ b/plugins/bats-locator
@@ -1,0 +1,2 @@
+repository=https://github.com/chestnut1693/bats-locator.git
+commit=193a627db439ba21dba6e8b9c805a73fe2d29b9f


### PR DESCRIPTION
This plugin will help locate bats at the thieving room inside Chambers of Xeric. See [original post](https://github.com/runelite/runelite/pull/10540). I closed #59 by accident.