### PR TITLE
Update OSRS Streamers to v1.2

### DIFF
--- a/plugins/osrs-streamers
+++ b/plugins/osrs-streamers
@@ -1,2 +1,2 @@
 repository=https://github.com/rhoiyds/osrs-streamers.git
-commit=abd9e1531fa63928cf90d50ea7da0ded12250274
+commit=01c3dd52051a60c715b1d6952514d542ba868136


### PR DESCRIPTION
- Adding 'Only show streamers who are live' configuration also with a warning to double check token.

- Adding minimap player highlighting.

- Tidying up a few imports & increasing version number