### PR TITLE
Update shortest-path to v1.3

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=f6073d99e00e3d06d62d6d41d506181dcee6be04
+commit=57e0271247d58a605ba602e8bda597e5575aaaae


### PR DESCRIPTION
- Code reorganization and improvements
- Adds path colour options ([issue](https://github.com/Runemoro/shortest-path/issues/17))
- Adds path tile counter ([issue](https://github.com/Runemoro/shortest-path/issues/3))
- Adds option to set/clear the path target in the scene (shift right-click)
- Adds option to set path start position (PS: set your recalculate distance considerably high to use this option) ([issue](https://github.com/Runemoro/shortest-path/issues/4))
- Adds a plugin icon
- Fixes offset world map tile drawing ([issue](https://github.com/Runemoro/shortest-path/issues/7))
- Fixes missing fullscreen world map drawing ([issue](https://github.com/Runemoro/shortest-path/issues/5))