### PR TITLE
Update tog-indicator to v1.1

### DIFF
--- a/plugins/tog-indicator
+++ b/plugins/tog-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tog-indicator.git
-commit=5b77773aacc2066cd59d4e3a86802799dcd5c5f5
+commit=07fa63c73ac41c773aa6bfac8be0d4dcd64bd35f


### PR DESCRIPTION
Auto-hides indicator when hovering over skills, to prevent rendering overtop of the XP tooltip:

![image](https://user-images.githubusercontent.com/1868974/123554316-64e33e80-d74d-11eb-8890-8962c2706f36.png)

Also reformats the plugin source to use RL styling, so apologies for the stylistic portions of the diff.
