### PR TITLE
Add toxic-npcs plugin

### DIFF
--- a/plugins/toxic-npcs
+++ b/plugins/toxic-npcs
@@ -1,0 +1,2 @@
+repository=https://github.com/ValerianClerc/toxic-npcs.git
+commit=bc80bf1e05d56e07be2f84aa5d9359c8f3caf68d


### PR DESCRIPTION
[This plugin](https://github.com/ValerianClerc/toxic-npcs) is intended to make the RuneScape playing experience optionally more immersive by roasting players for their mistakes. It's funny when you get hit for a 73 or you die, and a boss roasts you.

There's a lot of room for expanding on this plugin, such as having bosses roast you for safeing, missing prayers, having other players "roast" you, etc. Currently we have support for the following features:
- get roasted on death
- get roasted when boss hits you for a large number (customizable per boss)
- users can customize the frequency of the roasts

Picture attached for reference:

![image](https://user-images.githubusercontent.com/36084793/132112876-50cdda6e-ea10-4e72-8ea0-58f59400b519.png)

Thank you :)