### PR TITLE
Create bot-detector

### DIFF
--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,2 +1,3 @@
 repository=https://github.com/Ferrariic/bot-detector.git
 commit=2f7a166171e1e92bcc82b73663f544cb779698ae
+warning=This plugin submits the names of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,3 +1,3 @@
 repository=https://github.com/Ferrariic/bot-detector.git
-commit=387120b66cab7d50be4d045d4089bde865788342
+commit=23038226c60f6fe69ece9bd4064c6dfecef01a98
 warning=This plugin submits the names of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,0 +1,2 @@
+repository=https://github.com/Ferrariic/bot-detector.git
+commit=e7bb9264ec4d538326be3a6469a88f6f5f85c8ad

--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,3 +1,3 @@
 repository=https://github.com/Ferrariic/bot-detector.git
-commit=2f7a166171e1e92bcc82b73663f544cb779698ae
+commit=387120b66cab7d50be4d045d4089bde865788342
 warning=This plugin submits the names of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,2 +1,2 @@
 repository=https://github.com/Ferrariic/bot-detector.git
-commit=e7bb9264ec4d538326be3a6469a88f6f5f85c8ad
+commit=2f7a166171e1e92bcc82b73663f544cb779698ae


### PR DESCRIPTION
Client side (This Plugin): 

The Bot Detector Plugin gathers player names from within OSRS in order to aid in the training and evaluation of a bot-detecting neural network. This plugin pulls names from in-game upon a PlayerSpawned event, adds those player names to a temporary text file, removes duplicates from the text file by parsing into another file, and uploads that final text file to a one-way website which stores those names for use in the neural network. The upload of player names is controlled by the account user - by turning off the plugin. Currently - after sending a name batch to the listening server it is necessary to restart Runelite if another batch of collected names would like to be sent. This will be changed in future updates, along with making the plugin more user friendly and interactive for the player. 

----

Server side: Once names are sent by the user, these player names are sent through the OSRS Hiscores by a python script, and stats are pulled. These stats are then evaluated by a neural network and grouping algorithm which organizes player data from the Hiscores into distinct groups - and evaluates them against current and known bots in order to detect botting or malicious behaviors. Suspicious accounts are then forwarded to tipoff@jagex for final evaluation and consideration. 
 