### PR TITLE
world-hider: add plugin

### DIFF
--- a/plugins/world-hider
+++ b/plugins/world-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/dekvall/runelite-external-plugins.git
+commit=66b80b22ba1069375fa7748226678ae03b6b3958


### PR DESCRIPTION
The plugin hides your world in
 - World hopper, title bar and selected world highlight
 - Clan interface, players on the same world doesn't become green
 - Friend and ignore list, title bar and players online can become yellow at most