### PR TITLE
Classes of Gielinor

### DIFF
--- a/plugins/classes-of-gielinor
+++ b/plugins/classes-of-gielinor
@@ -1,0 +1,2 @@
+repository=https://github.com/Kraelll/ClassesOfGielinor.git
+commit=e59db0a57ead34a5b20a95c44bf58351d76cd13e

--- a/plugins/classes-of-gielinor
+++ b/plugins/classes-of-gielinor
@@ -1,2 +1,2 @@
 repository=https://github.com/Kraelll/ClassesOfGielinor.git
-commit=e59db0a57ead34a5b20a95c44bf58351d76cd13e
+commit=2b945820e6bf86320457b622fb4370895314e66b

--- a/plugins/classes-of-gielinor
+++ b/plugins/classes-of-gielinor
@@ -1,2 +1,0 @@
-repository=https://github.com/Kraelll/ClassesOfGielinor.git
-commit=e59db0a57ead34a5b20a95c44bf58351d76cd13e


### PR DESCRIPTION
This plugin adds some RPG-esque classes in to Runescape in order to create some artificial account restrictions for a more challenging experience.

These include:

- Allowing a user to select their class, which applies some of the below limitations:
- Can toggle the use of spells depending on whether it is suited to the class (eg: Paladins cannot cast spells, but Wizards can)
- Can toggle the use of prayer depending on whether it is suited to the class (eg: Necromancers cannot use prayer, but Paladins can)
- Locks classes to certain items so that they cannot equip items unsuited to the class (eg: Wizards can wield staves, but not bows)

These call all be overrided/disabled by the use of tick boxes in the plugin config - as well as set the class to "None" to perform a soft-disable to the plugin without having to turn it off (though they may choose to do so anyways). 