### PR TITLE
Add Daily Task Extensions Plugin

### DIFF
--- a/plugins/daily-task-extensions
+++ b/plugins/daily-task-extensions
@@ -1,0 +1,2 @@
+repository=https://github.com/Cyborger1/daily-task-extensions.git
+commit=bb943ca87ee322358b22b982b6755b039bfc61e3


### PR DESCRIPTION
This is a plugin akin to the Daily Task Indicators plugin that (so far) will remind the player to go buy their Chronicle Teleport Cards from Diango when they are available.

This was originally intended to be added to the aforementioned plugin, but due to the apparent lack of a VarBit associated with this limit, a lot of code had to be made to manually keep track of how many cards the player has bought.

I figured this plugin was niche enough to warrant a plugin hub addition instead. The clutter would have been too much for the regular daily plugin, Besides, there may still be issues with this I haven't caught and having players use this and report them would be nice.

This plugin resolves [#12154](https://github.com/runelite/runelite/issues/12154).