### PR TITLE
Add sextant locator

### DIFF
--- a/plugins/sextant-locator
+++ b/plugins/sextant-locator
@@ -1,0 +1,2 @@
+repository=https://github.com/Krazune/SextantLocator.git
+commit=c230b43a81ff5d44493d27cd46e4ef1fea36569f


### PR DESCRIPTION
This plugin has a few overlays that show sextant coordinates. It includes your current tile's coordinates, mouse hover tile's coordinates, and center of the map's coordinates.

This is not very useful for clues, but it can be useful for other community riddles that use sextant coordinates.

PS: I opened a new PR because I messed up something in the other branch.