### PR TITLE
Update Damage Counter to v1.4.2

### DIFF
--- a/plugins/damage-counter
+++ b/plugins/damage-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/0anth/damage-counter.git
-commit=e1ee4280c48486951dfe4207a4ff581669856d32
+commit=0d5dcebb708f40f11ec6f9c328a68cf03623fcff


### PR DESCRIPTION
- Bugfix for Barrows again
- Shortened chat log message
- Chat log message will now only mention percentage, if it is less than 100%