### PR TITLE
Spawn Marker plugin

### DIFF
--- a/plugins/spawn-marker
+++ b/plugins/spawn-marker
@@ -1,0 +1,2 @@
+repository=https://github.com/TalesRK/spawn_marker.git
+commit=706bbc49841f1fff657d53fa0be10eb8a97f20a8


### PR DESCRIPTION
This plugin marks the tile where creatures have spawned, with the creature's name on it.
It can be useful for hunting, combat, slayer, etc.