### PR TITLE
add quick-prayer-preview

### DIFF
--- a/plugins/quick-prayer-preview
+++ b/plugins/quick-prayer-preview
@@ -1,0 +1,2 @@
+repository=https://github.com/Hydrox6/external-plugins.git
+commit=ffa5d41c5dfc464c773681545107080645a8163b


### PR DESCRIPTION
A nice simple plugin that shows your current quick prayer selection as a tooltip on the orb.

![image](https://user-images.githubusercontent.com/2979691/100085475-fc914f00-2e43-11eb-8480-35c0a4469680.png)
