### PR TITLE
Add line of sight plugin

### DIFF
--- a/plugins/line-of-sight
+++ b/plugins/line-of-sight
@@ -1,0 +1,2 @@
+repository=https://github.com/Krazune/LineOfSight.git
+commit=c9b9f81d65d3fafb7dd09452a98b2ff0c90c613f


### PR DESCRIPTION
This plugin adds a line of sight overlay. It works just like the devtools' line of sight, but the range is adjustable, and it has improved performance.