### PR TITLE
Add Pm Highlight

### DIFF
--- a/plugins/pm-highlight
+++ b/plugins/pm-highlight
@@ -1,0 +1,2 @@
+repository=https://github.com/wtommyw/pm-highlight.git
+commit=3a2767f60fb253050cafa219b0fb4ef8b5d00cca

--- a/plugins/pm-highlight
+++ b/plugins/pm-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/wtommyw/pm-highlight.git
-commit=b62179d646e998221d5ab58503a3fe15013c5664
+commit=7a0697ec5a3434315dfc6ad21ef7f4ed02c1760d

--- a/plugins/pm-highlight
+++ b/plugins/pm-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/wtommyw/pm-highlight.git
-commit=3a2767f60fb253050cafa219b0fb4ef8b5d00cca
+commit=814c8e872e4b358db1cc308f0d9d825348970e3a

--- a/plugins/pm-highlight
+++ b/plugins/pm-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/wtommyw/pm-highlight.git
-commit=814c8e872e4b358db1cc308f0d9d825348970e3a
+commit=b62179d646e998221d5ab58503a3fe15013c5664


### PR DESCRIPTION
This plugin allows you to highlight different parts of a private message in different colors. The parts that can be highlighted are:
- Player name
- Message
- Log in/out notification

A small screenshot:
![image](https://user-images.githubusercontent.com/16599165/147508176-ac9e5b26-9ccd-4297-a2a0-9197d6636060.png)
