### PR TITLE
Create mouse-click-counter

### DIFF
--- a/plugins/mouse-click-counter
+++ b/plugins/mouse-click-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/rbespin/mouse-click-counter.git
+commit=4221cec4eb92e7eb427cce08f90186e08656bb10


### PR DESCRIPTION
This plugin allows the user to track and display the various number of click types they have performed in that active session.