### PR TITLE
Add combo-runes-only v1.0

### DIFF
--- a/plugins/combo-runes-only
+++ b/plugins/combo-runes-only
@@ -1,0 +1,2 @@
+repository=https://github.com/llamositopia/combo-runes-only.git
+commit=383ba1110066d49c92e5e3d3ed4a181945aaae11


### PR DESCRIPTION
This plugin removes the Craft-rune option from the fire altar, so that users don't accidentally make fire runes instead of lava/steam/whatever
