### PR TITLE
Update quest-helper to 2.8.0

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=fd48521d3d0902e1d725d1407005cfe7c4926737
+commit=b045eaa6a5932c229716576516e16705d3bf4928


### PR DESCRIPTION
- Removes some functionality which required peaking at varbits to work (spices in RFD, memory path in LD, scary caves in Soul's Bane)
- Adds Ardy Diary
- A lot of small fixes