### PR TITLE
bats-locator: enable by default

### DIFF
--- a/plugins/bats-locator
+++ b/plugins/bats-locator
@@ -1,2 +1,2 @@
 repository=https://github.com/chestnut1693/bats-locator.git
-commit=193a627db439ba21dba6e8b9c805a73fe2d29b9f
+commit=033714d0dee9e804e04e97512888c969b55dd359


### PR DESCRIPTION
Enable bats-locator plugin by default.