### PR TITLE
Update optimal-quest-guide

### DIFF
--- a/plugins/optimal-quest-guide
+++ b/plugins/optimal-quest-guide
@@ -1,2 +1,2 @@
 repository=https://github.com/cesoun/optimal-quest-guide.git
-commit=26d3b9c4bbd95d87eee976e67b30fc6abee3707a
+commit=b887ae9304e31549cfa72e56b1da910a9e1a4752


### PR DESCRIPTION
@palleiko Update name and link for Rag and Bone Man I
Quest was not showing as completed with name change from `Rag_and_Bone_Man` to `Rag_and_Bone_Man_I`

Version bump 1.7.0 -> 1.7.1