### PR TITLE
Create ninja-kick

### DIFF
--- a/plugins/ninja-kick
+++ b/plugins/ninja-kick
@@ -1,0 +1,2 @@
+repository=https://github.com/ErinTales/ninja-kick.git
+commit=00c5b928a9eecfeb2b861a7e85ad243e60d2d047


### PR DESCRIPTION
Allows you to set a blacklist of players to be automatically kicked on joining a clan chat. Also allows you to type a command to kick a player who has not yet joined.

Developed to help out a clan running short on ignore list space :)