### PR TITLE
Add corp-ffa07 plugin

### DIFF
--- a/plugins/corp-ffa07
+++ b/plugins/corp-ffa07
@@ -1,0 +1,2 @@
+repository=https://github.com/Box-Of-Hats/runelite-plugin-corp-ffa.git
+commit=0299e6ab5be21d662d5fca476a8cfcca52dd4b61

--- a/plugins/corp-ffa07
+++ b/plugins/corp-ffa07
@@ -1,2 +1,2 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-corp-ffa.git
-commit=0299e6ab5be21d662d5fca476a8cfcca52dd4b61
+commit=70636aaf66aebde49db524e095b6b6a28249bacc

--- a/plugins/corp-ffa07
+++ b/plugins/corp-ffa07
@@ -1,2 +1,2 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-corp-ffa.git
-commit=70636aaf66aebde49db524e095b6b6a28249bacc
+commit=8eb0ae0d22258a1c36c9044b0ed65df2567bf6d1


### PR DESCRIPTION
## Corp Ffa Plugin

A plugin for the Corp ffa07 clan chat.

When participating in the [Corp Ffa07](https://secure.runescape.com/m=forum/forums?320,321,348,66174430,goto,1) CC, there are rules around players needing to spec corp twice with BGS/DWH and there is also a list of banned equipment. This plugin highlights players who are not following the rules of the CC.

## Features
- Count DWH/BGS special attacks
- Highlight players using banned gear
- Count players in corp cave
- Highlight rangers