### PR TITLE
Update Flipping Utilities (v1.3.2)

### DIFF
--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/Belieal/flipping-utilities.git
-commit=0d88d4b9c7d9afd8d33cb7d2588be5c19ebff796
+commit=253fc01c848c96a9805d264f078331a3e36b3976

--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/Belieal/flipping-utilities.git
-commit=5bbc493d2ec3299a9722dbbf14eec04d9b31a102
+commit=0d88d4b9c7d9afd8d33cb7d2588be5c19ebff796


### PR DESCRIPTION
This update adds a new settings menu to the account selector. For now, you'll only be able to delete your account's data from here, but we plan on creating more things to include on this panel.

We've significantly improved the accuracy of the session timer.

Btw's will no longer be picked up by the account cacher since they stand alone and cannot be expected to use the GE.

We're also fixing some critical bugs that caused issues with registering and storing trades. We've not fully found a fix for the bug yet, however we've significantly reduced its disruptive behavior.