### PR TITLE
Added Vial Smasher Plugin

### DIFF
--- a/plugins/vial-smasher
+++ b/plugins/vial-smasher
@@ -1,0 +1,2 @@
+repository=https://github.com/infernostats/vialsmasher.git
+commit=a075fffdf35191856ecbf03840ca7c22976874eb


### PR DESCRIPTION
This plugin is similar in concept to the door kicker plugin. It plays the teleport tablet animation when the spam message for barbarian vial smashing is seen in the chat box.