### PR TITLE
Updated bank-tag-generation PluginDependency

### DIFF
--- a/plugins/bank-tag-generation
+++ b/plugins/bank-tag-generation
@@ -1,2 +1,2 @@
 repository=https://github.com/MitchBarnett/wiki-bank-tag-integration.git
-commit=51beb4b832352555d4bd24d56029358ef7f9a986
+commit=233f143f9994558bb44696411eccc6fd74d92d88


### PR DESCRIPTION
**Don't merge until next Runelite release please.**

Updated @PluginDependency to use BankTagsPlugin instead of ClueScrollsPlugin.

This is reliant on a Runelite fix in the next release.

https://github.com/MitchBarnett/wiki-bank-tag-integration/commit/233f143f9994558bb44696411eccc6fd74d92d88