### PR TITLE
Update lootbag utilities to version 1.1

### DIFF
--- a/plugins/lootbag-utilities
+++ b/plugins/lootbag-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/LootBagger/LootbagUtilities.git
-commit=36417eea0a2fa337874cc88b4bbcd6e75a6553fb
+commit=eca3b896ea04531071d17f0e21aabaf80bf4378c


### PR DESCRIPTION
Lootbag Utilities 1.1 adds a feature request to remove destroy options on other storage items besides the looting bag commit [eca3b896ea04531071d17f0e21aabaf80bf4378c](https://github.com/LootBagger/LootbagUtilities/commit/eca3b896ea04531071d17f0e21aabaf80bf4378c)
and bumps the version number commit [9734bed35d503dff220e89f41c3c31b6db24d136](https://github.com/LootBagger/LootbagUtilities/commit/9734bed35d503dff220e89f41c3c31b6db24d136)