### PR TITLE
Add runedoku helper

### DIFF
--- a/plugins/runedoku-helper
+++ b/plugins/runedoku-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/adituv/runedoku-plugin.git
-commit=2dd65fa93f743e420a10348d9fd470d2c4db4105
+commit=ab661434835e8e5c739d47a30c0946c9b1fafaf7

--- a/plugins/runedoku-helper
+++ b/plugins/runedoku-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/adituv/runedoku-plugin.git
-commit=0461811f6d4035c153b08017f633bf76e8558106
+commit=2dd65fa93f743e420a10348d9fd470d2c4db4105

--- a/plugins/runedoku-helper
+++ b/plugins/runedoku-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/adituv/runedoku-plugin.git
+commit=0461811f6d4035c153b08017f633bf76e8558106


### PR DESCRIPTION
Runedoku Helper

This is NOT a solver.  The Runedoku Helper provides standard sudoku-solving utilities to help make it easier to solve the runedoku manually, or to make it easier to type into an external solver.

The current features are:
* Draw numbers over the runes
* Highlight directly clashing runes in the grid
* Add pencil markings with right-click or shift-click

Sample of the interface with all features enabled:
![image](https://user-images.githubusercontent.com/1254246/120716195-986bd980-c4bd-11eb-9d53-53b4eeb8b38e.png)
