### PR TITLE
update dps-calculator to v1.4.5

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=844dcb2f5fadd3eb5d1aafe4df0392512ed3b0ba
+commit=ee0f47a26de1b45cd8de43e4d356a1882ee5266b


### PR DESCRIPTION
Fixes LlemonDuck/dps-calculator#23

Also revisits the autocast lists in the process since they were outdated (new crumble undead autocast-ables and arceuus spellbook autocast-ables)