### PR TITLE
Add Visual Sounds plugin

### DIFF
--- a/plugins/visual-sounds
+++ b/plugins/visual-sounds
@@ -1,3 +1,3 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds.git
-commit=88fac557dd1e3937db9fbfe96f750ae242b908c0
+commit=b4b0108172731c5af9121bb10898276b091f0580
 

--- a/plugins/visual-sounds
+++ b/plugins/visual-sounds
@@ -1,0 +1,3 @@
+repository=https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds.git
+commit=eea66b7bd20d660dc72c49fe5b28b16855eca024
+

--- a/plugins/visual-sounds
+++ b/plugins/visual-sounds
@@ -1,3 +1,3 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds.git
-commit=6be28245e8d14f4b6142be4e62e9c786058e1646
+commit=88fac557dd1e3937db9fbfe96f750ae242b908c0
 

--- a/plugins/visual-sounds
+++ b/plugins/visual-sounds
@@ -1,3 +1,3 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds.git
-commit=eea66b7bd20d660dc72c49fe5b28b16855eca024
+commit=6be28245e8d14f4b6142be4e62e9c786058e1646
 


### PR DESCRIPTION
# Visual Sounds

A plugin that allows you to see any sounds that are playing via an overlay.

## Features

-   Show a configurable number of sound effect IDs on screen
-   Configurable list of ignored sound effects
-   Configurable list of highlighted sound effects

## In-game screenshot
![in-game](https://user-images.githubusercontent.com/9083502/117677629-88a2f300-b1a6-11eb-967f-5a0e5cc4c469.jpg)

## Use case

This is aimed at players who want to be able to "hear" game sounds but are unable to. This could be due to deafness or from something situational, such as not wanting game sounds on at a specific time.

**Please note: Players need to have game sounds on at least partially in order for sound IDs to display. Sounds can be set to as low as 1% in-game but the client can still be muted on an OS level, such as in the Windows volume mixer.**
