### PR TITLE
Add Method Observer Plugin

### DIFF
--- a/plugins/method-observer
+++ b/plugins/method-observer
@@ -1,2 +1,2 @@
 repository=https://github.com/MildlyM/Method-Observer.git
-commit=69e77d76c4a3ab209363970158608e402f995aa4
+commit=2deb1adac266dc4c1714f793307baa8d79fede6c

--- a/plugins/method-observer
+++ b/plugins/method-observer
@@ -1,2 +1,2 @@
 repository=https://github.com/MildlyM/Method-Observer.git
-commit=2deb1adac266dc4c1714f793307baa8d79fede6c
+commit=547696d1961e1f952564845e849fb951702dded5

--- a/plugins/method-observer
+++ b/plugins/method-observer
@@ -1,0 +1,2 @@
+repository=https://github.com/MildlyM/Method-Observer.git
+commit=69e77d76c4a3ab209363970158608e402f995aa4


### PR DESCRIPTION
A tournament plugin for use by Method OSRS Tournament Participants to have their inventory, HP, damage and prayer% displayed on the live broadcast.