### PR TITLE
Update Pm highlight to version 1.0.3

### DIFF
--- a/plugins/pm-highlight
+++ b/plugins/pm-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/wtommyw/pm-highlight.git
-commit=7a0697ec5a3434315dfc6ad21ef7f4ed02c1760d
+commit=ad157f985c2ad39d27043ff37b1012110658b90e

--- a/plugins/pm-highlight
+++ b/plugins/pm-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/wtommyw/pm-highlight.git
-commit=ad157f985c2ad39d27043ff37b1012110658b90e
+commit=fbd8176f494e2f6ee1af9410bf25682bb95e167d


### PR DESCRIPTION
This update fixes an issues preventing the plugin from initializing on some fresh setups. It turns out the default highlight color could not always be decoded properly.