### PR TITLE
Create inferno-splits-logger

### DIFF
--- a/plugins/inferno-splits-logger
+++ b/plugins/inferno-splits-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/Magnusrn/inferno-splits-logger.git
+commit=0e0cb667e09d7caf62dab9457ff5cc93cc5213b6


### PR DESCRIPTION
A plugin to log inferno wave splits timers to a textfile in the .runelite folder, creates a directory "InfernoTimerLogs" and saves a file upon inferno kc, titled with killcount and duration. Depends upon the Inferno Split Timer Plugin by usa-usa-usa-usa. Without it it will simply record the total duration.