### PR TITLE
Add profit-tracker plugin

### DIFF
--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/nofatigue/runelite-profit-tracker.git
+commit=80b8fdc18e0be8267d684965bc7a36f381bd41fc

--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nofatigue/runelite-profit-tracker.git
-commit=cf4e424bbc12def70e1968808d5f2acf575a50bd
+commit=9a9bbebbd29d1bce375829267a1e7f5c46bebcd5

--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nofatigue/runelite-profit-tracker.git
-commit=80b8fdc18e0be8267d684965bc7a36f381bd41fc
+commit=cf4e424bbc12def70e1968808d5f2acf575a50bd


### PR DESCRIPTION
The purpose of this plugin is to show you how profitable you are when money making.
This plugin tracks inventory changes and calculates profit for each change (according to GE).
It begins a timer at plugin start and calculates profit per hour.
It has a toggled goldrop feature which is based on existing xpdrop mechanism,
showing your profit increase/decrease for each tick your inventory has changed. 

repo: https://github.com/nofatigue/runelite-profit-tracker