### PR TITLE
Updated plugin to display timer in an infobox

### DIFF
--- a/plugins/set-timer
+++ b/plugins/set-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/SetTimer.git
-commit=797a5110f2f34f3dbf4eaaa1350095a3ba04dd66
+commit=47b213dca5ae2afdd8132d04797fab4e17d06ee5


### PR DESCRIPTION
It was requested that the plugin have an optional infobox be displayed for users who didn't want to look at the panel as frequently.

Old commits were squashed due to some history issues w/ using both Intellij and WSL. You can probably find the old version in the reflog to diff if need be.