### PR TITLE
Update loot logger

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=4763fc792e9a40b898775873c8c85b529df844ab
+commit=adfbb740ea9254a416e9ec695fc05f24ccccccc2


### PR DESCRIPTION
Added a toggle to Ignore loot while in nmz
Fixed a bug when installing/toggling the plugin while logged in