### PR TITLE
Update leftclick-dropper to v1.6

### DIFF
--- a/plugins/zom-leftclick-dropper
+++ b/plugins/zom-leftclick-dropper
@@ -1,2 +1,2 @@
-repository=https://github.com/redrumze/zom-external-plugins.git
-commit=823102dcae7e4ed3be37be5f94c33bb9e48cadd4
+repository=https://github.com/JZomDev/zom-external-plugins.git
+commit=e21b2b56b29ed6adc0ae87938fa67672f2bf93dd


### PR DESCRIPTION
Renamed the class to stop clashing with menu entry swapper extended