### PR TITLE
Add new osrs wiki crowdsourcing plugin

### DIFF
--- a/plugins/crowdsourcing--osrs-wiki
+++ b/plugins/crowdsourcing--osrs-wiki
@@ -1,0 +1,2 @@
+repository=https://github.com/pwatts6060/osrs-wiki-crowdsourcing.git
+commit=de9090bf315e659cd2449dda420bf0f81e1f3160


### PR DESCRIPTION
A plugin to trial new features to the osrs wiki crowdsourcing e.g. mining crowdsourcing.