### PR TITLE
disable colourblind-chat

### DIFF
--- a/plugins/colourblind-chat
+++ b/plugins/colourblind-chat
@@ -1,2 +1,3 @@
 repository=https://github.com/Hydrox6/external-plugins.git
 commit=ac2a841c316744de35710fcf5dab80fe03d841b5
+disabled=true


### PR DESCRIPTION
The plugin was a half-serious attempt to help users see messages that they couldn't otherwise recolour. That now can be done with the `Force Recolor` plugin, and this one keeps causing random issues.