### PR TITLE
Add old-control-run plugin

### DIFF
--- a/plugins/old-control-run
+++ b/plugins/old-control-run
@@ -1,2 +1,2 @@
 repository=https://github.com/LordOfOtakus/OldControlRun.git
-commit=f499bf65a3a86daa0cbedeb394cb2d7886459f4c
+commit=4f7c8757e0531278a906717e230ed162213d0bc8

--- a/plugins/old-control-run
+++ b/plugins/old-control-run
@@ -1,2 +1,2 @@
 repository=https://github.com/LordOfOtakus/OldControlRun.git
-commit=7fbdc4b2cde32c38f6711c590fa1ef659a267beb
+commit=f499bf65a3a86daa0cbedeb394cb2d7886459f4c

--- a/plugins/old-control-run
+++ b/plugins/old-control-run
@@ -1,0 +1,2 @@
+repository=https://github.com/LordOfOtakus/OldControlRun.git
+commit=020ad16e3cd85aacae36a3aec8c290d166e5814f

--- a/plugins/old-control-run
+++ b/plugins/old-control-run
@@ -1,2 +1,2 @@
 repository=https://github.com/LordOfOtakus/OldControlRun.git
-commit=020ad16e3cd85aacae36a3aec8c290d166e5814f
+commit=7fbdc4b2cde32c38f6711c590fa1ef659a267beb


### PR DESCRIPTION
This plugin undoes the change to Control-Click running and reverts it to its old behavior, which was the Control-Click will result in the player always running, regardless of current run state.