### PR TITLE
Bump shooting stars plugin to 1.5.1

### DIFF
--- a/plugins/shooting-stars
+++ b/plugins/shooting-stars
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/plugin-repo.git
-commit=061ec2751ca4da6c25bac223b835b58fde88c8e4
+commit=ad8ed1f942db2ad23bc59e746ce18a77ee88c61f
 warning=This plugin submits the location and time of shooting stars along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
- POST requests updated to use `location` as the key instead of `loc` for consistency since `location` was being returned in the GET response. This should not break the server since it currently handles both.
- Change default layout to condensed
- Add filter for total level worlds (@breakthetargets)
- Minor bugfixes (allow refresh after changing pass, hide f2p worlds if they are returned)

In addition, the server has recently transitioned to using a falcon API in python ([link](https://github.com/andmcadams/shooting-stars-server)) running `server.py`.