### PR TITLE
Update better-renderer to v1.2

### DIFF
--- a/plugins/better-renderer
+++ b/plugins/better-renderer
@@ -1,3 +1,3 @@
 repository=https://github.com/Runemoro/better-renderer.git
-commit=026a8a7aecd4a86fdc6364e44ce2e97991e7641f
+commit=8b3e5be0d9e07074e08ffacf68273ca06b859194
 warning=This plugin is still in early beta and intended for testing only. Don't use in dangerous situations as it may still be unstable. Please report any bugs you find GitHub. It may take up to a few minutes for the plugin to work after installing since it needs to download a copy of the game cache.


### PR DESCRIPTION
 - Fixes things not being closed properly when the plugin is disabled
 - Makes "downloading cache" message more visible