### PR TITLE
Pvp performance tracker: Fail gracefully with corrupted fight history data

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=8ca9984f41e8d9aec326b3e54bca94e21d8c11e5
+commit=cd00d4a483073e038272170071b81ce7e7e23210

--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=cd00d4a483073e038272170071b81ce7e7e23210
+commit=295cc2e165b07a2e6a13c4b7806514141302e819


### PR DESCRIPTION
The main purpose of this commit is to prevent plugin crashes/failure to start when fight history data is corrupted/outdated. I tried to handle this initially, but I missed some things. Improved it the best I could, and also wrapped the whole deserialization in a try catch just to be safe. It's a bit dirty, but at least the plugin will continue working rather than silently crashing.

I found this from a user report who gave me logs, the issue was: 
`java.lang.NullPointerException: null at PvpPerformanceTrackerPlugin.importFightHistory(PvpPerformanceTrackerPlugin.java:421)`, which was caused by a Competitor or Opponent not being set while checking for their fightLogs. This was probably simply caused by outdated data, since the serialization changed since a previous version, but it could also be corrupted by the fact that the config server has a maximum of 262KB of data, which would presumably truncate the json array and cause it to fail deserialization.

This should now fail gracefully and allow the plugin to continue working.

Also:
- Made fight performances save across restarts more consistently (previously, I was under the impression `shutDown()` was called on client close, not just on plugin disable. Now the config is saved every time a new fight is added.
- Removed a potential division by 0 error.
- Made it so resetting the config will also reset the fight history and rebuild the panel. This can be useful if users somehow still have corrupted data after the above changes, to remove it and then have the fight history start from scratch properly.

Sorry about two commits, I didn't intend on the config reset feature initially, and rebase wasn't working as I expect for some reason. Removing the initial commit made yet another commit to remove it rather than actually removing it.