### PR TITLE
Added HotKey Support and bumped version to 1.2.0

### DIFF
--- a/plugins/set-timer
+++ b/plugins/set-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/SetTimer.git
-commit=e164bcf8beeee66d46494612d2e515c1c4c99f9c
+commit=a784672459d11a35578dabfe80d239c4f142c833


### PR DESCRIPTION
Adds keybind support to make it easier to start/stop the timer instead of pressing the button in the panel per https://github.com/InfernoStats/SetTimer/issues/2