### PR TITLE
Update osrskillboard to 1.0.0

### DIFF
--- a/plugins/osrskillboard
+++ b/plugins/osrskillboard
@@ -1,3 +1,3 @@
 repository=https://github.com/Osrskillboard/OSRSKillboard-plugin.git
-commit=5c0becf2b8048dc837f845aef4cf12f2b24a4c52
+commit=9d6acca99ea039d8d4657b2820cd6b2b34245f88
 warning=This plugin submits your username, Gear, PvP Kills, PvP Loot and IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
- No longer grouping kills for the same players.
- Re-wording description.
- Setting version number to 1.0.0