### PR TITLE
Update improved-tile-indicators

### DIFF
--- a/plugins/improved-tile-indicators
+++ b/plugins/improved-tile-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/LeikvollE/tileindicators.git
-commit=1c8dbacdd95e7e4e60a8fc6a90fbf63fa300a49e
+commit=300fc53f1b595da7c08654562137ede8e5475131


### PR DESCRIPTION
Have seen some people having runelite crash with my plugin enabled because of oom, so i have removed the most memory heavy part of the code.

The plugin now also draws the player in front of most other overlays of lower priority, like ground markers and agility indicators.

Becaues of removing the memory heavy part of the code, the plugin now requires either the gpu plugin or 117HD to be enabled to draw the player in front of other overlays. This is checked for in the plugin, and if not satisfied it will simply ignore this option.

The location of the arrow when using the rs3 style destination tile has been given more proper placement, and an option to completely remove it has been added.