### PR TITLE
create Force Recolor plugin

### DIFF
--- a/plugins/force-recolor
+++ b/plugins/force-recolor
@@ -1,0 +1,2 @@
+repository=https://github.com/Alexsuperfly/RuneLite-Hub-Plugins.git
+commit=826036d3a52dc9ce6d7fa47bd45927b91fc2e67c


### PR DESCRIPTION
Force recolors all game messages that contain specified text.

For example writing `divine` in the config will strip and replace the red color from the messages in chat telling you they are about to wear off.  
Or `exchange` to change that awful green color that can barely be read with the transparent chatbox.
