### PR TITLE
Add gnome restaurant plugin

### DIFF
--- a/plugins/gnome-restaurant
+++ b/plugins/gnome-restaurant
@@ -1,2 +1,2 @@
 repository=https://github.com/MMagicala/gnome-restaurant.git
-commit=23510d1ffd7039abf979b7a220056c03cc481a63
+commit=341c1b849987cd8b28811a31814a91e08761756b

--- a/plugins/gnome-restaurant
+++ b/plugins/gnome-restaurant
@@ -1,0 +1,2 @@
+repository=https://github.com/MMagicala/gnome-restaurant.git
+commit=23510d1ffd7039abf979b7a220056c03cc481a63

--- a/plugins/gnome-restaurant
+++ b/plugins/gnome-restaurant
@@ -1,2 +1,2 @@
 repository=https://github.com/MMagicala/gnome-restaurant.git
-commit=be2e6ec1c9c56219c48fd646a9bdc2d402971ef3
+commit=9ac3cdbb50f5e3af8b37b9370924d27cd4a67d15

--- a/plugins/gnome-restaurant
+++ b/plugins/gnome-restaurant
@@ -1,2 +1,2 @@
 repository=https://github.com/MMagicala/gnome-restaurant.git
-commit=ed9856006fe1dcc5bb7a9ba72d63d5743f2eae4d
+commit=be2e6ec1c9c56219c48fd646a9bdc2d402971ef3

--- a/plugins/gnome-restaurant
+++ b/plugins/gnome-restaurant
@@ -1,2 +1,2 @@
 repository=https://github.com/MMagicala/gnome-restaurant.git
-commit=341c1b849987cd8b28811a31814a91e08761756b
+commit=ed9856006fe1dcc5bb7a9ba72d63d5743f2eae4d


### PR DESCRIPTION
Partially closes [#12031](https://github.com/runelite/runelite/issues/12031)

This is a plugin that helps player create food orders for the gnome restaurant minigame.

Features:
* A timer that shows how long players have to deliver items. Hover over the timer to see the order and recipient name.
* An overlay that tells players how to create an order step-by-step
* A hint arrow that blinks over the recipient
* A timer that shows how long an order delay lasts

All features are toggleable. Reset the plugin by re-enabling it.