### PR TITLE
Update quest-helper to v1.2.2

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=72e875aae313c8749344eb17b429fb2d1229f5b0
+commit=93c4a7e376c8bb47863bfe67fdd879b5f42396e5


### PR DESCRIPTION
- Fixes for most recent Runelite version
- Adds discord link button for help
- Various small fixes to items for quests
- Chat dialog versatility fixes to help with certain quests like ZFE
- Adds The Feud, Getting Ahead, and Big Chompy Bird Hunting