### PR TITLE
Add dry-meter-for-raids

### DIFF
--- a/plugins/dry-meter-for-raids
+++ b/plugins/dry-meter-for-raids
@@ -1,0 +1,2 @@
+repository=https://github.com/RydawgRS/raids-dry-meter
+commit=d0556d7f57d99d930aa3fc4bb75987e09304d754


### PR DESCRIPTION
This plugin logs players raids and keeps track of how lucky and unlucky they are at raids. In beta and currently only works for solos Chambers of Xeric. Unique hider will cause the plugin to not work either.