### PR TITLE
Add Herb Farming Calculator plugin

### DIFF
--- a/plugins/herb-farm-calculator
+++ b/plugins/herb-farm-calculator
@@ -1,0 +1,2 @@
+repository=https://github.com/LucasPickering/runelite-herb-farm-calculator.git
+commit=528d8e83b5dfc001ad986e0715353aed80055e07


### PR DESCRIPTION
This plugin calculates potential profit and XP from farming herbs. It's basically a more powerful and easier-to-use version of [the Wiki's calculator](https://oldschool.runescape.wiki/w/Calculator:Farming/Herbs). The idea is that you configure the plugin once based on what patches and items you use, then any time you open the panel, it'll tell you what herb you should be farming based on current prices to make the most profit.

Here's an example of the output:

![image](https://user-images.githubusercontent.com/2382935/148541740-dafe8cc3-e52f-4113-a3bc-48b4f7750f7c.png)
