### PR TITLE
chat-logger: Update to version 1.3.1

### DIFF
--- a/plugins/chat-logger
+++ b/plugins/chat-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/hex-agon/chat-logger.git
-commit=be6e77b345c374e313c6a6a3fc1528362fa3a3fc
+commit=8cb91c8ee6cfe7dac266372c19cd717da0428c69
 warning=This plugin may submit all your friends chat (current clan chat) messages and IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
This pull request updates the chat-logger plugin to version 1.3.1.

Changelog:
- Send the cross world message ids to the remote endpoint;
- Fix sent private messages not being logged.