### PR TITLE
Release salamanders/swamp lizard for hunter training

### DIFF
--- a/plugins/zom-leftclick-dropper
+++ b/plugins/zom-leftclick-dropper
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomerlei/zom-external-plugins.git
-commit=6b8e2614270d57aa1fe7710359174680cb3823a7
+commit=ed4a7be462993ed589a2bc12e32783bac98ea5e5


### PR DESCRIPTION
Allow swamp lizard, red salamander, orange salamander, black salamander to be left clicked for release.