### PR TITLE
NMZ Optimal Points 1.2.0

### DIFF
--- a/plugins/nmz-optimal-points
+++ b/plugins/nmz-optimal-points
@@ -1,2 +1,2 @@
 repository=https://github.com/bloogeyz/nmz-optimal-points.git
-commit=896e5e29816b0d4b3ed44a8bd36830a44d06e47c
+commit=dbf75be699e78bd8cff058e9959fbbb7346b5e65


### PR DESCRIPTION
Adds flag that allows user to rank NMZ bosses by lowest defense instead of most points.