### PR TITLE
Update coxlightcolors to 1.3.2

### DIFF
--- a/plugins/cox-light-colors
+++ b/plugins/cox-light-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/cox-light-colors.git
-commit=8635ee731c7d987ca19539703778bd39f415877c
+commit=6a45d1c702f56bfb9ce146efc4160312fae5d963


### PR DESCRIPTION
Call Text.sanitize() when dealing with usernames to prevent nbsp from causing issues with the comparison.