### PR TITLE
Update Mahogany Homes (v1.1)

### DIFF
--- a/plugins/mahogany-homes
+++ b/plugins/mahogany-homes
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Mahogany-Homes.git
-commit=06e1dae26b130da74df4beca00c7126afed42fb4
+commit=e8e6861fc8fb35c466128d803883060f91a20d74


### PR DESCRIPTION
Plugin visuals will now timeout after 5 minutes to prevent collisions, such as the arrow at giant mole never showing up.