### PR TITLE
update loot-logger to v3.1.1

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=bbb9fa92ae5536106db00f8c0ea55bf45f51d4f6
+commit=e3420d86a97415360d0c2012f6dfd91b1db57670


### PR DESCRIPTION
Fixes panel refreshing when an npc alias is killed