### PR TITLE
Add the volcanic mine stability tracker plugin

### DIFF
--- a/plugins/vm-stability-tracker
+++ b/plugins/vm-stability-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/hex-agon/volcanic-mine-stability-tracker.git
+commit=538ebc80065d4d99c84bb06ac0516c4d1f00314c


### PR DESCRIPTION
This plugin tracks the latest two stability changes in the mine and displays them in the game HUD. It is useful for people performing certain roles inside the volcanic mine.

![hud](https://i.imgur.com/lHMha82.png)