### PR TITLE
Update hunllef-helper to v1.0.1

### DIFF
--- a/plugins/hunllef-helper
+++ b/plugins/hunllef-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Loze-Put/hunllef-helper.git
-commit=4df5cee79da718dafe41c564b20ba43ebcb3bedb
+commit=73e34aff9f87bf9848e1df7bf23e690db76d67e2


### PR DESCRIPTION
The audio of the plugin didn't work once deployed in the plugin hub. This PR (hopefully) fixes the audio.