### PR TITLE
Add ectofuntus-info plugin

### DIFF
--- a/plugins/ectofuntus-info
+++ b/plugins/ectofuntus-info
@@ -1,0 +1,2 @@
+repository=https://github.com/Cyborger1/ectofuntus-info.git
+commit=65e16955a327700f904f77ba3b27b7fb60f092fb


### PR DESCRIPTION
A plugin that adds an infobox when around the Ectofuntus area, which tells you how many tokens you have stored there from using bonemeal on it.

Don't question L134, it's the only way I can get this to work. You'll know when you see it. Sorry.

![image](https://user-images.githubusercontent.com/45152844/128111660-c76498f1-63c1-455b-b1f6-be838100ebec.png)