### PR TITLE
Emote Clue Items v1.0.4: set enabledByDefault to true.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=9a02b10b4b96cdb38e309eda7c2412e4c88fc441
+commit=02bdf8925cf38e5ad8e9e9df0429ba70162555e8


### PR DESCRIPTION
I noticed that not having the plugin enabled after installing felt counter-intuitive.