### PR TITLE
Add radius markers plugin

### DIFF
--- a/plugins/radius-markers
+++ b/plugins/radius-markers
@@ -1,0 +1,2 @@
+repository=https://github.com/Skretzo/runelite-plugins.git
+commit=16a80e8819d6353f7389ffffeeede89e7a799c22


### PR DESCRIPTION
A plugin that allows you to highlight the spawn point, wander range, retreat range and/or max range for NPCs in the game scene, on the minimap and/or on the world map.

![image](https://user-images.githubusercontent.com/53493631/135183598-774eb806-9fdc-4e52-8843-8fcd965936d5.png)  
*Radius marker for a lonely chicken north-east of Lumbridge east farm*

See the [repository](https://github.com/Skretzo/runelite-plugins/tree/radius-markers) for more detailed explanations.

Info about wander range and max range for NPCs is something the [OSRS Wiki](https://osrs.wiki) is looking to crowdsource and add to their pages, so knowledge about this topic is valuable.