### PR TITLE
Patch the IRC plugin to solve the clan update

### DIFF
--- a/plugins/irc
+++ b/plugins/irc
@@ -1,2 +1,2 @@
 repository=https://github.com/ryanwohara/irc-plugin.git
-commit=b80b9c226917ccdfacc7d38fee11b9a9352f8da6
+commit=9be1824f12ea182c14ff1f106e61177dc1bda08d


### PR DESCRIPTION
This update includes a crucial fix to accommodate the new clan system, and some cleanup and TODOs for me to address later. 

Here is a relevant discussion on the Twitch plugin that suffers the same problem:
https://discord.com/channels/301497432909414422/442492468307427330/845319212267995136