### PR TITLE
Add Bank Memory plugin

### DIFF
--- a/plugins/bank-memory
+++ b/plugins/bank-memory
@@ -1,2 +1,2 @@
 repository=https://github.com/Lazyfaith/runelite-bank-memory-plugin.git
-commit=eb57232651d2686ff33e23b764471481d29849e0
+commit=0b981e57520df2e9ce2a1502c11f058a913180c0

--- a/plugins/bank-memory
+++ b/plugins/bank-memory
@@ -1,2 +1,2 @@
 repository=https://github.com/Lazyfaith/runelite-bank-memory-plugin.git
-commit=0b981e57520df2e9ce2a1502c11f058a913180c0
+commit=0de4f51ec7d90dffdb79e5d0cb5b2f5441f132a1

--- a/plugins/bank-memory
+++ b/plugins/bank-memory
@@ -1,0 +1,2 @@
+repository=https://github.com/Lazyfaith/runelite-bank-memory-plugin.git
+commit=8f1f6f672296f94e5f6f91f566a6c9d97fff9748

--- a/plugins/bank-memory
+++ b/plugins/bank-memory
@@ -1,2 +1,2 @@
 repository=https://github.com/Lazyfaith/runelite-bank-memory-plugin.git
-commit=0de4f51ec7d90dffdb79e5d0cb5b2f5441f132a1
+commit=823a1042f0f69a8d67cc54cbd61cf703e4e23b46

--- a/plugins/bank-memory
+++ b/plugins/bank-memory
@@ -1,2 +1,2 @@
 repository=https://github.com/Lazyfaith/runelite-bank-memory-plugin.git
-commit=8f1f6f672296f94e5f6f91f566a6c9d97fff9748
+commit=eb57232651d2686ff33e23b764471481d29849e0


### PR DESCRIPTION
Features include:

- Remember users banks across all acounts (all accessible at any time)
- Automatic updating as their bank contents changes
- Saving a snapshot of a bank
- Comparing 2 bank saves to see the item differences
- Quick search of bank contents