### PR TITLE
Add kitten-tracker

### DIFF
--- a/plugins/kitten-tracker
+++ b/plugins/kitten-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/pieterjanbuntinx/kitten-tracker.git
-commit=f25a27edd7c769113ddaf20588a56ef4b2d48ad2
+commit=f785d6c2db84ae780931032573073b0f3026aa21

--- a/plugins/kitten-tracker
+++ b/plugins/kitten-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/pieterjanbuntinx/kitten-tracker.git
+commit=f25a27edd7c769113ddaf20588a56ef4b2d48ad2


### PR DESCRIPTION
I've added a plugin that allows you to track your kitten status. It will give notifications when anything changes with your kitten (time to feed, time to play with it, grown, overgrown, ran away...). It also shows timers for all of these items. This plugin is based on pull request [#2894](https://github.com/runelite/runelite/pull/2894) that was never finished/merged because the original creator is not on Github anymore. There are some improvements compared to his version. For example, the plugin uses overlays instead of infoboxes to show the timers because they can't show any durations longer than 60 minutes correctly. Also quite a lot of refactoring.
This plugin is especially useful for Iron Men that want to trade in their cats for death runes in Ardougne, that's what I use it for.