### PR TITLE
Update cox-light-colors to 1.1

### DIFF
--- a/plugins/cox-light-colors
+++ b/plugins/cox-light-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/cox-light-colors.git
-commit=ec3cf1a71b1e4ad860ae1d69d6210dd2ab12bf9f
+commit=ff03d737cd8840656c6630d260447b245a1905e2


### PR DESCRIPTION
Update version number
Reset light and entrance color when you leave the raid or turn the plugin off
Update README