### PR TITLE
Added Wiki Bank Tag Integration Plugin

### DIFF
--- a/plugins/bank-tag-generation
+++ b/plugins/bank-tag-generation
@@ -1,2 +1,2 @@
 repository=https://github.com/MitchBarnett/wiki-bank-tag-integration.git
-commit=d1f0c7a1e8ffe8f314ed573e6b8460d7c2ac05da
+commit=48f8c2e49617263de5cf7e010268a63fe8e216b4

--- a/plugins/wiki-bank-tag-integration
+++ b/plugins/wiki-bank-tag-integration
@@ -1,0 +1,2 @@
+repository=https://github.com/MitchBarnett/wiki-bank-tag-integration.git
+commit=d1f0c7a1e8ffe8f314ed573e6b8460d7c2ac05da


### PR DESCRIPTION
This Plugin allows BankTags to be applied to items using the categories on the http://osrs.wiki

Usage example chat command "::bt Potions" to tag all potions.