### PR TITLE
Add ToB time infobox plugin

### DIFF
--- a/plugins/tob-infoboxes
+++ b/plugins/tob-infoboxes
@@ -1,2 +1,2 @@
 repository=https://github.com/winterdaze/tob-time-infoboxes.git
-commit=d66ee4958d091118011e666996b18067a105cfeb
+commit=45e0f947a3833791788a29326d682b81eac50176

--- a/plugins/tob-infoboxes
+++ b/plugins/tob-infoboxes
@@ -1,0 +1,2 @@
+repository=https://github.com/winterdaze/tob-time-infoboxes.git
+commit=d66ee4958d091118011e666996b18067a105cfeb


### PR DESCRIPTION
Adds an infobox with the room's time after it is completed.
Resets when you enter the next raid (manually reset by toggling the plugin).


![img](https://i.imgur.com/xYtIcOA.png)

Would close https://github.com/runelite/runelite/issues/11876