### PR TITLE
Add Twitch Live Loadout Plugin

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
-repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin
+repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
 commit=18e4873cf87f7ef2a3acba45cefcdef717f3f3b8

--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=0ffaf8793045161f65a0967db17a8233e8d56fc0
+commit=8bdfc6d7510bbe648734b5c52222991b04e15248

--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=18e4873cf87f7ef2a3acba45cefcdef717f3f3b8
+commit=0ffaf8793045161f65a0967db17a8233e8d56fc0

--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=d159d13c5221f04bdbb56ed157afaf4a3ab684bb
+commit=8bfecea66636e47c9c985f2cd8041da2cbdaa692

--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,0 +1,2 @@
+repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin
+commit=18e4873cf87f7ef2a3acba45cefcdef717f3f3b8

--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=8bfecea66636e47c9c985f2cd8041da2cbdaa692
+commit=6edbf5da2efd6d72959afc6e5dc805967df5c885

--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=8bdfc6d7510bbe648734b5c52222991b04e15248
+commit=d159d13c5221f04bdbb56ed157afaf4a3ab684bb


### PR DESCRIPTION
This plugin allows the RuneLite client to synchronize game data to the Twitch Extension API (https://dev.twitch.tv/extensions) and give stream viewers live interfaces to interact. Currently inventory items, equipment items, bank items, skill levels and basic combat statistics are synchronized. 

It is built in such a way that any Twitch Extension can work with this (this is configurable via the plugin settings). The accompanied Twitch Extension is currently being reviewed by Twitch as well and is made completely in the style of the native game client (see screenshots in README).

Let me know if you have suggestions for improvements or would like to see a live stream with the plugin and Twitch extension in action. That is no problem to arrange (also doing the same with the Twitch reviewing team).