### PR TITLE
Update chat logger v1.1

### DIFF
--- a/plugins/chat-logger
+++ b/plugins/chat-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/hex-agon/chat-logger.git
+commit=77b0c0a044e0b0826f7a9734b72655e4644da22c

--- a/plugins/clan-chat-logger
+++ b/plugins/clan-chat-logger
@@ -1,2 +1,0 @@
-repository=https://github.com/hex-agon/clan-chat-logger.git
-commit=96febcd5a6492ce584c50ed53c221efcfbb56fa0


### PR DESCRIPTION
### V1.1
* Renamed the plugin from `clan-chat-logger` to `chat-logger` as it no longer logs only the clan chat
* The storage directory has been changed from clanchatlogs to chatlogs
* The plugin is now capable of logging public & private chat channels. Each chat channel has its own directory inside the chatlogs directory
* Each individual chat channel logging can be toggled on/off
