### PR TITLE
Add hydrate reminder plugin

### DIFF
--- a/plugins/hydrate-reminder
+++ b/plugins/hydrate-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/jmakhack/hydrate-reminder.git
+commit=07c1038fc0b0143cb1a18919f34b30714710b754


### PR DESCRIPTION
![Hydrate Reminder](https://i.imgur.com/bztOLOO.png)

A simple plugin that sends reminders to take hydration breaks on a configurable time interval.

Reminder notifications can be set to be sent via chat notification, computer notification, or both.

<hr>

Never forget to drink water while exploring the world of Old School RuneScape ever again! 

ﾟ+｡:.(\*･ω･)o旦　旦o(･ω･\*).:｡+ﾟ