### PR TITLE
Bump one-click-summer-garden to 1.2

### DIFF
--- a/plugins/one-click-summer-garden
+++ b/plugins/one-click-summer-garden
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/one-click-summer-garden.git
-commit=f9092f43ff780360445d4daa3bb25946da6db727
+commit=008aa591cf7c813d07304d092e3983d70d98aa65


### PR DESCRIPTION
Adds an optional notification when the launch cycle is starting, as requested by @vitorebom in LlemonDuck/one-click-summer-garden/issues/3

Closes LlemonDuck/one-click-summer-garden/issues/3