### PR TITLE
Fix issue with npc highlighing in Stealing Artefacts

### DIFF
--- a/plugins/stealing-artefacts
+++ b/plugins/stealing-artefacts
@@ -1,2 +1,2 @@
 repository=https://github.com/Chris-Bitler/Runelite-StealingArtefacts.git
-commit=6e1c03f352723c9aa7ac70214e93a37fb68b7a71
+commit=d63873cc82ba2872834e20bb684c82b3b1263f74


### PR DESCRIPTION
Fixes issue where NPC highlighting will randomly stop working in plugin