### PR TITLE
Add tob-notice-board plugin

### DIFF
--- a/plugins/tob-notice-board
+++ b/plugins/tob-notice-board
@@ -1,0 +1,2 @@
+repository=https://github.com/Broooklyn/runelite-external-plugins.git
+commit=6b4587c0c885c7eaaf373ef3ebf67bb232826d3b


### PR DESCRIPTION
Highlight friends and clan members on the Theatre of Blood Notice Board

<img width="500" alt="tob notice board" src="https://user-images.githubusercontent.com/54762282/110707004-acf24b80-81c6-11eb-97ab-9a078d30591c.png">