### PR TITLE
Create GECalc

### DIFF
--- a/plugins/gecalc
+++ b/plugins/gecalc
@@ -1,2 +1,2 @@
 repository=https://github.com/cman8396/GECalc.git
-commit=84b9ffc9d7f6f2ff02d61e8728091c8a744c6791
+commit=3a003105eb8686a6521ea6e64a4827e5c1efcdd8

--- a/plugins/gecalc
+++ b/plugins/gecalc
@@ -1,0 +1,2 @@
+repository=https://github.com/cman8396/GECalc.git
+commit=84b9ffc9d7f6f2ff02d61e8728091c8a744c6791


### PR DESCRIPTION
Removed requirement for JavaScript interpreter following feedback:

> abextm: This won't work on some clients since the javascript interpreter isn't always available. Also I don't really like this from a security standpoint anyway.