### PR TITLE
add tick counter

### DIFF
--- a/plugins/tick-counter
+++ b/plugins/tick-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/winterdaze/tick-counter.git
+commit=7a97f7d1f5a7520e8d60c6a6a4200961971ce34e


### PR DESCRIPTION
Adds a plugin that counts combat activity for nearby players. Counter can be automatically reset upon entering a new instance, or manually reset via shift+right clicking.