### PR TITLE
Add AccountChatFilter plugin

### DIFF
--- a/plugins/account-chat-filter
+++ b/plugins/account-chat-filter
@@ -1,0 +1,2 @@
+repository=https://github.com/MrSableye/account-chat-filter-plugin.git
+commit=bd0bcd30c5cd1e268f7e042dc08964b861c27a9b


### PR DESCRIPTION
Adds the Account Chat Filter plugin which allows the user to filter chat messages based on account type. This is useful for players who prefer to chat with players of the same gamemode and gain helpful insights and tips on that gamemode with those players.