### PR TITLE
Update BossingInfo to v1.6 add loot tracking and HM tob support

### DIFF
--- a/plugins/kph-tracker
+++ b/plugins/kph-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Mrnice98/BossingInfo.git
-commit=b72fb6b86ece7d62d58e84a34e2113ba6efd4d48
+commit=3d0d677fca4e27bfa965138074ef7426d7ce8402


### PR DESCRIPTION
Update BossingInfo to v1.6 add loot tracking and HM tob support in addition to various other small changes.