### PR TITLE
(Hotfix) Update camera-smoothing to v1.1

### DIFF
--- a/plugins/camera-smoothing
+++ b/plugins/camera-smoothing
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/camera-smoothing.git
-commit=e325be51d2296f8c28bd6f0d79f1a03dbedec515
+commit=17c27d3b060c4354feb35c8cb87e4c9119f31c00


### PR DESCRIPTION
I believe I have fixed an issue with angles snapping around weirdly. The issue seemed to lie with the modulo operator, and I applied a fix from [this stack overflow answer](https://stackoverflow.com/a/7869457).
This is a very small change, however it should fix the plugin.

The issue was observed with clockwise rotations going from 2048 Jagex Units to 0 Jagex Units. The change has been tested to work in both in my camera smoothing simulator and in-game.
![Simulator](https://i.imgur.com/vpnGcvR.gif)
(Note the wrapping of the angle from 2048 to 0)