### PR TITLE
Update hide widgets plugin to fix zoom in resizable classic

### DIFF
--- a/plugins/hide-widgets
+++ b/plugins/hide-widgets
@@ -1,2 +1,2 @@
 repository=https://github.com/PresNL/hide-widgets.git
-commit=d6474a63547f4bafa6a952dc2aed6a48e6126409
+commit=210599306bbe02504a60b2270fa2bb1381e67483


### PR DESCRIPTION
Update hide widgets to fix zoom in resizeable classic mode

closes PresNL/hide-widgets#4