### PR TITLE
Create patch-payment

### DIFF
--- a/plugins/patch-payment
+++ b/plugins/patch-payment
@@ -1,2 +1,2 @@
-repository=https://github.com/PolishToaster/patch-payment
+repository=https://github.com/PolishToaster/patch-payment.git
 commit=e03ec0becb6b629541b77d09011fc6ad60c2bb3b

--- a/plugins/patch-payment
+++ b/plugins/patch-payment
@@ -1,0 +1,2 @@
+repository=https://github.com/PolishToaster/patch-payment
+commit=e03ec0becb6b629541b77d09011fc6ad60c2bb3b

--- a/plugins/patch-payment
+++ b/plugins/patch-payment
@@ -1,2 +1,2 @@
 repository=https://github.com/PolishToaster/patch-payment.git
-commit=e03ec0becb6b629541b77d09011fc6ad60c2bb3b
+commit=9ead3afc96de9b4bdd32272419c278707ab37139


### PR DESCRIPTION
This plugin adds a new menu item on seeds/saplings that displays what a player needs to pay a farmer for the patch to be protected