### PR TITLE
emoji-madness: add reworked plugin

### DIFF
--- a/plugins/emoji-madness
+++ b/plugins/emoji-madness
@@ -1,0 +1,2 @@
+repository=https://github.com/dekvall/runelite-external-plugins.git
+commit=75a8ecbf4be3727fd7743361f76a3a8132bccf4b


### PR DESCRIPTION
Since the last version was reverted because the use of `:shortcodes:` would bleed into other players chat, i thought that i could rework this to work like the EmojiScape external plugin where normal words or phrases will be used as triggers for the emojis. In this way, there will be no `:codes:` typed and i have also removed weird phrases like `small medium black box` from the emojis and subsequently trigger phrases.

Typing `man in suit` will either append the emoji to the phrase or replace it entirely for example.

![emoji-madness-append](https://user-images.githubusercontent.com/25151927/75834665-f9899680-5dbc-11ea-967c-89822b3ab9c1.png)

A list of trigger phrases is available [here](https://github.com/dekvall/runelite-external-plugins/blob/emoji-madness/README.md)
