### PR TITLE
WOM-Utils Fix showing group icon for usernames with underscore

### DIFF
--- a/plugins/wom-utils
+++ b/plugins/wom-utils
@@ -1,3 +1,3 @@
 repository=https://github.com/dekvall/runelite-external-plugins.git
-commit=338b9a27e88707ca4b25635653c078345175fe81
+commit=31d9f41059080e8237c1d9ae537d3d1ea78ef7f4
 warning=This plugin submits the names of you, your friends and members of your clan chat to wiseoldman.net.


### PR DESCRIPTION
Correctly show the group icons for players with underscore in their name.