### PR TITLE
update quest-helper to v2.4.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=c10290c329580f38f585829ccf8461c172a10cdf
+commit=d4df63ab14ce99ba8002816ccdc30179b07c8a21


### PR DESCRIPTION
Fixes quest helper for most recent Runelite version.