### PR TITLE
Update Examine Tooltip to 1.3.1

### DIFF
--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=8ff2cc37145aa58d9d9aad97fffdac569d1cca68
+commit=deb5d1a644016f31e5ae109b6f2552014a5148cf


### PR DESCRIPTION
Improves the fallback to tile to using the tile's clickbox instead of a fixed point to calculate the examine box position.