### PR TITLE
Update quest-helper to v2.2.5

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=c68b7e7480a5dcf6a34ce52e2608888f2a747d3f
+commit=dc8262d1f2e7e00edc3d5002524dc0d7c6435918

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=dc8262d1f2e7e00edc3d5002524dc0d7c6435918
+commit=3d72125b6a11d34e90e0bf6c59f36600a2d232eb


### PR DESCRIPTION
Small fixes, including a fix to right-click starting helpers which broke due to the recent quest journal changes.