### PR TITLE
Updating loottable to 1.1.0

### DIFF
--- a/plugins/loot-table
+++ b/plugins/loot-table
@@ -1,2 +1,2 @@
 repository=https://github.com/Sir-Kyle-Richardson/OSRS-loottable.git
-commit=1f17b17c7e0b6a6843b27e4305029a0d2ebb2260
+commit=dc04c481dd8d44539634ee90ee88b25c736aa165


### PR DESCRIPTION
Updating loot table to 1.1.0

- Introducing OSRS box api. Replaced scaping the Wiki for loot tables