### PR TITLE
Update osrs-wiki-crowdsourcing

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=4b8ea1d4d87ef4473f6db11f89cb9ee6d2eab4f0
+commit=16b1e1efed211a948291334a19f9d7b5dbec8401


### PR DESCRIPTION
This PR adds crowdsourcing to map clue scroll ids to the actual clue they are