### PR TITLE
Combat Achievements Timers Plugin

### DIFF
--- a/plugins/ca-timers
+++ b/plugins/ca-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/lukamircetic/ca-timers.git
-commit=81cd18ff64939f03997b51db606528fa8da4b346
+commit=50bd49c77f62c76d77903260f005514f62e3776e

--- a/plugins/ca-timers
+++ b/plugins/ca-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/lukamircetic/ca-timers.git
-commit=c83731a331c926a64ce54f2aeb360e49e3f80406
+commit=81cd18ff64939f03997b51db606528fa8da4b346

--- a/plugins/ca-timers
+++ b/plugins/ca-timers
@@ -1,0 +1,2 @@
+repository=https://github.com/lukamircetic/ca-timers.git
+commit=c83731a331c926a64ce54f2aeb360e49e3f80406

--- a/plugins/ca-timers
+++ b/plugins/ca-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/lukamircetic/ca-timers.git
-commit=336980e731109ef7729c406165592958f470c60e
+commit=4f8a751c3c429934402181bed9e395053adaad3f

--- a/plugins/ca-timers
+++ b/plugins/ca-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/lukamircetic/ca-timers.git
-commit=50bd49c77f62c76d77903260f005514f62e3776e
+commit=336980e731109ef7729c406165592958f470c60e


### PR DESCRIPTION
Plugin that provides countdowns for various boss speedrun tasks in the combat achievements.
Currently supported bosses are Hespori, Vorkath and Zulrah but will be adding more soon.
When a boss kill is started a timer starts counting down from the desired goal and is displayed on screen.
The goal time can be adjusted in the sidebar panel for each boss, and "Off" can also be selected to turn off the timer for a given boss.

Check the Readme file for more info and please let me know if you need any more information. :)