### PR TITLE
pvp-performance-tracker: Fix initial load bug, new statistic

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=cf7dd10f95a320467349c458b7c9ac5077aebdb0
+commit=c5f3b9417d1e5c20844e150b36d3cf96811901db


### PR DESCRIPTION
Fixed a bug that happened on initial plugin load and triggered a modal for any new installations. Also removed that modal entirely since the behavior on Mac with always on top on was odd during client load. New statistic: offensive pray tracking (only for the player, not the opponent). Added to overlay (off by default), panel, and fight log. Also added config sections. Tested various times with old data from the previous version and it seems to be working no problem, even mixing it with new data and re-importing. Generally tested in LMS.