### PR TITLE
Update collection-log to v1.4.1

### DIFF
--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,2 +1,2 @@
 repository=https://github.com/evansloan/collection-log.git
-commit=7a3ae2561342acfacf2f5abbbab36320c2a2dfbc
+commit=afbd41421c7f97d183722f79d094172e80cc801d


### PR DESCRIPTION
- Update collection log item container ID
- Use widget ID's supplied by Runelite