### PR TITLE
Create hide widgets

### DIFF
--- a/plugins/hide-widgets
+++ b/plugins/hide-widgets
@@ -1,2 +1,2 @@
 repository=https://github.com/PresNL/hide-widgets.git
-commit=a4a180e5b35158cddb83dd62392d44887d5a5232
+commit=9d434de716c301464e2472e8db407dc9f8c966d1

--- a/plugins/hide-widgets
+++ b/plugins/hide-widgets
@@ -1,2 +1,2 @@
 repository=https://github.com/PresNL/hide-widgets.git
-commit=9d434de716c301464e2472e8db407dc9f8c966d1
+commit=d6474a63547f4bafa6a952dc2aed6a48e6126409

--- a/plugins/hide-widgets
+++ b/plugins/hide-widgets
@@ -1,0 +1,2 @@
+repository=https://github.com/PresNL/hide-widgets.git
+commit=a4a180e5b35158cddb83dd62392d44887d5a5232


### PR DESCRIPTION
This plugin enables you to hide all UI widgets in Oldschool Runescape using a hotkey. The default hotkey for this is CTRL + H.

This plugin only works in resizeable mode and does nothing in fixed mode. 

This was originally requested in this issue: [https://github.com/runelite/runelite/issues/10803](https://github.com/runelite/runelite/issues/10803)

![demo](https://user-images.githubusercontent.com/9059955/83951971-cd573900-a835-11ea-921b-ee15cdcbafd3.gif)

