### PR TITLE
Update shayzien-organised-crime plugin

### DIFF
--- a/plugins/shayzien-organised-crime
+++ b/plugins/shayzien-organised-crime
@@ -1,2 +1,2 @@
 repository=https://github.com/DylanLange/shayzien-organised-crime.git
-commit=180a07c99d7a8fa260df6f38158ad2371583edb3
+commit=0127956b202ef5e5bb85fc4aa27f6486f7f198aa


### PR DESCRIPTION
Small update to the [shayzien organised crime plugin](https://github.com/DylanLange/shayzien-organised-crime)

Clear stale data on login game event, update text for Hosidius pub location for parsing, and some code clean up.

`v1.0.0` -> `v1.0.1` 