### PR TITLE
Update Examine Tooltip to 1.3.4

### DIFF
--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=0e1a3bdbdae711d8988a85ba1ea45dd9e45a72cb
+commit=b2e578788c5717074c91de64f3ce8371a91c2cfc


### PR DESCRIPTION
Change another instance if `Perspective.getClickbox()` I forgot to remove.

Add a config option to distinguish between interface/inventory item examines and ground item examines.

Add a config option to turn off the clamping of the examine boxes and let them go offscreen.

Turn off accounting for drag in inventory to be consistent with examines on interfaces.