### PR TITLE
Add GIMPlugin

### DIFF
--- a/plugins/gim-plugin
+++ b/plugins/gim-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/davidvorona/gim-plugin.git
+commit=a511d5d6cc00903e24a0647b9faf4985fefd7f05


### PR DESCRIPTION
Adds a plugin that allows for tracking of fellow gimps on the world map.

Thought I might clarify a few things in the description:

This plugin is definitely similar to the existing plugin GIMP-Tracker, except it shows the players' locations on the in-game world map. Originally I made this for my friends to set up and run locally, but it works well and I think people willing to go through the steps to set up the server will enjoy its functionality. I do plan on adding more functionality, such as better messaging when another gimp is using the group storage, but it is definitely a nice little add as a standalone.

It uses the [`socket.io` implementation of websockets](https://github.com/socketio/socket.io-client-java) (like GIMP-Tracker, as it turns out). ~~I have not accounted for this in `package/verification-template/build.gradle` since GIMP-Tracker already does this, but I'd be happy to add this plugin's name to the `because` clause and update the metadata file on request.~~