### PR TITLE
Revert "Update tog-indicator to v1.1"

### DIFF
--- a/plugins/tog-indicator
+++ b/plugins/tog-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tog-indicator.git
-commit=07fa63c73ac41c773aa6bfac8be0d4dcd64bd35f
+commit=5b77773aacc2066cd59d4e3a86802799dcd5c5f5


### PR DESCRIPTION
Reverts runelite/plugin-hub#1599

After merging this I learned that my plugin conflicts with Skills Progress Bars, more info in runelite/runelite#13807. I'd like to revert my change to avoid impacting that plugin, especially since it's one of the more widely used ones.

I'll bring back an equivalent change once the above core PR is merged/alternative added.