### PR TITLE
Update collection-log v1.2.3

### DIFF
--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,2 +1,2 @@
 repository=https://github.com/evansloan/collection-log.git
-commit=25e8dd382240bc01cf97e5b54b0e80ab828abba9
+commit=20d052028eeecffc06ab7e1a87e17c529d1f3016


### PR DESCRIPTION
Fixes bug where highlighted categories were cleared if the user were to click on an already open category