### PR TITLE
Updated emote-clue-items to v3.2.1

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=c02c5ff18f662d34a37e962552eb11ae00aa3d87
+commit=a4ae4ad4e62801234bd71fe3ff981e67b74c9dc9


### PR DESCRIPTION
This update features a fix for an ArrayOutOfBoundsException when handling equipment item changes.

Related issue: https://github.com/larsvansoest/emote-clue-items/issues/31