### PR TITLE
Update 117hd to v1.0.9

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,2 +1,2 @@
 repository=https://github.com/RS117/RLHD.git
-commit=1d290f6d64c44acd306dfdc84553952ebc96b03e
+commit=0882350c301e6b88036a386293d67ff241f31878


### PR DESCRIPTION
- adjust dungeon lighting
- remove duplicate anti-aliasing code
- fix issue with wood texture
- port from GPU: add vsync settings
- add 16384 shadow map setting
- use vanilla textures when 'object textures' is disabled
- refactored model pushing
- port from GPU: UI texture improvements
- port from GPU: update suppressed openGL warnings
- add limited-time winter theme