### PR TITLE
Update Loot Logger (v3.1.3)

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=2d5185c5f3b943725829f8de9df96076a70ac1b6
+commit=7be34e3d0ba37b45e1097e2d7901f1556fa88895


### PR DESCRIPTION
Removes minion kills from the kills logged counter
Checks boss aliases for kill count messages (Fixes Vet'ion kill count tracking)