### PR TITLE
Remove Superior Size

### DIFF
--- a/plugins/superior-size
+++ b/plugins/superior-size
@@ -1,2 +1,0 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=b7376aabf3dd30dbae98ea909cc7f8c9eac02ce0


### PR DESCRIPTION
I'd based this plugin off of the idea that a superior has a set spawn location. As it turns out, [the superior will spawn in any place it can](https://twitter.com/JagexAsh/status/1258031231981273091), so this plugin isn't actually useful. 
Maybe if collision maps become available, this plugin could get resurrected to check if the superior has space, but this is not possible at the moment.