### PR TITLE
Update Monster Menu HP Plugin to 1.1.1

### DIFF
--- a/plugins/menuhp
+++ b/plugins/menuhp
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/npc-menu-hp.git
-commit=5bf2db8f3ef0aa24c586061c7af167d78677dc79
+commit=5217b8f9f14ddadad739527c33e609a2c1b8b3fd


### PR DESCRIPTION
Fix an issue with the feature that allows you to specify which NPCs to show HP for.