### PR TITLE
Update animation-transmog to v1.3.2

### DIFF
--- a/plugins/animation-transmog
+++ b/plugins/animation-transmog
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtimosPenguidor/animation-transmog.git
-commit=bdf95ee78609cef9571150d98bbaab06e3d482ae
+commit=39f255c4796eb1a9232265b9669390d1baf678eb


### PR DESCRIPTION
Fixed a bug that conflicted with @geheur 's [weapon-animation-replacer](https://github.com/geheur/weapon-animation-replacer) plugin. Now both plugins can be used at the same time.