### PR TITLE
Update skills-tab-progress-bars to v1.0

### DIFF
--- a/plugins/skills-tab-progress-bars
+++ b/plugins/skills-tab-progress-bars
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/skills-tab-progress-bars.git
-commit=edad37606858fb22dcea07ac9bb1f9324d737a80
+commit=26751e78f998e6d5770226c567b13b2fc6285643


### PR DESCRIPTION
Major rewrite from Hydrox6 to use Jagex widgets for the bars, enabling drawing underneath XP info tooltips