### PR TITLE
Update author info llamositopia->LlemonDuck after github rename

### DIFF
--- a/plugins/combo-runes-only
+++ b/plugins/combo-runes-only
@@ -1,2 +1,2 @@
-repository=https://github.com/llamositopia/combo-runes-only.git
-commit=383ba1110066d49c92e5e3d3ed4a181945aaae11
+repository=https://github.com/LlemonDuck/combo-runes-only.git
+commit=ea75dd3783cb71b41ce6a34108bda72783ddaa80

--- a/plugins/profit-calculator
+++ b/plugins/profit-calculator
@@ -1,2 +1,2 @@
-repository=https://github.com/llamositopia/profit-calculator.git
-commit=18abce17426dd9555c1b3f276cd0fef683ed97da
+repository=https://github.com/LlemonDuck/profit-calculator.git
+commit=237ed1e9cc0892ccb792ed021b6133602f32e3b9


### PR DESCRIPTION
I changed my GitHub name, so this updates the repo pointers and the plugins to my new name