### PR TITLE
Update pvp-performance-tracker to v1.4.7

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=396c9feed12e92c3349ad5c8d5c02f6f688d248f
+commit=2c291d601862d4cbc27d59b2f6b1d331c21050ed


### PR DESCRIPTION
Fixed dlong spec detection, for the recent update where dlong=VLS. Was mostly caused by a silly mistake, where I didn't flag dlong's spec animation as a special attack, so I did not know you were using the spec. However there was some other odd behaviors that I've fixed by improving how this was implemented. I didn't catch this as I wasn't member to properly test this new feature. However now I am, and I've confirmed that it works properly. Special thanks to Pan1c for funding my bond. Sorry about the rapid updates.