### PR TITLE
update tempoross to v1.2

### DIFF
--- a/plugins/tempoross
+++ b/plugins/tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/CasvM/runelite-external-plugins.git
-commit=d25d396318e7646171deceabaaae66b9e4059ba3
+commit=af72eacca6df48b132232cb4dd5775b225fa2e5e


### PR DESCRIPTION
## Changes

- Added the option to notify on the following events:
  1. A double spot appears.
  2. A wave is coming in.
  3. Storm clouds are rolling in.
  4. Tempoross' energy reaches 0%

- If a totem/mast needs repairing, it now shows a different color than the regular wave incoming color.
- Fixed a bug where the phase infobox showed up when disabled.
