### PR TITLE
clanchatcountryflags: use ScriptPostFired event instead of ScripCallbackEvent

### DIFF
--- a/plugins/clan-chat-country-flags
+++ b/plugins/clan-chat-country-flags
@@ -1,2 +1,2 @@
 repository=https://github.com/melkypie/clanchatcountryflags.git
-commit=362bddbdd3bf1daba96c1f6613da161cc07e6dec
+commit=c160df1ed780a44b98d9b91cc475cd49ef8bd0be


### PR DESCRIPTION
This should be merged only when runelite/runelite#10955 is in release, as this relies on the ScriptID created in that pr.