### PR TITLE
Update OSRS Streamers

### DIFF
--- a/plugins/osrs-streamers
+++ b/plugins/osrs-streamers
@@ -1,2 +1,2 @@
 repository=https://github.com/rhoiyds/osrs-streamers.git
-commit=4cf38c73d72ab31245055b9ce5292b99df27454b
+commit=77c9251c882e8d7ce7e19f41328ff319b8a9f5fc


### PR DESCRIPTION
Tiny update showing right click -> launch stream option for streams regardless of live/not live status, following user feedback.