### PR TITLE
Update tob-gear-checker's author name misspelling

### DIFF
--- a/plugins/tob-gear-checker
+++ b/plugins/tob-gear-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/tob-gear-checker.git
-commit=3cc721ccdb8fc07c5901dafb5cfee7f0aa009afa
+commit=f55ea8c6a54282c6f81a5c804049d6816e5f2bfd


### PR DESCRIPTION
I misspelled the author name and only just now realized it. I inserted one 'i' into the plugin properties. 