### PR TITLE
Update osrs-wiki-crowdsourcing

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=1a143e2aa3b5b8fb109f1fa9c4db0e11d990f2f1
+commit=3e932203f8d0949c73186fdb230f7133730ad96e


### PR DESCRIPTION
Keep a small fraction of blacklisted objects for sampling purposes