### PR TITLE
rainbow rave 1.0.4, fix math and update tags

### DIFF
--- a/plugins/rainbow-rave
+++ b/plugins/rainbow-rave
@@ -1,3 +1,3 @@
 repository=https://github.com/geheur/rainbow-rave.git
-commit=f0b471f4388ed97af2c58690a0fac8fa2d51b562
+commit=0c880ca1679fe56da19504865ec88c235cacaf1f
 warning=This plugin shows bright flashing lights.


### PR DESCRIPTION
Oopsie!

fix cosmetic scythe upgrade swing trails not being rainbow'd and update tags