### PR TITLE
Update quest-helper to v1.6.3

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=ae8615b65f2a25df0bd19e6982feef36611e1060
+commit=aa00c5f84c5e4844234e474a70889e9e854a9faf


### PR DESCRIPTION
- Adds Regicide
- Few bug fixes
- Makes it work with Runelite v1.7.1