### PR TITLE
PvM Anti Drag

### DIFF
--- a/plugins/pvm-anti-drag
+++ b/plugins/pvm-anti-drag
@@ -1,2 +1,2 @@
 repository=https://github.com/jcwhisman/pvmantidrag.git
-commit=9c1dcd3ffa30f8013f9395de8f28a0331ebf055a
+commit=d684eb75498078b746b565f6f5fbfbf77abc1273

--- a/plugins/pvm-anti-drag
+++ b/plugins/pvm-anti-drag
@@ -1,0 +1,2 @@
+repository=https://github.com/jcwhisman/pvmantidrag.git
+commit=9c1dcd3ffa30f8013f9395de8f28a0331ebf055a


### PR DESCRIPTION
Anti Drag plugin that does not require shift. 

Anti-Drag is disabled when a player is in any kind of interaction with another player.