### PR TITLE
Banked XP plugin PR

### DIFF
--- a/plugins/bank-xp-value
+++ b/plugins/bank-xp-value
@@ -1,2 +1,2 @@
 repository=https://github.com/seelrr/bank-xp-value.git
-commit=8eac8fd9b8007c1f3f13126fd86bbfc451b2e925
+commit=ed19835d634e91582a007ced8689f955be1f6896

--- a/plugins/banked-xp
+++ b/plugins/banked-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/seelrr/banked-xp.git
-commit=b7f4327d7231060d49f0128856f8f5f4acf21d7a
+commit=7c2db23b2789597a6ffda26d88460b00d6a5a7d3

--- a/plugins/banked-xp
+++ b/plugins/banked-xp
@@ -1,0 +1,2 @@
+repository=https://github.com/seelrr/banked-xp.git
+commit=b7f4327d7231060d49f0128856f8f5f4acf21d7a

--- a/plugins/banked-xp
+++ b/plugins/banked-xp
@@ -1,2 +1,2 @@
-repository=https://github.com/seelrr/banked-xp.git
-commit=7c2db23b2789597a6ffda26d88460b00d6a5a7d3
+repository=https://github.com/seelrr/bank-xp-value.git
+commit=8eac8fd9b8007c1f3f13126fd86bbfc451b2e925


### PR DESCRIPTION
This plugin calculates the total amount of XP in your bank and displays it in an overlay (instead of a side panel). By being able to see your total banked XP across 9 skills (in one view) with just a click of a button, it makes consuming this data quick and easy. Also, because this plugin uses an overlay, it allows streamers to display this neat information to viewers.