### PR TITLE
pvp-performance-tracker: Added hp healed statistic for player & config warning

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=80dcc7f3480dbbdedec56ff7f1c355e3768f9fdc
+commit=a0aef1b1280e5602253f14f642d94040262647af

--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=a0aef1b1280e5602253f14f642d94040262647af
+commit=0affe718324dcd5f1636143227ff2e9a46083cbc


### PR DESCRIPTION
Added HP healed statistic, only for the local player as it's not as reliably tracked for the opponent. Added a "config warning", which displays a big red "NOT SETUP - CHECK CONFIG" label on the panel until you've ticked a checkbox in the config, as many people don't realize there are a few level/gear settings which actually affect dps calculations. Also removed the "simple overlay" as you can roughly achieve the same thing with the regular/custom overlay; it added too much code for nothing.

As always, tested in LMS w/ footage to double-check stats in slowmo.

I'm also saving more data for an upcoming feature I discussed in #development, which I first need data for in order to properly implement/test. Technically I could make fake data or use alts to test but it would be a nightmare vs just getting real data. (requires data from two clients fighting each other). Code relating to the upcoming feature has been removed for this release, although I'm saving more data that is not yet used.