### PR TITLE
Add pathfinder plugin

### DIFF
--- a/plugins/pathfinder
+++ b/plugins/pathfinder
@@ -1,0 +1,2 @@
+repository=https://github.com/Milo-Piazza/pathfinder.git
+commit=36577c233135e3c3ff3fbc4f4a18cbe587c5549b

--- a/plugins/pathfinder
+++ b/plugins/pathfinder
@@ -1,2 +1,2 @@
 repository=https://github.com/Milo-Piazza/pathfinder.git
-commit=36577c233135e3c3ff3fbc4f4a18cbe587c5549b
+commit=7d6f5661c702767bbdef2de6065609cf1fa94a74


### PR DESCRIPTION
Pathfinder is similar to the built-in tile indicator plugin, but it computes and highlights the path the player's character will take to the hovered tile. It is mainly meant for Zalcano to help navigate the red symbols. For now it assumes there are no obstructions between the player and the tile, but this could be changed later.

I couldn't determine whether or not this breaks Jagex's third party client rules; to me it's in a bit of a grey zone. Sorry in advance if it is against the rules. I also couldn't find any plugins implementing this functionality already.