### PR TITLE
Magic Secateurs - Fix overlay showing when secateurs equipped

### DIFF
--- a/plugins/magic-secateurs
+++ b/plugins/magic-secateurs
@@ -1,2 +1,2 @@
 repository=https://github.com/Ryanbarker0/magic-secateurs.git
-commit=e08e25d93da6890008d0708506e459fea7b053ea
+commit=8406a6f28d5ef307ed4207dfa19f0491759d59b0


### PR DESCRIPTION
For the Magic Secateurs plugin, when testing I didn't revert the return statement, so currently the overlay will show when secateurs are equipped. This PR will fix that issue.