### PR TITLE
Updated EmoteClueItems to v3.2.0.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=d93da85428da055addf39f86a4d69d186795158e
+commit=c02c5ff18f662d34a37e962552eb11ae00aa3d87


### PR DESCRIPTION
Item highlighting now supports STASH unit filtering. Moreover, items in STASH units are not highlighted in the player's inventory. The filter is enabled by default and can be disabled in the plugin's settings. After filling a stash unit, with this feature, to encourage bank space preservation, future duplicate items can be recognised more easily.

This patch also includes a bugfix for inventory status updates (panels named "Eligible items in inventory").