### PR TITLE
Update Twitch Live Loadout to 0.0.4

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=278089735758b81712fae2f769945e10c04cbd6a
+commit=a9e32cbe2783e1ab3b0695a56df9a687c7250e76


### PR DESCRIPTION
Changelog:
- fix: resolved an issue where the overlay position would by default be 0 after initializing or resetting the plugin.
- feat: added advanced settings section for for example alternative extension client IDs to avoid confusion with the Extension Token setting.
- docs: added icon to show in the plugin hub.