### PR TITLE
Fix verification metadata for raid-data-tracker

### DIFF
--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
-repository=https://github.com/CasvM/runelite-external-plugins.git
-commit=219e5e33070dab7b5ed2f570598699a902855489
+repository=https://github.com/Cyborger1/casvm-runelite-external-plugins.git
+commit=107278518a476e54ebc700d7b77af1801502b25f


### PR DESCRIPTION
Temporary hijack of the plugin to fix the verification metadata until @CasvM takes this back. People on the discord REALLY want this plugin to work.

https://github.com/CasvM/runelite-external-plugins/pull/2