### PR TITLE
not-empty: add plugin

### DIFF
--- a/plugins/not-empty
+++ b/plugins/not-empty
@@ -1,0 +1,2 @@
+repository=https://github.com/dekvall/runelite-external-plugins.git
+commit=773c859d639046d2da4b9f01203c68fb4593ae34


### PR DESCRIPTION
Give users the ability to hide annoying right-click options on items