### PR TITLE
Update do-not-kick

### DIFF
--- a/plugins/do-not-kick
+++ b/plugins/do-not-kick
@@ -1,2 +1,2 @@
 repository=https://github.com/MarbleTurtle/DontKickHim.git
-commit=fbdc291c2765c69f79d21ea7ba94f65695d473dd
+commit=ec6dab339ca1a0bf5af1ed76d434296d834baa30


### PR DESCRIPTION
No longer removes the kick option from combat styles.