### PR TITLE
Update skills progress bars with new config option

### DIFF
--- a/plugins/skills-tab-progress-bars
+++ b/plugins/skills-tab-progress-bars
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/skills-tab-progress-bars.git
-commit=ab58a7463762e2707e2e51d5a0f1f15704b211a8
+commit=edad37606858fb22dcea07ac9bb1f9324d737a80


### PR DESCRIPTION
To show only the bar that is currently being hovered, hiding all other bars, and hiding also all bars when none are hovered.