### PR TITLE
Update Raid Tracker to v1.2

### DIFF
--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/raid-tracker.git
-commit=959d696982bd530fe3af9f43f0b2046af5299216
+commit=d818d39351efade78a7f85c1587e172f8c6dddaa


### PR DESCRIPTION
# v1.2:
- Added the option to filter kills shown in the UI, based on time or a total number of kills. It is also possible with the filter to only show CM kills, no CM kills, or to show both.
- Added the option to change purple splits in the UI, rather than having to change the logfile itself. When you get a purple it will show at the bottom of the UI, where you can change the team size, split, and whether it was FFA or not. These values will then update to the log file.
- Bugfix regarding not updating the UI after a kill has been made, due to the reset() function being called too early.
Now all the values in the UI will show at least zero. Previously, it was possible that it would show -1 * killcount, if there were no splits/points earned yet.