### PR TITLE
Add osrs-logger

### DIFF
--- a/plugins/osrs-logger
+++ b/plugins/osrs-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/0anth/osrs-logger.git
-commit=15378a3150ae164a41d97d801c006aebf15bd9d7
-warning=This plugin is in ALPHA and still being developed. An authorization code is required to use the features of this plugin.
+commit=8a838b383faf7ae267dcdc5975a03b77b3d36b62
+warning=This plugin is in ALPHA and still being developed. An authorization code is required to use the features of this plugin. This plugin submits your username and loot drops to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/osrs-logger
+++ b/plugins/osrs-logger
@@ -1,0 +1,3 @@
+repository=https://github.com/0anth/osrs-logger.git
+commit=15378a3150ae164a41d97d801c006aebf15bd9d7
+warning=This plugin is in ALPHA and still being developed. An authorization code is required to use the features of this plugin.

--- a/plugins/osrs-logger
+++ b/plugins/osrs-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/0anth/osrs-logger.git
-commit=8a838b383faf7ae267dcdc5975a03b77b3d36b62
-warning=This plugin is in ALPHA and still being developed. An authorization code is required to use the features of this plugin. This plugin submits your username and loot drops to a 3rd party website not controlled or verified by the RuneLite Developers.
+commit=23aacf32c895f1daf18ddc46f26669851fbfefbb
+warning=This plugin is in ALPHA and still being developed. An authorization code is required to use the features of this plugin. This plugin submits your display name and loot drops to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/osrs-logger
+++ b/plugins/osrs-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/0anth/osrs-logger.git
 commit=23aacf32c895f1daf18ddc46f26669851fbfefbb
-warning=This plugin is in ALPHA and still being developed. An authorization code is required to use the features of this plugin. This plugin submits your display name and loot drops to a 3rd party website not controlled or verified by the RuneLite Developers.
+warning=This plugin is in ALPHA and still being developed. An authorization code is required to use the features of this plugin.<br>This plugin submits your display name and loot drops to a 3rd party website not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This plugin logs loot drops to an external website for further data manipulation.

The plugin is currently working as intended and data is being logged while it is enabled. However the external website is still under construction. For this reason, an authorization code is required in the config, before the website will actually "accept" any data. This authorization code is intended to be temporary, to limit how much data is coming in, until it is ready for general public.

Plugin has been marked as 0.1-ALPHA and also has a warning, advising of a required authorization code for use.