### PR TITLE
Update Discord Level Notifications to 1.2.1

### DIFF
--- a/plugins/discord-level-notifications
+++ b/plugins/discord-level-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/ATremonte/Discord-Level-Notifications.git
-commit=406964bd8910e3d12e8bf738ddea474ff168daf1
+commit=6bb7623324477e8a1fb75eaee68bff025e43f55a


### PR DESCRIPTION
Update Discord Level Notifications to 1.2.1. Changed it to wait two ticks before sending the discord message.