### PR TITLE
update gnome-restaurant to v1.2

### DIFF
--- a/plugins/gnome-restaurant
+++ b/plugins/gnome-restaurant
@@ -1,2 +1,2 @@
 repository=https://github.com/MMagicala/gnome-restaurant.git
-commit=3c927d060e1157851c0d5cb55201555ed1ed538a
+commit=5d0f9fb20f43cc1587830d03d49e0ea5b909fb90


### PR DESCRIPTION
_(Uploading the remaining changes)_

**New features**
* Show hint arrow in minimap when NPC is out of range
* Allow user to re-enable overlay and hint arrow in config panel
* (_Internal_) Add `cancel` command for testing

**Bug fixes**
* (_Internal_) Prevent inventory errors when testing

**Miscellaneous**

* Performance improvements
* Add icon

`RewardsOverlay.java` was from another feature I was developing, but I accidentally included it in a commit. It has no use in the code.