### PR TITLE
Update chat-transcripts

### DIFF
--- a/plugins/chat-transcripts
+++ b/plugins/chat-transcripts
@@ -1,2 +1,2 @@
 repository=https://github.com/MarbleTurtle/ChatSnips.git
-commit=0bb0553cd3b841f6c6e8bade321c6c6e0a815968
+commit=2419bfa6fa95b82e581b1b18d3532c3168724837


### PR DESCRIPTION
Fix regarding < and > characters not displaying or being recognized when searching through messages