### PR TITLE
Update coal-bag to v1.1

### DIFF
--- a/plugins/coal-bag
+++ b/plugins/coal-bag
@@ -1,2 +1,2 @@
 repository=https://github.com/WolffTech/coal-bag-plugin.git
-commit=4d82930f94b1d7472cf79b30a58f9f4a193f786e
+commit=74d31f586ea9ce418b426186bf98b415351cf9e8


### PR DESCRIPTION
The counter now grabs the text in the widget that appears while emptying the coal bag and updates the counter accordingly.