### PR TITLE
Create f2pwiki

### DIFF
--- a/plugins/f2pwiki
+++ b/plugins/f2pwiki
@@ -1,2 +1,2 @@
-repository=https://github.com/FreckledDad/f2pwiki\
+repository=https://github.com/FreckledDad/f2pwiki
 commit=9b4b974e60600c1e91a6c768534efe2cce206845

--- a/plugins/f2pwiki
+++ b/plugins/f2pwiki
@@ -1,2 +1,2 @@
-repository=https://github.com/FreckledDad/f2pwiki
+repository=https://github.com/FreckledDad/f2pwiki.git
 commit=9b4b974e60600c1e91a6c768534efe2cce206845

--- a/plugins/f2pwiki
+++ b/plugins/f2pwiki
@@ -1,0 +1,2 @@
+repository=https://github.com/FreckledDad/f2pwiki\
+commit=9b4b974e60600c1e91a6c768534efe2cce206845

--- a/plugins/f2pwiki
+++ b/plugins/f2pwiki
@@ -1,3 +1,3 @@
 repository=https://github.com/FreckledDad/f2pwiki.git
-commit=640f29688ca28b86ff81d3051104112eceb48bf6
+commit=283449f09543eb3aebc26d14806b81e63fae896d
 warning=This plugin submits your username and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/f2pwiki
+++ b/plugins/f2pwiki
@@ -1,2 +1,3 @@
 repository=https://github.com/FreckledDad/f2pwiki.git
-commit=f0db9547a546cad663d82ec7455526c05edf30fb
+commit=640f29688ca28b86ff81d3051104112eceb48bf6
+warning=This plugin submits your username and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/f2pwiki
+++ b/plugins/f2pwiki
@@ -1,2 +1,2 @@
 repository=https://github.com/FreckledDad/f2pwiki.git
-commit=9b4b974e60600c1e91a6c768534efe2cce206845
+commit=f0db9547a546cad663d82ec7455526c05edf30fb


### PR DESCRIPTION
This allows the f2p community to have the same access as other with XP Tracking on external sites. This is specifically in use with https://www.f2p.wiki/

I have spoke with the developer of the site in which he is aware this plugin is being requested. The reason this is to be a plugin hub update is there is not a need for non free to play player to be utilizing this plugin. However, is very useful for those that are.

Thank you for your time.