### PR TITLE
Add life-saving-jewellery plugin

### DIFF
--- a/plugins/life-saving-jewellery
+++ b/plugins/life-saving-jewellery
@@ -1,0 +1,2 @@
+repository=https://github.com/molo-pl/runelite-plugins.git
+c85f68b381ce4eb64ad45e87a3db66177fd4f11f


### PR DESCRIPTION
This plugin adds infoboxes and destroy notifications for [Phoenix necklace](https://oldschool.runescape.wiki/w/Phoenix_necklace) and [Ring of life](https://oldschool.runescape.wiki/w/Ring_of_life).