### PR TITLE
add decimal-prices

### DIFF
--- a/plugins/decimal-prices
+++ b/plugins/decimal-prices
@@ -1,2 +1,2 @@
 repository=https://github.com/rmaes4/decimal-prices.git
-commit=a903deba1374f29c426d0fc555cc148bc46736be
+commit=a8040cf8eea9664d9769c1af38f18eb215e22767

--- a/plugins/decimal-prices
+++ b/plugins/decimal-prices
@@ -1,0 +1,2 @@
+repository=https://github.com/rmaes4/decimal-prices.git
+commit=a903deba1374f29c426d0fc555cc148bc46736be

--- a/plugins/decimal-prices
+++ b/plugins/decimal-prices
@@ -1,2 +1,2 @@
 repository=https://github.com/rmaes4/decimal-prices.git
-commit=a8040cf8eea9664d9769c1af38f18eb215e22767
+commit=5c99849a26774e5c7980af76a6c557654b7bbdef


### PR DESCRIPTION
This plugin lets you type decimals when buying and selling at the GE. For example you can type "1.2m" and it will be entered as "1,200,000". This saves you from having to type longer numbers.