### PR TITLE
Create Spring-Garden

### DIFF
--- a/plugins/Spring-Garden
+++ b/plugins/Spring-Garden
@@ -1,0 +1,2 @@
+repository=https://github.com/Jonesa5/Spring-Garden-Plugin.git
+commit=f3285139f925d559c7d3419d1bdcebfcf1b10219


### PR DESCRIPTION
This plugin highlights the tiles that are used to walk through the Sorceress's Garden/Spring either green when it is safe to walk to them or red when it is not safe. It uses the Spring Elemental NPCs' positions to determine if it is safe to move to the next tile. The README.md file has more details on what it does.
[README.md](https://github.com/runelite/plugin-hub/files/6322867/README.md)
