### PR TITLE
Create discord-notifications

### DIFF
--- a/plugins/discord-notifications
+++ b/plugins/discord-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/WilliamWinterDev/Discord-Notifications.git
+commit=5546a58d424e07cb0c70fc0ff1f553f2d0f93ad4


### PR DESCRIPTION
There are a couple of discord plugins out there using this same base for a discord webhook notification. I have expanded on the levelling plugin however when I tried to contact the developer via email got no response so thought I would make my own and continue to work on it.

Currently gives granular control over a couple of notifications you can send via discord, this is really helping my Group Ironmen friends so we can keep up to date with what each other are doing on the game while we're not logged in. Currently has levelling, deaths and quest tracking, potential features to add:

- Rare drops
- Pet drops
- Login / logout messages
- HC status removed