### PR TITLE
Update Monster Menu HP to 1.1.3

### DIFF
--- a/plugins/menuhp
+++ b/plugins/menuhp
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/npc-menu-hp.git
-commit=ffb8215ebb3fd1b18e53f93ec7c50bd8e1a786db
+commit=18b4f76f6248d03b3573004e83e38a090a87cf29


### PR DESCRIPTION
Fix dead NPCs showing unknown HP color when "Recolor when unknown" is enabled.