### PR TITLE
Update fashionscape to v1.1.8

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=01cd971edaaf218d874a0fba886ec9012351b4cd
+commit=f16e8ab4ce1ba472532b9388a065477aa1c7e324


### PR DESCRIPTION
I don't even realize I'm writing this much code. I appreciate the time taken to review these.

* BA and Soul Wars icons can now be selected in the "base" panel. They use the jaw-slot items like the ones used in these minigames today, but the plugin abstracts this so that facial hair and icon can be altered separately.
* Fashionscape is now easier to use in f2p, with a config option to exclude members-only items.
* New color data json and idle weapon animations for items released since the clans update.
* Bug fixes for edge cases like the magic carpet, minecart, and the in-game BA/SW icons.