### PR TITLE
Updating flipper to 1.2.2

### DIFF
--- a/plugins/flipper
+++ b/plugins/flipper
@@ -1,3 +1,3 @@
 repository=https://github.com/Sir-Kyle-Richardson/OSRS-Flipper.git
-commit=7c90051dc906f9f7d3b7dd4db61e34b1921829c5
+commit=15f9e825dc1a9ae2dbcd4a7ce3ad830f0bcec65f
 warning=This plugin submits Grand Exchange transactions and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers


### PR DESCRIPTION
Fixing issue where flips were rendered in reverse order of their creation date