### PR TITLE
Update TobMistakeTracker to v0.2

### DIFF
--- a/plugins/tob-mistake-tracker
+++ b/plugins/tob-mistake-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/QuestingPet/TobMistakeTracker.git
-commit=e1196be5b02ca95e6f135f061c8c604b4fe0c6bc
+commit=83b0d5c5a0ff4d2fe1bded11f35e6f5fb742169a


### PR DESCRIPTION
This is a pretty small change that adds the ability to read and write player mistake state to and from disk (as JSON). Currently, a write happens on every mistake change, since it's relatively infrequent and the file size is very small anyway.

I wanted to get this change out as soon as I could so that customers can immediately start having data saved to disk for them, instead of it all wiping when they close/reopen their client.