### PR TITLE
update trailblazer-clues to v1.2.5

### DIFF
--- a/plugins/trailblazer-clues
+++ b/plugins/trailblazer-clues
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=214c6753b8f1f506a8c305f146ccfffecedd3a0f
+commit=17d2a010f6a0852bce995ad739454f25aa8cf0ee


### PR DESCRIPTION
turns out writing code by poking it with a stick is not fun.