### PR TITLE
Update Corp FFA07 plugin

### DIFF
--- a/plugins/corp-ffa07
+++ b/plugins/corp-ffa07
@@ -1,2 +1,2 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-corp-ffa.git
-commit=615c7e8d2c2cfd4bcc89b2124b4f6e6debeb1cb0
+commit=dc538decc6f71d6b6bcc48ea7d86c4ea8214f8fa

--- a/plugins/corp-ffa07
+++ b/plugins/corp-ffa07
@@ -1,2 +1,2 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-corp-ffa.git
-commit=dc538decc6f71d6b6bcc48ea7d86c4ea8214f8fa
+commit=31f6674ae8aa6e4abcc0d067c14328dc67d54d2f

--- a/plugins/corp-ffa07
+++ b/plugins/corp-ffa07
@@ -1,2 +1,2 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-corp-ffa.git
-commit=31f6674ae8aa6e4abcc0d067c14328dc67d54d2f
+commit=69eb5c70d5656e7265c93ec397d8bec2e3d19f74

--- a/plugins/corp-ffa07
+++ b/plugins/corp-ffa07
@@ -1,2 +1,2 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-corp-ffa.git
-commit=69eb5c70d5656e7265c93ec397d8bec2e3d19f74
+commit=8e539f9a95c56e479bbcdc3619aa81d1fb5fbde9


### PR DESCRIPTION
## New Features
- Allow tagging of players
- Take screenshots of crashers
- Check gear on spawn instead of just when a player attacks corp
- Show the player's wielding a non-spec weapon if a player has 0/1 specced
- Regroup config options to be more user friendy
- Remove "always on" config option as it was not needed

## Bug fixes
- Remove teled players from the player count
- Fix duplicate player names in player list