### PR TITLE
Add home-enforcer

### DIFF
--- a/plugins/home-enforcer
+++ b/plugins/home-enforcer
@@ -1,0 +1,2 @@
+repository=https://github.com/Hydrox6/external-plugins.git
+commit=d93518a6c987b659ec2f5363dc42f4ac584944a7


### PR DESCRIPTION
A simple plugin to keep the homes in Mahogany Homes from shifting out of existence when you walk a few paces away.