### PR TITLE
WikiSync - Add <br>s in the warning to avoid one super long line of text

### DIFF
--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/WikiSync.git
 commit=65f928ec5b7448597c32866a5b696f7925f969bb
-warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone. We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your quest status could be detrimental to your account by giving away information about what you're currently doing.
+warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.


### PR DESCRIPTION
Just changes the warning text to add `<br>`s to help readability