### PR TITLE
Create PM Colors

### DIFF
--- a/plugins/pm-colors
+++ b/plugins/pm-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/PresNL/pm-colors.git
-commit=50f5df8f06475dc8713c08f7a9cbb94d6b270c5e
+commit=f3284e8aaf99e1c01b47be5415123f0090975439

--- a/plugins/pm-colors
+++ b/plugins/pm-colors
@@ -1,0 +1,2 @@
+repository=https://github.com/PresNL/pm-colors.git
+commit=e3f542e6c597e8453f48c605600f392a1a37e114

--- a/plugins/pm-colors
+++ b/plugins/pm-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/PresNL/pm-colors.git
-commit=e3f542e6c597e8453f48c605600f392a1a37e114
+commit=ce2f06a1e1af6a20bfcf14d208594c0b167efed2

--- a/plugins/pm-colors
+++ b/plugins/pm-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/PresNL/pm-colors.git
-commit=ce2f06a1e1af6a20bfcf14d208594c0b167efed2
+commit=50f5df8f06475dc8713c08f7a9cbb94d6b270c5e


### PR DESCRIPTION
This plugin adds the ability to highlight private messages from certain users in a specified color when using split private chat

[![Plugin at work](https://thumbs.gfycat.com/FewNegativeAnhinga-size_restricted.gif)](https://gfycat.com/fewnegativeanhinga)
