### PR TITLE
Readd the gnome restaurant plugin

### DIFF
--- a/plugins/gnome-restaurant
+++ b/plugins/gnome-restaurant
@@ -1,3 +1,2 @@
-repository=https://github.com/MMagicala/gnome-restaurant.git
-commit=1610597629f97d2e16a3d55d7952f569b0d5eaaa
-disabled=repository deleted
+repository=https://github.com/hex-agon/gnome-restaurant.git
+commit=558256e0763eb13f4a032810b6c4ee5227880e26


### PR DESCRIPTION
This PR re-adds the gnome restaurant plugin which the author deleted the original repository.