### PR TITLE
Create costume-room-highlighter

### DIFF
--- a/plugins/costume-room-highlighter
+++ b/plugins/costume-room-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/michaelperino/CostumeRoomChecker
+commit=8d378e25b1de54c8f7c89c2bb45bb91cd0472945

--- a/plugins/costume-room-highlighter
+++ b/plugins/costume-room-highlighter
@@ -1,2 +1,2 @@
-repository=https://github.com/michaelperino/CostumeRoomChecker
+repository=https://github.com/michaelperino/CostumeRoomChecker.git
 commit=8d378e25b1de54c8f7c89c2bb45bb91cd0472945


### PR DESCRIPTION
Plugin highlights all items that can be put into a house costume room as defined on the wiki. Only highlights in bank, color and enabled storage locations changeable in settings.