### PR TITLE
feat: add ring of recoil notifier plugin

### DIFF
--- a/plugins/ring-of-recoil-notifier
+++ b/plugins/ring-of-recoil-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/delps1001/recoil-plugin.git
-commit=42bcc6450244d033f0ffea7b2deae57fbeaac63c
+commit=d6cdfed22a336c8df49b0caaa74cd5fe68aea2f8

--- a/plugins/ring-of-recoil-notifier
+++ b/plugins/ring-of-recoil-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/delps1001/recoil-plugin.git
-commit=09dcc9b62ff4150f0509cdd89c3eaeed45d7656e
+commit=261c8a3dc58e6381194406d8ce9ebfbf399cb0e0

--- a/plugins/ring-of-recoil-notifier
+++ b/plugins/ring-of-recoil-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/delps1001/recoil-plugin.git
+commit=42bcc6450244d033f0ffea7b2deae57fbeaac63c

--- a/plugins/ring-of-recoil-notifier
+++ b/plugins/ring-of-recoil-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/delps1001/recoil-plugin.git
-commit=d6cdfed22a336c8df49b0caaa74cd5fe68aea2f8
+commit=09dcc9b62ff4150f0509cdd89c3eaeed45d7656e


### PR DESCRIPTION
adds an overlay if you character is not currently equipping a ring of recoil, supports scaling the overlay image.

![Annotation 2020-08-29 135917](https://user-images.githubusercontent.com/10621463/91643299-de13e700-e9ff-11ea-8895-76045d496a8f.png)
