### PR TITLE
Create green-thumb

### DIFF
--- a/plugins/green-thumb
+++ b/plugins/green-thumb
@@ -1,2 +1,2 @@
 repository=https://github.com/Asthereon/green-thumb.git
-commit=871f1d77fe93cc2ee4822227ee440a1939b8b72e
+commit=605b7c74814494bf411d68858fc9cf9e6a31d95d

--- a/plugins/green-thumb
+++ b/plugins/green-thumb
@@ -1,0 +1,2 @@
+repository=https://github.com/Asthereon/green-thumb.git
+commit=871f1d77fe93cc2ee4822227ee440a1939b8b72e

--- a/plugins/green-thumb
+++ b/plugins/green-thumb
@@ -1,2 +1,2 @@
 repository=https://github.com/Asthereon/green-thumb.git
-commit=605b7c74814494bf411d68858fc9cf9e6a31d95d
+commit=dfa65a978e4167df7b185e5b67b300144f4768e7


### PR DESCRIPTION
Green Thumb is a plugin that adds a configurable tooltip to seeds, seedlings, and saplings to display level requirement, patch type, seed amount required to plant a patch, farmer payments or flowers to protect the plant, and potential uses for the resulting crop.