### PR TITLE
Update virtual-level-ups to v1.1.4

### DIFF
--- a/plugins/virtual-level-ups
+++ b/plugins/virtual-level-ups
@@ -1,2 +1,2 @@
 repository=https://github.com/nightfirecat/plugin-hub-plugins.git
-commit=074e97dbf7654c3d6e490cd884d781de780a4cd8
+commit=4863bdbbb0e04195cb2087d0c49d01bca77371bf


### PR DESCRIPTION
This fixes a number of buggy cases which could cause users to miss
legitimate virtual level ups, or receive (many) duplicate MAX_EXP
virtual level ups.

Fixes Nightfirecat/plugin-hub-plugins#7
Fixes Nightfirecat/plugin-hub-plugins#9
Fixes Nightfirecat/plugin-hub-plugins#10
