### PR TITLE
Update Tempoross plugin to v1.1

### DIFF
--- a/plugins/tempoross
+++ b/plugins/tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/runelite-external-plugins.git
-commit=6e4b587017eb3f379bdd8e219e2c0b65ddaf5769
+commit=d25d396318e7646171deceabaaae66b9e4059ba3


### PR DESCRIPTION
Jagex changed the objectID of the fire within tempoross, and subsequently had to be changed in the plugin as well.

This PR also includes several code cleanups from Hydrox.