### PR TITLE
Updated EmoteClueItems to version 3.0.1. (bugfix)

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=b7cd809098f3b5c387ef4c7ed77b89af6a879b5e
+commit=51f7214643afabe8d8ef1ebf40e63d54df8f2396


### PR DESCRIPTION
Fixed a bug related to (re)starting plugin while logged in.

When starting the plugin while being logged in, stash build statuses were not displayed correctly. Also, when logging out, some remnants (visual only) were still displayed on the ui.
