### PR TITLE
Fix wrong support link in daily-task-extensions

### DIFF
--- a/plugins/daily-task-extensions
+++ b/plugins/daily-task-extensions
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/daily-task-extensions.git
-commit=bb943ca87ee322358b22b982b6755b039bfc61e3
+commit=8e60add0f1408a189b82487838e6cb560a4c1e5d


### PR DESCRIPTION
Fix wrong github support link. Oops!