### PR TITLE
add slayer-wiki plugin

### DIFF
--- a/plugins/slayer-wiki
+++ b/plugins/slayer-wiki
@@ -1,2 +1,2 @@
 repository=https://github.com/ffalor/slayer-wiki.git
-commit=2ab736f3d3e5ed6400b64e9f0acb69bb5c4886ce
+commit=ea6f502fef456e8c17528fa9402eabba4f13cce0

--- a/plugins/slayer-wiki
+++ b/plugins/slayer-wiki
@@ -1,0 +1,2 @@
+repository=https://github.com/ffalor/slayer-wiki.git
+commit=2ab736f3d3e5ed6400b64e9f0acb69bb5c4886ce


### PR DESCRIPTION
# Slayer Wiki

This plugin will add a Wiki menu option to slayer equipment.

# What it Does

The Wiki menu option will lookup your current slayer task on the OSRS wiki. This can be used as a quick way to learn more about your slayer task.

Gear with Wiki menu option:

-   Slayer Gem
-   Eternal Slayer Gem
-   Slayer Helmet (all forms)
-   Slayer Rings (all forms)
-   Black Mask

The wiki usually includes important information like:

-   Monster weakness
-   Monster strategies
-   Monster drop table
-   Monster locations
-   Useful tips
