### PR TITLE
Add Cannon Highlighter

### DIFF
--- a/plugins/cannon-highlighter
+++ b/plugins/cannon-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/ConorLeckey/Cannon-Highlighter.git
+commit=262e663ec17a77f4f45b9d67b756f7dcc251c045

--- a/plugins/cannon-highlighter
+++ b/plugins/cannon-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/ConorLeckey/Cannon-Highlighter.git
-commit=262e663ec17a77f4f45b9d67b756f7dcc251c045
+commit=237d8b0072f83951c10950543ceb863cd843e352


### PR DESCRIPTION
The cannon highlighter plugin does the following:

- Highlights attackable NPCs with their south western tiles a 7x7 square around a placed cannon

- Allows the user to configure how the NPC is highlighted (show hull, southwestern tile or/and text above)

- Highlights the NPCs a different, configurable, color depending on whether the cannon is unable to hit them, able to hit them once or able to hit them twice.

- Highlights tiles around the cannon where NPCs will get hit twice, or not at all