### PR TITLE
Update fight-cave-waves and virtual-level-ups

### DIFF
--- a/plugins/fight-cave-waves
+++ b/plugins/fight-cave-waves
@@ -1,2 +1,2 @@
 repository=https://github.com/nightfirecat/plugin-hub-plugins.git
-commit=17ccfb7deaa30f10e4392f60ba264c54b0030bd4
+commit=9ccbfe656e472a2bdd897a7a7c27d0caf23ec867

--- a/plugins/virtual-level-ups
+++ b/plugins/virtual-level-ups
@@ -1,2 +1,2 @@
 repository=https://github.com/nightfirecat/plugin-hub-plugins.git
-commit=c12ce8e2a683046bd3562785440764b4c06af9f3
+commit=c60b5c41d9ef9f2d43f8199506f9f57a77212450


### PR DESCRIPTION
This commit pulls the following changes for fight-cave-waves:

* Updated plugin name to match plugin-hub listing
* Support for inferno waves
* Resizable overlay support

It also pulls the following changes for both plugins:

* Updates the `author` field to use my username
* Updates the package path to match my own domain