### PR TITLE
Update shooting-stars to v1.6

### DIFF
--- a/plugins/shooting-stars
+++ b/plugins/shooting-stars
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/plugin-repo.git
-commit=ad8ed1f942db2ad23bc59e746ce18a77ee88c61f
+commit=3c95a16fb858ffda69f045cb4b3c0d8ea8964ee4
 warning=This plugin submits the location and time of shooting stars along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
- Support hiding stars for the wave via right click menu
- Allow opt-in to share leagues stars (right now the default server rejects these reports)