### PR TITLE
Add a Max Hit Plugin

### DIFF
--- a/plugins/maxhit
+++ b/plugins/maxhit
@@ -1,2 +1,2 @@
-repository=https://github.com/dominicfrost/maxhit_plugin
+repository=https://github.com/dominicfrost/maxhit_plugin.git
 commit=c86779a7a2de34aa460108f6cd3788b3dfa7d290


### PR DESCRIPTION
This plugin will calculate the max hit of your currently equipped gear.

![panel_screenshot](https://user-images.githubusercontent.com/5561540/130881511-4f0c1ca8-94fb-450d-b035-21cdb08b0643.png)


This plugin supports identifying bonus damage from the following gear

- melee void
- salve, salve(e), salve(ei)
- slayer helm
- dragonhunter lance

You can choose which prayer and potions you'll be using.

You can configure the monster type you'll be attacking