### PR TITLE
Update Marks of Grace Counter to 1.1.1

### DIFF
--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=b027ff4b483b5808a70909a96b0177c7d88d8fab
+commit=2e16572f9518087ad3b581ad6783b3363aa2d1d3

--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=2e16572f9518087ad3b581ad6783b3363aa2d1d3
+commit=eccd0c835c8d9fd19c21a6b5158b9ff2c1ee6bf4


### PR DESCRIPTION
Slight tweak, made spawn check synchronized to eliminate an edge case when multiple onGameTick events fire simultaneously due to client lag. This would cause the plugin to increment the spawn counter multiple times for the same spawn.

Also added a null check as I noticed it was firing null reference exceptions when closing down Runelite.