### PR TITLE
package: include update times and require licenses

### DIFF
--- a/package/package/src/main/java/net/runelite/pluginhub/packager/Plugin.java
+++ b/package/package/src/main/java/net/runelite/pluginhub/packager/Plugin.java
@@ -585,6 +585,20 @@ public class Plugin implements Closeable
 			}
 			waitAndCheck(gitlog, "git log ", 30, TimeUnit.SECONDS);
 		}
+
+		if (!new File(repositoryDirectory, "LICENSE").exists())
+		{
+			if (manifest.getLastUpdatedAt() < 1604534400)
+			{
+				writeLog("Missing LICENSE file. This will become fatal in the future\n");
+			}
+			else
+			{
+				throw PluginBuildException.of(this, "Missing LICENSE file")
+					.withHelp("All plugins must be licensed under a license that allows us to freely distribute the plugin jar standalone.\n" +
+					 "We recommend the BSD 2 Clause license.");
+			}
+		}
 	}
 
 	public void upload(UploadConfiguration uploadConfig) throws IOException

--- a/package/package/src/test/java/net/runelite/pluginhub/packager/PluginTest.java
+++ b/package/package/src/test/java/net/runelite/pluginhub/packager/PluginTest.java
@@ -115,7 +115,13 @@ public class PluginTest
 		try
 		{
 			Files.asCharSink(f, StandardCharsets.UTF_8).write(desc);
-			return new Plugin(f);
+			return new Plugin(f)
+			{
+				@Override
+				protected void realPluginChecks()
+				{
+				}
+			};
 		}
 		finally
 		{

--- a/package/upload/src/main/java/net/runelite/pluginhub/uploader/ExternalPluginManifest.java
+++ b/package/upload/src/main/java/net/runelite/pluginhub/uploader/ExternalPluginManifest.java
@@ -38,6 +38,9 @@ public class ExternalPluginManifest
 	private int size;
 	private String[] plugins;
 
+	private long createdAt;
+	private long lastUpdatedAt;
+
 	private String displayName;
 	private String version;
 	private String author;


### PR DESCRIPTION
This will require that any plugin updated after Nov. 5th has a LICENSE file to successfully build. This won't affect existing plugins until they need to update, at which point they will need to comply.

At some point I plan to open a follow up pr to this, removing the date check, which will cause any plugin missing a license to stop building after said pr is merged. I plan to open issues on all plugins with a missing license informing them of the change + linking to the pr. After ~2 weeks of having issues open I will merge the pr, then the next release would begin enforcing the changes.