### PR TITLE
Update quest-helper to v1.0.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=2daa04b3098f1238c23ea9677ad502a6dae771bc
+commit=163d7002bf952d129a4650cb106a1ce5285b230b


### PR DESCRIPTION
- Adds Shadow of the Storm, The Tourist Trap, and Priest in Peril.
- Bug fixes for various quests, varying from incorrect prompts, unneeded steps, to incorrect item checks.
- Default instance checks to the current player's plane, rather than the plane of the instance itself. This was due to an issue in Shadow of the Storm where the instance was on plane 2, but the origin was on plane 0.