### PR TITLE
Update aqp-finder

### DIFF
--- a/plugins/aqp-finder
+++ b/plugins/aqp-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/JamesShelton140/aqp-finder.git
-commit=c0fc1c1deaab630c89eec84d05d28dad831ac210
+commit=4f65f71ae6c64f8e2a1002a1fecf0334cdf9ec67


### PR DESCRIPTION
Update adds support for chat icons (ironman, pmod etc.) and private messages.

Also fixes bug that text after the last "q p" would generate an erroneous suggestion.