### PR TITLE
Update OSRS Streamers to v1.4.3

### DIFF
--- a/plugins/osrs-streamers
+++ b/plugins/osrs-streamers
@@ -1,2 +1,2 @@
 repository=https://github.com/rhoiyds/osrs-streamers.git
-commit=b74be12c2d8b28861afe8b85d4250de7b69d7c1a
+commit=5cbab5e9083a4413c6bee77285e5efc5fccd92b2


### PR DESCRIPTION
When logging in, prompt users with a misconfigured token to properly configure their token with a chat command ::gettoken