### PR TITLE
Add accounts-login plugin

### DIFF
--- a/plugins/accounts-login
+++ b/plugins/accounts-login
@@ -1,0 +1,2 @@
+repository=https://github.com/wesley-221/runelite-accounts-login.git
+commit=ef9b037d771fb3891f1abbf6a934a5c452602292


### PR DESCRIPTION
Add a simple plugin that allows you to save an account and password to a local file. When you click on the tile it simply pastes the username and password to the login screen. 

Somewhat similar to the "Profiles" plugin, but since the that plugin hasn't been updated in a while and doesn't support password saving in the current version, I decided to make my own plugin.