### PR TITLE
Update CoX Light Colors

### DIFF
--- a/plugins/cox-light-colors
+++ b/plugins/cox-light-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/cox-light-colors.git
-commit=e0853cac0876c5224c3c48a35320f6ba97c4dced
+commit=ec3cf1a71b1e4ad860ae1d69d6210dd2ab12bf9f


### PR DESCRIPTION
Update default colors for uniques and olm entrance to better match the color without the plugin