### PR TITLE
update osrs-wiki-crowdsourcing

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=3e932203f8d0949c73186fdb230f7133730ad96e
+commit=7adcf715ddcad525178b48728fc8a2cd6100762f


### PR DESCRIPTION
MLM crowdsouricing is proving a bit harder than anticipated. Three modifications:
- include base level
- fix NPE that was sometimes preventing paydirt data
- serialize the data in the queue at submission time