### PR TITLE
Update item-interactions

### DIFF
--- a/plugins/item-interactions
+++ b/plugins/item-interactions
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/item-interactions.git
-commit=e4d56382b9c0938e6fc9a9f1eef837e20ec10820
+commit=3f00fa27d0ff2305e4e544ae28bae9c39885a5c6


### PR DESCRIPTION
This fixes an issue where NPCs can get burned in to scenes if you hop worlds/log out