### PR TITLE
dense runecrafting: Fix the description

### DIFF
--- a/plugins/zom-dense-essence
+++ b/plugins/zom-dense-essence
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomerlei/zom-external-plugins.git
-commit=eed300e207f6baf48812785faedf5f692e1cdb5a
+commit=1053d8d1fa4898851c1a15b05cd262133258755a


### PR DESCRIPTION
Zeah should be capitalized I guess. I also removed the Test class that was moved to the main package because it's already in the test package..  I forget how it happened. 