### PR TITLE
Update osrs-wiki-crowdsourcing

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=235bb1b2bdfe59a26a75db2428b6ec574fbba285
+commit=1cd481ce367ac7de2162e552a03d4bf2625e5ddc


### PR DESCRIPTION
This adds pottery crowdsourcing and also sets the time between uploads back to 5 minutes, which gives us more surrounding context for things like random events.