### PR TITLE
Create roof-toggle

### DIFF
--- a/plugins/roof-toggle
+++ b/plugins/roof-toggle
@@ -1,2 +1,2 @@
-repository=https://github.com/ChrisScott9456/runelite-rooftoggle
+repository=https://github.com/ChrisScott9456/runelite-rooftoggle.git
 commit=82fc990da7ea5bd9caf986abdc1b0c4f9d490135

--- a/plugins/roof-toggle
+++ b/plugins/roof-toggle
@@ -1,2 +1,2 @@
 repository=https://github.com/ChrisScott9456/runelite-rooftoggle.git
-commit=82fc990da7ea5bd9caf986abdc1b0c4f9d490135
+commit=b8ebdcfbd86894289d9a1b71c4764b0bdce08fad

--- a/plugins/roof-toggle
+++ b/plugins/roof-toggle
@@ -1,0 +1,2 @@
+repository=https://github.com/ChrisScott9456/runelite-rooftoggle
+commit=82fc990da7ea5bd9caf986abdc1b0c4f9d490135


### PR DESCRIPTION
Allows use of a keybind for toggling roofs on and off without needing to open the in-game settings menu.

It simply has a default keybind "R" (configurable) that runs the setremoveroofs script that toggle roofs on and off.