### PR TITLE
Update quest-helper to v1.7.0

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=28a8af690896e57eedc1aafd11bc3545b03142f0
+commit=2235baef69662c8930f42dba9a50376a3e9ec0fc

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=d2cd5edc232720ebfb1c426ae7015565f59a18b6
+commit=28a8af690896e57eedc1aafd11bc3545b03142f0


### PR DESCRIPTION
- Adds Sheep Herder, Rag and Bone Man I + II, Hazeel Cult and Devious Minds
- Adds wiki links to helpers
- Persist bank states for item checks
- Add dynamic visibility of sidebar items/steps
- Option for sidebar to auto-open when a quest starts

Edit:
- Also adds Fairy Tale II, as well as a fix for the upcoming Object WorldPoint change.