### PR TITLE
Update fashionscape to v1.1.10

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=12d3f62658af42f83ff0aed26097e7e7bbf22a82
+commit=a7c6232ac3ced96b85337c7f4397dbda0142ea9b


### PR DESCRIPTION
Bug fix for BA / Soul Wars minigame icons not being clear-able after playing.