### PR TITLE
Create volcanic-mine-pre-reset-notifier

### DIFF
--- a/plugins/volcanic-mine-pre-reset-notifier
+++ b/plugins/volcanic-mine-pre-reset-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/Magnusrn/volcanic-mine-pre-reset-notifier.git
+commit=53fdacaf6c742034413bc30d1114fbeb9b6a0ba4


### PR DESCRIPTION
Plugin to notify prior to 6 minutes if vents need to be fixed pre-reset of VM.