### PR TITLE
Update Examine Tooltip to 1.2.1 (tiny fix)

### DIFF
--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=d8aeeea988b3ecb9edacafe1ec2e0e64b579b487
+commit=c5bd50bc82b1c49fb67d2869965ed8cbec66cd7e


### PR DESCRIPTION
Forgot to clear current examines on game state changes, causing floating examines in the wrong spots from local points being desynced when loading, for example.