### PR TITLE
Update Bot Detector to v1.3.4

### DIFF
--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,3 +1,3 @@
 repository=https://github.com/Bot-detector/bot-detector.git
-commit=ae0c0747ca1808367d3cafbb5abf23363ca7f37c
+commit=61c4ed1a035f66b7f2f27ffac9a19e186f74db67
 warning=This plugin submits the names, locations, and gear of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
- Added a configurable textbox field to the feedback panel, used to send detailed feedback (off by default, up to 250 characters).
- Added the right-click predict option to the new clan chat and guest clan chat side windows.
- Added a config to perform the 'predict' option alongside the in-game right-click 'report' option (off by default).
- Added a command `::bdToggleShowDiscordVerificationErrors`/`::bdToggleDVE` to toggle showing unsuccessful discord verification messages (show errors by default).
- Changed discord verification to accept codes of less than 4 digits, padding the value with zeroes if necessary.
- Changed discord verification error messages to be more descriptive.
- Changed the manual bot flagging to be allowed even when the API returns a prediction with a player ID of `-1` (e.g.: "Not in our database" or "Player not in highscores").
- Fixed a name cutoff substring off by one error when typing a name that's too long in the predict name bar.
- Most methods now have JavaDoc.
---
![image](https://user-images.githubusercontent.com/45152844/120671636-9410d380-c45f-11eb-9819-57a2b4402fb3.png)