### PR TITLE
add plank-sack

### DIFF
--- a/plugins/plank-sack
+++ b/plugins/plank-sack
@@ -1,0 +1,2 @@
+repository=https://github.com/Hydrox6/external-plugins.git
+commit=264dc01439897b207adcae40fe4029685a9c7162


### PR DESCRIPTION
Closes runelite/runelite#12425
(Not sure if that works ^)

Simply adds an overlay to the plank sack to show how many planks are in it. Given that you can only have a total of 28 planks of any type, and that most people will likely not store more than 1 type in it at a time, the plugin just displays an overall number