### PR TITLE
Update Monster Menu HP Plugin to 1.1

### DIFF
--- a/plugins/menuhp
+++ b/plugins/menuhp
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/npc-menu-hp.git
-commit=841208fddb2f1927721f54b2edfd3f311d50491b
+commit=5bf2db8f3ef0aa24c586061c7af167d78677dc79


### PR DESCRIPTION
Now stores the HP of NPCs to show it if the NPC has no other HP info available.
Added the option to specify which NPCs to show HP bars for (comma-separated, accepts '*' wildcard).
Minor code cleanup.