### PR TITLE
Update 117hd to v1.0.6

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,2 +1,2 @@
 repository=https://github.com/RS117/RLHD.git
-commit=acd6ced91b1c1a4b6dcc1af003fd3abc3dfadc48
+commit=803c7136ee133484ee8ca80e16974897def85bb5


### PR DESCRIPTION
- improvements to linear-gamma space conversions
-- convert textures to linear on load
-- precompute gamma->linear for lights, fog, etc.
-- hopefully fixes performance regression reported since 1.0.4
- add support URL to runelite-plugin.properties
- fix bug causing black pixels in dense fog
- fix for crashes caused by client.getLocalPlayer() returning null unexpectedly
- fix visual bug with water near khazard battlefield
- enable shadows by default; reduce default shadow quality
- miscellaneous changes to environments, lights, areas, materials
- boost strength of lights loaded from text file to account for gamma-linear conversions
- add new wood texture (created by j-meds)