### PR TITLE
Update tasks-tracker

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=15ef8cd7190b53a4d45b2ac0a5873ed6569f17b8
+commit=ab010f712f5053a9ec04019790ba0b1165bc208a

--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=48b4388744a12ef1272573d218826564f9b4e8d0
+commit=15ef8cd7190b53a4d45b2ac0a5873ed6569f17b8


### PR DESCRIPTION
Critical Fixes:

- Fixed race-condition with `startUp` loading a profile before GitHub responded with task jsons
  - The plugin would fail to start if users installed after already logging in or updated while logged in
  - Current solution requires reinstalling the plugin while logged out

Other Fixes:

- Changed export to export 0 instead of -1 for "null" ints
- Fixed a UI bug for users with RuneLite set to "Always on Top"
- Added plugin install stats badges to README.md
- Fixed task tooltips to be dynamically rendered so to keep up with player skills

Diff can be found here:
https://github.com/osrs-reldo/tasks-tracker-plugin/compare/48b4388744a12ef1272573d218826564f9b4e8d0..ab010f712f5053a9ec04019790ba0b1165bc208a