### PR TITLE
Bump WikiSync to 1.1.1

### DIFF
--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/WikiSync.git
-commit=65f928ec5b7448597c32866a5b696f7925f969bb
+commit=c2d1eaa46bd87750a2619e8cc4878595827bcfee
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.


### PR DESCRIPTION
- Attempt to re-store data on failed submission so it goes through the next time
- Check `onGameTick` for profile type change to fix a bug where hopping to a new world type could carry over info from previous world type
- Add calls to a version endpoint to check if the manifest needs to be updated (every 20 mins)
- Add icon