### PR TITLE
Left click dropper

### DIFF
--- a/plugins/zom-leftclick-dropper
+++ b/plugins/zom-leftclick-dropper
@@ -1,2 +1,2 @@
 repository=https://github.com/redrumze/zom-external-plugins.git
-commit=065eca5a35bbc78f774ab9641d378aca1c2832ff
+commit=823102dcae7e4ed3be37be5f94c33bb9e48cadd4


### PR DESCRIPTION
Fixes errors thrown on shutdown caused by trying to clear an immutable list. Now sets it to null.