### PR TITLE
Toggle option, Initial menu config

### DIFF
--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,2 +1,2 @@
 repository=https://github.com/Antipixel/nexus-map.git
-commit=3bc525381bf2ce834fa66ac1fe0046ce76b1d465
+commit=f2527527bb92ca77aeaf5dcea18293783a6c7b7f


### PR DESCRIPTION
-Checkbox to toggle between the map and the default Nexus menu added to top-left of Nexus window
-Added a config option to select whether or not the map should be automatically displayed upon opening the menu
-Fixed the sprite ID for the inactive Lumbridge teleport icon