### PR TITLE
Update weight-calculator to v1.2.1

### DIFF
--- a/plugins/weight-calculator
+++ b/plugins/weight-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/weight-calculator.git
-commit=209a9d5320b5314662f9bf9bbc50f64240d430ad
+commit=34568a412b7125d4ba68fb3a47659bdef8d3deae


### PR DESCRIPTION
- Minor bugfixes
- Remove ability to unequip using "Deposit all worn items" and immediately weigh due to issue with client.getWeight() calls
- Update messages to be more instructive
- Disallow the weighing of objects used as weights