### PR TITLE
Create discord-webhook-notifier

### DIFF
--- a/plugins/discord-webhook-notifier
+++ b/plugins/discord-webhook-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/Kipx/discord-notifier.git
-commit=7782f011e5f1d4aa21cb386c4d878f019eee8424
+commit=26bd02de3910b465ad17cc2cd99d4fbb32466706


### PR DESCRIPTION
A Discord Webhook Notifying plugin that will be able to notify a channel or server about certain events using a webhook. Currently, the plugin only supports quest notifications, but will be expanded upon to include drops, boss kills, skilling, and whatever else may be neat. Started a GIM with my friends and was inspired to make this when I saw that there wasn't already a Questing notifier.