### PR TITLE
Update line of sight to version 2021.12.1

### DIFF
--- a/plugins/line-of-sight
+++ b/plugins/line-of-sight
@@ -1,2 +1,2 @@
 repository=https://github.com/Krazune/LineOfSight.git
-commit=c9b9f81d65d3fafb7dd09452a98b2ff0c90c613f
+commit=84fde70c79d1676ebf1bca946995823e3669a861


### PR DESCRIPTION
Added a new outline only mode:
![outline](https://user-images.githubusercontent.com/10135839/145688582-478d3e66-4774-4aef-a52d-37c5fd271fcd.png)

Added the option to have fill color:
![fill](https://user-images.githubusercontent.com/10135839/145688584-15ab4f2e-55dc-4724-8940-e1cad580f323.png)