### PR TITLE
Added remote-clan-info-logger plugin

### DIFF
--- a/plugins/remote-clan-info-logger
+++ b/plugins/remote-clan-info-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/Rykee/remote-clan-info-logger.git
-commit=c0e2f0d25375a348688c395af7087326805f2630
+commit=9ca0d065b21682bb0cadfd703cdf9b67ecdf583e

--- a/plugins/remote-clan-info-logger
+++ b/plugins/remote-clan-info-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/Rykee/remote-clan-info-logger.git
+commit=c0e2f0d25375a348688c395af7087326805f2630


### PR DESCRIPTION
This plugin is used to send clan related info as HTTP requests with JSON body:

Clan chat log
Clan member list
Clan member joined
Clan member left/kicked
Clan member last login time

(More info in Readme)