### PR TITLE
Add Monster Menu HP plugin

### DIFF
--- a/plugins/menuhp
+++ b/plugins/menuhp
@@ -1,0 +1,2 @@
+repository=https://github.com/AnkouOSRS/npc-menu-hp.git
+commit=841208fddb2f1927721f54b2edfd3f311d50491b


### PR DESCRIPTION
This plugin shows the HP of monsters by recoloring their right-click menu entry text