### PR TITLE
Add idle alarm plugin

### DIFF
--- a/plugins/idle-alarm
+++ b/plugins/idle-alarm
@@ -1,0 +1,2 @@
+repository=https://github.com/observnad/Idle-Alarm.git
+commit=925c6dc9b0217036ac26ee29dc0ff3aba872dbaf


### PR DESCRIPTION
This plugin plays an alarm sound while the player is idle. Unlike the idle notifier plugin, this plugin will repeat the sound at a configurable rate. 

Alarm delay, Alarm speed, Max duration, and Alarm volume are all configurable and well defined in the README.md and the plugin config.

The alarm sound played is the "tick" sound from the metronome plugin which most players are familiar with.