### PR TITLE
Add ability to build with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: plugin-hub builder
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - name: Install openjdk8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Run build
+      env:
+        REPO_CREDS: ${{ secrets.REPO_CREDS }}
+        REPO_ROOT: ${{ secrets.REPO_ROOT }}
+        SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      run: 'TRAVIS_COMMIT_RANGE="$(git rev-parse @~)..$(git rev-parse @)" ./travis.sh'


### PR DESCRIPTION
Once merged this needs secrets (REPO_CREDS, REPO_ROOT, SIGNING_KEY) setup for it to work (tell me if I missed any).
This is ran only manually under Actions->plugin-hub builder->Run Workflow.

Unfortunately due to github actions cache not supporting workflow_dispatch, there is no way to keep a gradle cache.