### PR TITLE
Add spirit-tree-menu

### DIFF
--- a/plugins/spirit-tree-menu
+++ b/plugins/spirit-tree-menu
@@ -1,2 +1,2 @@
 repository=https://github.com/dekuScrub731/spirit-tree-menu.git
-commit=86729d5377440a820b91a918a6f07c06e109ff3d
+commit=bbf3af0e306e248a745431733927eb68834053f4

--- a/plugins/spirit-tree-menu
+++ b/plugins/spirit-tree-menu
@@ -1,0 +1,2 @@
+repository=https://github.com/dekuScrub731/spirit-tree-menu.git
+commit=86729d5377440a820b91a918a6f07c06e109ff3d


### PR DESCRIPTION
Plugin to split the Spirit Tree menu into two columns (and provides other configurable options for the menu)