### PR TITLE
Fixed the another-bronzeman-mode plugin support URL and plugin tags.

### DIFF
--- a/plugins/another-bronzeman-mode
+++ b/plugins/another-bronzeman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/CodePanter/another-bronzeman-mode.git
-commit=ea33ff12e943cd4ec2dd370589a25e71a52f0299
+commit=463d6e6915290c58c4eff476fb0a73aa722fc7f3


### PR DESCRIPTION
This  commit fixes the incorrect support URL and tags for the 'another-bronzeman-mode' plugin. Sorry about that!