### PR TITLE
Added new plugin Name Change Detector

### DIFF
--- a/plugins/name-change-detector
+++ b/plugins/name-change-detector
@@ -1,3 +1,3 @@
 repository=https://github.com/fatfingers23/osrs-name-change-detector.git
-commit=51b366a65fb38897f0e3e4d0d974ca910aecb911
+commit=b1520008dea89b169a3e6a769f0aa740d9b66686
 warning=This plugin makes web requests to the Wise Old Man and Crystal Math Labs websites to retrieve players previous names.

--- a/plugins/name-change-detector
+++ b/plugins/name-change-detector
@@ -1,2 +1,3 @@
 repository=https://github.com/fatfingers23/osrs-name-change-detector.git
-commit=7847a7b7ee29807a9fd08f60d4cf45c1f04b368f
+commit=51b366a65fb38897f0e3e4d0d974ca910aecb911
+warning=This plugin makes web requests to the Wise Old Man and Crystal Math Labs websites to retrieve players previous names.

--- a/plugins/name-change-detector
+++ b/plugins/name-change-detector
@@ -1,0 +1,2 @@
+repository=https://github.com/fatfingers23/osrs-name-change-detector.git
+commit=c0966cf89fe4b5a91cb6bf3a852704d18de13372

--- a/plugins/name-change-detector
+++ b/plugins/name-change-detector
@@ -1,2 +1,2 @@
 repository=https://github.com/fatfingers23/osrs-name-change-detector.git
-commit=c0966cf89fe4b5a91cb6bf3a852704d18de13372
+commit=7847a7b7ee29807a9fd08f60d4cf45c1f04b368f


### PR DESCRIPTION
Adds menu option to look up previous names of players.

A fellow clan mate changed their name and did not realize it was them. Did not have them added to my friends list to notice. Thought this may help other people who may be having the same issues