### PR TITLE
Update Pm Highlight to version 1.0.4

### DIFF
--- a/plugins/pm-highlight
+++ b/plugins/pm-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/wtommyw/pm-highlight.git
-commit=fbd8176f494e2f6ee1af9410bf25682bb95e167d
+commit=9c03fe58613e328931b20e6f0013205a4c29bd0f


### PR DESCRIPTION
This update fixes an issue where names containing spaces may not be recognized. 