### PR TITLE
Update InventorySetups to support gradle 7.3.2

### DIFF
--- a/plugins/inventory-setups
+++ b/plugins/inventory-setups
@@ -1,2 +1,2 @@
 repository=https://github.com/dillydill123/inventory-setups.git
-commit=a801c482312c09ba6e85e599f97e9b27ace0eb07
+commit=4afe2c417983ba37d12af1d5757b99c6a5591a54


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15637422/147885738-f81e1295-f7d4-4678-8b4f-8e0d4d2bc6d0.png)

Also disabled filtering in group ironmen group storage.