### PR TITLE
barbarian-assault-pbs 1.1.0 Version update

### DIFF
--- a/plugins/barbarian-assault-pbs
+++ b/plugins/barbarian-assault-pbs
@@ -1,2 +1,2 @@
 repository=https://github.com/SkylerPIlot/Barbarians-Assault-Personal-Bests.git
-commit=01a91a43b4477641ffbaf90598cc9c856e44c797
+commit=2211d57cf3a0dda0c37faca81ee9d8ea287d3c7b


### PR DESCRIPTION
This fixes some day 1 bugs, adds cases and updates the README

This will also wipe the PBs from the 1.0.0 version, but no more Pb wipes at all in the future.