### PR TITLE
update dont-eat-it to v1.0.1

### DIFF
--- a/plugins/dont-eat-it
+++ b/plugins/dont-eat-it
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=035a99f098d90ecc8ae30bf8c76843267b1c870c
+commit=fcedf02026b7fd32f90fee97a7898c6be30eb24c


### PR DESCRIPTION
now it ignores shift, so MES's Shift Click config will still work