### PR TITLE
Add Sandstone Buckets Counter plugin

### DIFF
--- a/plugins/sandstone-buckets-counter
+++ b/plugins/sandstone-buckets-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/klisiu-net/sandstone-buckets-counter.git
+commit=a9aa599883bc2ca3f7740c1b2f1dcfd35ddf40d0


### PR DESCRIPTION
A simple RL plugin which counts how many buckets of sand player can get based on the different types of sandstones kept in inventory.

The plugin could be potentially useful for ironman accounts which are grinding their crafting supplies.