### PR TITLE
Update fashionscape to 1.1.7

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=3c479b4b6a9814048a0efa1fce3b3d706d04c97c
+commit=01cd971edaaf218d874a0fba886ec9012351b4cd


### PR DESCRIPTION
Minor enhancements and fixes:
Save last known "real" kits (per RS user) and preferred sort mode to config. Add warning when using any fallback kits. (https://github.com/equirs/fashionscape-plugin/issues/25)
Allow some duplicated models with different enough names to show up in results (https://github.com/equirs/fashionscape-plugin/issues/8)
Remove 2h weapon if shield is set to "nothing" (https://github.com/equirs/fashionscape-plugin/issues/27)