### PR TITLE
Add one tick flick metronome

### DIFF
--- a/plugins/one-tick-flick-metronome
+++ b/plugins/one-tick-flick-metronome
@@ -1,0 +1,2 @@
+repository=https://github.com/Minhs2/one-tick-flick-metronome.git
+commit=2f7f17a0710b8dc612a1462155b47570579ba092


### PR DESCRIPTION
Modified version of the vanilla RuneLite metronome plugin specifically timed for one tick prayer flicking.

Plays a pair of tock-tick noises on when the player should click to prayer flick.