### PR TITLE
Bump task checker plugin to v1.2

### DIFF
--- a/plugins/task-checker
+++ b/plugins/task-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/task-checker-plugin.git
-commit=c961eb8c0f26e06a5832d2e683678e849eeaf3f3
+commit=61b77fdd8770ed39fad02c54c9cd41e3e458eaa1


### PR DESCRIPTION
Bumps to v1.2 and adds new varbits and associated tasks:
- Secret exit in the Troll Stronghold*
- Piscatoris tools, Ancient letter*, Tatty note*, and Teddy* loot tasks
- Dampe and Drunken dwarf initial dialogue, Hamal post quest dialogue,  Candle seller dialogue, Black Knights' Fortress guard dialogue*
- Rag and Bone Man II rewards claimed (changes dialogue of Odd old man)
*These have no known effect other than setting the associated varbit to 1