### PR TITLE
update trailblazer-clues to v1.2.6

### DIFF
--- a/plugins/trailblazer-clues
+++ b/plugins/trailblazer-clues
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=17d2a010f6a0852bce995ad739454f25aa8cf0ee
+commit=b2451f86a0c0993985e52f3819dd341306fccc8d


### PR DESCRIPTION
~~This will be the final update; Jagex is making the plugin obsolete next Wednesday~~
nvm, looks like Jagex won't be making this plugin obsolete (probably)
still want to add the following stuff though
* Fix clue detection (again)
* Also fix NPEs in certain interfaces
* Fix Chaos Temple emote clue
* Add reqs for Beginner Hot/Cold
* Don't show reqs at all on Master Hot/Colds