### PR TITLE
Runecrafting LClick Only

### DIFF
--- a/plugins/runecraftinglclickonly
+++ b/plugins/runecraftinglclickonly
@@ -1,2 +1,2 @@
 repository=https://github.com/Airacan/runecrafinglclickonly.git
-commit=9e16fc0349d52ce1d48ac6b50eb7a9fe0cbf27fe
+commit=a0668b64d6aacda459499d02164b2ec29d9e69e4

--- a/plugins/runecraftinglclickonly
+++ b/plugins/runecraftinglclickonly
@@ -1,2 +1,2 @@
 repository=https://github.com/Airacan/runecrafinglclickonly.git
-commit=cb097489002ff731584ecf252f6cabb88b99b27c
+commit=9e16fc0349d52ce1d48ac6b50eb7a9fe0cbf27fe

--- a/plugins/runecraftinglclickonly
+++ b/plugins/runecraftinglclickonly
@@ -1,2 +1,2 @@
 repository=https://github.com/Airacan/runecrafinglclickonly.git
-commit=a0668b64d6aacda459499d02164b2ec29d9e69e4
+commit=c425c22197fc58c95d97a26f1d98dc43e2684164


### PR DESCRIPTION
Plugin that changes most default actions (Left Clicks) related to Runecrafting so that the player no longer needs to R-Click and navigate through tons of menus. Helps the wrist with long Runecrafting sessions.

Example: Default action of Essence Pouches is normally 'Fill', this has been replaced with 'Empty'. Whereas the Fill option is set to be the default action while in Bank. This is especially useful for places like the Ourania Altar, where acidentally clicking off the bank costs an extra 20+ Runes.