### PR TITLE
update dps-calculator to v1.3.3

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=512046b7098f73f7b174a093c3eae478dfa0af54
+commit=ac3c693b150495298a2b985687cf2b3513311566


### PR DESCRIPTION
I have a second fix to crystal armour, in that I switched around the strength and accuracy. This is another quick-fix for that.

Sorry Hydrox 😓