### PR TITLE
update trailblazer-clues to v1.3

### DIFF
--- a/plugins/trailblazer-clues
+++ b/plugins/trailblazer-clues
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=b2451f86a0c0993985e52f3819dd341306fccc8d
+commit=122333958103cd8a93a187bfd0381b35653803e2


### PR DESCRIPTION
Content! Big diff! Excitement!

* Now shows a marker when the requirement is exceedingly rare (eg. getting a Mystic Fire Staff from Killerwatts)
* Also shows tooltips for the new icon.
* Fixed the requirements for a bunch of clues
* Fixed detection for that one stupid map clue that decided it was special enough to have an entire model dedicated to it (like, come on!)