### PR TITLE
Add protect item notifier plugin.

### DIFF
--- a/plugins/protect-item-notifier
+++ b/plugins/protect-item-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/mathewchapman/protect-item-notify.git
+commit=2473d7d33185cc66896eab7dae6d0c02dfa115e7

--- a/plugins/protect-item-notifier
+++ b/plugins/protect-item-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/mathewchapman/protect-item-notify.git
-commit=2473d7d33185cc66896eab7dae6d0c02dfa115e7
+commit=569f4503343d5613a0aba48f6dea79b70572c290


### PR DESCRIPTION
A plugin which overlays a large protect item image over the screen when the player does not have the protect item prayer enabled. 

This is for users to ensure they have protect item enabled incase the prayer drops off.