### PR TITLE
Add BirdhouseOverlay plugin

### DIFF
--- a/plugins/birdhouse-overlay
+++ b/plugins/birdhouse-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/hong-niu/runelite-birdhouse-overlay.git
+commit=ee4cb1a87d6c63dac500afedfdb802a06a5db91d


### PR DESCRIPTION
Adds a customizable graphical overlay that acts as reminder to players to fill their birdhouses with seeds after building them. 

For more information + screenshots: 

https://github.com/hong-niu/runelite-birdhouse-overlay/blob/master/README.md

cc: @li-cody 