### PR TITLE
Update profit-calculator support link to match git repo address

### DIFF
--- a/plugins/profit-calculator
+++ b/plugins/profit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/llamositopia/profit-calculator.git
-commit=720e27bf7915b6a2811d80cf272442922be314b3
+commit=bd9128a63c08e9410a84a33a9376fa686abe714b


### PR DESCRIPTION
When first submitting the plugin I linked to a 404 page due to a typo in the support link. No functional changes in this, just updating the support link to be accurate.