### PR TITLE
fullscreen: add status popup if not working

### DIFF
--- a/plugins/fullscreen
+++ b/plugins/fullscreen
@@ -1,2 +1,2 @@
 repository=https://github.com/dekvall/runelite-fullscreen.git
-commit=c2b266b02d4a64389097b1d9e9a5830b5b8d8875
+commit=915ad231c4b031f8ea2f15c738b1d21efed1ea57


### PR DESCRIPTION
It's confusing for players when the only information about why it's
not starting is in the logs. This also disables the plugin by default
so that the plugin doesn't go into fullscreen mode intantly when installing.