### PR TITLE
Update discord-level-notifications to 1.2.0

### DIFF
--- a/plugins/discord-level-notifications
+++ b/plugins/discord-level-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/ATremonte/Discord-Level-Notifications.git
-commit=fc24af1ae8b1399833aa995bb3f0544b80b03842
+commit=406964bd8910e3d12e8bf738ddea474ff168daf1


### PR DESCRIPTION
Updates discord-level-notifications to 1.2.0.

The update takes a different approach to detecting level-up. Before we were waiting for the level up widget to appear but have since found we cannot rely on that since the player taking an action on the same tick will cause it to not appear. 

This approach closely watches the levels for any changes and immediately sends a message when one changes.