### PR TITLE
update bank-tag-layouts to v1.2.1

### DIFF
--- a/plugins/bank-tag-layouts
+++ b/plugins/bank-tag-layouts
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/bank-tag-custom-layouts.git
-commit=47918d16aeebb2c5c7f12f2c0d205e6b16c95470
+commit=bea190047561fa83b1e903b4361a7df7d53b4425


### PR DESCRIPTION
Updates layout-ed bank tag tabs to no longer show more scroll height than necessary.