### PR TITLE
Add wintertodt-notifications.

### DIFF
--- a/plugins/wintertodt-notifications
+++ b/plugins/wintertodt-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/jodelahithit/runelite-plugins.git
+commit=ba06560d1bfd6475efd148e9aaf720a6d91f70aa


### PR DESCRIPTION
Plugin similar to [skilling-notifications](https://github.com/jodelahithit/runelite-plugins/tree/skilling-notifications) that's based on the original Runelite Wintertodt plugin.

The plugin provides visual notifications so the player doesn't forget to start a new action after finishing one or being interrupted by a Wintertodt event.