### PR TITLE
fixed-mode-hide-chat: Resize ToB darkness overlay when needed

### DIFF
--- a/plugins/fixed-mode-hide-chat
+++ b/plugins/fixed-mode-hide-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/deathbeam/example-plugin.git
-commit=5336a0c228b77c89556ed04c1d448a808b9d9832
+commit=f7692cb94647b0d936e046f594ecb6aadb079fe2


### PR DESCRIPTION
The issue:

![](https://cdn.discordapp.com/attachments/442492468307427330/702032421649907782/6506e3055af8cab3b745b936cbcb07e1.png)

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>