### PR TITLE
Create drop-simulator

### DIFF
--- a/plugins/drop-simulator
+++ b/plugins/drop-simulator
@@ -1,0 +1,2 @@
+repository=https://github.com/mxp190009/drop-simulator.git
+commit=013d53487565a82f8e02f304016ae560e4e51876


### PR DESCRIPTION
This drop simulator plugin allows for the simulation of any number of trials of most NPCs with a drop table. Uses the [osrsbox-api](https://api.osrsbox.com/index.html) to gather an NPC's drop data. Drops are then simulated and displayed in the plugin panel. Hovering over a drop will display the name, quantity, and value of the item stack.