### PR TITLE
create herblorerecipes

### DIFF
--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,2 +1,2 @@
 repository=https://github.com/skiclimbcode/herblore-recipes.git
-commit=df4a0b84c47a3b3354bf62b4a3199861e007e00d
+commit=611cc8e6023d8339b80d2c35d78b150ab6793b17

--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,0 +1,2 @@
+repository=https://github.com/skiclimbcode/herblore-recipes.git
+commit=df4a0b84c47a3b3354bf62b4a3199861e007e00d


### PR DESCRIPTION
This is a small plugin that will show a tooltip overlay on herblore ingredients, showing which potions that item is a primary or secondary ingredient for, with configuration options to toggle 1st/2nd ingredients as well as herblore level requirements.
This version does not support barbarian mixes.
For performance reasons, a tooltip cache gets created as users hover over herblore ingredients and gets cleared with certain configuration changes.

Please let me know if any changes need to be made!