### PR TITLE
Update resource-packs to 1.2.1

### DIFF
--- a/plugins/resource-packs
+++ b/plugins/resource-packs
@@ -1,2 +1,2 @@
 repository=https://github.com/melkypie/resource-packs.git
-commit=1cfe8f5d21da1a3fab0324b9a6b6e6c90184d44f
+commit=ff9f26af468e7ccea03e0aad904d3fabe2d5acc4


### PR DESCRIPTION
- Fixes the login screen and overlay not toggling when switching the hub option to None
- Adds a new color option make_all_background_clicked
- Fixes not being able to recolor the xpgoals overlay goal border.
- Rename Advanced options to Experimental options and added a toggle to enable color current pack option and toggle to disable overlay recoloring