### PR TITLE
Update Bank Memory plugin to v1.1

### DIFF
--- a/plugins/bank-memory
+++ b/plugins/bank-memory
@@ -1,2 +1,2 @@
 repository=https://github.com/Lazyfaith/runelite-bank-memory-plugin.git
-commit=823a1042f0f69a8d67cc54cbd61cf703e4e23b46
+commit=a1de83212170811627a406acec4af15551a2bd58


### PR DESCRIPTION
Added in the most requested feature which was to show total bank values and the difference when comparing banks.

And with the new league about to start, added proper consideration for banks on special mode worlds (DMM, League, Tournament). Now there'll be a separate "current" bank for each special world type, instead of the data of one world being completely replaced with another each time the user switches & opens their bank.