### PR TITLE
Bump shooting-stars to 1.1

### DIFF
--- a/plugins/shooting-stars
+++ b/plugins/shooting-stars
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/plugin-repo.git
-commit=3f42bde7fc112425ca8163449556dd793fcb4f73
+commit=e2a7b0f223d1fab624851bca6ec8870e73d5e053
 warning=This plugin submits the location and time of shooting stars along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/shooting-stars
+++ b/plugins/shooting-stars
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/plugin-repo.git
-commit=e3515ed29a703f2b1842c10cd537f606a4c46e57
+commit=91a581c00eedf655db12d138987fc994103649cc

--- a/plugins/shooting-stars
+++ b/plugins/shooting-stars
@@ -1,2 +1,3 @@
 repository=https://github.com/andmcadams/plugin-repo.git
-commit=cdcbec64835c9eca7e53dfb003750287011a365a
+commit=3f42bde7fc112425ca8163449556dd793fcb4f73
+warning=This plugin submits the location and time of shooting stars along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/shooting-stars
+++ b/plugins/shooting-stars
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/plugin-repo.git
-commit=91a581c00eedf655db12d138987fc994103649cc
+commit=cdcbec64835c9eca7e53dfb003750287011a365a


### PR DESCRIPTION
- Replaces overlay with sidebar detailing all scouted stars

![sidebar](https://user-images.githubusercontent.com/5871961/111837686-40620580-88c6-11eb-858c-5da75b553ca1.png)
