### PR TITLE
Add clan chat logger plugin

### DIFF
--- a/plugins/clan-chat-logger
+++ b/plugins/clan-chat-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/hex-agon/clan-chat-logger.git
+commit=96febcd5a6492ce584c50ed53c221efcfbb56fa0


### PR DESCRIPTION
A simple plugin that writes clan chat messages to a file. The files are stored at RuneLite's home under the `clanchatlogs` directory.