### PR TITLE
Create raid-player-names

### DIFF
--- a/plugins/raid-player-names
+++ b/plugins/raid-player-names
@@ -1,0 +1,2 @@
+repository=https://github.com/stevenkaan/raid-name-logger.git
+commit=7fe4d33792d26e4220ed16818ff767481889976e


### PR DESCRIPTION
This plugin will log the players with who you raid.
This may be usefull for players who want to log all the names (Like raid teachers who needs to keep track of the learners)
They names are not saved anywhere.. They will only be put in the panel.