### PR TITLE
Revert "Remove player-tile"

### DIFF
--- a/plugins/player-tile
+++ b/plugins/player-tile
@@ -1,0 +1,2 @@
+repository=https://github.com/1Defence/player-tile.git
+commit=a38b6ea76db77edd022a345883a417264ece6045


### PR DESCRIPTION
This reverts commit db8fa9d3dc43d3e57a12403dcfdd284d1701b630.

plugin-hub is independent on realeases, so I shouldn't have merged this in first place until we will make new release, my bad