### PR TITLE
Inventory-Setups-1.6

### DIFF
--- a/plugins/inventory-setups
+++ b/plugins/inventory-setups
@@ -1,2 +1,2 @@
 repository=https://github.com/dillydill123/inventory-setups.git
-commit=3102b4d1622885bad907077dee03b63a6b2184a4
+commit=7372f1bfd1f715ab8638fa6db563ec6e6048c971


### PR DESCRIPTION
Inventory Setups 1.6:

Adds a way to view setups in game using the "Show worn items" menu.

Adds Spellbook to the setup so you can make sure you are on the correct setup

Adds a help button that links to the read me (https://github.com/dillydill123/inventory-setups#inventory-setups) which now contains pictures and gifs to help new users. This button can be hidden in the config (learning from jagex's mistakes).