### PR TITLE
Cosmetics Network v1.0

### DIFF
--- a/plugins/cosmetics
+++ b/plugins/cosmetics
@@ -1,3 +1,3 @@
 repository=https://github.com/JohnathonNow/runelite-cosmetic-network.git
-commit=5029bf9789d9f0ce44b39c4e7a1f0ebc50a51f45
+commit=9f58304e61b4f2c8e494648d48e0165bbc3b1c1c
 warning=This plugin submits the in-game names of you and players around you, as well as your equipped items to a server not controlled or verified by the RuneLite developers.

--- a/plugins/cosmetics
+++ b/plugins/cosmetics
@@ -1,0 +1,3 @@
+repository=https://github.com/JohnathonNow/runelite-cosmetic-network.git
+commit=5029bf9789d9f0ce44b39c4e7a1f0ebc50a51f45
+warning=This plugin submits the in-game names of you and players around you, as well as your equipped items to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This plugin allows users to set their current equipped items to act as a cosmetic override visible to all players using the plugin. Trusted users of the plugin may request an API key to act as verifiers for cosmetic overrides - when a user wishes to set their override they must find a trusted user in-game and send them the message `!cosmetics`. To make this process easier, a chat channel `RLCosmetics` was created for users to find a verifier.