### PR TITLE
Add Flipping Utilities

### DIFF
--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/Belieal/flipping-utilities.git
-commit=3b74a8ed5d9f878f94363492ee3bdb78895e2185
+commit=a0647652cb1c7f3df686282f9211a41cff08e368

--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,0 +1,2 @@
+repository=https://github.com/Belieal/flipping-utilities.git
+commit=3d5bf47494dd3e5c758470bbbd86ea6ed12caee4

--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/Belieal/flipping-utilities.git
-commit=5894ea7869f5a1235e6b889e1a8d79d576253664
+commit=3b74a8ed5d9f878f94363492ee3bdb78895e2185

--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/Belieal/flipping-utilities.git
-commit=3d5bf47494dd3e5c758470bbbd86ea6ed12caee4
+commit=5894ea7869f5a1235e6b889e1a8d79d576253664


### PR DESCRIPTION
Hi! This is my first PR, so please excuse the obvious errors. I'm still learning! 🙂 

This is a tool to help people with flipping items on the Grand Exchange. The tool works by detecting and storing new bought and sold offers. This data is saved in the config, so it should be accessible between game sessions. It then shows relevant information on the side panel, like margins, GE limits and return on investments. This is useful for when you are looking for items to flip; you want to get the biggest ROI, which can be annoying to calculate for every item.

Apart from this, it also helps when you've bought all the items you want to flip and then want to sell them. The game's history tab can be messy and items may be pushed out entirely, if you've bought a lot of things between flips. This plugin will highlight the item that is in the sell or buy offer slot on the side panel so that it is easy and convenient to set the right price.

It also features time tracking on latest prices and shows the users warnings if a price is outdated and may be inaccurate. I plan to expand this in coming updates with showing how many more items you can buy in the GE limit and tracking when the 4-hour limit resets.

![EGVYBPfLo1](https://user-images.githubusercontent.com/14042923/77129588-e0d3de80-6a54-11ea-870b-600c3490a0aa.gif)

Lastly, I just want to make it clear, **this plugin does not send or receive price data to other users.** So, it is not a replacement for OSB Exchange. 😉 

If you'd like to know more, check out my [repo.](https://github.com/Belieal/flipping-utilities)