### PR TITLE
Update Inventory Setups to v1.10.1

### DIFF
--- a/plugins/inventory-setups
+++ b/plugins/inventory-setups
@@ -1,2 +1,2 @@
 repository=https://github.com/dillydill123/inventory-setups.git
-commit=8a27e3118a36ea70c0e373c1ee38d69c09e86dd9
+commit=525bf62622ea66e298d180c42ad0243f7768f428


### PR DESCRIPTION
Fixing issue where version was being truncated and causing patch notes window to show up for logged in accounts.