### PR TITLE
Update InventorySetups to remove properties file dependency

### DIFF
--- a/plugins/inventory-setups
+++ b/plugins/inventory-setups
@@ -1,2 +1,2 @@
 repository=https://github.com/dillydill123/inventory-setups.git
-commit=13e6cce2d6a6e420099c885dba34b18c887c1a5f
+commit=34b30918f7e8ca01e6ec2e9f40eeaa8a416b0ae8


### PR DESCRIPTION
Changes gradle to use txt file instead of properties file as @abextm requested, due to properties adding a timestamp.