### PR TITLE
Update drop-simulator to v1.2

### DIFF
--- a/plugins/drop-simulator
+++ b/plugins/drop-simulator
@@ -1,2 +1,3 @@
 repository=https://github.com/mxp190009/drop-simulator.git
 commit=06ad48965981b9aa22b32baf88183b7d1bc334d0
+warning=This plugin submits the ID of monsters you kill and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/drop-simulator
+++ b/plugins/drop-simulator
@@ -1,2 +1,2 @@
 repository=https://github.com/mxp190009/drop-simulator.git
-commit=461404baf05f68468572adfdbdff872f594c39f2
+commit=06ad48965981b9aa22b32baf88183b7d1bc334d0


### PR DESCRIPTION
General fixes + ability to simulate trials of non NPC tables. (ToB, CoX, Barrows, etc.)