### PR TITLE
Add Brewing Plugin

### DIFF
--- a/plugins/brewing
+++ b/plugins/brewing
@@ -1,0 +1,2 @@
+repository=https://github.com/InfernoStats/Brewing.git
+commit=890e18beee21d3b362f7a94aa5d42379daf53e90

--- a/plugins/brewing
+++ b/plugins/brewing
@@ -1,2 +1,3 @@
 repository=https://github.com/InfernoStats/Brewing.git
-commit=794dd35d8370432c636f17ad3aa805c17497d40a
+commit=68266f44da62c56728a3379eeea417a2dc4ba0eb
+warning=This plugin sends brewing data to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/brewing
+++ b/plugins/brewing
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Brewing.git
-commit=890e18beee21d3b362f7a94aa5d42379daf53e90
+commit=794dd35d8370432c636f17ad3aa805c17497d40a


### PR DESCRIPTION
# Brewing

This plugin provides an infobox for fermenting vats that can be set to alert you when your brews are completed.

## Data Collection

You can **opt-in** to brewing data collection by selecting the `Send Data to Server` checkbox in the configuration settings.

Brewing data is automatically collected when your brews finish fermenting, whether that results in a bad ale, normal brew, or mature brew.

No IP addresses are logged and the only information sent is the location of your finished brew (Keldagrim or Phasmatys), the state (bad, normal, mature as well as what type), and whether or not you used "The stuff".