### PR TITLE
runewatch: v2.0.1 release

### DIFF
--- a/plugins/runewatch
+++ b/plugins/runewatch
@@ -1,2 +1,2 @@
 repository=https://github.com/while-loop/runelite-plugins.git
-commit=e64b2da7e1ada52bbd8f10287df9af5e62c59a94
+commit=7c2d8bd31518d5463a8e774e47fcb07b637b6747

--- a/plugins/runewatch
+++ b/plugins/runewatch
@@ -1,3 +1,2 @@
 repository=https://github.com/while-loop/runelite-plugins.git
-commit=b9a6debeab9c764e90de41ba4bb5e6782808cb16
-warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
+commit=e64b2da7e1ada52bbd8f10287df9af5e62c59a94


### PR DESCRIPTION
v2 includes the following changes:

* use github as host for [WDR/RW watchlist](https://raw.githubusercontent.com/while-loop/runelite-plugins/runewatch/data/mixedlist.json)
* include WDR as a source for reported users
* make clan chat alerting toggleable
* add option to disable/notifiy screenshots

**Note:** The warning upon plugin installation has been removed as we now store the watchlist on GitHub so users are not directly accessing RuneWatch's public API.