### PR TITLE
update dps-calculator to v1.3.2

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=3d34ff50672f3e611b2029a4b8941302ea7f77c7
+commit=512046b7098f73f7b174a093c3eae478dfa0af54


### PR DESCRIPTION
Quick-fix to resolve a strength bonus miscalculation for crystal armour.

LlemonDuck/dps-calculator#13

Thanks @ThePharros!