### PR TITLE
Create raid-speed-run-tracker

### DIFF
--- a/plugins/raid-speed-run-tracker
+++ b/plugins/raid-speed-run-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/garryhuang1/raid-speed-run-tracker.git
+commit=498418a602ed40618a95bca7ab18e241b206e261


### PR DESCRIPTION
A speed run tracker for solo cox cms. Will add additional support for multi-man teams in the future.