### PR TITLE
Update world-highligher

### DIFF
--- a/plugins/world-highligher
+++ b/plugins/world-highligher
@@ -1,2 +1,2 @@
 repository=https://github.com/MarbleTurtle/WorldHighlighter.git
-commit=b84c562c74f20fd50c1a5f688b0b366a931c7f7e
+commit=0ea8e506427f464ab1790bb7e5323115054b7b19


### PR DESCRIPTION
Fixed plugin description.
Fixed error if player was not in a clan when trying to highlight a world.