### PR TITLE
Add simple license check

### DIFF
--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -86,6 +86,7 @@ SIGNING_KEY="" REPO_CREDS="" gradle \
 
 [ -s "$BUILDDIR/plugin.jar" ]
 [ -s "$BUILDDIR/plugin.manifest" ]
+[ -f "$BUILDDIR/LICENSE" ]
 
 cat "$BUILDDIR/plugin.manifest"
 


### PR DESCRIPTION
This commit adds a build-time check for a LICENSE file with the BSD 2-Clause "Simplified" license header.

Unfortunately, GitHub's license API does not allow for checking the license type of a repo at a given commit, so we cannot use that here.