### PR TITLE
Add Tears of Guthix Indicator

### DIFF
--- a/plugins/tog-indicator
+++ b/plugins/tog-indicator
@@ -1,0 +1,2 @@
+repository=https://github.com/LlemonDuck/tog-indicator.git
+commit=201d4fcfd2333cce7518eeb46756882d45fd7b38

--- a/plugins/tog-indicator
+++ b/plugins/tog-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tog-indicator.git
-commit=201d4fcfd2333cce7518eeb46756882d45fd7b38
+commit=5b77773aacc2066cd59d4e3a86802799dcd5c5f5


### PR DESCRIPTION
This plugin adds a small quest icon to the skill that will receive your Tears of Guthix exp reward. Useful to see if you need to train some skills to ensure that ToG goes into the skill you want.