### PR TITLE
update shattered-relic-xp to v1.4

### DIFF
--- a/plugins/shattered-relic-xp
+++ b/plugins/shattered-relic-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=f65da5f30b3c7e2418619f09d4c7876934b8f744
+commit=ec81a121bab13922dd71afeaf64df9b785e20ab3


### PR DESCRIPTION
- Fixed the issue where xp bars were appearing on set effects (thanks to @testing-ongithub for the help)
- Indirectly fixed incorrect overlays and tooltips for slot 6 & 7