### PR TITLE
Update shayzien-organised-crime to v1.0.2

### DIFF
--- a/plugins/shayzien-organised-crime
+++ b/plugins/shayzien-organised-crime
@@ -1,2 +1,2 @@
 repository=https://github.com/DylanLange/shayzien-organised-crime.git
-commit=0127956b202ef5e5bb85fc4aa27f6486f7f198aa
+commit=a65fcb8ec458154da86031232cb0d2522ffbb909


### PR DESCRIPTION
Update to v1.0.2 with a fix to a location message which was causing a gang location to not be recorded.