### PR TITLE
Create weapon-charges

### DIFF
--- a/plugins/weapon-charges
+++ b/plugins/weapon-charges
@@ -1,0 +1,2 @@
+repository=https://github.com/ZemyCode/weapon-charges.git
+commit=1d7b253d175a07da06a8b6e44b3f96feaa2cdfec

--- a/plugins/weapon-charges
+++ b/plugins/weapon-charges
@@ -1,2 +1,2 @@
 repository=https://github.com/ZemyCode/weapon-charges.git
-commit=1d7b253d175a07da06a8b6e44b3f96feaa2cdfec
+commit=919d91a1dbab8552f63cb98ff0aa7537f73b56df

--- a/weapon-charges
+++ b/weapon-charges
@@ -1,0 +1,2 @@
+repository=https://github.com/ZemyCode/weapon-charges.git
+commit=1d7b253d175a07da06a8b6e44b3f96feaa2cdfec

--- a/weapon-charges
+++ b/weapon-charges
@@ -1,2 +1,0 @@
-repository=https://github.com/ZemyCode/weapon-charges.git
-commit=1d7b253d175a07da06a8b6e44b3f96feaa2cdfec


### PR DESCRIPTION
This is a plugin which tracks a player's weapon charges. This applies to most weapons which consume charges such as a Trident or Scythe of Vitur. This was made by modifying files from the official plugin "item charges". Currently is functional and should be working, sorry if I am incorrectly doing this pull request, this is my first time submitting an external plugin. Thanks.