### PR TITLE
Add NPC Idle Timer Plugin

### DIFF
--- a/plugins/npc-idle-timer-plugin
+++ b/plugins/npc-idle-timer-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/vonpawn/npc-idle-timer-plugin.git
+commit=b05a666a26056ec0f8f4e85f3894eb5911d8a564


### PR DESCRIPTION
A generalized solution to ConradicalMel's MasterFarmer plugin found [here](https://github.com/ConradicalMel/master-farmer)

Displays an overhead countdown timer above select NPCs that starts at 300 seconds (5 minutes) and resets every time the NPC moves. The timer is useful while pickpocketing an NPC trapped in a 1x2 tile corridor. If the NPC does not move for 300 seconds, the NPC will disappear and respawn elsewhere. When the timer approaches 15-30 seconds, give the NPC room to move and reset their timer. Be careful not to wait until too close to 0 seconds remaining, or the NPC may not willingly wander in time before respawning.