### PR TITLE
(Bug Fix) Update tasks-tracker to move json into github

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=45192f036b16e8a83cc875f82f8561b543d922e3
+commit=48b4388744a12ef1272573d218826564f9b4e8d0


### PR DESCRIPTION
There was a bug where the Wiki data we scraped wasn't matching names in-game. I remedied this by pulling the names from the client scripts.

Instead of making small incremental task json changes, we replaced the included json resource with a GET to GitHub. This will reduce small updates like this in the future (and so we can build out the task metadata - skill reqs, etc - without updates to plugin-hub).

Diff can be found here:
https://github.com/osrs-reldo/tasks-tracker-plugin/compare/45192f036b16e8a83cc875f82f8561b543d922e3..48b4388744a12ef1272573d218826564f9b4e8d0