### PR TITLE
update CoX SE to 1.1

### DIFF
--- a/plugins/cox-scouter-external
+++ b/plugins/cox-scouter-external
@@ -1,2 +1,2 @@
 repository=https://github.com/Blackberry0Pie/CoX-Scouter-External.git
-commit=715e253bace661026675644fe43b1f16b3b10138
+commit=084ae805ae0bc44ef637418de08b2b1dd1df14c3


### PR DESCRIPTION
fixed bug where plugin was not showing the overlays(technically not starting up) when config collection import(s) referenced null value(s)
fixed regression for "unknown (combat)" and "unknown (puzzle)" differentiation for whitelist/blacklist not working
plugin tags added
tutorial overlay moved to top right