### PR TITLE
Add new plugin for Tithe Farm

### DIFF
--- a/plugins/tictac7x-tithe
+++ b/plugins/tictac7x-tithe
@@ -1,2 +1,2 @@
 repository=https://github.com/TicTac7x/runelite-plugins.git
-commit=b7c1c30c9eafe5580e9e95698d6b52fca5e54d7d
+commit=b24942c6f24347d6524017d6bad17b05342bf024


### PR DESCRIPTION
Tithe farm plugin that:
* shows progress of the plants that only you have planted with game-tick precision
* highlights farming patches on mouse hover
* highlights seeds and watering cans in the inventory
* shows overlay of available/total amount of water in the inventory