### PR TITLE
Added Set Timer Plugin

### DIFF
--- a/plugins/set-timer
+++ b/plugins/set-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/InfernoStats/SetTimer.git
+commit=797a5110f2f34f3dbf4eaaa1350095a3ba04dd66


### PR DESCRIPTION
This is a TzKal-Zuk set timer plugin that is completely manual and does not use any game events. It is a replica of the commonly used timer here: https://bistools.github.io/timers.html