### PR TITLE
Update better-renderer to v1.5

### DIFF
--- a/plugins/better-renderer
+++ b/plugins/better-renderer
@@ -1,3 +1,3 @@
 repository=https://github.com/Runemoro/better-renderer.git
-commit=a8dcca8be8f90d1d828cfcd8f4bd2a1933af3077
+commit=a8cd16243b29d7f9ee85b14f10f6b34dcbc2afc6
 warning=This plugin is still in early beta and intended for testing only. Don't use in dangerous situations as it may still be unstable. Please report any bugs you find GitHub. It may take up to a few minutes for the plugin to work after installing since it needs to download a copy of the game cache.


### PR DESCRIPTION
Fixes crash when the plugin is enabled after GPU was enabled without a client restart. I accidentally removed the fix in the last update.