### PR TITLE
Update coxlightcolors to 1.3.3

### DIFF
--- a/plugins/cox-light-colors
+++ b/plugins/cox-light-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/cox-light-colors.git
-commit=6a45d1c702f56bfb9ce146efc4160312fae5d963
+commit=caed95658520d3fe382169c1213adf269e78b502


### PR DESCRIPTION
Fix an issue where random objects would sometimes get recolored instead of the entrance to olm.
Removed the "Experimental" label on the config for groups as this has been confirmed to be working properly since 1.3.2.
Update Readme.