### PR TITLE
Update ba-minigame

### DIFF
--- a/plugins/ba-minigame
+++ b/plugins/ba-minigame
@@ -1,2 +1,2 @@
 repository=https://github.com/BegOsrs/Ba-minigame.git
-commit=1990887c4cf6dff26ece7d3432b1110163e5d63f
+commit=1a1edcac73a5b1a355477dbee0ce6a1f0049f47d

--- a/plugins/ba-minigame
+++ b/plugins/ba-minigame
@@ -1,2 +1,2 @@
 repository=https://github.com/BegOsrs/Ba-minigame.git
-commit=4a3c01323da4a86f4c21b64d65ffade5a44a35eb
+commit=1990887c4cf6dff26ece7d3432b1110163e5d63f


### PR DESCRIPTION
Fix role sprites. Role sprite should be to who they call rather than its own role.
Fix role names. Like the sprite icons, the role names should also be to who they call.
