### PR TITLE
Update MLM Upper Level Markers to 1.2.1

### DIFF
--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=622ad5182edaf6b7f0dd5f4be102e071a1bab15f
+commit=0663d3883faf1b96df2f4548d7642573bf08be4c

--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=0663d3883faf1b96df2f4548d7642573bf08be4c
+commit=6945e4da603a48d7a47eeb20b76dc054446948b0


### PR DESCRIPTION
Adds a config option to toggle showing only the full seconds on the marker timers from 1.2