### PR TITLE
Fix loading lines graphical issue in instances

### DIFF
--- a/plugins/loading-lines
+++ b/plugins/loading-lines
@@ -1,2 +1,2 @@
 repository=https://github.com/dey0/pluginhub-plugins.git
-commit=5d5688a74c15a80da718c8d1859bfa999fcbdbcc
+commit=165415451492586db6d9056062f964b2b7000e1f


### PR DESCRIPTION
Fixes an issue of drawing the lines in empty instance chunks like this one at crab room: ![](https://i.imgur.com/pO0FwUG.png)

[This commit shows the relevant changes](https://github.com/dey0/pluginhub-plugins/commit/4de82fa8887415440fd711b8c289be867a360c47)