### PR TITLE
Add sextant locator

### DIFF
--- a/plugins/sextant-locator
+++ b/plugins/sextant-locator
@@ -1,0 +1,2 @@
+repository=https://github.com/Krazune/SextantLocator.git
+commit=da42d5d3d10f1ba4f2230011ec7b57b8314dc1f8


### PR DESCRIPTION
This plugin has a few overlays that show sextant coordinates. It includes your current tile's coordinates, mouse hover tile's coordinates, and center of the map's coordinates.

This is not very useful for clues, but it can be useful for other community riddles that use sextant coordinates.