### PR TITLE
Add Miasma Tiles plugin

### DIFF
--- a/plugins/miasma-tiles
+++ b/plugins/miasma-tiles
@@ -1,0 +1,2 @@
+repository=https://github.com/dey0/pluginhub-plugins.git
+commit=82f075a1017f3d6e6441d1354e2ba77c397dadc2


### PR DESCRIPTION
Simple plugin that shows a grid of tiles at Olm for dissipating burn in masses. (Essentially a preset set of ground markers). Includes config for color customization.

Preview:
![](https://i.imgur.com/fLuq11s.png)