### PR TITLE
Make pm-colors plugin compatible with Java 11

### DIFF
--- a/plugins/pm-colors
+++ b/plugins/pm-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/PresNL/pm-colors.git
-commit=f3284e8aaf99e1c01b47be5415123f0090975439
+commit=7bf2cd7356ac9f56e8541d41a087df49dc21b27c


### PR DESCRIPTION
I have removed an unnecessary import incompatible with java 11