### PR TITLE
Fire beats: Fix for getting whitelist resource from jar on runtime.

### DIFF
--- a/plugins/fire-beats
+++ b/plugins/fire-beats
@@ -1,3 +1,3 @@
 repository=https://github.com/RKGman/fire-beats.git
-commit=aef69dd75a14e0430711db3f78c36118c9423448
+commit=e5ec92474234e67ba6b6257a9de09000f0b0daae
 warning=This plugin downloads music on demand from anonfiles.com, a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Now getting resource as input stream correctly for whitelist.  Bumped version number and retested with shadowJar script for production run.