### PR TITLE
Update MLM Upper Level Markers to 1.2.5

### DIFF
--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=2028f8c9ddcf1b203398df936fd8baa039c92d7d
+commit=7414508fa98ab8d10d999aaf940d7c2380f63f02


### PR DESCRIPTION
Sorry for the back to back update, last one I made the colors `@Alpha` and my drawing logic for Contour Timer markers didn't like those.

Improves rendering logic for Counter Timer markers and fixes broken alpha coloring for them.