### PR TITLE
Added wasted-bank-space plugin

### DIFF
--- a/plugins/wasted-bank-space
+++ b/plugins/wasted-bank-space
@@ -1,2 +1,2 @@
-repository=8df1931610d92a5bdb0df92f5b99db4a03b6f1a3
-commit=https://github.com/mcgeer/WastedBankSpace.git
+repository=https://github.com/mcgeer/WastedBankSpace.git
+commit=8df1931610d92a5bdb0df92f5b99db4a03b6f1a3

--- a/plugins/wasted-bank-space
+++ b/plugins/wasted-bank-space
@@ -1,0 +1,2 @@
+repository=8df1931610d92a5bdb0df92f5b99db4a03b6f1a3
+commit=https://github.com/mcgeer/WastedBankSpace.git

--- a/plugins/wasted-bank-space
+++ b/plugins/wasted-bank-space
@@ -1,2 +1,2 @@
 repository=https://github.com/mcgeer/WastedBankSpace.git
-commit=8df1931610d92a5bdb0df92f5b99db4a03b6f1a3
+commit=4207e723641ed2af9c0b178e6cd86634b657d783


### PR DESCRIPTION
Plugin to add an overlay/tooltip to items in your bank which can be stored elsewhere in Gilinor. A panel, accessed with the caution sign icon, shows a total count, the list of all items in your bank which can be stored elsewhere, and some tips.
Example:
![image](https://user-images.githubusercontent.com/11418505/123197976-5ad5ed00-d47a-11eb-846b-ec146a76d6e7.png)
