### PR TITLE
Bump bankxpvalue to version 1.2

### DIFF
--- a/plugins/bank-xp-value
+++ b/plugins/bank-xp-value
@@ -1,2 +1,2 @@
 repository=https://github.com/dseeler/bank-xp-value.git
-commit=076d21a191b5cec70ae9b6a78c42d0f848c337d7
+commit=e121e5ad739c5229ddecc8fb44eec1a132b3a0b3


### PR DESCRIPTION
Update notes:
- Allow the bankxpvalue overlay to be moved and persist custom location
- Replace `keepFixed` config option with `resetToCenter`