### PR TITLE
Create drop-simulator

### DIFF
--- a/plugins/drop-simulator
+++ b/plugins/drop-simulator
@@ -1,2 +1,2 @@
 repository=https://github.com/mxp190009/drop-simulator.git
-commit=6d343ba41abdcb04e496e88cbf5d2e47486a205b
+commit=9db374fc205c5aae1f99bd5fd127266076f40ec8

--- a/plugins/drop-simulator
+++ b/plugins/drop-simulator
@@ -1,0 +1,2 @@
+repository=https://github.com/mxp190009/drop-simulator.git
+commit=6d343ba41abdcb04e496e88cbf5d2e47486a205b


### PR DESCRIPTION
This drop simulator plugin allows for the simulation of any number of trials of most NPCs with a drop table. Uses the [osrsbox-api](https://api.osrsbox.com/index.html) to gather an NPC's drop data. Drops are then simulated and displayed in the plugin panel. Hovering over a drop will display the name, quantity, and value of the item stack.
