### PR TITLE
Motherlode Mine Improved - v0.3

### DIFF
--- a/plugins/tictac7x-motherlode
+++ b/plugins/tictac7x-motherlode
@@ -1,2 +1,2 @@
 repository=https://github.com/TicTac7x/runelite-plugins.git
-commit=d6dffffb3a650e727928207486cdb12f40d44bb9
+commit=7178603e760daa4d10c8ada3df6e60271f6d2e07


### PR DESCRIPTION
v0.3 - Custom sack widget more configurable, deposit left added. Setting to toggle sack pay-dirt maximization. Setting to only show upstairs veins and rockfalls. Missing NW sector coordinate added. README pictures updated.