### PR TITLE
plugins/optimal-quest-guide

### DIFF
--- a/plugins/optimal-quest-guide
+++ b/plugins/optimal-quest-guide
@@ -1,0 +1,2 @@
+repository=https://github.com/cesoun/optimal-quest-guide.git
+commit=3d65d2de20f002d10b6b368c3f0766a6bab15f67


### PR DESCRIPTION
This plugin is for following the track of the [optimal quest guide](https://oldschool.runescape.wiki/w/Optimal_quest_guide) that is found on the osrs wiki. I, and presumably others, don't update the quests we complete and get lost with the next quest we are supposed to do. I also switch between systems for college and don't want to update the completed quests on each system.

The plugin loads a file that I generated from the wiki and then compares it against your characters completed quests. It then displays the quests, in order of the wiki's guide, in a side panel that you can complete while hiding all the ones you have completed. This panel updates when you complete a quest.

You can also right click the quests in the side panel to open the wiki page for that quest.