### PR TITLE
Add easyparty plugin

### DIFF
--- a/plugins/easyparty
+++ b/plugins/easyparty
@@ -1,2 +1,2 @@
 repository=https://github.com/wesley-221/easyparty.git
-commit=f2e3f0ef7435726f15507459fefd335101263b77
+commit=6db690cfc98539d568f3033d03a3f9e3dccf83da

--- a/plugins/easyparty
+++ b/plugins/easyparty
@@ -1,2 +1,2 @@
 repository=https://github.com/wesley-221/easyparty.git
-commit=ebdb7f3dc2123e4cd5dce4c382bb959ad7ae1a46
+commit=1717fa2ccd85c990a379c2e7e5fe311b526e0f0f

--- a/plugins/easyparty
+++ b/plugins/easyparty
@@ -1,0 +1,2 @@
+repository=https://github.com/wesley-221/easyparty.git
+commit=f2e3f0ef7435726f15507459fefd335101263b77

--- a/plugins/easyparty
+++ b/plugins/easyparty
@@ -1,2 +1,2 @@
 repository=https://github.com/wesley-221/easyparty.git
-commit=6db690cfc98539d568f3033d03a3f9e3dccf83da
+commit=ebdb7f3dc2123e4cd5dce4c382bb959ad7ae1a46


### PR DESCRIPTION
A plugin that allows you to create a party using the PartyService by sharing a party UUID, without having to add people on Discord. 

On a later date I will try to implement inviting through Runescape itself so you can simply enter a command in chat and it'll generate an invite for people to accept. 