### PR TITLE
Update osrs-wiki-crowdsourcing to v1.5

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=616e970ba2dcf73f805abf75638338ebc05181e6
+commit=51f539496d8ee8cd8aeb54d2bd060f7055af1d94


### PR DESCRIPTION
This adds crowdsourcing for NPC respawn times, which will go directly on the wiki