### PR TITLE
Add camera keys plugin

### DIFF
--- a/plugins/camera-keys
+++ b/plugins/camera-keys
@@ -1,0 +1,2 @@
+repository=https://github.com/neilrush/Camera-Keys.git
+commit=d95db17fa17bcaa2b6ae06cba6774b5719f09729


### PR DESCRIPTION
An accessibility/QOL plugin that adds hotkeys for camera zoom and compass direction.