### PR TITLE
Update better-renderer to v1.1

### DIFF
--- a/plugins/better-renderer
+++ b/plugins/better-renderer
@@ -1,3 +1,3 @@
 repository=https://github.com/Runemoro/better-renderer.git
-commit=6e183f4d5ccab302d0d134e313534a0a31ceb52d
+commit=026a8a7aecd4a86fdc6364e44ce2e97991e7641f
 warning=This plugin is still in early beta and intended for testing only. Don't use in dangerous situations as it may still be unstable. Please report any bugs you find GitHub. It may take up to a few minutes for the plugin to work after installing since it needs to download a copy of the game cache.


### PR DESCRIPTION
Fixes some bugs:
 - Compatibility for Java 8
 - Move initialization to a separate thread
 - Chunks being cached for too long after last seen
 - Disabled broken "disable off-thread rendering" option
 - Print exception and shut down plugin, rather than crashing client, when an exception is thrown in the draw method