### PR TITLE
Update Bossing Info to 1.5.9

### DIFF
--- a/plugins/kph-tracker
+++ b/plugins/kph-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Mrnice98/BossingInfo.git
-commit=146fae6dc83a6ef9a1c90c211700a76c51287e09
+commit=40eb0073d2d9b4d749234b7cd42d3a642bbc1b2d


### PR DESCRIPTION
Fix getKillTime method to work with precise kill times
allows plugin to work with precise kill time option