### PR TITLE
Bump Task Checker to 1.0.1

### DIFF
--- a/plugins/task-checker
+++ b/plugins/task-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/task-checker-plugin.git
-commit=86c57f3f8e6265fee49bc8e85cf1c7be68f39bab
+commit=f3be688d554b167faacdc5a6b4c0eab097ff4093


### PR DESCRIPTION
- Fix beginner, elite, and master clue varps
- Add note to Kalphite Hive ropes saying you may need to go inside to get the task to proc