### PR TITLE
Add combo-runes-only v1.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,17 @@
 BSD 2-Clause License
 
-Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+Copyright (c) 2020, llamositopia
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/plugins/combo-runes-only
+++ b/plugins/combo-runes-only
@@ -1,0 +1,2 @@
+repository=https://github.com/llamositopia/combo-runes-only
+commit=d770a9f4bcd6f7dbbb505ff933d3ede38fc43bc3

--- a/plugins/combo-runes-only
+++ b/plugins/combo-runes-only
@@ -1,2 +1,2 @@
-repository=https://github.com/llamositopia/combo-runes-only
+repository=https://github.com/llamositopia/combo-runes-only.git
 commit=d770a9f4bcd6f7dbbb505ff933d3ede38fc43bc3


### PR DESCRIPTION
This plugin removes the Craft-rune option from the fire altar, so that users don't accidentally make fire runes instead of lava/steam/whatever