### PR TITLE
Update tob-mistake-tracker to v2.1

### DIFF
--- a/plugins/tob-mistake-tracker
+++ b/plugins/tob-mistake-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/QuestingPet/TobMistakeTracker.git
-commit=ab7d8470f9aefa4f50fc5e664e108724222015d3
+commit=b9838b82fc1edc3a821898829bd99d9f2a8cefaf


### PR DESCRIPTION
Changes:
* Add config for toggling mistake overhead text
  * Disabling overhead text would make it so that mistakes no longer appear to be said by players when detected. All other mistake detection/tracking implementation would stay the same (including viewing mistakes in the panel).
* Fix bug where plugin thinks a player dies who didn't actually die
  * This change makes use of onAnimationChanged with AnimationID.DEATH instead of the previously used onActorDeath. This is because onActorDeath would sometimes get triggered even if the server determines that the player is not actually dead (like regen-ing hp on the same tick that you would go to 0).
