### PR TITLE
Shooting Stars Tracking

### DIFF
--- a/plugins/shooting-stars-tracking
+++ b/plugins/shooting-stars-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/HarveyWilson/Shooting-Stars-Tracking.git
-commit=c2d9098a115e34232ed8fc1ec0bc7921acc2486a
+commit=34c2ed9f97cfd05270cb3c13ff25b94a853c9a99

--- a/plugins/shooting-stars-tracking
+++ b/plugins/shooting-stars-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/HarveyWilson/Shooting-Stars-Tracking.git
-commit=5d65212b08107a675cf912124816cbcc7f15b49f
+commit=8b4235ce80190707a46bb1cd2ada0a5e59068830

--- a/plugins/shooting-stars-tracking
+++ b/plugins/shooting-stars-tracking
@@ -1,0 +1,2 @@
+repository=https://github.com/HarveyWilson/Shooting-Stars-Tracking.git
+commit=c2d9098a115e34232ed8fc1ec0bc7921acc2486a

--- a/plugins/shooting-stars-tracking
+++ b/plugins/shooting-stars-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/HarveyWilson/Shooting-Stars-Tracking.git
-commit=22b36055036e1983666efb57fde66d300edc3b12
+commit=5d65212b08107a675cf912124816cbcc7f15b49f

--- a/plugins/shooting-stars-tracking
+++ b/plugins/shooting-stars-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/HarveyWilson/Shooting-Stars-Tracking.git
-commit=34c2ed9f97cfd05270cb3c13ff25b94a853c9a99
+commit=22b36055036e1983666efb57fde66d300edc3b12


### PR DESCRIPTION
Tracks the location of shooting stars that the player has seen through their telescope and the time until they land. 
Stores these values on a side panel allowing for sorting by world, location or time. Stars that have landed after a given number of minutes are automatically removed and coloured differently.
Can also export the stars found to the clipboard allowing them to be imported by other users to share locations.
![image](https://user-images.githubusercontent.com/32651842/111893038-e3666c80-89f7-11eb-81a2-3f956cb5a65f.png)


