### PR TITLE
Update to v1.1

### DIFF
--- a/plugins/ba-minigame
+++ b/plugins/ba-minigame
@@ -1,2 +1,2 @@
 repository=https://github.com/BegOsrs/Ba-minigame.git
-commit=5ded68bddac61bd6b02add7c380c7bdd615b5d17
+commit=1f4a3ef21a44f7570405e5332789ab91747667fb


### PR DESCRIPTION
Added:
1. Highlight ground item tile 
2. Allow configuration of team healthbar alpha color value

Fixed:
1. Handle grounditem's highlighted list to avoid ground item highlighting from both plugins
2. Plugin was losing the ability to revert grounditem/barbarian assault plugins configs after reseting this plugin configuration