### PR TITLE
Add influxdb stats plugin

### DIFF
--- a/plugins/influxdb-stats
+++ b/plugins/influxdb-stats
@@ -1,0 +1,2 @@
+repository=https://github.com/Equinox-/runelite-influxdb.git
+commit=ffe12d55c2a83290a23205a713e8a1fab2540959

--- a/plugins/influxdb-stats
+++ b/plugins/influxdb-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/Equinox-/runelite-influxdb.git
-commit=ffe12d55c2a83290a23205a713e8a1fab2540959
+commit=604235e9b6b3c52770efa4b8ad140862672d9123


### PR DESCRIPTION
Adds a plugin that submits real-time xp/level/bank statistics to a customizable InfluxDB server.  This plugin requires users to setup their own InfluxDB server, and is not designed for sharing a single statistics server with untrusted parties.

Specific statistics that are recorded:
- Per-skill experience and levels
- Bank, seed vault, and inventory value, plus the top items from each
- Player combat level, quest points, skulled status, name, and overhead prayer
- Player position
