### PR TITLE
Bump shooting-stars to 1.4

### DIFF
--- a/plugins/shooting-stars
+++ b/plugins/shooting-stars
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/plugin-repo.git
-commit=a0b49135709e2b15fd0dd273bce20d164fa81143
+commit=061ec2751ca4da6c25bac223b835b58fde88c8e4
 warning=This plugin submits the location and time of shooting stars along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
- Fix WorldType issues post update

- Fix tooltips in condensed panel eating up mouse events

- Config changes and Add Hopping to Large Panels
  * Increase default/limit for landed stars and add hopper toggle
  * Default API is now 60 minutes
  * Add highlighting/world hopping to Large Panels UI