### PR TITLE
Create item-comparison

### DIFF
--- a/plugins/item-comparison
+++ b/plugins/item-comparison
@@ -1,0 +1,2 @@
+repository=https://github.com/intervenience/Runelite-Item-Comparison.git
+commit=0e73e552776427f1069baa1d46aba3ff268783d8

--- a/plugins/item-comparison
+++ b/plugins/item-comparison
@@ -1,2 +1,2 @@
 repository=https://github.com/intervenience/Runelite-Item-Comparison.git
-commit=0e73e552776427f1069baa1d46aba3ff268783d8
+commit=226b5cb94aba03c6080ee61dd906c18a3b802648


### PR DESCRIPTION
Allows users to compare items stats in the sidebar, instead of having to load the wiki in a browser or visit the GE in game.
It queries the oldschool.runescape.wiki API for the search parameters input by the user and then will either: 
a) return an error if it does not exist
b) accept the page redirect by the wiki for searches that are similarly named (ie Firecape redirects to Fire_cape) and then
c) load the contents of the page found by the wiki API.

The contents are scanned for the item stat bonuses, which are then displayed in their appropriate text field next to icons to indicate what kind of stat bonus they are.

![image](https://user-images.githubusercontent.com/9075175/91636887-7ed9c500-ea47-11ea-8e3b-b52e1fcc09c0.png)