### PR TITLE
Updated the another-bronzeman-mode plugin to the 1.6.20 API.

### DIFF
--- a/plugins/another-bronzeman-mode
+++ b/plugins/another-bronzeman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/CodePanter/another-bronzeman-mode.git
-commit=ef387944f6db4e8b3c1c1c8fdeb8bb477daa3b25
+commit=a5b43002390e34925ab0addc9bb0a4696f363a03


### PR DESCRIPTION
This should resolve all API incompatibilties with the clan chat manager in the 'another-bronzeman-mode' plugin.