### PR TITLE
Update Collection log plugin to v1.3.1

### DIFF
--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,2 +1,2 @@
 repository=https://github.com/evansloan/collection-log.git
-commit=6a5f99c245055ac6edb7979c835766696fe4c3c6
+commit=86973999e57f4c009273b3f0236cddec81f02737


### PR DESCRIPTION
Don't show chat notification on player drops