### PR TITLE
Update clan-chat-warnings

### DIFF
--- a/plugins/clan-chat-warnings
+++ b/plugins/clan-chat-warnings
@@ -1,2 +1,2 @@
 repository=https://github.com/MarbleTurtle/ClanChatWarnings.git
-commit=746b95e5864ce8828a862bb6caf08070b354b65d
+commit=3f622f88ac34ab64a8fd44e62af7abe1576b4683


### PR DESCRIPTION
Fixed cases of alerts not working when not adding notes to regular players
Removed regex from exempt players to avoid false positives
Added option to kick from messages