### PR TITLE
Slash-Swapper Plugin added to the plugin hub

### DIFF
--- a/plugins/slash-swapper
+++ b/plugins/slash-swapper
@@ -1,0 +1,2 @@
+repository=https://github.com/nganzalo/Slash-Swapper.git
+commit=538185792bb9db694b5389bf4dfaced7f0f4c40d

--- a/plugins/slash-swapper
+++ b/plugins/slash-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/nganzalo/Slash-Swapper.git
-commit=538185792bb9db694b5389bf4dfaced7f0f4c40d
+commit=9e2a7a7e395e37bcbfe42496dd9d3fb35f22370e

--- a/plugins/slash-swapper
+++ b/plugins/slash-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/nganzalo/Slash-Swapper.git
-commit=9e2a7a7e395e37bcbfe42496dd9d3fb35f22370e
+commit=2f8ce7e52dbbe7283519a320299e03aa1a731393

--- a/plugins/slash-swapper
+++ b/plugins/slash-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/nganzalo/Slash-Swapper.git
-commit=2f8ce7e52dbbe7283519a320299e03aa1a731393
+commit=0870d527aa88e8c75ec110127d533b21f0e6b83a


### PR DESCRIPTION
A Plugin that allows users to send messages in their clan chat with '/' instead of '//' and send messages in their friends chat with '//' instead of '/'.


Closes runelite/runelite#13651.