### PR TITLE
map-waypoints

### DIFF
--- a/plugins/map-waypoints
+++ b/plugins/map-waypoints
@@ -1,2 +1,2 @@
 repository=https://github.com/iipom/map-waypoints.git
-commit=435daded702be4ba5758ac919f372f2d65573cf0
+commit=14f52c2b8e2dc0669208a5a2fc59120d25de0e29

--- a/plugins/map-waypoints
+++ b/plugins/map-waypoints
@@ -1,0 +1,2 @@
+repository=https://github.com/iipom/map-waypoints.git
+commit=435daded702be4ba5758ac919f372f2d65573cf0

--- a/plugins/map-waypoints
+++ b/plugins/map-waypoints
@@ -1,2 +1,2 @@
 repository=https://github.com/iipom/map-waypoints.git
-commit=d2dcd6c156ff89cdecda3428c0c217c25129ad28
+commit=eb7e01823f64d56795c90c97ded802496dcc4778

--- a/plugins/map-waypoints
+++ b/plugins/map-waypoints
@@ -1,2 +1,2 @@
 repository=https://github.com/iipom/map-waypoints.git
-commit=14f52c2b8e2dc0669208a5a2fc59120d25de0e29
+commit=d2dcd6c156ff89cdecda3428c0c217c25129ad28


### PR DESCRIPTION
Plugin that enables waypoints on the world map, similar to Pre-EOC. Once a waypoint is set with a double-click on the world map (or shift-click), an overlay will show you the direction, and the number of tiles you are away from that waypoint. A waypoint is removed by double-clicking or shift-clicking on it.