### PR TITLE
Update collection-log v1.2.1

### DIFF
--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,2 +1,2 @@
 repository=https://github.com/evansloan/collection-log.git
-commit=a386fdb27f35a8a0c5c841ff271f6dcacf369f38
+commit=6b2b12cd998de21508a195e28a0b8779fea0e354


### PR DESCRIPTION
* Add null check to collection log list widget
* Move export option to bottom of collection log right click menu