### PR TITLE
DPS Calculator 1.1

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=60a77623630ea53b7c8d964bd0f6ce5ca44bcdc0
+commit=c251ede7de7fa7e7ae1dd250a6fcfefe9e169387


### PR DESCRIPTION
DPS Calculator to version 1.1. Includes the following:

* Adds preset skill boosts, like potions (LlemonDuck/dps-calculator#3)
* Adds multiple input sets, to compare setups (LlemonDuck/dps-calculator#4)
* Fixes bug setting autocast max hit to 0 (LlemonDuck/dps-calculator#5)
* Fixes the plugin description (LlemonDuck/dps-calculator#7)
* Adds navigation button tooltip
* Fixes an NPE that could occur by not selecting a prayer
* Fixes a bug preventing DPS calculation with powered staves