### PR TITLE
Add Shattered Relics Fragment Presets plugin

### DIFF
--- a/plugins/shattered-relics-fragment-presets
+++ b/plugins/shattered-relics-fragment-presets
@@ -1,2 +1,2 @@
-repository=https://github.com/SyntaxBlitz/osrs-shattered-relics-fragment-presets
+repository=https://github.com/SyntaxBlitz/osrs-shattered-relics-fragment-presets.git
 commit=fd443329da25a09c9bd6a4a41e474b389cd397ed

--- a/plugins/shattered-relics-fragment-presets
+++ b/plugins/shattered-relics-fragment-presets
@@ -1,2 +1,2 @@
 repository=https://github.com/SyntaxBlitz/osrs-shattered-relics-fragment-presets.git
-commit=fd443329da25a09c9bd6a4a41e474b389cd397ed
+commit=38282da476125ad0996f6e967946910b130087ed

--- a/plugins/shattered-relics-fragment-presets
+++ b/plugins/shattered-relics-fragment-presets
@@ -1,0 +1,2 @@
+repository=https://github.com/SyntaxBlitz/osrs-shattered-relics-fragment-presets
+commit=fd443329da25a09c9bd6a4a41e474b389cd397ed


### PR DESCRIPTION
This plugin lets users create fragment presets. Though they won't be auto-equipped (since plugins can't send actions directly to the server), the fragment pane will automatically scroll as you equip your preset fragments one-by-one, until you've fully equipped the preset (I assume this is alright, since the clue scroll plugin does the same for the emote window).

See the video for details: https://www.youtube.com/watch?v=HBbKZbDsXio

This code is a little dirty (lots of global state with no encapsulation), so apologies in advance to those reviewing it. I wanted to get this done as quickly as possible so I could get back to playing Leagues :)