### PR TITLE
Created Bank Withdraw Swapper

### DIFF
--- a/plugins/bankwithdrawswapper
+++ b/plugins/bankwithdrawswapper
@@ -1,0 +1,2 @@
+repository=https://github.com/Sholto/BankWithdrawSwapper.git
+commit=7fd3f093b5983587e76d2d469b79346e2399804a


### PR DESCRIPTION
Plugin that allows you to change the left click withdraw amount for different items.
For example can configure Fire runes to left click Withdraw-All and Abyssal whip to left click Withdraw-1.
For things like Blast furnace, you want to withdraw all your Coal, however you only want to withdraw 1 Stamina pot dose.

Only allows the withdraw amounts that already exist in the bank. Does **not** allow custom amounts to be set.