### PR TITLE
Add "Hotkeyable Menu Swaps" plugin to plugin hub

### DIFF
--- a/plugins/hotkeyable-menu-swaps
+++ b/plugins/hotkeyable-menu-swaps
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/More-menu-entry-swaps.git
-commit=07566eaae83d550fffa8081b81e9a8880c35c4f2
+commit=94428e6779da4c593254e62d06da759088b95bbc

--- a/plugins/hotkeyable-menu-swaps
+++ b/plugins/hotkeyable-menu-swaps
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/More-menu-entry-swaps.git
-commit=06e6bfd961d1cb674671fa5baa685adeda27f6c0
+commit=07566eaae83d550fffa8081b81e9a8880c35c4f2

--- a/plugins/more-menu-swaps
+++ b/plugins/more-menu-swaps
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/More-menu-entry-swaps.git
-commit=55a4fb1d3b0e5f5daa0be4b4cc00b5e872b11fae
+commit=06e6bfd961d1cb674671fa5baa685adeda27f6c0

--- a/plugins/more-menu-swaps
+++ b/plugins/more-menu-swaps
@@ -1,0 +1,2 @@
+repository=https://github.com/geheur/More-menu-entry-swaps.git
+commit=55a4fb1d3b0e5f5daa0be4b4cc00b5e872b11fae


### PR DESCRIPTION
This plugin adds some menu entry swaps that can be activated by holding customizable hotkeys instead of just shift (e.g. hold "T" to swap "withdraw-10" but hold "F" to swap "withdraw-5" in the bank). Currently affects bank withdraw/deposit, spirit tree/fairy ring, and occult altar.