### PR TITLE
Flipping-Utilities: Perfomance increases to prevent client crashes

### DIFF
--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/Belieal/flipping-utilities.git
-commit=fc664cbf2819b6bf8f2d003005f7e02a2c02d177
+commit=cf21b9e1aea29a23626161af05005f364911da01


### PR DESCRIPTION
Since release v1.4.0 users have been experiencing lag and some users aren't able to log in due to the client crashing. The problem has to do with release v1.4.0 displaying ever single offer you made on an item as a panel. This led to a huge increase in the amount of panels making up the GUI. The statistics tab and Flipping tab started having horrendous rebuild times along with causing huge cpu spikes for some users.

This update solves this issue by placing a hard cap on the amount of panels viewable at a time. Now, instead of every single panel being present, only panels of a certain "page" are present at a time. For the flipping and statistics tab this is only 20 panels per page. For the trade history of an item, its only 10 panels per page.

As a result, when running the plugin with a trade file from a user experiencing crashes, the rebuild times for the stat panel went down from **2000 milliseconds to 50 milliseconds**. This will probably be more drastic depending on how large a user's trade file is/what specs they have. 