### PR TITLE
Update quest-helper to v1.1.5

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=7162ea29687ec799223ec165a15595e210dc751f
+commit=c6bc5c565df55641753e7e6d8360178f908e6eb2


### PR DESCRIPTION
- Adds Dragon Slayer II, Holy Grail, and Tribal Totem
- Fixes to Olaf's Quest, Fremmy Isles, Death to Durg and Tale of the Righteous