### PR TITLE
Update 117hd to v1.0.12

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,2 +1,2 @@
 repository=https://github.com/RS117/RLHD.git
-commit=d99ec13309e0794f403c1960580d447252641270
+commit=9512f55c725ba62abe7830a35b42999fd0263de9


### PR DESCRIPTION
-fix POH performance by forcing scene reload
-implement macOS stretched mode fix from GPU plugin
-prevent tile recoloring when ground blending is disabled
-use dummy shadow map when shadows are disabled to prevent a warning on some devices
-expand GWD area to cover Nex's ancient prison