### PR TITLE
Add the osleague.tools exporter plugin

### DIFF
--- a/plugins/os-league-tools-exporter
+++ b/plugins/os-league-tools-exporter
@@ -1,2 +1,2 @@
-repository=https://github.com/spudjb/os-league-tools-exporter
+repository=https://github.com/spudjb/os-league-tools-exporter.git
 commit=6f960880a3cb6cc2e89acd13e4b9263c6e98715c

--- a/plugins/os-league-tools-exporter
+++ b/plugins/os-league-tools-exporter
@@ -1,0 +1,2 @@
+repository=https://github.com/spudjb/os-league-tools-exporter
+commit=6f960880a3cb6cc2e89acd13e4b9263c6e98715c


### PR DESCRIPTION
This plugin allows users to export their completed leagues tasks both in CSV format, and a format compatible with https://www.osleague.tools which is a very handy website to track progression!