### PR TITLE
Add Marks of Grace Counter Plugin

### DIFF
--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=3440f2b6d57dd6c2f27c390f1d451af0583400e3
+commit=e936b775dfe7c042fd69cd8bd4239bc9aa824f09

--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/Cyborger1/marks-of-grace-counter.git
+commit=3440f2b6d57dd6c2f27c390f1d451af0583400e3


### PR DESCRIPTION
Resolves [#4909](https://github.com/runelite/runelite/issues/4909).

This is a plugin to help keep track of Marks of Grace spawning on rooftop agility courses. It can track total spawns, the number of marks on the ground, the time since the last mark spawn and give an estimated number of mark spawns per hour.