### PR TITLE
Add Play Time plugin file to plugin-hub

### DIFF
--- a/plugins/play-time
+++ b/plugins/play-time
@@ -1,0 +1,2 @@
+repository=https://github.com/andham97/play-time.git
+commit=13282321bbd89e831b28916c4dfcdfe98f973d54


### PR DESCRIPTION
Play Time is a plugin for tracking in-game time spent. It tracks the time for the current session (like the report button plugin), with all data stored locally so cross-device is not tracked. However, the plugin also tracks the time between sessions for each day. It displays:

- Current session time
- Total time for the current day, week, and month
- Total time played (if you speak with Hans in Lumbridge it imports previous time played into the total counter taking into account the already tracked time.
- It can also show the average playtime for the week and month.