### PR TITLE
Create healer-tracker plugin

### DIFF
--- a/plugins/healer-tracker
+++ b/plugins/healer-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/mmdts/runelite-track-healers.git
+commit=160b4fc2c8e01c1803968a19c3f9030e3105f36a

--- a/plugins/healer-tracker
+++ b/plugins/healer-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/mmdts/runelite-track-healers.git
-commit=160b4fc2c8e01c1803968a19c3f9030e3105f36a
+commit=7ad7d9cfcdf2739fd46589de30144fd23d62712b


### PR DESCRIPTION
This plugin simply tracks healer information, and logs it to a file in your `.runelite` home folder.

This plugin is **not** rule breaking, as per Mod Ash's tweet: https://twitter.com/JagexAsh/status/1402529156533981191

Edit: Keep in mind that this is my first plugin, it works in a Runelite build, the only things I changed before I threw it in a template were the package names (`net.runelite.client.plugins.trackhealers` to `mmdts.trackhealers`). I hope it has no problems.