### PR TITLE
Add Superior Size plugin

### DIFF
--- a/plugins/superior-size
+++ b/plugins/superior-size
@@ -1,0 +1,2 @@
+repository=https://github.com/Hydrox6/external-plugins.git
+commit=d03d8a22606c17fd5fc4473b51fcb9a8765734e3


### PR DESCRIPTION
Shows the size of Superior slayer monsters over their normal counterparts