### PR TITLE
Updated plugin to display timer in an infobox

### DIFF
--- a/plugins/set-timer
+++ b/plugins/set-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/SetTimer.git
-commit=6c6fcd41c3c396079de1f5188e0be384bbd03179
+commit=e164bcf8beeee66d46494612d2e515c1c4c99f9c

--- a/plugins/set-timer
+++ b/plugins/set-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/SetTimer.git
-commit=797a5110f2f34f3dbf4eaaa1350095a3ba04dd66
+commit=6c6fcd41c3c396079de1f5188e0be384bbd03179


### PR DESCRIPTION
It was requested that the plugin have an optional infobox be displayed for users who didn't want to look at the panel as frequently.

@abextm I've fixed the commit history so it should diff fine now.