### PR TITLE
Update CoX Light Colors

### DIFF
--- a/plugins/annoyance-mute
+++ b/plugins/annoyance-mute
@@ -1,2 +1,2 @@
 repository=https://github.com/Broooklyn/runelite-external-plugins.git
-commit=1d6b4264fb088519a3649b1f1e492f8585c9e2ca
+commit=1e11ab3dfbfe7ff54635cc351ee9c27f04f087e8

--- a/plugins/cox-light-colors
+++ b/plugins/cox-light-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/cox-light-colors.git
-commit=ec3cf1a71b1e4ad860ae1d69d6210dd2ab12bf9f
+commit=ff03d737cd8840656c6630d260447b245a1905e2

--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=0e1a3bdbdae711d8988a85ba1ea45dd9e45a72cb
+commit=b2e578788c5717074c91de64f3ce8371a91c2cfc

--- a/plugins/zom-dense-essence
+++ b/plugins/zom-dense-essence
@@ -1,0 +1,2 @@
+repository=https://github.com/JZomerlei/zom-external-plugins.git
+commit=eed300e207f6baf48812785faedf5f692e1cdb5a


### PR DESCRIPTION
Reset light and entrance color when you leave the raid or turn the plugin off
Fix light defaulting to white if the light type variable was never set.
Update README