### PR TITLE
Bone Running Plugin

### DIFF
--- a/plugins/bone-running
+++ b/plugins/bone-running
@@ -1,2 +1,2 @@
 repository=https://github.com/Elrol/Run4LessPlugin.git
-commit=c084894e13d25495c76d04ff233dccf330d0fdf9
+commit=dcadca1ba598b7e186c8981faf7607902dd42a22

--- a/plugins/bone-running
+++ b/plugins/bone-running
@@ -1,0 +1,2 @@
+repository=https://github.com/Elrol/Run4LessPlugin.git
+commit=d81ca6325dd943ce865ef75ea9047fa8f390df9d

--- a/plugins/bone-running
+++ b/plugins/bone-running
@@ -1,2 +1,2 @@
 repository=https://github.com/Elrol/Run4LessPlugin.git
-commit=3a273889fc32943407e04723b13a1cd9a223807d
+commit=25fe5314477c1e1c0b105faf96d4383f0b36b09a

--- a/plugins/bone-running
+++ b/plugins/bone-running
@@ -1,2 +1,2 @@
 repository=https://github.com/Elrol/Run4LessPlugin.git
-commit=d81ca6325dd943ce865ef75ea9047fa8f390df9d
+commit=38692838263d2973dd577cecb877949013e06772

--- a/plugins/bone-running
+++ b/plugins/bone-running
@@ -1,2 +1,2 @@
 repository=https://github.com/Elrol/Run4LessPlugin.git
-commit=38692838263d2973dd577cecb877949013e06772
+commit=2c35b65741c25249ff18188840e87ac39c4fdd47

--- a/plugins/bone-running
+++ b/plugins/bone-running
@@ -1,2 +1,2 @@
 repository=https://github.com/Elrol/Run4LessPlugin.git
-commit=b41b4d73cbe7fd8611d41111c212bdced1e9fe55
+commit=3a273889fc32943407e04723b13a1cd9a223807d

--- a/plugins/bone-running
+++ b/plugins/bone-running
@@ -1,2 +1,2 @@
 repository=https://github.com/Elrol/Run4LessPlugin.git
-commit=9aa26f6f497ec8f2ed5798fda2b202838ee4454d
+commit=c084894e13d25495c76d04ff233dccf330d0fdf9

--- a/plugins/bone-running
+++ b/plugins/bone-running
@@ -1,2 +1,2 @@
 repository=https://github.com/Elrol/Run4LessPlugin.git
-commit=25fe5314477c1e1c0b105faf96d4383f0b36b09a
+commit=9aa26f6f497ec8f2ed5798fda2b202838ee4454d

--- a/plugins/bone-running
+++ b/plugins/bone-running
@@ -1,2 +1,2 @@
 repository=https://github.com/Elrol/Run4LessPlugin.git
-commit=2c35b65741c25249ff18188840e87ac39c4fdd47
+commit=b41b4d73cbe7fd8611d41111c212bdced1e9fe55


### PR DESCRIPTION
This is a plugin was made to make bone running easier
It adds lots of features: 
-Displaying clan chat above the chat window
-A calculator to price bone ran
-Turns 1 trade request into 8 to keep the client from having to spam trade
-Allows you to set a client to highlight and filter messages sent by them
-Filters trade chat to hide messages that aren't trade requests
-Allows for coloring the clan chat as well as displaying ranked members in a different color
-Switches the Offer option with the Offer All option to make trades easier

It also has some clan specific features for Run4Less
-Runner data, which displays who you ran for, how many bones, what type of bones, how much you were paid etc
-Adds in chat bone calculator to price bones in chat
-Allows for the pinging of ranked members in the clan chat
-Will display the Run4Less logo if you are a ranked member in the clan