### PR TITLE
update transmog to v1.1.1

### DIFF
--- a/plugins/transmog
+++ b/plugins/transmog
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=5ca099091242bad115f7ef9b2c22aefd8122e4c4
+commit=802386b554a3c3b87732b1f6f69841a794774523


### PR DESCRIPTION
Turns out save was broken, and tbh it and delete were pretty useless. They'll return in v1.2 or v1.3 (depends on what order I do features in)