### PR TITLE
Add Rogues' Den plugin

### DIFF
--- a/plugins/rogues-den
+++ b/plugins/rogues-den
@@ -1,0 +1,2 @@
+repository=https://github.com/nightfirecat/plugin-hub-plugins.git
+commit=811fffe982259f55ce5e0b9493c3c34c5ab88952


### PR DESCRIPTION
This adds the Rogues' Den plugin (with additional enhancements from runelite/runelite#6257) to the plugin hub.