### PR TITLE
Update tob-hm-timer to v1.0.1

### DIFF
--- a/plugins/tob-hm-timer
+++ b/plugins/tob-hm-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/Loze-Put/tob-hm-timer.git
-commit=fe5c9ac19363b74db28456a6020192517ffbbb89
+commit=508483b878226811bb4114e3afdc63690d589538


### PR DESCRIPTION
An update to fix the plugin after today's [game update](https://secure.runescape.com/m=news/new-client-features-milestone-1?oldschool=1). The timer now starts upon entering the Maiden room, instead of entering the Theatre.