### PR TITLE
Update pvp-performance-tracker to v1.4.6

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=e03163d8e864d973eede074f4c9765913525dbda
+commit=396c9feed12e92c3349ad5c8d5c02f6f688d248f


### PR DESCRIPTION
-Fix crystal armor boost; the max hit modifier was applied at the wrong point in the "formula's chain", causing max hits (and therefore also deserved damage) to be lower than expected. I spoke with Koekenpan, the current maintainer of Bitterkoekje's DPS calculator spreadsheet to confirm how this buff was applied. It was also improperly detecting the itemIds.
-Track Dragon Longsword as Vesta's Longsword (requested for dmm practice); can be turned off, but it's defaulted to on since nobody really uses dlong in PvP where the tracker is relevant. Only does it for the attacker, so defensive bonuses aren't modified but that should be negligible.
-Fixed void, forgot to -512 a few itemIds taken from getComposition.

Once again, couldn't thoroughly test these fixes/updates as I am not member and don't really play the game lately (nor do I own crystal armor anyways). But I did play a few matches of casual LMS(F2P) to make sure nothing critical was broken.