### PR TITLE
update contextual-cursor to v1.2.3

### DIFF
--- a/plugins/contextual-cursor
+++ b/plugins/contextual-cursor
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=ab570bbd71b4c979072c36f645960bae600c13a8
+commit=88ee7127c1e428acfd0914c71bf017399159bd83


### PR DESCRIPTION
Update to support the new arceuus spellbook, and a load of random extra cursors I've been finding since last year