### PR TITLE
Update Examine Tooltip to 1.3.2

### DIFF
--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=deb5d1a644016f31e5ae109b6f2552014a5148cf
+commit=27f040820f6103a59e2438086cb27712575d1a85


### PR DESCRIPTION
Did away with trying to account for every possible widget like the Examine Plugin does. This should now catch any examine in any widget.