### PR TITLE
Create friends-exporter

### DIFF
--- a/plugins/friends-exporter
+++ b/plugins/friends-exporter
@@ -1,0 +1,2 @@
+repository=https://github.com/MarbleTurtle/FriendsExporter.git
+commit=8bf1042122fda202f7d4309da7b57373a95ec7cb


### PR DESCRIPTION
Adds ability to export friends/ignore list with light configuration options. Made primarily for cc owners who like to keep their ban list up to date.