### PR TITLE
Add the no social messages plugin

### DIFF
--- a/plugins/no-social-messages
+++ b/plugins/no-social-messages
@@ -1,0 +1,2 @@
+repository=https://github.com/hex-agon/no-social-messages.git
+commit=ce129baf70c5ae4f65544f0413e219546b93e95e


### PR DESCRIPTION
A simple plugin that removes the 'player has logged in' and 'player has logged out' messages from ever appearing.