### PR TITLE
Update quest-helper to 2.2.2.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=e2e187c8c92d31090945de2d55e9b021d08bd734
+commit=d89a078e850ade4db73872a6d090bcfd677963a4


### PR DESCRIPTION
Fixes some ScriptIDs with the most recent update. If somehow the 2.2.3 PR is merged first, please close this one rather than merging it over it.