### PR TITLE
add fish-barrel

### DIFF
--- a/plugins/fish-barrel
+++ b/plugins/fish-barrel
@@ -1,0 +1,2 @@
+repository=https://github.com/molo-pl/runelite-plugins.git
+commit=b6216374b44a80643da67e0cbcd906d805bd6379


### PR DESCRIPTION
Fixes https://github.com/runelite/runelite/issues/13422

MVP of a plugin to track contents of the [Fish barrel](https://oldschool.runescape.wiki/w/Fish_barrel).
- can track fish added to the barrel when the player is fishing
- supports all types of [Fish](https://oldschool.runescape.wiki/w/Fish)
- supports [Rada's blessing](https://oldschool.runescape.wiki/w/Rada%27s_blessing) and [Spirit flakes](https://oldschool.runescape.wiki/w/Spirit_flakes) double catch
- supports [Infernal harpoon](https://oldschool.runescape.wiki/w/Infernal_harpoon) consumption
- limitations mentioned in [README.md](https://github.com/molo-pl/runelite-plugins/blob/fish-barrel/README.md)