### PR TITLE
Update tob-mistake-tracker to v2.1

### DIFF
--- a/plugins/tob-mistake-tracker
+++ b/plugins/tob-mistake-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/QuestingPet/TobMistakeTracker.git
-commit=ab7d8470f9aefa4f50fc5e664e108724222015d3
+commit=b9838b82fc1edc3a821898829bd99d9f2a8cefaf

--- a/plugins/tob-mistake-tracker
+++ b/plugins/tob-mistake-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/QuestingPet/TobMistakeTracker.git
-commit=b9838b82fc1edc3a821898829bd99d9f2a8cefaf
+commit=e0d39d2d41d0602c9a330c1772d392e0ce8f1d13


### PR DESCRIPTION
Changes:
* Add config for toggling mistake overhead text
  * Disabling overhead text would make it so that mistakes no longer appear to be said by players when detected. All other mistake detection/tracking implementation would stay the same (including viewing mistakes in the panel).