### PR TITLE
Updated clan-member-list-sort

### DIFF
--- a/plugins/clan-member-list-sort
+++ b/plugins/clan-member-list-sort
@@ -1,2 +1,2 @@
 repository=https://github.com/jodelahithit/runelite-plugins.git
-commit=ae2ac5f5fa658814eb2104f7e7c18229d9cef3ed
+commit=60370c1ce69bcb7b6ee1b7aea6ba514e2f720314


### PR DESCRIPTION
- Fixed sort by rank conflicting with Wise Old Man group plugin.
- Fixed sort button not initializing properly when clan tab is not selected.