### PR TITLE
inventory-scrabble: worn items and missing letters message

### DIFF
--- a/plugins/inventory-scrabble
+++ b/plugins/inventory-scrabble
@@ -1,2 +1,2 @@
 repository=https://github.com/dekvall/runelite-external-plugins.git
-commit=7163cd9c8faa44dcc52cd73a1f86ab6718cdfa43
+commit=a913ada3d49bbba117cb6f96f6c8400d70130200


### PR DESCRIPTION
Adds an option to also consider worn items when checking if interaction is
allowed as well as a message showing which letters you are missing when
examining an npc because it became annoying to count items after a while.