### PR TITLE
Update Raid Data Tracker to v1.2.1

### DIFF
--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/raid-tracker.git
-commit=d818d39351efade78a7f85c1587e172f8c6dddaa
+commit=da8f27c3b4f841a10c4218705ad910360ff83922


### PR DESCRIPTION
### v1.2.1:
- **Fixed a bug where, if you switched from one account to the other, the data would overwrite the last account's data.**
- Sorted the Change Purple list to be in chronological order
- Fixed a bug for players that have a space in their name: The space would show as "Â ", now correctly shows as " "