### PR TITLE
add rune.cafe cashflow plugin

### DIFF
--- a/plugins/rune-cafe-cashflow
+++ b/plugins/rune-cafe-cashflow
@@ -1,0 +1,2 @@
+repository=https://github.com/rune-cafe/rc-plugin-cashflow.git
+commit=f9d2df237df697ad5298116ed0ec3ff684f10392


### PR DESCRIPTION
This plugin provides RuneLite integration for rune.cafe's cash flow analysis feature.

The plugin itself does two things:

1. Let users plug in an API key they got off rune.cafe
2. Upload the contents of the GE history UI to api.rune.cafe whenever the UI is opened.

The rest is :sparkles: server magic :sparkles: 