### PR TITLE
left click dropper: Add anti shift drag disclaimer

### DIFF
--- a/plugins/zom-leftclick-dropper
+++ b/plugins/zom-leftclick-dropper
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomerlei/zom-external-plugins.git
-commit=c450c52613ddd9558477a30f4462412cee24775d
+commit=c78212e6152dd38e937628a350bb17e36d11b329


### PR DESCRIPTION
My plugin doesn't interact well with 'Shift Anti Drag' due to my over ride of anti drag on items being dropped.

I am looking into a solution for shift anti drag but also think that users should just disable the plugin when they're not using it.