### PR TITLE
Update Loot Logger (v2.1.1)

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=203e28215dd3b2d68dd19f9d8dd01a11c521af04
+commit=aeb5ea309672616df97d4ba2d11642aa1992bec6


### PR DESCRIPTION
Fixes `Ankou's Leggings` ItemID reference