### PR TITLE
Create respawns

### DIFF
--- a/plugins/respawns
+++ b/plugins/respawns
@@ -1,0 +1,2 @@
+repository=https://github.com/leejt/respawns.git
+commit=dc4c75983e46664af211783872f1d311c36a9b5e


### PR DESCRIPTION
This plugin is for a wiki project to add respawn times for items and scenery to article infoboxes. This is meant to augment the main crowdsourcing.