### PR TITLE
Update discord-rare-drop-notificater

### DIFF
--- a/plugins/discord-rare-drop-notificater
+++ b/plugins/discord-rare-drop-notificater
@@ -1,3 +1,3 @@
 repository=https://github.com/BossHuso/discord-rare-drop-notificater.git
-commit=6df9bd76c0f3aed3fc4cdbf6c92e9518db8b8105
+commit=0a6bf8daa8db6dc33f9556eeb31e9d3754d0e7fb
 warning=This plugin submits the ID of monsters you kill, items you receive, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Add support for pickpocket loot, AND instead of OR for value+rarity, cox/tob common loot

The owner(s) of the plugin have been MIA for a few months and they never pushed some of the changes that were made since then. I'm making a pull request in their stead. I'm a contributor on the repo.