### PR TITLE
update optimal-quest-guide

### DIFF
--- a/plugins/optimal-quest-guide
+++ b/plugins/optimal-quest-guide
@@ -1,2 +1,2 @@
 repository=https://github.com/cesoun/optimal-quest-guide.git
-commit=3d65d2de20f002d10b6b368c3f0766a6bab15f67
+commit=018148e0b24b9b11e9dcff3a458bb0107c436036


### PR DESCRIPTION
A bug fix for users using stretched mode and expand to screen display settings. This would cause the plugin not to update when logging in for users with this setting. The plugin now checks for the minimap widget group instead. This also causes the plugin to update right away after login instead of after pressing `Click Here to Play` which is nice.

Thank you to Dahl for finding and reporting this bug.

Also a spelling mistake was fixed for the side panel. `Optimal QuestInfo Guide` -> `Optimal Quest Guide`