### PR TITLE
Added Inferno Stats Plugin

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,0 +1,2 @@
+repository=https://github.com/InfernoStats/InfernoStats.git
+commit=6406eb124a35d7423f729ea61513265f02a13b52


### PR DESCRIPTION
This plugin collects a lot of interesting information around inferno runs. Most useful are the wave-by-wave breakdown in the panel and the special attack counter that would help players know if bringing a SGS/Eldritch staff is worth it or not.

Panel that displays a wave-by-wave breakdown:

![unknown](https://user-images.githubusercontent.com/77599829/118548688-302ca200-b720-11eb-9706-444c444bf78e.png)

Within the plugin panel are clickable JPanels that take you to a [line of sight tool](https://infernostats.github.io/inferno.html?melee=[[16,17]]&bat=[[22,5],[23,12]]) with the monsters pre-placed on the map which is very helpful for sharing spawns with others when seeking advice if you have a bad wave.