### PR TITLE
Added CoX Special Loot Hider plugin links

### DIFF
--- a/plugins/cox-special-loot-hider
+++ b/plugins/cox-special-loot-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/Karambtwo/cox-special-loot-hider.git
+commit=578a77e78d9549261825fdf433aa9637a1767a22


### PR DESCRIPTION
This plugin adds the ability to censor a rare loot received at CoX while keeping the person's name uncensored. For example, "Karambtwo - Twisted bow" would turn into "Karambtwo - ???" so that the player can see who gets an item while not knowing what it is to keep suspense when raiding with friends. This is a solution to people going to trade chat and not seeing when their friends get a drop. If you would like to see what the item is, turning off the plugin shows the loot from the most recent raid. This also works with multiple drops in the same raid.