### PR TITLE
update resource-packs to 1.1.3

### DIFF
--- a/plugins/resource-packs
+++ b/plugins/resource-packs
@@ -1,2 +1,2 @@
 repository=https://github.com/melkypie/resource-packs.git
-commit=37cf4a86eedddcb272a5f4df5172dfc91b41fd18
+commit=4b6561b269144d85bc85ab4b2d2e77841af6519a


### PR DESCRIPTION
- Add the widely request quest tab sprites along with some other sprites
- The plugin-hub and the resource hub icons have been changed to rainbow paint brushes (All credits go to [psyda](https://github.com/melkypie/resource-packs/commits?author=Psyda) for creating them)