### PR TITLE
Add "Fuck Helmies" plugin

### DIFF
--- a/plugins/fuck-helmies
+++ b/plugins/fuck-helmies
@@ -1,0 +1,2 @@
+repository=https://github.com/MrSableye/fuck-helmies.git
+commit=4db8b07aa95115b648b517f5171ae1fd3c8250f8


### PR DESCRIPTION
Adds the "Fuck Helmies" plugin, a plugin that allows users to filter chat messages and overhead messages from desired account types.

See: [MrSableye/fuck-helmies](https://github.com/MrSableye/fuck-helmies)