### PR TITLE
Create friend-live-locations

### DIFF
--- a/plugins/friend-live-locations
+++ b/plugins/friend-live-locations
@@ -1,2 +1,2 @@
 repository=https://github.com/TiboDeMunck/runelite-live-friend-locations-plugin.git
-commit=5f49ff1e83c537a8c6e73b1cdd156d55913e81f6
+commit=f1642f20913ee229be1a109cff471495feaab41f


### PR DESCRIPTION
This plugin allows for 'live location' sharing between players, based on account type you will see your friends/trusted acquaintances on the world map. It is possible to only receive data without sending it when going into the wilderness.

This plugin uses an external API that has to be setup for each group of friends (see README).