### PR TITLE
Add skills-tab-progress-bars plugin

### DIFF
--- a/plugins/skills-tab-progress-bars
+++ b/plugins/skills-tab-progress-bars
@@ -1,0 +1,2 @@
+repository=https://github.com/m0bilebtw/skills-tab-progress-bars.git
+commit=cbee7d7d259ac833d7560bc2271be6fc4d55deb5

--- a/plugins/skills-tab-progress-bars
+++ b/plugins/skills-tab-progress-bars
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/skills-tab-progress-bars.git
-commit=cbee7d7d259ac833d7560bc2271be6fc4d55deb5
+commit=cc02d2adf5371088f104d88be576048f8d8d0d96


### PR DESCRIPTION
This plugin adds a progress bar to each non-99 skill on the skills tab, showing at a quick glance the approximate distance to the next level-up.

The bars are configurable in terms of height, transparency, and whether or not a background should be drawn (increases visibility of the bars).