### PR TITLE
Create shooting-stars-tracking

### DIFF
--- a/plugins/shooting-stars-tracking
+++ b/plugins/shooting-stars-tracking
@@ -1,0 +1,2 @@
+repository=https://github.com/HarveyWilson/Shooting-Stars-Tracking.git
+commit=c2d9098a115e34232ed8fc1ec0bc7921acc2486a


### PR DESCRIPTION
Tracks the location of shooting stars that the player has seen through their telescope and the time until they land. Stores these values on a side panel allowing for sorting by world, location or time. Stars that are over 5 minutes old are automatically removed.
Can also export the stars found allowing them to be imported by other users to share locations between players.

![image](https://user-images.githubusercontent.com/32651842/111851363-c56f0e00-890a-11eb-804a-e48e6b623d1f.png)
