### PR TITLE
Create tray-indicators

### DIFF
--- a/plugins/tray-indicators
+++ b/plugins/tray-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/DMAD777/tray-indicators.git
+commit=1e8638eaac4b939d879b98779e7e4164773d6b1c

--- a/plugins/tray-indicators
+++ b/plugins/tray-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/DMAD777/tray-indicators.git
-commit=1e8638eaac4b939d879b98779e7e4164773d6b1c
+commit=15f09a13494161cf1b9f573c33d91ee6671bcd83


### PR DESCRIPTION
Displays your hitpoints, prayer, or absorption in the system tray.

Icons can be disabled individually. Colors are fully customizable.