### PR TITLE
Tempoross Harpoonfish Notifier Plugin

### DIFF
--- a/plugins/tempoross-harpoonfish-notifier
+++ b/plugins/tempoross-harpoonfish-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/Matt-J-H/tempoross-harpoonfish-notifier.git
+commit=d822db16dda7b7f6f8f3c7a11478f7b71f105e4c


### PR DESCRIPTION
A plugin that notifies you when a double Harpoonfish spot appears while doing Tempoross