### PR TITLE
Update quest-helper to v2.2.0

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=33da2582c1dcfc60f9b2124b54e58aeb2ec7a77c
+commit=c09c61499e9bc16ff501fc3060b362b195cd7418


### PR DESCRIPTION
- Adds Falador, Kandarin and Fremmy Diaries
- Fixes issues with Karamja Diary not progressing
- Fixes to various Zeah quest helpers which broke with the new quest