### PR TITLE
Create ba-role-randomizer plugin

### DIFF
--- a/plugins/ba-role-randomizer
+++ b/plugins/ba-role-randomizer
@@ -1,0 +1,2 @@
+repository=https://github.com/ransty/role-randomizer-ba.git
+commit=67e98c3e906304b6def21d55aea35a30d1e5a461


### PR DESCRIPTION
This plugin gives the chat command `::r` to randomly select roles based on preferences for barbarian assault.

example:
![example](https://media1.giphy.com/media/T3EyEHbt3cpHiQFzDA/giphy.gif)

Currently we have to load a website to randomize roles between players, or use a discord bot. 

So this plugin is an alternative to loading up a website / discord.