### PR TITLE
Update Collection log plugin to v1.4

### DIFF
--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,3 +1,2 @@
 repository=https://github.com/evansloan/collection-log.git
-commit=86973999e57f4c009273b3f0236cddec81f02737
-disabled=broken from update
+commit=7a3ae2561342acfacf2f5abbbab36320c2a2dfbc


### PR DESCRIPTION
* Simplify existing obtained items config
* Add config options to show unique, total, or both item counts in collection log title
* Remove chat notifications for new collection log items
* Remove config that stored completed categories