### PR TITLE
Create level30wilderness

### DIFF
--- a/plugins/level30wilderness
+++ b/plugins/level30wilderness
@@ -1,0 +1,2 @@
+repository=https://github.com/yrrah2/level30wilderness
+commit=2ac296a53b694d431305d0fd04ee3f1f8498ece5


### PR DESCRIPTION
My plugin is a very simple plugin which does the following:

Between Level 30 Wilderness and Level 31 Wilderness there is now a blue line when the plugin is enabled

There is currently no config or settings to change, and when the plugin is disabled the blue line is removed

The purpose is to see where you can activate certain teleports from