### PR TITLE
Joined date and rank were no longer exporting with names

### DIFF
--- a/plugins/clanmate-export
+++ b/plugins/clanmate-export
@@ -1,2 +1,2 @@
 repository=https://github.com/fatfingers23/runelite-osrs-clanmate-export.git
-commit=56ecf9c4bb1c9a1ea295ace0339541d198141e24
+commit=278589d516d630fbdef9cb08aa05c876764fc8bd


### PR DESCRIPTION
This should solve this [issue](https://github.com/fatfingers23/runelite-osrs-clanmate-export/issues/3) in my repo.

