### PR TITLE
Update radius markers to v1.2

### DIFF
--- a/plugins/radius-markers
+++ b/plugins/radius-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=bbe3dcb8ff773465d0c9922f2534eb7d58f5947e
+commit=ce004cfc34294376afe4d3bcf59e50fb9b0b75a6


### PR DESCRIPTION
Adds new radius types and fixes incorrect old ones.

As of this update markers from the previous versions of this plugin will no longer show up in the plugin. To re-import these old markers use [this webpage conversion tool](https://skretzo.github.io/runelite-plugins/radius-markers/update-converter/) and manually add the converted markers to the `settings.properties` file in the `.runelite` folder.