### PR TITLE
Update tob-mistake-tracker to v2.2

### DIFF
--- a/plugins/tob-mistake-tracker
+++ b/plugins/tob-mistake-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/QuestingPet/TobMistakeTracker.git
-commit=e0d39d2d41d0602c9a330c1772d392e0ce8f1d13
+commit=9dd1e66df1b4ebf8f540d69fa14075ff29a92147


### PR DESCRIPTION
Fix issue where malformed mistake-state file would cause plugin to not load