### PR TITLE
Update Twitch Live Loadout to 0.0.3

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=6edbf5da2efd6d72959afc6e5dc805967df5c885
+commit=278089735758b81712fae2f769945e10c04cbd6a


### PR DESCRIPTION
Changelog:
- fix: added additional check to make sure the bank item slicing will also work properly when having few items in the bank.
- feat: the error message after Twitch authentication issues will now not reset its throttling when there was a successful one in between. This prevents repeating messaging in theoretical situations where one requests succeeds, one fails, one succeeds, etc. etc.