### PR TITLE
Update Cox Light Colors plugin to 1.3

### DIFF
--- a/plugins/cox-light-colors
+++ b/plugins/cox-light-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/cox-light-colors.git
-commit=06c3604e67c809a06afec73c4904158f6f3b323d
+commit=abb0d56c34b94e5d1e5f4a7509a559e74112e299


### PR DESCRIPTION
Mark item group functionality as 'experimental' in the config and make several changes to the logic to attempt to resolve issues some users are experiencing with it.