### PR TITLE
Impling-Finder

### DIFF
--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,0 +1,2 @@
+repository=https://github.com/Hablapatabla/ImplingFinder.git
+commit=8173868f79e63e0b7e79472a882df230dcf9c181

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,2 +1,3 @@
 repository=https://github.com/Hablapatabla/ImplingFinder.git
 commit=8173868f79e63e0b7e79472a882df230dcf9c181
+warning=warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
This plugin uses an Oracle Autonomous Database backend to crowd-source impling locations. The plugin scrapes OnNpcSpawned, and if it finds an impling of Ninja quality or higher, packs it into an object and posts it to the database, all asynchronously and in the background. Uploading is only done when an impling is actually discovered, so there is no constant upload process running and using up bandwidth. The sidebar button holds a user interface that users can use to fetch the 25 most recent implings that have been stored in the database, and can choose to filter for a specific impling type as well. API is non-authenticated and has security checks for input constraints and a rate limiter. Users can also use the config to supply their own API endpoints if they want to use a personal server instead.