### PR TITLE
Add collection-log plugin

### DIFF
--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,0 +1,2 @@
+repository=https://github.com/evansloan/collection-log.git
+commit=434e27b57af310258d0154f07f367537b564e977

--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,2 +1,2 @@
 repository=https://github.com/evansloan/collection-log.git
-commit=434e27b57af310258d0154f07f367537b564e977
+commit=2f5bf21a94ed15f494927587b9543c9efc33dee0


### PR DESCRIPTION
Adds items obtained/total items to the top of the collection log. 

Open the collection log and click through all the categories to get your total progress. In order to update your progress you must re-open the categories in which you've recently received new items.