### PR TITLE
Create cox-light-colors

### DIFF
--- a/plugins/cox-light-colors
+++ b/plugins/cox-light-colors
@@ -1,0 +1,2 @@
+repository=https://github.com/AnkouOSRS/cox-light-colors.git
+commit=86b6d5861ad67a7e8773ee76a1a1959df8221934


### PR DESCRIPTION
Set the colors of the light above the loot chest in Chambers of Xeric