### PR TITLE
Update clan-event-attendance

### DIFF
--- a/plugins/clan-event-attendance
+++ b/plugins/clan-event-attendance
@@ -1,2 +1,2 @@
 repository=https://github.com/JoRouss/runelite-ClanEventAttendance.git
-commit=1171f5b452c4c9e017b5f88da82da0dba7dad9cd
+commit=f3d2c54abfff5341bc358c0434daf7bb1ed83c8b


### PR DESCRIPTION
Fix an issue where changing config after the event is stopped would refresh the event duration to the current game tick instead of the actual event ending tick.