### PR TITLE
Update influxdb-stats

### DIFF
--- a/plugins/influxdb-stats
+++ b/plugins/influxdb-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/Equinox-/runelite-influxdb.git
-commit=886ec0f04b6548682e9254b49950570963334428
+commit=950801553ecf9f849fe06dd0af6ddf4939e4e793


### PR DESCRIPTION
Fix using incompatible okhttp version causing crashes when run with plugin-hub