### PR TITLE
Update Examine Tooltip to 1.3 (Tooltip Fadeout)

### DIFF
--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=c5bd50bc82b1c49fb67d2869965ed8cbec66cd7e
+commit=9eff8c3797fa22e7807886dee5f5fb321b30c408

--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=9eff8c3797fa22e7807886dee5f5fb321b30c408
+commit=8ff2cc37145aa58d9d9aad97fffdac569d1cca68


### PR DESCRIPTION
The logic I was using to clean up a hashmap was incorrect, leading to a buildup of examine objects in certain cases. This fix remedies this by always clearing the hashmap when there are no active examines or if its size gets too large.

This update also adds tooltip fadeouts. A bit dirty right now because I had to copy paste classes from the main runelite branch and modify them, but I'll be looking into doing a separate PR for that which, if it passes, will let me get rid of these custom classes. [This is the branch](https://github.com/Cyborger1/runelite/tree/tooltip-alpha) with the changes.

![scbQpBvekx](https://user-images.githubusercontent.com/45152844/88945969-a0833900-d25c-11ea-9001-1e20f446ccdb.gif)