### PR TITLE
Update Zero remover

### DIFF
--- a/plugins/zero-remover
+++ b/plugins/zero-remover
@@ -1,2 +1,2 @@
 repository=https://github.com/GeChallengeM/zero-remover.git
-commit=d591f79029fd53f525f2dad8e502d8e4ec757171
+commit=d4daebb7fc1ea5bd276b9a2100c9dbc1140d908c

--- a/plugins/zero-remover
+++ b/plugins/zero-remover
@@ -1,2 +1,2 @@
 repository=https://github.com/GeChallengeM/zero-remover.git
-commit=3b8ac7a4a3fe1c74f3325674a53e9661de3200f8
+commit=d591f79029fd53f525f2dad8e502d8e4ec757171


### PR DESCRIPTION
The plugin now also works for interfaces.  
Improve some access modifier keywords.  
Compared to (closed) pull request #1525: disabling the plugin now works correctly.