### PR TITLE
Update osrs-wiki-crowdsourcing to v1.2

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=8a6923cb0b3c8bd4ffd04587004218333c5a1acf
+commit=3f71bce8c68822a4dc55b8cfb239a95277a743ad


### PR DESCRIPTION
version 1.2 adds whitelisted item/npc tracking