### PR TITLE
Add new plugin: Audible 2-Ticking

### DIFF
--- a/plugins/audible-2ticking
+++ b/plugins/audible-2ticking
@@ -1,0 +1,2 @@
+repository=https://github.com/dylanhebert/audible-2ticking.git
+commit=684ce182ffd1dbe363b929b4e604c4f073085c91


### PR DESCRIPTION
A RuneLite plugin that plays sounds to aid with some 2-ticking allowing the player to at least look away from the screen.
- Plays a sound when a NPC hits the player with a zero/splash (useful for rats & birds)
- Plays a sound to let the player know when their inventory is low on space (useful for knowing when to drop fish/logs)

Currently, this plugin is optimized for 2-tick fishing swordfish in Piscarilius.