### PR TITLE
Update MLM Upper Level Markers to 1.2.3

### DIFF
--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=e42b7a51fb2010aa1aefce598c07bef7cb7d7b8d
+commit=e1a3e055203573d7086bab68bb49b5e8f1effb5d


### PR DESCRIPTION
Replaced a config field for Contour Timer Markers to an enum type, allowing more marker types in the future.

This is mostly for adding a way of hiding the tile markers for people who use the timers and want less visual clutter.

Also adds a toggle for showing the text outline for the timers.