### PR TITLE
Add aqp finder plugin

### DIFF
--- a/plugins/aqp-finder
+++ b/plugins/aqp-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/JamesShelton140/aqp-finder.git
-commit=afd76f315a4681ddcce27f0b3117ae7fde45d88d
+commit=c0fc1c1deaab630c89eec84d05d28dad831ac210


### PR DESCRIPTION
Plugin scans new chat messages for "q p" and appends the number of spaces and other characters needed to match a W on the next line.

Includes option to show the raw number of pixels required before the W instead.
Can be configured to send a notification when a "q p" is found. (off by default)