### PR TITLE
ProximityScape Plugin

### DIFF
--- a/plugins/proximity-scape
+++ b/plugins/proximity-scape
@@ -1,2 +1,2 @@
 repository=https://github.com/warnerblue/proximityscape.git
-commit=b37bf469e3ec0a015f487a62fa7138a3ba335b70
+commit=f630e5a655386e1dab148f510f9339b106309679

--- a/plugins/proximity-scape
+++ b/plugins/proximity-scape
@@ -1,2 +1,2 @@
 repository=https://github.com/warnerblue/proximityscape.git
-commit=f630e5a655386e1dab148f510f9339b106309679
+commit=c02c62fe2ce54b81f73fd7db72701468359c1145


### PR DESCRIPTION
This plugin enables the ability to have proximity chat in OSRS. It works by sending data to a Discord bot (World Number & Region) which then moves your linked Discord account. If you have any questions or concerns feel free to add me on Discord: warnerBlue#1458