### PR TITLE
update inferno-splits-logger

### DIFF
--- a/plugins/inferno-splits-logger
+++ b/plugins/inferno-splits-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/Magnusrn/inferno-splits-logger.git
-commit=bc57841819c463679474db3a49f449745f2281b1
+commit=57c84041506f4a70d5ab43cf1920b6b9185be095


### PR DESCRIPTION
Should solve the problem with runescape timers being different, splits by tags instead now and replace . with , for filenaming