### PR TITLE
Add Loot Lookup Plugin

### DIFF
--- a/package/verification-template/build.gradle
+++ b/package/verification-template/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 		because "discord-rare-drop-notifier"
 	}
 	thirdParty("org.jsoup:jsoup:1.13.1") {
-		because "discord-rare-drop-notifier, drop-simulator, fire-beats, loot-table"
+		because "discord-rare-drop-notifier, drop-simulator, fire-beats, loot-table, loot-lookup"
 	}
 	thirdParty("com.miglayout:miglayout-swing:5.2") {
 		because "drop-simulator"

--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=785e9e97c50700e431b2cbef0e6b2bb72b54186d
+commit=e5fdff4f97072a48b0be042367d0a381e5500bae

--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=f36e577fbbffe4e459497d40c0dc3411d5397196
+commit=39e80920e12629e2c5b17c44282aac3f9046ff65

--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=39e80920e12629e2c5b17c44282aac3f9046ff65
+commit=785e9e97c50700e431b2cbef0e6b2bb72b54186d

--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,0 +1,2 @@
+repository=https://github.com/donth77/loot-lookup-plugin.git
+commit=f36e577fbbffe4e459497d40c0dc3411d5397196


### PR DESCRIPTION
Add plugin to quickly reference the monster drop tables from OSRS Wiki in the right sidebar panel

[README](https://github.com/donth77/loot-lookup-plugin/blob/master/README.md)

Features
- "Lookup Drops" menu option
- Search bar for monster names
- Collapsible sections for each drop table
- Collapse all / Expand all button
- Display rarity as percentage
- Button to open the OSRS Wiki page for the monster in default web browser
- List and Grid views
- Links to wiki pages for items in List view
- Customize colors for rarity and prices