### PR TITLE
package: Increase build.gradle column limit to 120

### DIFF
--- a/package/package/src/main/java/net/runelite/pluginhub/packager/Plugin.java
+++ b/package/package/src/main/java/net/runelite/pluginhub/packager/Plugin.java
@@ -301,12 +301,12 @@ public class Plugin implements Closeable
 							return 4;
 						}
 						return 1;
-					}).sum() > 100)
+					}).sum() > 120)
 					.findAny()
 					.orElse(null);
 				if (badLine != null)
 				{
-					throw PluginBuildException.of(this, "All gradle files must wrap at 100 characters or less")
+					throw PluginBuildException.of(this, "All gradle files must wrap at 120 characters or less")
 						.withFileLine(path.toFile(), badLine);
 				}
 			}


### PR DESCRIPTION
Even with a narrow browser, 120 characters can easily be seen without any wrapping occurring.

This helps prevent [files such as this one](https://github.com/Rickboy26/Infernal/blob/08e1a92f19c2949576af84fb462687f4c6dcff05/build.gradle#L26) from being denied for being a few characters over.