### PR TITLE
Update dps-calculator to v1.4.2

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=0df6daac4772895b2e6dd93b867115aa25fcca88
+commit=cb7183417205588d3e400f88666e6ed3e67b0b28


### PR DESCRIPTION
Apologies for the back-to-back, a quick fix to make slayer helms from the soul wars update work again, which broke from #2007.

Will probably be replaced eventually by some better item id merging process.