### PR TITLE
Create player-tile

### DIFF
--- a/plugins/player-tile
+++ b/plugins/player-tile
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/player-tile.git
-commit=418f9fdb496a2f671bb333a42e7ca8c0bacbbafe
+commit=cd768c914fb2d45f097517ee8d2423b585a58382

--- a/plugins/player-tile
+++ b/plugins/player-tile
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/player-tile.git
-commit=cd768c914fb2d45f097517ee8d2423b585a58382
+commit=eb6a630bde4471419e183c00d51cc370769b83a5

--- a/plugins/player-tile
+++ b/plugins/player-tile
@@ -1,0 +1,2 @@
+repository=https://github.com/1Defence/player-tile.git
+commit=418f9fdb496a2f671bb333a42e7ca8c0bacbbafe


### PR DESCRIPTION
Highlights the local players server-tile, different from the local tile available within the player-indicators  plugin which is delayed by animations.