### PR TITLE
Add shayzien-organised-crime plugin

### DIFF
--- a/plugins/analogue-timestamps
+++ b/plugins/analogue-timestamps
@@ -1,2 +1,2 @@
 repository=https://github.com/loldudester/analogue-timestamps.git
-commit=6cd4736ae3478ba8a2b28146a8ab10522d9e632f
+commit=f41e07f36b4a74734948dbb84d17cdc7d21cff98

--- a/plugins/shayzien-organised-crime
+++ b/plugins/shayzien-organised-crime
@@ -1,0 +1,2 @@
+repository=https://github.com/DylanLange/shayzien-organised-crime.git
+commit=c3ff5fc240836d1e1c8184f79eda1f87bb86b475


### PR DESCRIPTION
Adds [Shayzien organised crime plugin ](https://github.com/DylanLange/shayzien-organised-crime)

Check out the [README.md](https://github.com/DylanLange/shayzien-organised-crime/blob/master/README.md) for more info!