### PR TITLE
Add Emoji Palette plugin

### DIFF
--- a/plugins/emoji-palette
+++ b/plugins/emoji-palette
@@ -1,0 +1,2 @@
+repository=https://github.com/hjdarnel/runelite-emoji-palette-plugin.git
+commit=71c2cbcf28f6c5a9ccacd815ceaa5777a4144f27


### PR DESCRIPTION
This plugin adds a panel on the main client navbar (right-hand side, with all the icons) listing all the emojis in the client. Hover over the image to get the trigger text. 

It looks like this:
![image](https://user-images.githubusercontent.com/7868899/76062773-fcff5800-5f4b-11ea-9cd6-03ec478420f2.png)
