### PR TITLE
Add shooting stars plugin

### DIFF
--- a/plugins/shooting-stars
+++ b/plugins/shooting-stars
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/plugin-repo.git
-commit=a9b489537a87d220470f49e83f214f4dd1a07e7e
+commit=e3515ed29a703f2b1842c10cd537f606a4c46e57

--- a/plugins/shooting-stars
+++ b/plugins/shooting-stars
@@ -1,0 +1,2 @@
+repository=https://github.com/andmcadams/plugin-repo.git
+commit=a9b489537a87d220470f49e83f214f4dd1a07e7e


### PR DESCRIPTION
Add a basic shooting stars plugin. The plugin sends out post requests to the given endpoint, and makes get requests to retrieve the information. The endpoints need to be configured in the plugin config. Currently, it only displays the star that is closest to landing in an overlay. Eventually, the node server I'm using will be made open source as well.