### PR TITLE
Add Smart Metronome

### DIFF
--- a/plugins/smart-metronome
+++ b/plugins/smart-metronome
@@ -1,0 +1,2 @@
+repository=https://github.com/Broooklyn/runelite-external-plugins.git
+commit=d3ddafb54d42fd32a5fc60a690e4f87c56f680b2


### PR DESCRIPTION
A metronome plugin that automatically ticks when you are in a location or are doing an activity in which it is useful, and then automatically stops when you leave so you don't have to deal with tick-tick-ticking while sitting at the GE or other inopportune locations.