### PR TITLE
Add clandropswebhook plugin

### DIFF
--- a/plugins/clandropswebhook
+++ b/plugins/clandropswebhook
@@ -1,2 +1,2 @@
 repository=https://github.com/xncz8h/clandropswebhook.git
-commit=6190df4426eb50e2f8e79136c99e7c70110bc88d
+commit=bbcd03e6706c1cfbc3a66886115cab28bfc10355

--- a/plugins/clandropswebhook
+++ b/plugins/clandropswebhook
@@ -1,0 +1,2 @@
+repository=https://github.com/xncz8h/clandropswebhook.git
+commit=6190df4426eb50e2f8e79136c99e7c70110bc88d


### PR DESCRIPTION
# Clan Drops Webhook
##### A plugin for [RuneLite](https://runelite.net/)
A plugin which allows to send a message to your Discord server using a webhook whenever there is a clan broadcast in your name. 

### The webhook is triggered in the following instanced:
* When you receive a drop which is broadcasted to the clan channel. Minimum value for the drop is set by the clan administrators.
* When you receive a pet drop.

### Config options:
* Webhook URL.
* Upload image or text.
* Screenshot only the chatbox instead of the screen.
* Automatically post a message in the chat with or without the current date (useful for bingo phrases).

### TODO:
* Add support for level ups.
* Add support for multiple webhook links for specific channels