### PR TITLE
add colourblind-chat

### DIFF
--- a/plugins/colourblind-chat
+++ b/plugins/colourblind-chat
@@ -1,0 +1,2 @@
+repository=https://github.com/Hydrox6/external-plugins.git
+commit=ac2a841c316744de35710fcf5dab80fe03d841b5


### PR DESCRIPTION
Edits Jagex colour tags by moving as much of one colour to another as it can.

Not sure how well this will work, but it's interesting to look at at least.