### PR TITLE
Update Bank Memory plugin to v1.1.1 for bugfix

### DIFF
--- a/plugins/bank-memory
+++ b/plugins/bank-memory
@@ -1,2 +1,2 @@
 repository=https://github.com/Lazyfaith/runelite-bank-memory-plugin.git
-commit=a1de83212170811627a406acec4af15551a2bd58
+commit=5c6fdc6789e0f195e799846f38dd0d752d36cca9


### PR DESCRIPTION
Introduced a bug with v1.1 last night :( That being that the current bank panel can sometimes be reset & left empty when it shouldn't be (most easily reproduceable by world hopping). Easy enough to fix though.