### PR TITLE
bank tag layouts 1.4 - duplicate items

### DIFF
--- a/plugins/bank-tag-layouts
+++ b/plugins/bank-tag-layouts
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/bank-tag-custom-layouts.git
-commit=6f9fa00ec5a50ec7bb4d31d4b5370b0069c336b4
+commit=608ba4bc3d14527ec314f9524668865b821b38bf


### PR DESCRIPTION
Adds the ability to duplicate items in bank tag layouts.

![image](https://user-images.githubusercontent.com/41499327/120877337-d8d56100-c56a-11eb-8086-33a917ac2b88.png)

This is accomplished by using an overlay to draw items in all but one of the places the item is supposed to be, and moving the actual item widget under the cursor when the mouse is moved near one of the fake overlay items.
