### PR TITLE
Add tick timestamp plugin

### DIFF
--- a/plugins/tick-timestamp
+++ b/plugins/tick-timestamp
@@ -1,0 +1,2 @@
+repository=https://github.com/Skretzo/runelite-plugins.git
+commit=7db6223bc66975fc7aacd697dd3aee6ff7109ccb


### PR DESCRIPTION
# Tick Timestamp

![illustration](https://user-images.githubusercontent.com/53493631/148578017-f46d9ea8-4392-40ee-8573-9bdd411a01e7.png)

## Info
Display a game client tick count as a timestamp on game chat messages. Useful for knowing if you are on pace when skilling or timing actions. Useful for e.g. [editing OSRS Wiki recipes](https://oldschool.runescape.wiki/w/Category:Recipes_missing_ticks).

## Config options
- [x] Relative tick
  - Whether to display the tick timestamp as a tick count relative to the previous timestamped chat message