### PR TITLE
update loot-logger to v2.2.2

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=29cc722c3b8f2e4b6c0821ae71e74e75f069bef3
+commit=04d275c4373ee7902cf99778193aa689c4e94803


### PR DESCRIPTION
Fixed an NPE when reclaiming sire loot