### PR TITLE
map-waypoints

### DIFF
--- a/plugins/map-waypoints
+++ b/plugins/map-waypoints
@@ -1,0 +1,2 @@
+repository=https://github.com/iipom/map-waypoints
+commit=435daded702be4ba5758ac919f372f2d65573cf0


### PR DESCRIPTION
Plugin that enables waypoints on the world map, similar to Pre-EOC. Once a waypoint is set with a double-click on the world map (or shift-click), an overlay will show you the direction, and the number of tiles you are away from that waypoint. A waypoint is removed by double-clicking or shift-clicking on it.