### PR TITLE
Update inferno-stats plugin to latest

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=a36d75e16b7e679246c3e9d00a22cd8fdbb1dc06
+commit=fcdebffcc360a8c2acfa460d6de17896480b414e

--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=fcdebffcc360a8c2acfa460d6de17896480b414e
+commit=d961645dedfb35fea9b0b463e02a61d0efd5904d


### PR DESCRIPTION
Added a 'idle tick' tracker to the plugin so players can analyse how many ticks they weren't attacking something during a run. Does not actively notify players or tell them what to do so I don't think this breaks any rules.