### PR TITLE
Update pvp-performance-tracker to v1.5.1

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=414ee5dc3dd3174252c3169f0c712f096e8a5d9a
+commit=6aeed770c8e4cfaf99c47e16b74281bf623d9179


### PR DESCRIPTION
Minor fixes only:
- Include/save AGS' proper max hit in the actual saved max hit(shown in fight log) rather than only temporarily including it in the deserved damage calculation
- Include Ferox Enclave regions for "restrict to LMS" setting, so you can view fight history after the match is over rather than only during an LMS match (accidental behavior from when it was moved to ferox).
- Update excessive/spammy log.info to log.debug