### PR TITLE
Update OSRS Streamers to v1.1

### DIFF
--- a/plugins/osrs-streamers
+++ b/plugins/osrs-streamers
@@ -1,2 +1,2 @@
 repository=https://github.com/rhoiyds/osrs-streamers.git
-commit=77c9251c882e8d7ce7e19f41328ff319b8a9f5fc
+commit=abd9e1531fa63928cf90d50ea7da0ded12250274


### PR DESCRIPTION
- Updating group and project name.

- Starting versioning.

- Updating 'Add new streamer' messaging to guide users to the application form better, adding icon, and using an anchor on the link (shuffling interface around a little)