### PR TITLE
Update contextual-cursor to v1.2.1

### DIFF
--- a/plugins/contextual-cursor
+++ b/plugins/contextual-cursor
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=448cd91cb2e66b1eb55fe1c5dea9e095b3a53e80
+commit=e5e177950d4e8f261bb6b3beb37781cfa0464d08


### PR DESCRIPTION
* Fixed a weird caching bug that caused the cursor to disappear when pressing Alt (no, really)
* Fixed WIKI not working properly on tagged NPCs
* Added more triggers