### PR TITLE
Add invalid movement plugin

### DIFF
--- a/plugins/invalid-movement
+++ b/plugins/invalid-movement
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=3ed39e801d3f99aafa144bc36acc008da01d7bc2
+commit=1f2a68a963f0811a3ca69e71558673da4f44c11f

--- a/plugins/invalid-movement
+++ b/plugins/invalid-movement
@@ -1,0 +1,2 @@
+repository=https://github.com/Skretzo/runelite-plugins.git
+commit=986473a553e9c8054af9452e614adee70374f679

--- a/plugins/invalid-movement
+++ b/plugins/invalid-movement
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=986473a553e9c8054af9452e614adee70374f679
+commit=3ed39e801d3f99aafa144bc36acc008da01d7bc2


### PR DESCRIPTION
A plugin that highlights tiles that are blocked (invalid movement) in the game scene, on the minimap and on the world map.
| Game scene | Minimap | World map |
|:----------:|:-------:|:---------:|
| ![illustration-scene-medium](https://user-images.githubusercontent.com/53493631/135289090-7fce4350-e475-40af-bbff-5ca53bcb9736.PNG) | ![illustration-minimap](https://user-images.githubusercontent.com/53493631/135289187-93a02c5b-467d-474c-a58a-171297f6ffda.png) | ![illustration-worldmap-medium](https://user-images.githubusercontent.com/53493631/135289257-cae3ac92-2c1c-4c25-b94d-bc8c67581acb.PNG) |

This is equivalent to the [OSRS Wiki](https://osrs.wiki) supported [map by Mejrs](https://mejrs.github.io/osrs?m=-1&z=4&p=0&x=3201&y=3345&layer=nomove&layer=objects).