### PR TITLE
update Equipment Restrictor to v1.0.2

### DIFF
--- a/plugins/equipment-restrictor
+++ b/plugins/equipment-restrictor
@@ -1,2 +1,2 @@
 repository=https://github.com/KevKode/equipment-restrictor.git
-commit=adea7da9c7f927bbb2f2e7138438ced9e6c0d740
+commit=6281a450a0aa610bc1b91ca897c274e19f99fe7a


### PR DESCRIPTION
- Fixed a bug where the whitelist and blacklist weren't clearing on shutdown
- Switched to `null` checking over `NullPointerException` handling
- Changed if statement style to prefer early return over nesting
- Changed `itemId` source to be from a widget rather than from an event
- Plugin now works when equipping items from the bank interface
- Checkbox config sections now are open by default