### PR TITLE
add friend-list-viewer plugin

### DIFF
--- a/plugins/friend-list-viewer
+++ b/plugins/friend-list-viewer
@@ -1,0 +1,2 @@
+repository=https://github.com/molo-pl/runelite-plugins.git
+commit=fca1cff39c0f719c1afd03e67b1b5c369a246ccd


### PR DESCRIPTION
Adds an overlay showing a list of currently logged in friends and the worlds they are playing on.

![Screenshot](https://github.com/molo-pl/runelite-plugins/raw/friend-list-viewer/screenshot.png)