### PR TITLE
Add Runite Rocks plugin

### DIFF
--- a/plugins/runite-rocks
+++ b/plugins/runite-rocks
@@ -1,0 +1,2 @@
+repository=https://github.com/TheStonedTurtle/RuniteRocks.git
+commit=aa31020c9622b502c03a104b533d9e517ad7c1cb


### PR DESCRIPTION
Adds a plugin to track Runite ore respawns. Includes hop-to functionality via right-clicking in the side-panel.

A majority of the UI and hopping logic is based off/copied from the World Switcher plugin

![image](https://user-images.githubusercontent.com/29030969/80300926-6eda6d80-8755-11ea-9e90-af9879a09edd.png)


