### PR TITLE
Updated quest-helper to v1.2.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=839cd6d7b66d8893dd5ada2e4d15c1c6ccb775a5
+commit=72e875aae313c8749344eb17b429fb2d1229f5b0


### PR DESCRIPTION
- Adds In Aid of Myreque, Darkness of Hallowvale and Fight Arena
- Allow minimap arrows to work outside of local area
- Addition of a 'General requirements' section to the sidebar
- Added capability to identify NPCs with game hint arrows to not overlap arrows + better identify a player's NPC which has spawned
- Fixes to various existing quest helpers