### PR TITLE
Add Daily Chronicle Plugin

### DIFF
--- a/plugins/daily-chronicle
+++ b/plugins/daily-chronicle
@@ -1,0 +1,2 @@
+repository=https://github.com/Cyborger1/daily-chronicle.git
+commit=33b69c5fea7811c67cd7a61b1840801666a41ab0

--- a/plugins/daily-chronicle
+++ b/plugins/daily-chronicle
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/daily-chronicle.git
-commit=33b69c5fea7811c67cd7a61b1840801666a41ab0
+commit=be89042a5a7c007dc7f5c890b75974eb60989fc9


### PR DESCRIPTION
This is a plugin akin to the Daily Task Indicators plugin that will remind the player to go buy their Chronicle Teleport Cards when they are available.

This was originally intended to be added to the aforementioned plugin, but due to the apparent lack of a VarBit associated with this limit, a lot of code had to be made to manually keep track of how many cards the player has bought.

I figured this plugin was niche enough to warrant a plugin hub addition instead. The clutter would have been too much for the regular daily plugin, Besides, there may still be issues with this I haven't caught and having players use this and report them would be nice.

This plugin resolves [#12154](https://github.com/runelite/runelite/issues/12154).