### PR TITLE
Add Discord Level Notifications Plugin

### DIFF
--- a/plugins/discord-level-notifications
+++ b/plugins/discord-level-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/ATremonte/Discord-Level-Notifications.git
+commit=08d29405f7d5eeb6ab8fc9c516f618cff60d14c7


### PR DESCRIPTION
Added the Discord Level Notifications Plugin to the plugins folder.

This is a fairly simple plugin. Each game tick it checks to see if the level up widget was created. If it was it takes a screenshot and sends a message to a discord webhook.