### PR TITLE
Update Plugin Presets to v1.5.0

### DIFF
--- a/plugins/plugin-presets
+++ b/plugins/plugin-presets
@@ -1,2 +1,2 @@
 repository=https://github.com/antero111/plugin-presets.git
-commit=ed50173420cd945d6b43981081598d73c0aedd94
+commit=c9ec051a7d3c153526ceb1f74b81521eb21bcb0d


### PR DESCRIPTION
Plugin now warns from unsaved configurations when making changes to plugin configurations.
Fixed presets not staying in alphabethical order when renaming them.
Preset renaming improvements. Preset names now contains more valid characters.
Fixed bug causing all presets disappearing when turning the plugin off.
Code refactoring.