### PR TITLE
Add weight calculator plugin

### DIFF
--- a/plugins/weight-calculator
+++ b/plugins/weight-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/weight-calculator.git
-commit=fde37f99577fedf274c929821f2c73e30fbdacba
+commit=7a70593fde5986dc03b33d04e61633bce2a27086

--- a/plugins/weight-calculator
+++ b/plugins/weight-calculator
@@ -1,2 +1,2 @@
-repository=https://github.com/andmcadams/weight-calculator
+repository=https://github.com/andmcadams/weight-calculator.git
 commit=fde37f99577fedf274c929821f2c73e30fbdacba

--- a/plugins/weight-calculator
+++ b/plugins/weight-calculator
@@ -1,0 +1,2 @@
+repository=https://github.com/andmcadams/weight-calculator
+commit=fde37f99577fedf274c929821f2c73e30fbdacba


### PR DESCRIPTION
This is a plugin that makes it simpler to calculate precise item weights by highlighting specific items to deposit/withdraw from the bank. As you deposit/withdraw items, the possible weights are calculated and new instructions are given until the actual weight has been identified. Requires a gnomeball, ground bat bones, brass keys, and rocks (from Troll Stronghold leprechaun or earth elementals) in order to use it effectively.