### PR TITLE
Add bank value history tracker

### DIFF
--- a/plugins/bank-value-tracker
+++ b/plugins/bank-value-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/AdrianLeeElder/runelite-bank-history-plugin.git
-commit=fa9c494b2ce0c2b9e785b18d3ec2bf17156d7dad
+commit=ec29eddc8236f03c65b7f85846f73c09fd78b3ea

--- a/plugins/bank-value-tracker
+++ b/plugins/bank-value-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/AdrianLeeElder/runelite-bank-history-plugin.git
-commit=ec29eddc8236f03c65b7f85846f73c09fd78b3ea
+commit=6221eca8471aa2c280f249362b68c89f431cb1ce

--- a/plugins/bank-value-tracker
+++ b/plugins/bank-value-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/AdrianLeeElder/runelite-bank-history-plugin.git
-commit=ec29eddc8236f03c65b7f85846f73c09fd78b3ea
+commit=fa9c494b2ce0c2b9e785b18d3ec2bf17156d7dad

--- a/plugins/bank-value-tracker
+++ b/plugins/bank-value-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/AdrianLeeElder/runelite-bank-history-plugin.git
-commit=1cc961eb307ab5de61244b6d213aca4e48687adf
+commit=ec29eddc8236f03c65b7f85846f73c09fd78b3ea

--- a/plugins/bank-value-tracker
+++ b/plugins/bank-value-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/AdrianLeeElder/runelite-bank-history-plugin.git
-commit=a97015a581adac616b526921a57de39078023c0f
+commit=1cc961eb307ab5de61244b6d213aca4e48687adf

--- a/plugins/bank-value-tracker
+++ b/plugins/bank-value-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/AdrianLeeElder/runelite-bank-history-plugin.git
-commit=3816b84059b2ca5a182af27deda8998fc5aa9593
+commit=a97015a581adac616b526921a57de39078023c0f

--- a/plugins/bank-value-tracker
+++ b/plugins/bank-value-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/AdrianLeeElder/runelite-bank-history-plugin.git
+commit=3816b84059b2ca5a182af27deda8998fc5aa9593


### PR DESCRIPTION
Adds a new panel in the right-hand menu for tracking bank value over time. 

Current features:
- Automatic, periodic tracking of the current bank value (can be disabled, so only manual entries are added
- Data is tracked based on bank tab numbers, so you can filter data by bank tabs. 
- Graph displaying current bank value over time
- Simple time selection ranges (Today, 24 hours, 6 months) or an advanced time selection using a date/time picker.
- Ability to open in a new window

More information/images located on the repo [readme](https://github.com/AdrianLeeElder/runelite-bank-history-plugin). 