### PR TITLE
Update Pm Highlight to version 1.0.5

### DIFF
--- a/plugins/pm-highlight
+++ b/plugins/pm-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/wtommyw/pm-highlight.git
-commit=9c03fe58613e328931b20e6f0013205a4c29bd0f
+commit=f18ebf895d704bcbc1da927cffbc0a156be52f05

--- a/plugins/pm-highlight
+++ b/plugins/pm-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/wtommyw/pm-highlight.git
-commit=fbd8176f494e2f6ee1af9410bf25682bb95e167d
+commit=9c03fe58613e328931b20e6f0013205a4c29bd0f


### PR DESCRIPTION
This update fixes an issue preventing names containing spaces from being highlighted on log in/out messages.