### PR TITLE
Update MLM Upper Level Markers to 1.2.4

### DIFF
--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=e1a3e055203573d7086bab68bb49b5e8f1effb5d
+commit=2028f8c9ddcf1b203398df936fd8baa039c92d7d


### PR DESCRIPTION
Reorders some config fields and adds a config to force a higher rendering layer for the plugin's overlay so it can appear above the Motherlode mining icons.

Fixes https://github.com/Cyborger1/mlm-upper-level-markers/issues/1