### PR TITLE
Inferno Wave Splits plugin

### DIFF
--- a/plugins/inferno-wave-splits
+++ b/plugins/inferno-wave-splits
@@ -1,0 +1,2 @@
+repository=https://github.com/usa-usa-usa-usa/inferno-wave-splits.git
+commit=5e0265350ff0d7420440965cf0b666f2cf4ebcf5


### PR DESCRIPTION
Displays a chat message with inferno elapsed time for the various inferno wave milestones.

To avoid re-inventing the wheel. The plugin is dependent on @winterdaze 's recent addition of the tzhaar timers on the base clients Timers plugin. This is stated within the support documentation for the plugin.

All this plugin does is parses the Wave: # chat message to determine if it is a split wave, reads the text on the infobox implemented in the Timers plugin, then displays a chat message with the elapsed time.