### PR TITLE
Update fashionscape to 1.1.5

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=73a5cdb0d79eb0ce192ecbc13dca6034cffff24e
+commit=e17166acd9dd0914ae8c052af08407ff744863b5


### PR DESCRIPTION
New stuff:
* Fashionscape now persists across login sessions and client restarts: swaps are only temporarily disabled on logout/plugin shutdown as opposed to completely cleared, and current swaps are periodically serialized to configs (https://github.com/equirs/fashionscape-plugin/issues/13)
* Allows certain item-only slots to be manually set to "nothing", as opposed to defaulting to the player's actual item (https://github.com/equirs/fashionscape-plugin/issues/22)
* Updates to color json data to include the imcando hammer and barronite mace.

Bug fixes:
* When equipping some items without a virtual item overlaying it, but with kits that conflict with said item, the real item would clip with the virtual kits. These problematic items are now hidden when they cause conflicts.
* Saved setup feature did not account for loading outfits made by opposite genders (https://github.com/equirs/fashionscape-plugin/issues/21). The plugin now checks for kits that are inapplicable to the current player's gender and either converts them to analogous kits or removes those kits from the import, similar to how the copy-outfit menu entry works.
* Loading saved setups and copying other players now clears the current outfit before attempting to import (https://github.com/equirs/fashionscape-plugin/issues/12)