### PR TITLE
bats-locator: fix dots and numbers not getting drawn

### DIFF
--- a/plugins/bats-locator
+++ b/plugins/bats-locator
@@ -1,2 +1,2 @@
 repository=https://github.com/chestnut1693/bats-locator.git
-commit=033714d0dee9e804e04e97512888c969b55dd359
+commit=df7f5564ae5b9da3d8bcf34821fae71d9830f969


### PR DESCRIPTION
Use a constant instead of `.getDrawDistance()` to determine if the player is close enough for the dots or numbers to be drawn. `.getDrawDistance()` returns 0 if it's not set by the gpu plugin, this is intentional behaviour.