### PR TITLE
Update fashionscape to 1.1.3

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=9a074c1a7e75e8abf9291940f42bd6789a9c0045
+commit=93bfe021fccbb07c0b93a6f5a8e94e89a36adad1

--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=75328a5c6552ba456fb4b2a9437d6ee04af3978f
+commit=9a074c1a7e75e8abf9291940f42bd6789a9c0045


### PR DESCRIPTION
1.1.3 expanded the swap capabilities to kits, which required reworking the entire swap logic (sorry for big diff)
also added a menu option to "copy-outfit" from other players, so now you can instantly become a clone of someone else