### PR TITLE
add master-scroll-book

### DIFF
--- a/plugins/master-scroll-book
+++ b/plugins/master-scroll-book
@@ -1,0 +1,2 @@
+repository=https://github.com/Hydrox6/external-plugins.git
+commit=c92839345f0fa62e8045517754497ac0c32eb3f4


### PR DESCRIPTION
Simple plugin that display the contents of the player's Master Scroll Book as a tooltip, along with the selected default teleport as an item overlay if one is selected.