### PR TITLE
update raid tracker to v1.2.2

### DIFF
--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/raid-tracker.git
-commit=da8f27c3b4f841a10c4218705ad910360ff83922
+commit=14721861337ec464bc4442fe7073063739c6d726


### PR DESCRIPTION
### v1.2.2
- Fixed a bug with the migrate function, where the wrong RaidTracker list was added to the new file.
- Changed the value formatter to show decimals up until 100m instead of up until 10m.