### PR TITLE
Add temple tracker plugin

### DIFF
--- a/plugins/temple-tracker
+++ b/plugins/temple-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/runelite-external-plugins.git
-commit=4d2bcac3a9a7db68269b2ea3e9001ad6e24f33ab
+commit=cb5e37e85d442bf25b05a72161c3a4e5a4d1df2c

--- a/plugins/temple-tracker
+++ b/plugins/temple-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/runelite-external-plugins.git
-commit=cb5e37e85d442bf25b05a72161c3a4e5a4d1df2c
+commit=93c9d770d8ce166527090db63f124b979e67e41f

--- a/plugins/temple-tracker
+++ b/plugins/temple-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/CasvM/runelite-external-plugins.git
+commit=4d2bcac3a9a7db68269b2ea3e9001ad6e24f33ab


### PR DESCRIPTION
- Adds an overlay to the temple trek ui, which shows the points and duration of a temple trek, as well as all encounters, and the duration of each encounter. This data can be logged to a file. 
- Adds another overlay showing treks done/hour as well as average points per trek.
- Adds menu entry swaps specific temple trekking, such as continue-trek, escort for each companion, and use on the druid pouch.