### PR TITLE
Add shayzien-organised-crime plugin

### DIFF
--- a/plugins/shayzien-organised-crime
+++ b/plugins/shayzien-organised-crime
@@ -1,2 +1,2 @@
 repository=https://github.com/DylanLange/shayzien-organised-crime.git
-commit=f41e07f36b4a74734948dbb84d17cdc7d21cff98
+commit=180a07c99d7a8fa260df6f38158ad2371583edb3

--- a/plugins/shayzien-organised-crime
+++ b/plugins/shayzien-organised-crime
@@ -1,0 +1,2 @@
+repository=https://github.com/DylanLange/shayzien-organised-crime.git
+commit=f41e07f36b4a74734948dbb84d17cdc7d21cff98


### PR DESCRIPTION
Adds [Shayzien organised crime plugin ](https://github.com/DylanLange/shayzien-organised-crime)

Check out the [README.md](https://github.com/DylanLange/shayzien-organised-crime/blob/master/README.md) for more info!