### PR TITLE
Add WikiSync plugin

### DIFF
--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,0 +1,3 @@
+repository=https://github.com/andmcadams/WikiSync.git
+commit=65f928ec5b7448597c32866a5b696f7925f969bb
+warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone. We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your quest status could be detrimental to your account by giving away information about what you're currently doing.


### PR DESCRIPTION
cc @leejt 
Adds the WikiSync plugin, which pushes up player's quests and skills to our server to be used on the wiki Soon :tm:.