### PR TITLE
Create wiki-search-shortcuts

### DIFF
--- a/plugins/wiki-search-shortcuts
+++ b/plugins/wiki-search-shortcuts
@@ -1,2 +1,2 @@
 repository=https://github.com/IronCory/WikiSearchShortcuts.git
-commit=ddcf88358a9f14339fe3fd08fed10880c5c436c8
+commit=7f0606d3cb6b6ad14d92e6540bfe7f1287a692d3

--- a/plugins/wiki-search-shortcuts
+++ b/plugins/wiki-search-shortcuts
@@ -1,0 +1,2 @@
+repository=https://github.com/IronCory/WikiSearchShortcuts.git
+commit=ddcf88358a9f14339fe3fd08fed10880c5c436c8


### PR DESCRIPTION
Currently just a configurable hotkey to open the wiki search interface in runelite