### PR TITLE
Update Pet-Info to 4.0 (load pet info from github)

### DIFF
--- a/plugins/pet-info
+++ b/plugins/pet-info
@@ -1,2 +1,2 @@
 repository=https://github.com/microtavor5/PetInfoPlugin.git
-commit=baa33ed97500f233974c5099d2c1b6f3b07e6772
+commit=dce286070830a322969f2024856c5e65fca9c89a


### PR DESCRIPTION
Made it so the plugin can load the pet info text from the github to facilitate faster addition of new pets and typo fixing (without having to bother you fine folks). It also saves a local fallback copy of the json.
Additionally the two right-click menu options were merged into one nicer option.