### PR TITLE
update discord-rare-drop-notificater

### DIFF
--- a/plugins/discord-rare-drop-notificater
+++ b/plugins/discord-rare-drop-notificater
@@ -1,3 +1,3 @@
 repository=https://github.com/BossHuso/discord-rare-drop-notificater.git
-commit=0a6bf8daa8db6dc33f9556eeb31e9d3754d0e7fb
+commit=5eca8793cad2d3c87af99215ba6cdc5dc4c68f81
 warning=This plugin submits the ID of monsters you kill, items you receive, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Updates the notificater to get rid of spam. Also adds a new option to send 'unique' loot only.
Besides that, some refactoring, optimisation, thread safety & applying RL's coding conventions toke place.

https://github.com/BossHuso/discord-rare-drop-notificater/commit/5eca8793cad2d3c87af99215ba6cdc5dc4c68f81