### PR TITLE
add dont-eat-it

### DIFF
--- a/plugins/dont-eat-it
+++ b/plugins/dont-eat-it
@@ -1,0 +1,2 @@
+repository=https://github.com/Hydrox6/external-plugins.git
+commit=035a99f098d90ecc8ae30bf8c76843267b1c870c


### PR DESCRIPTION
A simple plugin that swaps *every* item's left click to Use, as long as they have one.