### PR TITLE
Add polybar-integration plugin

### DIFF
--- a/plugins/polybar-integration
+++ b/plugins/polybar-integration
@@ -1,0 +1,2 @@
+repository=https://github.com/SirArchLinux/runelite-polybar-integration.git
+commit=7bfe8159599c1498bf77166339a7450a7e688b9f


### PR DESCRIPTION
Adds a plugin that integrates some in-game information (currently only woodcutting and idle animation state) in the systems [Polybar](https://github.com/polybar/polybar).
![Woodcutting](https://user-images.githubusercontent.com/60399833/73377619-9e491d80-42bf-11ea-93a0-3b681c771071.png)
![Idle](https://user-images.githubusercontent.com/60399833/73377620-9e491d80-42bf-11ea-9c94-37da6448f28e.png)

