### PR TITLE
Update Track Healers to 1.1

### DIFF
--- a/plugins/healer-tracker
+++ b/plugins/healer-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/mmdts/runelite-track-healers.git
+commit=160b4fc2c8e01c1803968a19c3f9030e3105f36a

--- a/plugins/healer-tracker
+++ b/plugins/healer-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/mmdts/runelite-track-healers.git
-commit=7ad7d9cfcdf2739fd46589de30144fd23d62712b
+commit=3ad356d99bdb14d623cdc83f46b308619420192e

--- a/plugins/healer-tracker
+++ b/plugins/healer-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/mmdts/runelite-track-healers.git
-commit=160b4fc2c8e01c1803968a19c3f9030e3105f36a
+commit=7ad7d9cfcdf2739fd46589de30144fd23d62712b


### PR DESCRIPTION
Upon popular request:

1) Allows defender to use the plugin.
2) Unifies name within the plugin hub search and after install (to "Track Healers").

Not sure why the pull request shows as "Creates file with 2 additions" instead of "Modifies file with 1 addition and 1 deletion" :o