### PR TITLE
Added ScapeCloud

### DIFF
--- a/plugins/scapecloud
+++ b/plugins/scapecloud
@@ -1,3 +1,3 @@
 repository=https://github.com/scape-cloud/scape-cloud-runelite.git
-commit=f16609b63bfd6f64d9e6fcb7071c8e68a92ac045
+commit=896c29d01ff326b67c0c7910e5bd1ecbb4d6be10
 warning=This plugin captures and uploads screenshots/images, submits metadata (e.g. combat level, location, total level) about your player, surrounding players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/scapecloud
+++ b/plugins/scapecloud
@@ -1,3 +1,3 @@
 repository=https://github.com/scape-cloud/scape-cloud-runelite.git
 commit=f16609b63bfd6f64d9e6fcb7071c8e68a92ac045
-warning=This plugin submits metadata (e.g. combat level, location, total level) about your player, surrounding players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
+warning=This plugin captures and uploads screenshots/images, submits metadata (e.g. combat level, location, total level) about your player, surrounding players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/scapecloud
+++ b/plugins/scapecloud
@@ -1,0 +1,3 @@
+repository=https://github.com/scape-cloud/scape-cloud-runelite.git
+commit=f16609b63bfd6f64d9e6fcb7071c8e68a92ac045
+warning=This plugin submits metadata (e.g. combat level, location, total level) about your player, surrounding players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
ScapeCloud is an image upload service for Old School RuneScape. Instead of users images being saved to their local machine, they are uploaded to the cloud ready to be shared. We utilize metadata from the client to provide extra functionality about the image such as: Combat Level, Nearby Players, Total Level, Player Name, Account Type (Ironman), and more.