### PR TITLE
Addition of RaidShamer plugin.

### DIFF
--- a/plugins/raidshamer
+++ b/plugins/raidshamer
@@ -1,0 +1,2 @@
+repository=https://github.com/ejedev/raidshamer.git
+commit=f98b079fb4a2413591645deac74b10c8fda63db0


### PR DESCRIPTION
This plugin is quite simple, it screenshots deaths during a Theater of Blood raid. It also has Discord Webhook integration to send them into a channel of your choice.