### PR TITLE
Update resource-packs to 1.4.2

### DIFF
--- a/plugins/resource-packs
+++ b/plugins/resource-packs
@@ -1,2 +1,2 @@
 repository=https://github.com/melkypie/resource-packs.git
-commit=6e34de529cd621a183ba7e897ffe5016b0f7badf
+commit=b1ea1326e8ca414812ae1e057f1bfbecb2b30d5a

--- a/plugins/resource-packs
+++ b/plugins/resource-packs
@@ -1,2 +1,2 @@
 repository=https://github.com/melkypie/resource-packs.git
-commit=3705810a3a9ce0c92f8159ebbc972629299a5552
+commit=6e34de529cd621a183ba7e897ffe5016b0f7badf


### PR DESCRIPTION
- Add relic unlock trailblazer emote
- Correct the ids of the arceuus salve graveyard teleport sprites
- Potentially fix a bug where if the selected pack is being updated on the startup, the hub panel would stop loading, and some sprites may not load