### PR TITLE
update master-scroll-book to v1.1

### DIFF
--- a/plugins/master-scroll-book
+++ b/plugins/master-scroll-book
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=c92839345f0fa62e8045517754497ac0c32eb3f4
+commit=f268b5ed60e6b6b5b6231db97db6444a87726672


### PR DESCRIPTION
After some confusion in the support channel about a vanilla feature that did not exist, I decided to make it myself.

The plugin can now display a message when teleporting using the scroll book, similar to the ones for Jewellery.