### PR TITLE
Update Set Timer plugin to v1.2.1

### DIFF
--- a/plugins/set-timer
+++ b/plugins/set-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/SetTimer.git
-commit=a784672459d11a35578dabfe80d239c4f142c833
+commit=a8134cf6ee8c0f548a0d47896a50194a93b4b081


### PR DESCRIPTION
Fixes a bug where you complete or die in the inferno and the set timer infobox is unable to be removed via hotkeys.