### PR TITLE
Update Inventory Setups to v.1.12.1

### DIFF
--- a/plugins/inventory-setups
+++ b/plugins/inventory-setups
@@ -1,2 +1,2 @@
 repository=https://github.com/dillydill123/inventory-setups.git
-commit=89f404d05f6e7a34d6cdd954d21f277f804aeb6a
+commit=813bb2e1796ce5cc590cbea627121382ccf8bca4


### PR DESCRIPTION
Fix for bank tab separators
Potential fix for disappearing setups on certain platforms