### PR TITLE
Update fashionscape plugin to v1.1.2

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=b8b475c2176c6b85c5fffa13c00e283900f41225
+commit=75328a5c6552ba456fb4b2a9437d6ee04af3978f

--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=a75c7a9fa6b304fd5a48c1730a06d776aa5ae9de
+commit=b8b475c2176c6b85c5fffa13c00e283900f41225


### PR DESCRIPTION
Silly fashionscape updates:
The plugin now supports setting the sort order of search results: by release, in alphabetical order, and by "color distance" to the current outfit.
The randomizer has multiple "intelligence" settings that utilize the new color distance algorithm.
The "clear all" option is now a "hard" clear by the default left-click. The right click option has become a soft clear, which doesn't remove locks.
More model-less and non-standard items have been added to the filters.

And bug fixes:
Bald male characters can now safely use fashionscape without worry of their heads disappearing.
The undo/redo functionality no longer accidentally imports items you're wearing in-game.
Changing accounts with the plugin enabled no longer swaps your hair / sleeves to the previously logged in account's models.
Some other latent bugs around swap logic are also fixed, I don't remember them anyway but oh well.