### PR TITLE
Updated EmoteClueItems to v3.1.0.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=ff78da9155c8c713c5348a6f86e05f5ad5d4157e
+commit=258fdc892683b8e0360f3035159c7c4075e04475

--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=51f7214643afabe8d8ef1ebf40e63d54df8f2396
+commit=ff78da9155c8c713c5348a6f86e05f5ad5d4157e


### PR DESCRIPTION
### 3.1.0 Patch notes
Opening your bank to begin progression logging is no longer a requirement. Instead, the progression logging will now start right after a player has logged in. A new disclaimer will inform the user that opening the bank will add its contents to the collection log.