### PR TITLE
Create discord-rare-drop-notificater

### DIFF
--- a/plugins/discord-rare-drop-notificater
+++ b/plugins/discord-rare-drop-notificater
@@ -1,2 +1,2 @@
 repository=https://github.com/MasterKenth/discord-rare-drop-notificater.git
-commit=c0c97ba842e11288a3a85d9a4e0577fc8439836d
+commit=d19ad18af3d7154c337d43d43260de61abdba59e

--- a/plugins/discord-rare-drop-notificater
+++ b/plugins/discord-rare-drop-notificater
@@ -1,0 +1,2 @@
+repository=https://github.com/MasterKenth/discord-rare-drop-notificater.git
+commit=c6ee8e19a3f03a874c38717549d6a704e1ac9696

--- a/plugins/discord-rare-drop-notificater
+++ b/plugins/discord-rare-drop-notificater
@@ -1,2 +1,2 @@
 repository=https://github.com/MasterKenth/discord-rare-drop-notificater.git
-commit=c6ee8e19a3f03a874c38717549d6a704e1ac9696
+commit=c0c97ba842e11288a3a85d9a4e0577fc8439836d

--- a/plugins/discord-rare-drop-notificater
+++ b/plugins/discord-rare-drop-notificater
@@ -1,2 +1,3 @@
 repository=https://github.com/MasterKenth/discord-rare-drop-notificater.git
 commit=d19ad18af3d7154c337d43d43260de61abdba59e
+warning=This plugin submits the ID of monsters you kill, items you receive, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Plugin for automatically posting detailed loot notifications and screenshots to Discord using webhooks when receiving a rare/unique drop. Configurable rarity/value threshold. Activities (Barrows, CoX etc.) and pets supported.

![example](https://user-images.githubusercontent.com/2890987/95611954-d31e8e80-0a62-11eb-9a54-6589c09b2bfd.png)
