### PR TITLE
Add Region Chat

### DIFF
--- a/package/verification-template/build.gradle
+++ b/package/verification-template/build.gradle
@@ -73,6 +73,7 @@ dependencies {
 	}
 	thirdParty("io.ably:ably-java:1.2.5") {
 		because "broadcaster"
+		because "region-chat"
 		exclude group: 'com.google.code.gson'
 	}
 }

--- a/plugins/region-chat
+++ b/plugins/region-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/region-chat.git
-commit=b53dc7fbacdc0c6ae30a8c65b7d023c741cf7902
+commit=1aa9d977ff5ad7d9c04fe8caf65198effcc78514
 warning=This plugin submits your IP Address, in-game name, and chat messages in certain regions to a server not controlled or verified by the RuneLite developers.

--- a/plugins/region-chat
+++ b/plugins/region-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/region-chat.git
-commit=b21034321cbba5c07e92e4d0c19c2dacd913aa08
+commit=b53dc7fbacdc0c6ae30a8c65b7d023c741cf7902
 warning=This plugin submits your IP Address, in-game name, and chat messages in certain regions to a server not controlled or verified by the RuneLite developers.

--- a/plugins/region-chat
+++ b/plugins/region-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/region-chat.git
-commit=22aca01bcf0a3317878d30ab7c783f275424fa72
+commit=b21034321cbba5c07e92e4d0c19c2dacd913aa08
 warning=This plugin submits your IP Address, in-game name, and chat messages in certain regions to a server not controlled or verified by the RuneLite developers.

--- a/plugins/region-chat
+++ b/plugins/region-chat
@@ -1,0 +1,3 @@
+repository=https://github.com/Zoinkwiz/region-chat.git
+commit=22aca01bcf0a3317878d30ab7c783f275424fa72
+warning=This plugin submits your IP Address, in-game name, and chat messages in certain regions to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Adds region chat to certain are.as of the game. This allows for players in said areas to see messages from one another even if they're not currently on screen. The main intention is to avoid the irritation of splitting up and missing things other players say

Regions added with this:

* Barbarian Fishing south of Barbarian Outpost
* The Tempoross Island
* Zeah Runecrafting area
* Motherlode mine
* Sepulchre
* Zalcano