### PR TITLE
Update npc-overhead-dialogue

### DIFF
--- a/plugins/npc-overhead-dialogue
+++ b/plugins/npc-overhead-dialogue
@@ -1,2 +1,2 @@
 repository=https://github.com/Stevester118/NPC-Overhead-Dialogue.git
-commit=d4f34a4949db3389a3d011dc4fd960b4cdf89508
+commit=b14a6dbe8b0752022c05f33bd9393a4835545630


### PR DESCRIPTION
fixed issues with different types of NPCs having the same name (dragon drakes were quacking, supposed to be duck drakes quacking), also implemented more dragon text