### PR TITLE
Create thrall-helper

### DIFF
--- a/plugins/thrall-helper
+++ b/plugins/thrall-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/PortAGuy/thrall-helper.git
+commit=156c11a5d0479cde4c355612369fa526f2f72239


### PR DESCRIPTION
This plugin displays a red box when the player does not have a thrall active