### PR TITLE
Clanmate Export

### DIFF
--- a/plugins/clanmate-export
+++ b/plugins/clanmate-export
@@ -1,0 +1,2 @@
+repository=https://github.com/fatfingers23/runelite-osrs-clanmate-export.git
+commit=d8847e99b9f78740b75cd3b4057edf3802fd5bdd

--- a/plugins/clanmate-export
+++ b/plugins/clanmate-export
@@ -1,2 +1,2 @@
 repository=https://github.com/fatfingers23/runelite-osrs-clanmate-export.git
-commit=d8847e99b9f78740b75cd3b4057edf3802fd5bdd
+commit=56ecf9c4bb1c9a1ea295ace0339541d198141e24


### PR DESCRIPTION
I created this plugins to help clan leaders manage clan mates. It exports the clan mates usernames, joined date, and rank. It can export this to either CSV or JSON to the users clipboard. Or if you add a URL in settings it will send a POST request with the data. This data is collected in the new clans screen in side of members page

I am hoping this will be able to help the developer community use this tool to build various clan managment tools. For example my next step is I am planning on creating a Discord bot that will consume these exports and can auto rank clan members to discord ranks. 

Thank you! 