### PR TITLE
add transmog

### DIFF
--- a/plugins/transmog
+++ b/plugins/transmog
@@ -1,0 +1,2 @@
+repository=https://github.com/Hydrox6/external-plugins.git
+commit=44c50c660accc5173ab4dfbcb8b8190e76564bc8


### PR DESCRIPTION
Adds a plugin that allows the user to change how their armour looks.

I've had this somewhat working since June, except for an issue where either teleporting would break the transmog, or the transmog would be aggressively applied no matter what. Those issues are fixed now, and I have no idea how I missed them.

Also, sorry @equirs

This plugin works off of a custom UI in the Equipment tab that I am extremely proud of. The downside is the codebase is very large, but the idea was to make it a modular system, and I think I half succeeded in that regard. I've tried to make it as user friendly as possible.

One point of note is that it is disabled in PvP situations. This is due to being based on the ideas of the RS3 customisation systems. There it's disabled since the data is shared across clients, and while it would be very nice to eventually maybe get that in the plugin, with PvP having a big emphasis on gear switching, I wanted to make sure that in the (hopefully) rare case that this broke, it wouldn't negatively affect people not being able to see their own switches at a glance.

![image](https://user-images.githubusercontent.com/2979691/105579849-e985f700-5d80-11eb-9862-7de9b63c3c49.png)
(The character model does rotate)
