### PR TITLE
add combat level public chat filter

### DIFF
--- a/plugins/chat-level-filter
+++ b/plugins/chat-level-filter
@@ -1,0 +1,2 @@
+repository=https://github.com/Johnmancini30/chat-level-filter.git
+commit=d5c6483cd48c996f4e7bb52d64c77d20684fcc08

--- a/plugins/chat-level-filter
+++ b/plugins/chat-level-filter
@@ -1,2 +1,2 @@
 repository=https://github.com/Johnmancini30/chat-level-filter.git
-commit=d5c6483cd48c996f4e7bb52d64c77d20684fcc08
+commit=7ccc5f81330d5bec6b404149fa66ede6413257f9

--- a/plugins/chat-level-filter
+++ b/plugins/chat-level-filter
@@ -1,2 +1,2 @@
-repository=https://github.com/Johnmancini30/chat-level-filter.git
-commit=738f08dc0cc64b39043ffd7a0ee941950eacb809
+repository=https://github.com/orange-puff/runelite-plugins-external.git
+commit=7ac1421b6c92164b01b9046acee48bed6fdf5072

--- a/plugins/chat-level-filter
+++ b/plugins/chat-level-filter
@@ -1,2 +1,2 @@
 repository=https://github.com/Johnmancini30/chat-level-filter.git
-commit=7ccc5f81330d5bec6b404149fa66ede6413257f9
+commit=738f08dc0cc64b39043ffd7a0ee941950eacb809

--- a/plugins/combat-level-filter
+++ b/plugins/combat-level-filter
@@ -1,0 +1,2 @@
+repository=git@github.com:Johnmancini30/chat-level-filter.git
+commit=d5c6483cd48c996f4e7bb52d64c77d20684fcc08

--- a/plugins/combat-level-filter
+++ b/plugins/combat-level-filter
@@ -1,2 +1,0 @@
-repository=git@github.com:Johnmancini30/chat-level-filter.git
-commit=d5c6483cd48c996f4e7bb52d64c77d20684fcc08


### PR DESCRIPTION
Addresses https://github.com/runelite/runelite/issues/14350 by filtering public chat to remove people below a certain level. This is good for annoying GE bots that are almost always level 3.