### PR TITLE
Added clan notifications plugin

### DIFF
--- a/plugins/clan-notifications
+++ b/plugins/clan-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/itzwolly/clannotifications.git
+commit=c57273be0e7a0e97137fca7ac6a4d38a2982c696


### PR DESCRIPTION
* The plugin utilizes the new clan chat and sends a message to the clan chat channel when a user levels up a skill.
* Future updates include: boss drops and various other relevant notifications.