### PR TITLE
Update inferno-stats

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=26f886fbdfeae7895377bce25999348d2cdc298c
+commit=a36d75e16b7e679246c3e9d00a22cd8fdbb1dc06


### PR DESCRIPTION
This is a one-line fix to make the link that is opened by the panel easily clickable when pasted as a link in Discord.

Currently the link ends in `]]` which Discord does not include as a hyperlink. This hack will make it end in `&copyable` which will be included.