### PR TITLE
Updated quest-helper to v1.2.0

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=cdfeb45d6edb83f11115ac7c068661519a038f93
+commit=839cd6d7b66d8893dd5ada2e4d15c1c6ccb775a5


### PR DESCRIPTION
- Adds Monkey Madness II, Recruitment Drive, Giant Dwarf, Jungle Potion, Dwarf Cannon, Tree Gnome Village, Gertrude's Cat, and Queen of Thieves.
- Quest helper will now auto-start for players when starting a quest
- Many small fixes to existing helpers