### PR TITLE
Update quest-helper to v1.4.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=7e27706956ee983f96c337f6172f71f68634548d
+commit=962a2dcfdb33ae787edcb619566903fc5dc7b26f


### PR DESCRIPTION
Updates default quest difficulty filter to all, rather than novice.