### PR TITLE
Update herblorerecipes to 1.1

### DIFF
--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,2 +1,2 @@
 repository=https://github.com/skiclimbcode/herblore-recipes.git
-commit=f40e7364fae89b654dc6c9c66ecbe3acd763c6c9
+commit=deb1d8c79da098a3f8f2ea71bc920c2cc75e0697

--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,2 +1,2 @@
 repository=https://github.com/skiclimbcode/herblore-recipes.git
-commit=0ba27a1688c782b9eda92ce211b1754263c94e7d
+commit=f40e7364fae89b654dc6c9c66ecbe3acd763c6c9


### PR DESCRIPTION
Update for the plugin that includes support for recipe tooltips when hovering over finished potions (screenshot example added to README), as well as relevant configuration option for this tooltip.