### PR TITLE
Update weight-calculator to v1.2

### DIFF
--- a/plugins/weight-calculator
+++ b/plugins/weight-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/weight-calculator.git
-commit=671637211a9867613ee417f527301ca68f0f0b1e
+commit=209a9d5320b5314662f9bf9bbc50f64240d430ad


### PR DESCRIPTION
- Allow oak roots to be used for 0.001 kg weights and set as default
- Add a toggle to show the possible weights while weighing items
- Fix bug that stops the OverlayPanel from updating when using "Deposit worn items" bank button