### PR TITLE
add raid data tracker to the pluginhub

### DIFF
--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/raid-tracker.git
-commit=a62854ad2f5763f7ba8b45137e42de89449aa923
+commit=3498f732499e9adc0cd6400ebc87519a30036d1c

--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/CasvM/raid-tracker.git
+commit=a62854ad2f5763f7ba8b45137e42de89449aa923


### PR DESCRIPTION
For now, the plugin only adds all the raid data to a log file stored in runelite_home/loots/user/cox (as inspired by stonedturtle).

Will add a ui and config in the near future