### PR TITLE
pvp-performance-tracker: prevent invalid fights from being saved

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=c5f3b9417d1e5c20844e150b36d3cf96811901db
+commit=80dcc7f3480dbbdedec56ff7f1c355e3768f9fdc


### PR DESCRIPTION
There was a bug where if you or another player attacked _anything_ after interacting with each other (by following, trading, teleothering, etc), the plugin would assume you started fighting them and track your attacks as a fight against them. This was fixed by ensuring a player is attacking their tracked target, meaning in such a case, no attacks will be added and the fight will be discarded shortly since there is no activity. Of course this will also prevent random pvm attacks from being added to a fight, or boxing an npc/other player from continuing a fight, and should make multi-combat use make more sense (although multi is still not really supported). Generally re-tested in LMS.