### PR TITLE
Add autocast-utilities

### DIFF
--- a/plugins/autocast-utilities
+++ b/plugins/autocast-utilities
@@ -1,0 +1,2 @@
+repository=https://github.com/jcarbelbide/runelite-external-plugins.git
+commit=ae0ec022be072a24a38bbdea85017a06c567dc5e

--- a/plugins/autocast-utilities
+++ b/plugins/autocast-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/jcarbelbide/runelite-external-plugins.git
-commit=be715ad94b144b962b77688f8f5bf04b73bb6f82
+commit=78b73945e76a4f02b575d6ec1391f866ca640cb1

--- a/plugins/autocast-utilities
+++ b/plugins/autocast-utilities
@@ -1,2 +1,2 @@
-repository=https://github.com/jcarbelbide/runelite-external-plugins.git
+repository=https://github.com/jcarbelbide/autocast-utilities.git
 commit=78b73945e76a4f02b575d6ec1391f866ca640cb1

--- a/plugins/autocast-utilities
+++ b/plugins/autocast-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/jcarbelbide/runelite-external-plugins.git
-commit=077e8441cce9026670d56997219e1b0404831cbc
+commit=be715ad94b144b962b77688f8f5bf04b73bb6f82

--- a/plugins/autocast-utilities
+++ b/plugins/autocast-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/jcarbelbide/runelite-external-plugins.git
-commit=4ad6fe6e61599da6eb72bf742ed5214bdf5fc1c8
+commit=2cae9b3c7c04eb4fb0b4072f53b20cd3b8900e3a

--- a/plugins/autocast-utilities
+++ b/plugins/autocast-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/jcarbelbide/runelite-external-plugins.git
-commit=ae0ec022be072a24a38bbdea85017a06c567dc5e
+commit=4ad6fe6e61599da6eb72bf742ed5214bdf5fc1c8

--- a/plugins/autocast-utilities
+++ b/plugins/autocast-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/jcarbelbide/runelite-external-plugins.git
-commit=2cae9b3c7c04eb4fb0b4072f53b20cd3b8900e3a
+commit=077e8441cce9026670d56997219e1b0404831cbc


### PR DESCRIPTION
Add Autocast Utilities external plugin. 

This plugin displays an overlay when a magic weapon capable of autocasting is equipped. The overlay shows the name and icon of the current spell. If the player's magic level falls below the level required for the spell, the overlay has the option to flash and send a game notification. 

[Link to plugin](https://github.com/jcarbelbide/autocast-utilities/tree/rename-package-statements).

Thank you for your time! 