### PR TITLE
Update Flipping Utilities (v1.1.1)

### DIFF
--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/Belieal/flipping-utilities.git
-commit=b1c453f3556496315d31c8616ab34133c4a92aac
+commit=662d7df1d2f284fea17901e1008cdf4402cff748


### PR DESCRIPTION
Added 12 hour format to clocks.
Fixed timers' format.
Fixed items expanding beyond wrapper when the item's name was too long.
Fixed an issue that caused the GE limit to not reset after 4 hours.