### PR TITLE
 [region-locker] Update GPU to RuneLite 1.7.25

### DIFF
--- a/plugins/region-locker
+++ b/plugins/region-locker
@@ -1,2 +1,2 @@
 repository=https://github.com/slaytostay/region-locker.git
-commit=1a5927bbc0f316ac28187e62abc4533c6f982c27
+commit=d31513834bf8aa8ccbd8451bfa94e8f4d0285526


### PR DESCRIPTION
Based on https://github.com/runelite/runelite/commit/4cab29cf2f3f1e969dfa13705baa52d4ee80ff38
Also, now the RegionGpuPlugin has the GpuPlugin as a conflict in its PluginDescriptor