### PR TITLE
lowercase-usernames: add plugin

### DIFF
--- a/plugins/lowercase-usernames
+++ b/plugins/lowercase-usernames
@@ -1,0 +1,2 @@
+repository=https://github.com/dekvall/runelite-external-plugins.git
+commit=fe87a17876583b75b8375c96d11b388bd529904c


### PR DESCRIPTION
Display usernames in upper/lowercase to avoid lookalikes

Closes: runelite/runelite#11386