### PR TITLE
Add the Item Share plugin

### DIFF
--- a/plugins/item-share
+++ b/plugins/item-share
@@ -1,3 +1,3 @@
 repository=https://github.com/vyxyl/runelite-item-share.git
-commit=3d7ab17f2b78784bb710bef7ecba40ed189ab589
+commit=8d30a648ab941da9a7b62484dab52993f3e3415e
 warning=In order to share your items with other players, this plugin sends player data (including IP address) to an open-source 3rd party server. The server is not controlled or verified by the RuneLite Developers

--- a/plugins/item-share
+++ b/plugins/item-share
@@ -1,3 +1,3 @@
 repository=https://github.com/vyxyl/runelite-item-share.git
-commit=5b56a0419b59086503913237bf77ca3daab82923
+commit=dc9448977bca5a05bf1e01bcf3f64d2e3500fb2d
 warning=In order to share your items with other players, this plugin sends player data (including IP address) to an open-source 3rd party server. The server is not controlled or verified by the RuneLite Developers

--- a/plugins/item-share
+++ b/plugins/item-share
@@ -1,0 +1,2 @@
+repository=https://github.com/vyxyl/runelite-item-share.git
+commit=0bffbce3c20dfd11e8f46179c5fd752447a92903

--- a/plugins/item-share
+++ b/plugins/item-share
@@ -1,3 +1,3 @@
 repository=https://github.com/vyxyl/runelite-item-share.git
-commit=8d30a648ab941da9a7b62484dab52993f3e3415e
+commit=5b56a0419b59086503913237bf77ca3daab82923
 warning=In order to share your items with other players, this plugin sends player data (including IP address) to an open-source 3rd party server. The server is not controlled or verified by the RuneLite Developers

--- a/plugins/item-share
+++ b/plugins/item-share
@@ -1,3 +1,3 @@
 repository=https://github.com/vyxyl/runelite-item-share.git
-commit=0bffbce3c20dfd11e8f46179c5fd752447a92903
+commit=3d7ab17f2b78784bb710bef7ecba40ed189ab589
 warning=In order to share your items with other players, this plugin sends player data (including IP address) to an open-source 3rd party server. The server is not controlled or verified by the RuneLite Developers

--- a/plugins/item-share
+++ b/plugins/item-share
@@ -1,2 +1,3 @@
 repository=https://github.com/vyxyl/runelite-item-share.git
 commit=0bffbce3c20dfd11e8f46179c5fd752447a92903
+warning=This plugin saves your username, items, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers

--- a/plugins/item-share
+++ b/plugins/item-share
@@ -1,3 +1,3 @@
 repository=https://github.com/vyxyl/runelite-item-share.git
-commit=dc9448977bca5a05bf1e01bcf3f64d2e3500fb2d
+commit=772a0f6a7cab3082efca98efdc2ae0c072ee4bd1
 warning=In order to share your items with other players, this plugin sends player data (including IP address) to an open-source 3rd party server. The server is not controlled or verified by the RuneLite Developers

--- a/plugins/item-share
+++ b/plugins/item-share
@@ -1,3 +1,3 @@
 repository=https://github.com/vyxyl/runelite-item-share.git
 commit=0bffbce3c20dfd11e8f46179c5fd752447a92903
-warning=This plugin saves your username, items, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers
+warning=In order to share your items with other players, this plugin sends player data (including IP address) to an open-source 3rd party server. The server is not controlled or verified by the RuneLite Developers


### PR DESCRIPTION
This plugin gives players the ability to share items from their Equipment, Inventory, Bank, and GIM Storage to other players within their invite-only group

https://github.com/vyxyl/runelite-item-share

![install](https://user-images.githubusercontent.com/66688162/150685572-16dc30f3-3a49-44e0-9d3e-98797d8adfbd.png)
![view-items](https://user-images.githubusercontent.com/66688162/150685586-fade07ee-6270-4e3b-ad7d-062ca067ee3f.png)

