### PR TITLE
Update Examine Tooltip to 1.4.1

### DIFF
--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=4add3626e46a9c0b79375a715a59da3ac84c6d0d
+commit=4de9ca0325762dc9b870b13c290d0b00a2d008aa

--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=4de9ca0325762dc9b870b13c290d0b00a2d008aa
+commit=3478b1edc082d6a19e54c89a672b11fcf95125e5


### PR DESCRIPTION
Add compatibility as "tooltip only" for PolishToaster's Patch Payment plugin, similarly to how Price Checks are handled.

https://github.com/PolishToaster/patch-payment/issues/1