### PR TITLE
Update aqp-finder

### DIFF
--- a/plugins/aqp-finder
+++ b/plugins/aqp-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/JamesShelton140/aqp-finder.git
-commit=4f65f71ae6c64f8e2a1002a1fecf0334cdf9ec67
+commit=c5b0e810069f5b3bc1f955d79666266fc3695438


### PR DESCRIPTION
Adds "no-break space" character to the character width map. Plugin now works for RSNs with spaces.