### PR TITLE
wom-utils: add chat commands

### DIFF
--- a/plugins/wom-utils
+++ b/plugins/wom-utils
@@ -1,3 +1,3 @@
 repository=https://github.com/dekvall/runelite-external-plugins.git
-commit=a5481f19e8501934042f2e2c56072a775c46c09c
+commit=4f42921c0701a00fa9b888bd46431e25fbb73ae9
 warning=This plugin submits the names of you, your friends and members of your clan chat to wiseoldman.net.


### PR DESCRIPTION
Moves away from `PlayerMenuOptionClicked` and adds ehp/ehb chat commands.
![wom-commands](https://user-images.githubusercontent.com/25151927/105802407-5ecd1400-5f9b-11eb-8bee-ef03953f04c4.gif)
