### PR TITLE
Update fishing-notifier and spec-regen-timer

### DIFF
--- a/plugins/fishing-notifier
+++ b/plugins/fishing-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/Bram91/fishing-notifier.git
-commit=2a622bb226f23c336f28a6daa03dabbdb5e29162
+commit=f2105733f8d130f562e36dc4fb13d1cdb1b897b5

--- a/plugins/spec-regen-timer
+++ b/plugins/spec-regen-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/Bram91/SpecRegenTimerPlugin.git
-commit=8acca5452ab359b9799f44073754ab308c8f3f39
+commit=a0895eae15d100f61bfaa000180ea0680353456a


### PR DESCRIPTION
Fixes the wrong spec % for the eldritch nightmare staff.
Fixes the fishing notifier notifying on world hop/login out and back in while fishing