### PR TITLE
Add multicolor-highlights

### DIFF
--- a/plugins/multicolor-highlights
+++ b/plugins/multicolor-highlights
@@ -1,0 +1,2 @@
+repository=https://github.com/sgfost/multicolor-highlights.git
+commit=0ad4513c87b28e755ed1717a660bfab93232c439


### PR DESCRIPTION
NPC highlighting plugin with (currently) very simple functionality, but allows for multiple (up to 5) colors for different NPCs.