### PR TITLE
Add osleague plugin

### DIFF
--- a/plugins/osleague
+++ b/plugins/osleague
@@ -1,2 +1,2 @@
 repository=https://github.com/tylerthardy/osleague-runelite-plugin.git
-commit=d82da7188b57337ddc1c5da682c0a6c39a6d2068
+commit=4badbe6260bc3fc14cb3b1d71db8880298d92efd

--- a/plugins/osleague
+++ b/plugins/osleague
@@ -1,2 +1,2 @@
 repository=https://github.com/tylerthardy/osleague-runelite-plugin.git
-commit=348fcdb2fb5f5033577c1ad6ca07823a297324da
+commit=d82da7188b57337ddc1c5da682c0a6c39a6d2068

--- a/plugins/osleague
+++ b/plugins/osleague
@@ -1,0 +1,2 @@
+repository=https://github.com/tylerthardy/osleague-runelite-plugin.git
+commit=348fcdb2fb5f5033577c1ad6ca07823a297324da


### PR DESCRIPTION
Allows you to export Trailblazer League tasks, relics, and areas from Runelite to https://www.osleague.tools/.

![osleague](https://user-images.githubusercontent.com/17709869/98068789-aa4fa600-1e22-11eb-879e-c4261cb752cd.gif)

### Notes
This feature is dependent on the Runelite plugin also developed by me.
PR here: https://github.com/chaiinchomp/os-league-tools/pull/2
