### PR TITLE
Add Magic Secateurs plugin

### DIFF
--- a/plugins/magic-secateurs
+++ b/plugins/magic-secateurs
@@ -1,2 +1,2 @@
 repository=https://github.com/Ryanbarker0/magic-secateurs.git
-commit=d3c78882262eaf7c03c94537508e9e6e8563a06d
+commit=36816c80988fb06d01b3b4e53e80981e6629d163

--- a/plugins/magic-secateurs
+++ b/plugins/magic-secateurs
@@ -1,2 +1,2 @@
-repository=https://github.com/Ryanbarker0/magic-secateurs
+repository=https://github.com/Ryanbarker0/magic-secateurs.git
 commit=d3c78882262eaf7c03c94537508e9e6e8563a06d

--- a/plugins/magic-secateurs
+++ b/plugins/magic-secateurs
@@ -1,0 +1,2 @@
+repository=https://github.com/Ryanbarker0/magic-secateurs
+commit=d3c78882262eaf7c03c94537508e9e6e8563a06d

--- a/plugins/magic-secateurs
+++ b/plugins/magic-secateurs
@@ -1,2 +1,2 @@
 repository=https://github.com/Ryanbarker0/magic-secateurs.git
-commit=36816c80988fb06d01b3b4e53e80981e6629d163
+commit=e08e25d93da6890008d0708506e459fea7b053ea


### PR DESCRIPTION
The plugin adds a notification when the magic secateurs are in inventory and not equipped. Acts as a reminder to equip them before harvesting crops on farm runs to maximize yield and XP.