### PR TITLE
Update pvp-performance-tracker to v1.4.3

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=1e0a38ae7b6f4a00159c0a977f8b94fa1d7f329d
+commit=4b6c2a76f89f2256d0015574b09a5da2ddee7fa3


### PR DESCRIPTION
Fixed a layout bug that occurred when changing the state of the "config warning", which aims to help users acknowledge the existence of the config. Small bugfix, but it's a confusing bug that likely happens to most new users, and is only fixed by restarting the plugin. Used GridLayout in a dumb way + wasn't using constants, and the row count got messed up. Now using constants so this won't happen again. I probably shouldn't be using GridLayout in this case, but at this point it works and I'm afraid to change it. May do so in the next update where I plan to do a lot of UI changes.
![image](https://user-images.githubusercontent.com/28902643/111416295-015f6480-86ba-11eb-8ab5-4b14ee800ac2.png)
