### PR TITLE
update shattered-relic-xp to v1.1

### DIFF
--- a/plugins/shattered-relic-xp
+++ b/plugins/shattered-relic-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=c4cd766403a2a00c14270a30e915985757f1a560
+commit=248ee3a44ea01dcdbcece4c4da0d40d26e12383d


### PR DESCRIPTION
Turns out the fragments don't stop gaining xp after 8000, the client just stops displaying it. The plugin now caps it to 8000 to match.