### PR TITLE
Fix npc overlay for real this time in stealing artefacts

### DIFF
--- a/plugins/stealing-artefacts
+++ b/plugins/stealing-artefacts
@@ -1,2 +1,2 @@
 repository=https://github.com/Chris-Bitler/Runelite-StealingArtefacts.git
-commit=d63873cc82ba2872834e20bb684c82b3b1263f74
+commit=0a7c2ba0bd21e105dc592bacfe4967f4e89a865c


### PR DESCRIPTION
The issue ended up being some code that was clearing the marked NPC list on 'loading' game state, which I didn't realize happened outside of the initial game load.