### PR TITLE
FlippingUtilities

### DIFF
--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/Belieal/flipping-utilities.git
-commit=a66c00144f9276a72070b3ec9e723742f68e159b
+commit=a56d15644c06ce216d666492474f1917f5d07419


### PR DESCRIPTION
Small change that prevents a wiki request from being made if the Flipping Utilities panel is not visible. This is to stop requests being made by clients that don't even have flipping utilities open.