### PR TITLE
Update osrs-streamers

### DIFF
--- a/plugins/osrs-streamers
+++ b/plugins/osrs-streamers
@@ -1,2 +1,2 @@
 repository=https://github.com/rhoiyds/osrs-streamers.git
-commit=a6c06ce48cc21979cfeb484e67b7b66ec3058724
+commit=8f360929f703139c65debfaf8b8d464249202e9e


### PR DESCRIPTION
- If a streamer is using the plug-in, not highlighting their own character.
- Changing twitch icon and overhead link color for a more vibrant purple.
- Updating plugin descriptor for nicer wording.