### PR TITLE
Update optimal-quest-guide

### DIFF
--- a/plugins/optimal-quest-guide
+++ b/plugins/optimal-quest-guide
@@ -1,2 +1,2 @@
 repository=https://github.com/cesoun/optimal-quest-guide.git
-commit=e4d86684a8168a742c89cd2fe79def2b1d33b086
+commit=7a826682b4afc2603582d3690bd81eb7db31ec34


### PR DESCRIPTION
Update internal quest name `Dragon Slayer` -> `Dragon Slayer I`. Quest was missing otherwise.

Thanks to Kas#2854 on Discord for the report.