### PR TITLE
Bump Task Checker to 1.0.2

### DIFF
--- a/plugins/task-checker
+++ b/plugins/task-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/task-checker-plugin.git
-commit=f3be688d554b167faacdc5a6b4c0eab097ff4093
+commit=23ea3f7b9db629f4d5226e401df6263b87d6dcbb


### PR DESCRIPTION
- This ACTUALLY fixes master clues not being counted correctly, since it uses the master clue kc varp instead of the gauntlet kc varp to check your master clue count
