### PR TITLE
Update tob-mistake-tracker to v2.0

### DIFF
--- a/plugins/tob-mistake-tracker
+++ b/plugins/tob-mistake-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/QuestingPet/TobMistakeTracker.git
-commit=7559f8bd5a564b2f349b0ccbe6c999b450ab4a3a
+commit=a673ee572fcee857fdcda47317dfc87a9991a999

--- a/plugins/tob-mistake-tracker
+++ b/plugins/tob-mistake-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/QuestingPet/TobMistakeTracker.git
-commit=a673ee572fcee857fdcda47317dfc87a9991a999
+commit=ab7d8470f9aefa4f50fc5e664e108724222015d3


### PR DESCRIPTION
This update sees the tracking of both raid counts per player, and deaths per boss room. This includes lots of UI changes, too.

Unfortunately, due to the rigidness of the previous mistake state, as part of refactoring and implementing the new info, the old data is no longer compatible and this users will have to start over. From the feedback I've received, lots of people don't necessarily seem to care, especially because they usually only care about the "Current Raid" or just this session's info anyway.

Because of this, ideally I would like to get this out before the update this week so that users can get the latest update ASAP instead of being on an old version with stale data that will wipe (which will also prolong when the wiping of their data will be).

Thank you!

---

Changes

* Track raid counts for each player
* Track deaths per boss rom
* Add death grouping with new death icons per boss room to panel
* Fix chat overhead messages not always displaying long enough
* Reorder boxes in panel to have local player first followed by current raiders