### PR TITLE
Update skills-tab-progress-bars v0.2: Hide bars except for current sk…

### DIFF
--- a/plugins/skills-tab-progress-bars
+++ b/plugins/skills-tab-progress-bars
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/skills-tab-progress-bars.git
-commit=cc02d2adf5371088f104d88be576048f8d8d0d96
+commit=d910bd8596f55f62d285998144ccb14444a532dd


### PR DESCRIPTION
…ill when skill is hovered to avoid drawing over tooltips.
Also increases the maximum bar draw height to match the widget height.