### PR TITLE
Update hide-widgets

### DIFF
--- a/plugins/hide-widgets
+++ b/plugins/hide-widgets
@@ -1,2 +1,2 @@
 repository=https://github.com/PresNL/hide-widgets.git
-commit=210599306bbe02504a60b2270fa2bb1381e67483
+commit=fde10b69df137aa661db707c662484c348f98295


### PR DESCRIPTION
Fix the hide widgets plugin to work properly with the latest version of runelite/runescape 