### PR TITLE
Added Equipment Restrictor

### DIFF
--- a/plugins/equipment-restrictor
+++ b/plugins/equipment-restrictor
@@ -1,0 +1,2 @@
+repository=https://github.com/KevKode/equipment-restrictor.git
+commit=da39382cceba7619c8ff3c04fb222d75b1290388


### PR DESCRIPTION
Adds the Equipment Restrictor plugin.

Mainly made for Snowflake Ironmen, this plugin allows you to restrict the kinds of equipment your character can use.

[README.md](https://github.com/KevKode/equipment-restrictor/blob/master/README.md)