### PR TITLE
Ninja kick

### DIFF
--- a/plugins/ninja-kick
+++ b/plugins/ninja-kick
@@ -1,2 +1,2 @@
 repository=https://github.com/ErinTales/ninja-kick.git
-commit=d057dc60f37725837f02c50ceb1efee48e553536
+commit=609269b2b3130cc516b556b9eee9ee682549cd29

--- a/plugins/ninja-kick
+++ b/plugins/ninja-kick
@@ -1,0 +1,2 @@
+repository=https://github.com/ErinTales/ninja-kick.git
+commit=00c5b928a9eecfeb2b861a7e85ad243e60d2d047

--- a/plugins/ninja-kick
+++ b/plugins/ninja-kick
@@ -1,2 +1,2 @@
 repository=https://github.com/ErinTales/ninja-kick.git
-commit=c3c09b0896ab1999c536a2becf616df9a95265ce
+commit=77897eb95371e86e99cb49743bbf67c4aff606f4

--- a/plugins/ninja-kick
+++ b/plugins/ninja-kick
@@ -1,2 +1,2 @@
 repository=https://github.com/ErinTales/ninja-kick.git
-commit=609269b2b3130cc516b556b9eee9ee682549cd29
+commit=c3c09b0896ab1999c536a2becf616df9a95265ce

--- a/plugins/ninja-kick
+++ b/plugins/ninja-kick
@@ -1,2 +1,2 @@
 repository=https://github.com/ErinTales/ninja-kick.git
-commit=00c5b928a9eecfeb2b861a7e85ad243e60d2d047
+commit=d057dc60f37725837f02c50ceb1efee48e553536


### PR DESCRIPTION
Two functions:

1. Allows you to use a chat command to kick a player from a clan chat. This is useful for a large/popular cc with an overflowing ignore list who wants to be able to preemptively refresh the kick on a user when the key rank/owner is not on to ban them.

2. Contains a blacklist which notifies you whenever a user on it enters the clan, allowing you to easily kick them. Removed the functionality to have this auto-kick them, as that's why this plugin was rejected before.