### PR TITLE
Update Marks of Grace Counter (1.1)

### DIFF
--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=3440f2b6d57dd6c2f27c390f1d451af0583400e3
+commit=e936b775dfe7c042fd69cd8bd4239bc9aa824f09

--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=e936b775dfe7c042fd69cd8bd4239bc9aa824f09
+commit=5977699dfcb222a6959a7e0dba75a2726616c471

--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/Cyborger1/marks-of-grace-counter.git
+commit=3440f2b6d57dd6c2f27c390f1d451af0583400e3


### PR DESCRIPTION
Modified the marks per hour logic to mirror the agility plugin's lap counter. This makes the counter a lot more consistent and less prone to over-estimate the amount of marks per hour.