### PR TITLE
Update osrs-wiki-crowdsourcing to v1.6

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=21918bea8750098db3239cd17ac97d203880c2d7
+commit=e89502de7e7137821d5077ef230abffa73bccffb


### PR DESCRIPTION
Move item/scenery respawns into main plugin-hub crowdsourcing.

Move monster examine into main plugin-hub crowdsourcing.