### PR TITLE
Update collection-log v1.2.5

### DIFF
--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,2 +1,2 @@
 repository=https://github.com/evansloan/collection-log.git
-commit=fcd05a3a0c9cb95fa4800d321d23968c2d401f97
+commit=5039fa2bf731f49fe70de3fd9dedc5b7cc9f0edb


### PR DESCRIPTION
Fix bug where previously completed categories are remaining highlighted when all items are no longer obtained