### PR TITLE
Add ToB Gear Checker plugin

### DIFF
--- a/plugins/tob-gear-checker
+++ b/plugins/tob-gear-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/tob-gear-checker.git
-commit=3c7731897843be2c4b5e4e32c0ac4dee24a33870
+commit=3cc721ccdb8fc07c5901dafb5cfee7f0aa009afa


### PR DESCRIPTION
A plugin that automatically double-checks everything for your ToB setup.
![In-use](https://user-images.githubusercontent.com/35227462/136711994-518585b7-cf98-41af-8972-18241b28cf1c.png)
![Configuration](https://user-images.githubusercontent.com/35227462/136711999-6cb3e124-eb8f-4c1b-b990-a7834a5c125b.png)

 