### PR TITLE
fix: ring of recoil notifier build fix

### DIFF
--- a/plugins/ring-of-recoil-notifier
+++ b/plugins/ring-of-recoil-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/delps1001/recoil-plugin.git
-commit=261c8a3dc58e6381194406d8ce9ebfbf399cb0e0
+commit=5b61813ee225cb9e25ef3f0120ff642b737870ba


### PR DESCRIPTION
Updates the plugin to the latest commit hash that hopefully fixes the broken build. thanks @LlemonDuck