### PR TITLE
WDR-banlist

### DIFF
--- a/plugins/wdr-banlist
+++ b/plugins/wdr-banlist
@@ -1,0 +1,2 @@
+repository=https://github.com/jasont20015/WDR-Banlist.git
+commit=c0d8d75dd922d06c7dd51aaceca1f707459fe946

--- a/plugins/wdr-banlist
+++ b/plugins/wdr-banlist
@@ -1,2 +1,2 @@
 repository=https://github.com/jasont20015/WDR-Banlist.git
-commit=c0d8d75dd922d06c7dd51aaceca1f707459fe946
+commit=e25e83beab61b7d6c9abeae58b7cdfd618d2044c


### PR DESCRIPTION
This is an integration of the WDR banlist. It's very much like the runewatch plugin but instead uses an updated list of the WDR banlist.