### PR TITLE
nmz util Remove rock cake guzzle

### DIFF
--- a/plugins/zom-nmz-util
+++ b/plugins/zom-nmz-util
@@ -1,2 +1,2 @@
-repository=https://github.com/JZomerlei/zom-external-plugins.git
-commit=457b8b0d523a84fe76c0dad598c12629bcb98fd0
+repository=https://github.com/redrumze/zom-external-plugins.git
+commit=22e4256e3987f5f028a9d945002414cc89750146


### PR DESCRIPTION
Rock cake guzzle is now part of default Menu Entry Swapper plugin as of 12/18/2020 in commit e69a854a7edffa45ce64837f41c320464366dd50