### PR TITLE
Update Marks of grace counter to 1.1.2

### DIFF
--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=eccd0c835c8d9fd19c21a6b5158b9ff2c1ee6bf4
+commit=91dad8d8107769a603c049b82a91f1745c156c79


### PR DESCRIPTION
Increases mark times queue from 10 to 20 for the spawns per hour counter.
Adds a range to the time to reset config field.
Changes the format string for the displayed last spawn time.