### PR TITLE
Update Loot Logger (v1.3)

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=95056be3afb4091e60ecfe4b52f781695ee78699
+commit=a6e76c73ab6cd4bad49eb9a9249f0fdba91143af


### PR DESCRIPTION
Fixes a unique item ID and makes clue scrolls and caskets stack in the UI