### PR TITLE
Update input-recolor

### DIFF
--- a/plugins/input-recolor
+++ b/plugins/input-recolor
@@ -1,2 +1,2 @@
 repository=https://github.com/MarbleTurtle/Color-Coordinator.git
-commit=8f1b5b3d74ca6bfe69fce2e85e7b8ddfa48a8383
+commit=813a35df61fbc948a60c0cc51cfc9ea40383bafe


### PR DESCRIPTION
A re-write of large parts of the plugin, as well as a display name change and some bug-fixes. @MarbleTurtle invited me to be a contributor for the Color-Coordinator repository, since he is currently rather inactive. That's why this PR is coming from me, and my plugin hub fork, and not from him.