### PR TITLE
Updated Emote Clue Items to v3.3.1.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=7b9f13c3f475d99a26b12cb2d27908daaa32b759
+commit=e5a449e24c1c7567983e5348ae32743c9190052c


### PR DESCRIPTION
Patch notes:
- Updated RuneLite version to 1.8.9.
- Fixed typo in stash unit name ([#37](https://github.com/larsvansoest/emote-clue-items/pull/37))