### PR TITLE
mse: update swap method

### DIFF
--- a/plugins/menu-swapper-extended
+++ b/plugins/menu-swapper-extended
@@ -1,2 +1,2 @@
 repository=https://github.com/raiyni/menu-swapper-extended.git
-commit=4a2c8d1edd7f490e0c92c5767ee36eda74b5804c
+commit=1a4c21e1edb49e9805c72c59598d694db5db2ea2


### PR DESCRIPTION
Use current RuneLite swapping method without the shift click config. 