### PR TITLE
Update skills-tab-progress-bars to v1.1

### DIFF
--- a/plugins/skills-tab-progress-bars
+++ b/plugins/skills-tab-progress-bars
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/skills-tab-progress-bars.git
-commit=26751e78f998e6d5770226c567b13b2fc6285643
+commit=18047c3808d093a5f906036db1ae7f9a137f653e


### PR DESCRIPTION
Re-adds only show on hover functionality that was removed in previous version during switch to jagex widgets