### PR TITLE
Add "Unresponsive Cursor" Repository

### DIFF
--- a/plugins/unresponsive-cursor
+++ b/plugins/unresponsive-cursor
@@ -1,0 +1,2 @@
+repository=https://github.com/bluelightzero/unresponsive-cursor.git
+commit=57f2bd58134d5ad63c02ec12b951b1558b91a643

--- a/plugins/unresponsive-cursor
+++ b/plugins/unresponsive-cursor
@@ -1,2 +1,2 @@
 repository=https://github.com/bluelightzero/unresponsive-cursor.git
-commit=57f2bd58134d5ad63c02ec12b951b1558b91a643
+commit=b05a14dc5e7c0e19c5222920627abb3b940bb5e2


### PR DESCRIPTION
When the server is unresponsive (Lag), the cursor will change.

You can set a threshold (milliseconds) for how long you want to wait after lag is detected before it changes your cursor.

A value of 0ms will flicker thee cursor constantly as the server has micro stutters.

A value of 100ms (Default) should remove these flickers, while still letting you know when longer lag spikes happen. You often see these as the whole world stopping for everyone.

It should help when you are doing activities that require timing, but the server is lagging.

This plugin does not work with Custom Cursors.