### PR TITLE
update subtle-virtual-levels to v1.1

### DIFF
--- a/plugins/subtle-virtual-levels
+++ b/plugins/subtle-virtual-levels
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=b23206ea5c042e1d7e8c9f3f727a0412fd21ee2f
+commit=94a9b3ce00be54a2954b4737c259d4b655987037


### PR DESCRIPTION
Forgot to actually remove the widgets when turning off the plugin, oops :d 
Also made it add the widgets if the plugin is started after the skill tab has been built, which is nice.