### PR TITLE
Update better-renderer to v1.6

### DIFF
--- a/plugins/better-renderer
+++ b/plugins/better-renderer
@@ -1,3 +1,3 @@
 repository=https://github.com/Runemoro/better-renderer.git
-commit=a8cd16243b29d7f9ee85b14f10f6b34dcbc2afc6
+commit=ee38a26f48f25d4362304e4123dce27a0d096b61
 warning=This plugin is still in early beta and intended for testing only. Don't use in dangerous situations as it may still be unstable. Please report any bugs you find GitHub. It may take up to a few minutes for the plugin to work after installing since it needs to download a copy of the game cache.


### PR DESCRIPTION
Fixes compatibility with Java 8. 

The problem was that I compiled `lwjgl-awt` with Java 11, making it use the overriding `IntBuffer.rewind()` added in Java 9 rather than `Buffer.rewind()`.