### PR TITLE
Update raid-name-logger to v1.1

### DIFF
--- a/plugins/raid-player-names
+++ b/plugins/raid-player-names
@@ -1,2 +1,2 @@
 repository=https://github.com/stevenkaan/raid-name-logger.git
-commit=e5e88e54a34fcab4c2105d0adc20e89738a6a7b0
+commit=c5b18b7e92acf2cf11d145b68ee1b4370e4d81d4

--- a/plugins/raid-player-names
+++ b/plugins/raid-player-names
@@ -1,2 +1,2 @@
 repository=https://github.com/stevenkaan/raid-name-logger.git
-commit=c5b18b7e92acf2cf11d145b68ee1b4370e4d81d4
+commit=b218971d3ff8f858865e87d02f1302444639d62a

--- a/plugins/raid-player-names
+++ b/plugins/raid-player-names
@@ -1,2 +1,2 @@
 repository=https://github.com/stevenkaan/raid-name-logger.git
-commit=7fe4d33792d26e4220ed16818ff767481889976e
+commit=455ae8d32e74eabe2c147f8ca6267e6d267b1d01

--- a/plugins/raid-player-names
+++ b/plugins/raid-player-names
@@ -1,2 +1,2 @@
 repository=https://github.com/stevenkaan/raid-name-logger.git
-commit=455ae8d32e74eabe2c147f8ca6267e6d267b1d01
+commit=e5e88e54a34fcab4c2105d0adc20e89738a6a7b0


### PR DESCRIPTION
Made some small changes to the plugin
- Changed the root directory
- Made the plugin so it shows the raids in the top of the plugin instead of the middle