### PR TITLE
Update herblorerecipes to v1.2.2

### DIFF
--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,2 +1,2 @@
 repository=https://github.com/skiclimbcode/herblore-recipes.git
-commit=853ed53e3759c1b903d7cd29cf8ce4c7a8f8ee3b
+commit=0ff16ec2a83fd70f86fbaee9c1185dce5a89ed6b


### PR DESCRIPTION
Tooltips weren't appearing on Red spiders' eggs. This is now fixed.