### PR TITLE
Add Examine Tooltip Plugin

### DIFF
--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,0 +1,2 @@
+repository=https://github.com/Cyborger1/examine-tooltip.git
+commit=6657397c63e0bd0e0f26bbdfa72fc4e856831130

--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=6657397c63e0bd0e0f26bbdfa72fc4e856831130
+commit=09523b9c0791200a35120518f4d56a9086404ed4


### PR DESCRIPTION
Potentially resolves [#12196](https://github.com/runelite/runelite/issues/12196).

Shows examine text in a tooltip underneath the cursor.

![examine_tooltip](https://user-images.githubusercontent.com/45152844/88570705-86eab300-d00a-11ea-84ff-bf4199dddc18.gif)