### PR TITLE
raid points overlay: fix crashing

### DIFF
--- a/plugins/raid-points-overlay
+++ b/plugins/raid-points-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/Trevor159/RaidPointsOverlay.git
-commit=d831f9fa46e38bafb00e6a07740022956b5d0ce4
+commit=a507f6f174df74f11cc539c6e9b9293bed07036e


### PR DESCRIPTION
I did not have assertions enabled when I tested this and it crashes people who have assertions enabled