### PR TITLE
Update npc-dialog-log to v1.3.1

### DIFF
--- a/plugins/npc-dialog-log
+++ b/plugins/npc-dialog-log
@@ -1,2 +1,2 @@
 repository=https://github.com/neilrush/npc-dialog-log.git
-commit=bbf80252efaa8d596647d774f67b3a89e9e37ef3
+commit=dc1d8a74db4dc04853fb049396239ad1317bd511


### PR DESCRIPTION
Fixed an issue where overhead dialog was left uncleared.