### PR TITLE
Inital commit of prayer calc plugin

### DIFF
--- a/plugins/prayer-calc
+++ b/plugins/prayer-calc
@@ -1,0 +1,2 @@
+repository=https://github.com/tkylim/runelite-plugin-prayer-calc.git
+commit=c1c6ab3116f3c162fc55dd7976ab40d980cc1063


### PR DESCRIPTION
Displays calculated prayer experience in bank. Prayer xp is viewable per stack of items if relevant as well as per bank tab. Prayer training methods are configurable i.e "Ectofunctus" or "Chaos Altar" as well as the usage of ensouled heads.