### PR TITLE
Update MLM Upper Level Markers to 1.1

### DIFF
--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=c2b4da9dd87b203ef645c6b90f85f37bac84ca8b
+commit=0e9e86d7b9ea75b32a8f85d6baf7266fab678c22


### PR DESCRIPTION
Added 3rd Age and Trailblazer animations for parity with the official Motherlode Mine Plugin.