### PR TITLE
Update Os league plugin: Remove hardcoded task count

### DIFF
--- a/plugins/osleague
+++ b/plugins/osleague
@@ -1,2 +1,2 @@
 repository=https://github.com/tylerthardy/osleague-runelite-plugin.git
-commit=c2f1b5c48045daa92a37675b3164daa7d3c84c59
+commit=c7d899654bc3af06706bbcf177edf2ccb077d90f


### PR DESCRIPTION
Game update today duplicated a task (nice one jagex) which broke the plugin since it depends on a hardcoded task count. Removed that to just rely on checking the task filters state instead.