### PR TITLE
Add zom-dense-essence

### DIFF
--- a/plugins/zom-dense-essence
+++ b/plugins/zom-dense-essence
@@ -1,0 +1,2 @@
+repository=https://github.com/JZomerlei/zom-external-plugins.git
+commit=eed300e207f6baf48812785faedf5f692e1cdb5a


### PR DESCRIPTION
Config: 
![image](https://user-images.githubusercontent.com/14265490/89125386-1c26f500-d4ac-11ea-8248-5c3cf9ef6aee.png)

When one is available and not the other:
![image](https://user-images.githubusercontent.com/14265490/89125424-6d36e900-d4ac-11ea-9393-855cd910dd51.png)

Both available:
![image](https://user-images.githubusercontent.com/14265490/89125436-7fb12280-d4ac-11ea-89b3-696151bfd3b7.png)

There is a max draw distance set so that it's not visible until your local point compared to the north/south runestone is within 2550.
