### PR TITLE
Add Plugin pre-eoc-xp-drops

### DIFF
--- a/plugins/pre-eoc-xp-drops
+++ b/plugins/pre-eoc-xp-drops
@@ -1,0 +1,2 @@
+repository=https://github.com/rsn-INVU/preeocxp.git
+commit=e3c75a3d1497364a59737c24fcfe6e5f21ed6475

--- a/plugins/pre-eoc-xp-drops
+++ b/plugins/pre-eoc-xp-drops
@@ -1,2 +1,2 @@
-repository=https://github.com/rsn-INVU/preeocxp.git
-commit=e3c75a3d1497364a59737c24fcfe6e5f21ed6475
+repository=https://github.com/rsn-INVU/pre-eoc-xp-drops.git
+commit=63201c9ec5e362242b1d6a31a943cf684f08967f

--- a/plugins/pre-eoc-xp-drops
+++ b/plugins/pre-eoc-xp-drops
@@ -1,2 +1,2 @@
 repository=https://github.com/rsn-INVU/pre-eoc-xp-drops.git
-commit=63201c9ec5e362242b1d6a31a943cf684f08967f
+commit=365901e1a73838079208fdacb9ce1068cd914e12


### PR DESCRIPTION
Creates custom xp drops in the style of 2010-2011 era Runescape.

Thorough description:

Draws an xp counter overlay, and experience drops, graphically resembling the era (with the aim of being identical)

Features:

"XP: Lots!" if the experience in the chosen skill to be displayed surpasses a certain threshold set by the user (default being approx maxInt/10, just like in 2010.)

Set the fontsize of the xp drops (the font itself scales poorly, unfortunately. Still looks reasonably sharp nonetheless)

The counter scales with the size of the xp displayed - but only to a certain extent (intentional)

Displayed text is oriented right and left - with the displayed xp and the drops using their respective 2010 fonts.

The xp drop animation mimics that of 2010 - may be off by a pixel or two due to rounding and inaccuracies when pulling from videos.

