### PR TITLE
Removed import causing global consciousness plugin build to fail. Re-submitting with updated version/hash.

### DIFF
--- a/plugins/global-consciousness
+++ b/plugins/global-consciousness
@@ -1,2 +1,2 @@
 repository=https://github.com/Unholypanda/global-consciousness-plugin.git
-commit=ec700453cc7397bfad2e6c1562a26dcc14a7b543
+commit=977f4c5b63d6deb89cd6fa590d522ddfa161b293

--- a/plugins/global-consciousness
+++ b/plugins/global-consciousness
@@ -1,0 +1,2 @@
+repository=https://github.com/Unholypanda/global-consciousness-plugin.git
+commit=ec700453cc7397bfad2e6c1562a26dcc14a7b543


### PR DESCRIPTION
Removed import causing global consciousness plugin build to fail. Re-submitting with updated version/hash.