### PR TITLE
Update clan-chat-warnings

### DIFF
--- a/plugins/clan-chat-warnings
+++ b/plugins/clan-chat-warnings
@@ -1,2 +1,2 @@
 repository=https://github.com/MarbleTurtle/ClanChatWarnings.git
-commit=3f622f88ac34ab64a8fd44e62af7abe1576b4683
+commit=2f23caaf702556d707b2e6649c647a9d7d57e052


### PR DESCRIPTION
Changed the note symbol to ~ to avoid problems while using regex.
Changed priority of notifications so specific players notifications take priority over regex,
Made configs descriptions/names more consistent, 
Made it somewhat more readable with more specialized variable names (its not really but least now you know the difference between test and test2 did)