### PR TITLE
zulrah-helper: remove nav button from toolbar on shutDown

### DIFF
--- a/plugins/zulrah-helper
+++ b/plugins/zulrah-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/while-loop/runelite-plugins.git
-commit=2b6ea21e275736a15c853f8d60c2186900aa7f74
+commit=68037c26fb267c257c2b7148c253aaf395bd28f2


### PR DESCRIPTION
Correctly remove navigation button from toolbar on `shutDown()`.

also official v1.0.0 release