### PR TITLE
Left click dropper: Remove generic item requirement

### DIFF
--- a/plugins/zom-leftclick-dropper
+++ b/plugins/zom-leftclick-dropper
@@ -1,2 +1,2 @@
-repository=https://github.com/JZomerlei/zom-external-plugins.git
-commit=d0ea0a406e6e2a06f6bb7e70a6c0d953854c7154
+repository=https://github.com/redrumze/zom-external-plugins.git
+commit=46c2ea52c1306696220ba9e078096a050bc626f9


### PR DESCRIPTION
If item has drop option, replace first option with drop if it's in the list.