### PR TITLE
Clue Hunter Finder plugin

### DIFF
--- a/plugins/clue-hunter-finder
+++ b/plugins/clue-hunter-finder
@@ -1,0 +1,2 @@
+repository=https://github.com/bromkommer/clue-hunter-finder-plugin.git
+commit=2c664531f34ab8d6f96d253143a4aa23c53162d3


### PR DESCRIPTION
This plugin helps you find the clue hunter gear. It does so on a command based system by typing `::find <item descriptor>` in the chat. It will give you a hint text with the general location and an arrow pointing to where you need to go on the minimap.