### PR TITLE
updated Equipment Restrictor

### DIFF
--- a/plugins/equipment-restrictor
+++ b/plugins/equipment-restrictor
@@ -1,2 +1,2 @@
 repository=https://github.com/KevKode/equipment-restrictor.git
-commit=6281a450a0aa610bc1b91ca897c274e19f99fe7a
+commit=e73b29dc82f235965361e9c0b6ae32b26db0ab36


### PR DESCRIPTION
- Added odd edge case equip menu options to check for
- Discovered that I had the power to change my plugin version and got rid of that pesky `SNAPSHOT`