### PR TITLE
Update Bank Memory plugin to v1.1.2 for new RuneLite APIs

### DIFF
--- a/plugins/bank-memory
+++ b/plugins/bank-memory
@@ -1,2 +1,2 @@
 repository=https://github.com/Lazyfaith/runelite-bank-memory-plugin.git
-commit=5c6fdc6789e0f195e799846f38dd0d752d36cca9
+commit=9521135d3c696071c018f48d9709320f389eda89


### PR DESCRIPTION
Back from my holiday so I could finally look at the user submitted fix (thanks to Septem151 for that). 