### PR TITLE
Update Drop Simulator to v1.1

### DIFF
--- a/plugins/drop-simulator
+++ b/plugins/drop-simulator
@@ -1,2 +1,2 @@
 repository=https://github.com/mxp190009/drop-simulator.git
-commit=ab058499069a72d5f3ab82f2f22987e74e7214d4
+commit=461404baf05f68468572adfdbdff872f594c39f2


### PR DESCRIPTION
- Fixed manually changing the number of trials to update properly
- Fixed instances of individual item popup menu info lingering upon right click simulating more drops