### PR TITLE
Update Runelogger to 0.2.1

### DIFF
--- a/plugins/runelogger
+++ b/plugins/runelogger
@@ -1,3 +1,3 @@
 repository=https://github.com/Joopjr/Runelogger.git
-commit=1ddeaaf1e4896bc68a2e6cf7cc610518dd4a1a4a
+commit=b9cd5bd0fd54d1d7b1df1c236b9c82c637f6a95f
 warning=This plugin submits your character name, membership status, activities and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Fixed a bug that clue scrolls weren't processed properly.