### PR TITLE
Update Inventory-value-overlay to latest commit

### DIFF
--- a/plugins/inventory-value-overlay
+++ b/plugins/inventory-value-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/wikiworm/InventoryValue.git
-commit=a64940d73f5a42f625c4f8ae13ec75d7a3e87aab
+commit=3f728fc29b1f8dbd74e3149156798dfa9d01bd60


### PR DESCRIPTION
New feature to allow the inventory value calculation to ignore items.
Added defensive code. 
