### PR TITLE
Native Mac Notifications

### DIFF
--- a/plugins/native-mac-notifications
+++ b/plugins/native-mac-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/fatfingers23/mac-runelite-native-notifications.git
-commit=6e0eb2deda8c5c72845a2952a150d92d2cbf8a15
+commit=960760ee87b67463ecf45be76762ce0cb5357574

--- a/plugins/native-mac-notifications
+++ b/plugins/native-mac-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/fatfingers23/mac-runelite-native-notifications.git
-commit=162ab3bf86839967880e379d024b1dc1f69c3a79
+commit=733ffb5a64e96d36bedecfe526ce3ebeafd18867

--- a/plugins/native-mac-notifications
+++ b/plugins/native-mac-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/fatfingers23/mac-runelite-native-notifications.git
-commit=960760ee87b67463ecf45be76762ce0cb5357574
+commit=89472f4d2a15f93963c41a7d5e2bf693f3eb0cd6

--- a/plugins/native-mac-notifications
+++ b/plugins/native-mac-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/fatfingers23/mac-runelite-native-notifications.git
-commit=89472f4d2a15f93963c41a7d5e2bf693f3eb0cd6
+commit=162ab3bf86839967880e379d024b1dc1f69c3a79

--- a/plugins/native-mac-notifications
+++ b/plugins/native-mac-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/fatfingers23/mac-runelite-native-notifications.git
+commit=6e0eb2deda8c5c72845a2952a150d92d2cbf8a15


### PR DESCRIPTION
This implements native Mac notifications via how IntelliJ implements them. 

If this is tested locally it will show the notification came from Java, but should say Runelite in production since the code is run from the Runelite bundle. 
