### PR TITLE
Fix typo in author name for Custom Settings Easter Eggs

### DIFF
--- a/plugins/custom-settings-easter-eggs
+++ b/plugins/custom-settings-easter-eggs
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/custom-settings-easter-eggs.git
-commit=9cb304f4148a7044b7e3d5aa9bbd9f1d3e0fd019
+commit=42ce58060152f97484f7ab812f8791fde29b3a7f


### PR DESCRIPTION
I just realised I put "Cyborger" instead of "Cyborger1", oops!