### PR TITLE
Addition of osrs-streamers to plugin hub

### DIFF
--- a/plugins/osrs-streamers
+++ b/plugins/osrs-streamers
@@ -1,0 +1,2 @@
+repository=https://github.com/rhoiyds/osrs-streamers.git
+commit=858d2bedf1d0c4720316ca3848470243ccdddad5


### PR DESCRIPTION
- Highlights characters that are known to be owned by Twitch streamers. 

- Checks if the streamer is currently live on Twitch, and adds a 'Right Click -> Open stream' option to go directly to their stream.

- Only performs this from a curated list of verified streamers with proof that they own the characters. Streamers can apply to be on this list through the plug-ins GitHub page.

- GitHub page additionally provides a tool for getting a Twitch user access token which is required for using Twitch API for checking if a streamer is live or not.