### PR TITLE
Update qolting to v1.2

### DIFF
--- a/plugins/qolting
+++ b/plugins/qolting
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/Qolting.git
-commit=a8597cdbe855cdd1798559c4759a906cc670e80f
+commit=f08abfdb44aecc158c510321dcba7d7972102977

--- a/plugins/qolting
+++ b/plugins/qolting
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/Qolting.git
-commit=944a610527dc42519248b41d7bee9578459501fc
+commit=f9ee6ee22f1af9edf03ee3ba5770a41b274c2810

--- a/plugins/qolting
+++ b/plugins/qolting
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/Qolting.git
-commit=f08abfdb44aecc158c510321dcba7d7972102977
+commit=83e95d2c2cc77c1d0eadefaa9ea8bbec62eef5b5

--- a/plugins/qolting
+++ b/plugins/qolting
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/Qolting.git
-commit=0a7af2454c3fd984ea9ea8a8bb743ebeae0f279e
+commit=944a610527dc42519248b41d7bee9578459501fc

--- a/plugins/qolting
+++ b/plugins/qolting
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/Qolting.git
-commit=f9ee6ee22f1af9edf03ee3ba5770a41b274c2810
+commit=a8597cdbe855cdd1798559c4759a906cc670e80f


### PR DESCRIPTION
# __v1.2 Changelog__

### New:
- Blackout Overlay
The blackout overlay is a big ol' black rectangle that covers any unncessary elements and leaves you with the bare essentials when you need them: Bank highlighting when low on inventory space, altar highlighting when low on prayer, and valuable loot highlighting.
It has a configurable color, however I recommend black with low transparency.
[Demonstration](https://i.imgur.com/FzAljHZ.gif)
### Account Manager:
- Disable Blackout Option
- Always On Top Option
- Profit tracking (per hour and total in session)
(New Layout)
![Account Manager](https://i.imgur.com/9HqaGyM.png)
### Ear Blasters:
- Fixed bugs
- Health/prayer/regular-drop ear blasters added
- New directories and names for ear blasters
### Profit Tracker:
- Shift-right-click to clear profits
### General:
- Valuable item blacklists for highlighting