### PR TITLE
Update NPC ID plugin to v1.1

### DIFF
--- a/plugins/npc-id
+++ b/plugins/npc-id
@@ -1,2 +1,2 @@
 repository=https://github.com/XrioBtw/npc-id.git
-commit=9dc9413c19a95cceb88f744f024716c65f79c240
+commit=23c7e1e2dff7fcd491b4a3390612678db1b91e3a


### PR DESCRIPTION
Adds a config option to hide invisible NPCs.