### PR TITLE
Removed System.out.println() from bot-detector

### DIFF
--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,3 +1,3 @@
 repository=https://github.com/Ferrariic/bot-detector.git
-commit=23038226c60f6fe69ece9bd4064c6dfecef01a98
+commit=18eebe4b12fef58af177e461860a21d52410e007
 warning=This plugin submits the names of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
- Minor edit, removed System.out.println() from the bot-detector plugin.