### PR TITLE
Update corp-ffa07

### DIFF
--- a/plugins/corp-ffa07
+++ b/plugins/corp-ffa07
@@ -1,2 +1,2 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-corp-ffa.git
-commit=92b8de165ee567590f25506858f6e71c7faabca5
+commit=d711e113f9ff939c1f963c0292d5da791ea9df98


### PR DESCRIPTION
# Plugin updates 
- Keep spec count in player list when a player leaves
- Add option to hide "Corp FFA" banner in player list
- Remove unused ranger options now that range is banned in FFA


## Code updates
- Bump up Runelite version
- Code tidy up (big thanks to @Adam- !)
