### PR TITLE
Update region-chat to v1.0.2

### DIFF
--- a/plugins/region-chat
+++ b/plugins/region-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/region-chat.git
-commit=096a3ab49355ef4f2e94863d5fb46c23bc59cca4
+commit=aed70a0bf1c14c7742cd92c9a12fb01e0ac4fa52
 warning=This plugin submits your IP Address, in-game name, and chat messages in certain regions to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Fixes region chat to work with the most recent Runelite update.