### PR TITLE
Add hydrate reminder plugin

### DIFF
--- a/plugins/hydrate-reminder
+++ b/plugins/hydrate-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/jmakhack/hydrate-reminder.git
+commit=bbfb0b3479b2f38b0b62cd8ee016f8f5b76547b4


### PR DESCRIPTION
![Hydrate Reminder](https://i.imgur.com/bztOLOO.png)

A simple plugin that sends reminders to take hydration breaks on a configurable time interval.

Reminder notifications can be set to be sent via chat notification, computer notification, or both.

<hr>

Never forget to drink water while exploring the world of Old School RuneScape ever again! 

ﾟ+｡:.(\*･ω･)o旦　旦o(･ω･\*).:｡+ﾟ