### PR TITLE
Update visual-metronome to v1.3.6

### DIFF
--- a/plugins/visual-metronome
+++ b/plugins/visual-metronome
@@ -1,2 +1,2 @@
 repository=https://github.com/vincent0955/Visual-metronome.git
-commit=b8180e58dee9efabcca54135be928cf884e0de4d
+commit=ddb2c0f0a96cad94bb3defa0c564913363f22196


### PR DESCRIPTION
-fix bug with tick count that made it start from -1
-show tick number starts from 1 instead of 0