### PR TITLE
update trailblazer-clues to v1.2.4

### DIFF
--- a/plugins/trailblazer-clues
+++ b/plugins/trailblazer-clues
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=032b0e2be13370af1ca319c9ac09a584aa361ead
+commit=214c6753b8f1f506a8c305f146ccfffecedd3a0f


### PR DESCRIPTION
In theory, this should be the last time I update this plugin to fix something

Now where have I heard that before?

If Jagex had just put ALL clues in a common container (Widget 203 or something), this would be infinitely easier.