### PR TITLE
add mining-Special-Effect-Tracker Plugin

### DIFF
--- a/plugins/mining-Special-Effect-Tracker
+++ b/plugins/mining-Special-Effect-Tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/adnapPanda/Mining-Special-Effect-Tracker.git
+commit=486cdcd8dfca87d1b393f69d111a47be99dd5e3b


### PR DESCRIPTION
This plugin shows and tracks the number of mining special effects that occur. Supports Varrock Amour, celestial ring, mining cape, and mining gloves.