### PR TITLE
update trailblazer-clues to v1.1

### DIFF
--- a/plugins/trailblazer-clues
+++ b/plugins/trailblazer-clues
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=dfb5a71c8594792771ad94526f51024d42f3ada1
+commit=18f81de9bbb8fe7d660440fc6a89df4c1af87472


### PR DESCRIPTION
v1.0.1:
* Fixed a layouting issue with SingleItemRequirements

v1.1:
* Add Sherlock and Falo clues, since apparently they're actually obtainable

v1.1.1:
* Add DESERT as a requirement for `veil veda` anagram, due to requiring Shadow of the Storm.

v1.1.2:
* Remove impossible emote clue, due to requiring a Proselyte hauberk