### PR TITLE
Add player outline plugin

### DIFF
--- a/plugins/player-outline
+++ b/plugins/player-outline
@@ -1,2 +1,2 @@
 repository=https://github.com/neilrush/Player-Outline.git
-commit=07cff5dba52a5aee28c37483debf2fbb4d5715d2
+commit=aa9cb441f5a5eaa676e6111335b73cd1f21a7376


### PR DESCRIPTION
A simple plugin that outlines the player allowing you to see the player behind objects.

<img src="https://i.imgur.com/HxiVLnZ.gif" alt="gif preview of outline" height="400" >