### PR TITLE
Update verification metadata for loot-table

### DIFF
--- a/plugins/loot-table
+++ b/plugins/loot-table
@@ -1,2 +1,2 @@
-repository=https://github.com/Sir-Kyle-Richardson/OSRS-loottable.git
-commit=a4677274ebc9f3e237b92d95ade9efe7d502db06
+repository=https://github.com/Cyborger1/Sir-Kyle-Richardson-OSRS-loottable.git
+commit=7b1d78b9a98969198a257f9a96a607f9e9e7ff99


### PR DESCRIPTION
Temporary hijack of the plugin to fix the verification metadata until @Sir-Kyle-Richardson takes this back.

https://github.com/Sir-Kyle-Richardson/OSRS-loottable/pull/4