### PR TITLE
Add manifest for Dorgesh-Kaan lights plugin

### DIFF
--- a/plugins/dorgesh-kaan-lights
+++ b/plugins/dorgesh-kaan-lights
@@ -1,0 +1,2 @@
+repository=https://github.com/andmcadams/dk-lights.git
+commit=1240d09335224a5e98d8aa9517e6fa24a4902b74

--- a/plugins/dorgesh-kaan-lights
+++ b/plugins/dorgesh-kaan-lights
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/dk-lights.git
-commit=1240d09335224a5e98d8aa9517e6fa24a4902b74
+commit=4f95f5f515e211f748605cfe898c2002642908bc


### PR DESCRIPTION
Plugin that tells you the locations of broken lamps in Dorgesh-Kaan based on the associated varbit. As you move around the city, the overlay will update with a list of known broken lights and the number of unknown ones (if any). These will be removed as you fix them. Note that the varbit only changes when you move between the two map squares and planes of the city, so you will need to move around quite a bit to discover all the lights. 