### PR TITLE
Add H.A.M Store Rooms plugin

### DIFF
--- a/plugins/ham-store-rooms
+++ b/plugins/ham-store-rooms
@@ -1,0 +1,2 @@
+repository=https://github.com/geel9/runelite-ham-storerooms.git
+commit=9deefcc01ca6a026eb9044c55a818a79d1c5ed4d


### PR DESCRIPTION
This plugin highlights H.A.M Store Room chests when the player has the corresponding key (bronze/iron/steel/silver), and renders text over the chest to represent the quantity of keys the player has for said chest.

This is mainly beneficial for ironmen, as this is dead content for non-ironman accounts. The keys look extremely similar, and it's annoying to remember which chest is in which quadrant of the storerooms -- this fixes that.

![tj566gbuhkfudl190g1w 1](https://user-images.githubusercontent.com/1294419/87417009-8b8c8180-c59d-11ea-9729-d213faceeb1b.png)
