### PR TITLE
Add group bronzeman plugin

### DIFF
--- a/package/verification-template/build.gradle
+++ b/package/verification-template/build.gradle
@@ -59,9 +59,20 @@ dependencies {
 		because "chat-logger"
 	}
 	thirdParty("com.google.apis:google-api-services-sheets:v4-rev581-1.25.0") {
-		because "elysiumevents-plugin"
+		because "elysiumevents-plugin, group-bronzeman-mode"
 		exclude group: 'com.google.guava'
-		exclude group: 'com.google.oauth-client'
+        	exclude group: 'com.google.ouath-client'
+		exclude group: 'org.apache.httpcomponents'
+		exclude group: 'org.apache.commons'
+		exclude group: 'org.apache'
+		exclude group: 'commons-logging'
+		exclude group: 'commons-codec'
+	}
+	thirdParty("com.google.oauth-client:google-oauth-client-jetty:1.23.0") {
+		because "group-bronzeman-mode"
+        	exclude group: 'org.slf4j'
+		exclude group: 'com.google.guava'
+        	exclude group: 'com.google.ouath-client'
 		exclude group: 'org.apache.httpcomponents'
 		exclude group: 'org.apache.commons'
 		exclude group: 'org.apache'

--- a/package/verification-template/build.gradle
+++ b/package/verification-template/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 	thirdParty("com.google.apis:google-api-services-sheets:v4-rev581-1.25.0") {
 		because "elysiumevents-plugin, group-bronzeman-mode"
 		exclude group: 'com.google.guava'
-        	exclude group: 'com.google.ouath-client'
+		// exclude group: 'com.google.oauth-client' // Dependency for group-bronzeman-mode
 		exclude group: 'org.apache.httpcomponents'
 		exclude group: 'org.apache.commons'
 		exclude group: 'org.apache'
@@ -70,9 +70,8 @@ dependencies {
 	}
 	thirdParty("com.google.oauth-client:google-oauth-client-jetty:1.23.0") {
 		because "group-bronzeman-mode"
-        	exclude group: 'org.slf4j'
+		exclude group: 'org.slf4j'
 		exclude group: 'com.google.guava'
-        	exclude group: 'com.google.ouath-client'
 		exclude group: 'org.apache.httpcomponents'
 		exclude group: 'org.apache.commons'
 		exclude group: 'org.apache'

--- a/plugins/group-bronzeman-mode
+++ b/plugins/group-bronzeman-mode
@@ -1,0 +1,2 @@
+repository=https://github.com/NicholasDenaro/another-bronzeman-mode-group.git
+commit=a101e3e5a540ea4a43de9341fc0edb33920ae368

--- a/plugins/group-bronzeman-mode
+++ b/plugins/group-bronzeman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/NicholasDenaro/another-bronzeman-mode-group.git
-commit=a101e3e5a540ea4a43de9341fc0edb33920ae368
+commit=735b924e27abaefe846ce53a258f787cb51db429

--- a/plugins/group-bronzeman-mode
+++ b/plugins/group-bronzeman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/NicholasDenaro/another-bronzeman-mode-group.git
-commit=735b924e27abaefe846ce53a258f787cb51db429
+commit=9a0a945592fb9c96a90b7d604553f390663b5eed

--- a/plugins/group-bronzeman-mode
+++ b/plugins/group-bronzeman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/NicholasDenaro/another-bronzeman-mode-group.git
-commit=9a0a945592fb9c96a90b7d604553f390663b5eed
+commit=60fa77e2e4b7840c9175dd051079040c0e322ac3


### PR DESCRIPTION
This plugin iterates on the bronzeman gamemode by adding a way to sync items across a group of accounts. It also adds some quality of life features like marking ground items which are valid for the bronzeman to pick up (which includes PVP drops, naturally spawning items, and projectiles). The group sync is done via Google Sheets and requires at least single user in each group to supply client credentials to members in their group (each user can provide their own).