### PR TITLE
Update corp-ffa07

### DIFF
--- a/plugins/corp-ffa07
+++ b/plugins/corp-ffa07
@@ -1,2 +1,2 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-corp-ffa.git
-commit=8eb0ae0d22258a1c36c9044b0ed65df2567bf6d1
+commit=7b5241a904c1e64924685713befd7b1229b729c6

--- a/plugins/corp-ffa07
+++ b/plugins/corp-ffa07
@@ -1,2 +1,2 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-corp-ffa.git
-commit=7b5241a904c1e64924685713befd7b1229b729c6
+commit=615c7e8d2c2cfd4bcc89b2124b4f6e6debeb1cb0


### PR DESCRIPTION
# Update Corp FFA 07 plugin

## New features
- add option to split rangers in player count
- add option to group rangers in player list
- mark players that have died/teled
- add missing banned gear to gear list (fremmy kilt, inquisitors top + bottom)
- add option to show more than 1 piece of banned gear when player holds more than 1
- add option to remove banned gear check (set Max Shown Items to 0)
- group config options

## Bug fixes
- remove text overlay when player teleports/dies
- prevent overlapping of no spec + banned gear overlays