### PR TITLE
feat: wilderness-level-indicators added

### DIFF
--- a/plugins/wilderness-level-indicators
+++ b/plugins/wilderness-level-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/arnaudperalta/wilderness-level-indicators.git
+commit=7c5431d917b19731f23d4f6a7903efe7265edecc


### PR DESCRIPTION
New plugin intended to highlight players in the wilderness within the same combat bracket.