### PR TITLE
Update MLM Upper Level Markers to 1.2.6

### DIFF
--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=fcbaa66550ab44d6e66f1a719bab2a9f3e1ca0d6
+commit=0fe358faeba29aeb33ff95358fee26b1910e9fe4

--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=7414508fa98ab8d10d999aaf940d7c2380f63f02
+commit=fcbaa66550ab44d6e66f1a719bab2a9f3e1ca0d6

--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=0fe358faeba29aeb33ff95358fee26b1910e9fe4
+commit=c23ddc9fe6bfca287aeebc6c435facee53ce24ff


### PR DESCRIPTION
Adds a new marker timer option that persist on screen when it reaches 0 so you can tell which veins are "one-rocks" with tile markers hidden.