### PR TITLE
clan hall checker

### DIFF
--- a/plugins/clan hall checker
+++ b/plugins/clan hall checker
@@ -1,0 +1,2 @@
+repository=https://github.com/Gmoley/Clanhall-checker-plugin.git
+commit=35fb5154189cd3b6517dec9de40dcb1b1d6709bb


### PR DESCRIPTION
checks what clan members are in sight upon using !Clanmembers in public chat. and prints them in chat 
this is feature is only available when in the clan hall