### PR TITLE
Add Hidden Drop Party plugin

### DIFF
--- a/plugins/hidden-drop-party
+++ b/plugins/hidden-drop-party
@@ -1,2 +1,2 @@
 repository=https://github.com/Krazune/HiddenDropParty.git
-commit=7563a2c089c2526c5d4f9516a230bef8b1d995f7
+commit=6989262b762c3ab9042993df594937e9d8016656

--- a/plugins/hidden-drop-party
+++ b/plugins/hidden-drop-party
@@ -1,2 +1,2 @@
 repository=https://github.com/Krazune/HiddenDropParty.git
-commit=6989262b762c3ab9042993df594937e9d8016656
+commit=61e69edf81b7a635f3358c585374c0979709d22a

--- a/plugins/hidden-drop-party
+++ b/plugins/hidden-drop-party
@@ -1,2 +1,2 @@
 repository=https://github.com/Krazune/HiddenDropParty.git
-commit=be17c85425de98b74b4cc5ce3d3c5f575bb7a3c2
+commit=7563a2c089c2526c5d4f9516a230bef8b1d995f7

--- a/plugins/hidden-drop-party
+++ b/plugins/hidden-drop-party
@@ -1,2 +1,2 @@
 repository=https://github.com/Krazune/HiddenDropParty.git
-commit=61e69edf81b7a635f3358c585374c0979709d22a
+commit=307d88abc3788e758cc3f9f91a04296bf7178912

--- a/plugins/hidden-drop-party
+++ b/plugins/hidden-drop-party
@@ -1,0 +1,2 @@
+repository=https://github.com/Krazune/HiddenDropParty.git
+commit=be17c85425de98b74b4cc5ce3d3c5f575bb7a3c2


### PR DESCRIPTION
Hides drops. Useful for streamers that want to make drop parties on stream but don't want to show where the good drops were placed.

![Demo](https://raw.githubusercontent.com/Krazune/HiddenDropParty/master/resources/hiddendropparty.gif)