### PR TITLE
left click dropping: Remove anti drag

### DIFF
--- a/plugins/zom-leftclick-dropper
+++ b/plugins/zom-leftclick-dropper
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomerlei/zom-external-plugins.git
-commit=ed4a7be462993ed589a2bc12e32783bac98ea5e5
+commit=d0ea0a406e6e2a06f6bb7e70a6c0d953854c7154


### PR DESCRIPTION
Now that shift anti drag is just 'anti drag' I am removing anti drag on the plugin so it no longer clashes with anti drag set on the other config. 