### PR TITLE
add last-seen-online plugin

### DIFF
--- a/plugins/last-seen-online
+++ b/plugins/last-seen-online
@@ -1,2 +1,2 @@
 repository=https://github.com/molo-pl/runelite-plugins.git
-commit=dddb32c705d7edce8600abb6b569cf9fb64f1a12
+commit=f58e4c8303b3bd041c81dec14d0a8a08a9f739dd

--- a/plugins/last-seen-online
+++ b/plugins/last-seen-online
@@ -1,0 +1,2 @@
+repository=https://github.com/molo-pl/runelite-plugins.git
+commit=dddb32c705d7edce8600abb6b569cf9fb64f1a12


### PR DESCRIPTION
Allows to check when was the last time you've seen your friends online.

![Screenshot](https://github.com/molo-pl/runelite-plugins/raw/last-seen-online/screenshot.png)

This plugin only tracks friends' activity while a player is logged in. Anything that happens when offline won't be recorded.