### PR TITLE
Update osrs-wiki-crowdsourcing to v1.7

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=6d536d74229f1c79a15be532d2fbc9026dbba408
+commit=235bb1b2bdfe59a26a75db2428b6ec574fbba285


### PR DESCRIPTION
This PR adds NPC overhead text logging, and quest journal logging when the journal is opened.