### PR TITLE
inventory-scrabble: add plugin

### DIFF
--- a/plugins/inventory-scrabble
+++ b/plugins/inventory-scrabble
@@ -1,0 +1,2 @@
+repository=https://github.com/dekvall/runelite-external-plugins.git
+commit=d1a72170bdad8b4649aece62470c976f0ff4ee6c


### PR DESCRIPTION
A gamemode where you're only allowed to interact with npcs which name you can spell with the first letter of every item in your inventory. You can only use one item for each letter i.e `Giant rat` requires two `t`s.