### PR TITLE
Fixed switching trainer

### DIFF
--- a/plugins/switching-trainer
+++ b/plugins/switching-trainer
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/switching-trainer.git
-commit=69fd8d22f791cbdfd1c337b4be0a4f4e39d6113d
+commit=10a636a521a66f88f51c9b51799285bd01bf3212


### PR DESCRIPTION
There was a bug that would cause switches to count as double in most situations. This is now fixed.