### PR TITLE
Add hunllef-helper v1.0.0

### DIFF
--- a/plugins/hunllef-helper
+++ b/plugins/hunllef-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Loze-Put/hunllef-helper.git
-commit=46f8ed25a4a529f53ab0153e2ebb59dca3f0eb21
+commit=4df5cee79da718dafe41c564b20ba43ebcb3bedb

--- a/plugins/hunllef-helper
+++ b/plugins/hunllef-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Loze-Put/hunllef-helper.git
+commit=46f8ed25a4a529f53ab0153e2ebb59dca3f0eb21


### PR DESCRIPTION
Adds the Hunllef Helper plugin. The plugin is similar in use to the [gauntlet counter](https://gauntletcounter.herokuapp.com/). It assists the user by informing them about the Hunllefs attacks. In order to comply with the Jagex third party plugin rules, the plugin does not use any game state information. The only interaction it has with the game is to automatically hide the plugin panel when a player is not in The Gauntlet area. This behavior equals the already existing zulrah-helper.