### PR TITLE
Update raid data tracker to v1.3.1

### DIFF
--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/raid-tracker.git
-commit=a030e11b454c5cc73209d0e062338ce10d051f54
+commit=aa9e43c7770b4e53a18f52dba47cad67ec5c03bf

--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/raid-tracker.git
-commit=88d9645f45d79ae31fccefc8a7233ca3803bdf15
+commit=a030e11b454c5cc73209d0e062338ce10d051f54

--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/raid-tracker.git
-commit=14721861337ec464bc4442fe7073063739c6d726
+commit=88d9645f45d79ae31fccefc8a7233ca3803bdf15

--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/raid-tracker.git
-commit=da8f27c3b4f841a10c4218705ad910360ff83922
+commit=14721861337ec464bc4442fe7073063739c6d726


### PR DESCRIPTION
### v1.3.1
- Fixed a bug caused by not importing the StringEscapeUtils dependency in build.gradle (not tested).
- Improved ui performance by not pausing the swing thread, but instead updating the panel when the variable is loaded.