### PR TITLE
Crab Stun Timers

### DIFF
--- a/plugins/crab-stun-timers
+++ b/plugins/crab-stun-timers
@@ -1,0 +1,2 @@
+repository=https://github.com/AnkouOSRS/crab-stun-timers.git
+commit=acb87a6d10609c2f66f5fe3200a12b57eaba73b5

--- a/plugins/crab-stun-timers
+++ b/plugins/crab-stun-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/crab-stun-timers.git
-commit=acb87a6d10609c2f66f5fe3200a12b57eaba73b5
+commit=d597937f4aae64f17b7d259a76aebe97bb8f4585


### PR DESCRIPTION
Don't merge until version 1.6.9 is released as this plugin relies on a change to the GraphicChanged event which is part of that version. It will not work properly without that change.

This plugin displays a timer over crabs in Chambers of Xeric to show how long they will remain stunned.