### PR TITLE
NPC ID

### DIFF
--- a/plugins/npc-id
+++ b/plugins/npc-id
@@ -1,2 +1,2 @@
 repository=https://github.com/XrioBtw/npc-id.git
-commit=0243065b9c0e07f12605730b418f5dbe8f561a92
+commit=9dc9413c19a95cceb88f744f024716c65f79c240

--- a/plugins/npc-id
+++ b/plugins/npc-id
@@ -1,0 +1,2 @@
+repository=https://github.com/XrioBtw/npc-id.git
+commit=0243065b9c0e07f12605730b418f5dbe8f561a92


### PR DESCRIPTION
Add a plugin to display identification information as text above NPCs.
* NPC ID
  - NPC specific [identifier](https://chisel.weirdgloop.org/moid/npc_id.html).
* NPC index
  - Unique identifier to distinguish between NPCs with the same ID.

Useful for editing the [OSRS wiki](https://oldschool.runescape.wiki/).

![image](https://user-images.githubusercontent.com/33559295/122277523-46c44580-cee6-11eb-9a62-ede812cde101.png)