### PR TITLE
add coffin-counter

### DIFF
--- a/plugins/coffin-counter
+++ b/plugins/coffin-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/Hydrox6/external-plugins.git
+commit=6ed5afa539a4856cedb5340fc277b93fbd6dea6c


### PR DESCRIPTION
A simple plugin to track how many remains the player has in their coffin
![record_2021-03-16__09-25-41](https://user-images.githubusercontent.com/2979691/111293454-34194680-8641-11eb-9b69-f6150cf81438.png)
