### PR TITLE
Update baplus

### DIFF
--- a/plugins/baplus
+++ b/plugins/baplus
@@ -1,2 +1,2 @@
 repository=https://github.com/hisean1/BAPlus.git
-commit=61a03ce883747a0cc6a04712a096cd15a84a1401
+commit=0bfe230a648a877239d4e8169274267cceed8183


### PR DESCRIPTION
Fixes bugs with the point breakdown where using the vanilla plugin's wave duration would cause the readout to show all 0's, and allows users to only readout points at the end of a game, instead of every wave