### PR TITLE
Update shattered-relics-fragment-presets to 1.1

### DIFF
--- a/plugins/shattered-relics-fragment-presets
+++ b/plugins/shattered-relics-fragment-presets
@@ -1,2 +1,2 @@
 repository=https://github.com/SyntaxBlitz/osrs-shattered-relics-fragment-presets.git
-commit=38282da476125ad0996f6e967946910b130087ed
+commit=4c24002769409537f75f335a72fca4ed7f96cbd7


### PR DESCRIPTION
- Move preset panel in fixed mode
- Add config for manual panel offset
- Small QoL tweaks ([1](https://github.com/SyntaxBlitz/osrs-shattered-relics-fragment-presets/commit/09679b7ddc08bc2dce4020d2c947c18dfe0f4d5c), [2](https://github.com/SyntaxBlitz/osrs-shattered-relics-fragment-presets/commit/cfc8c9c89ba287565ab8a3b057192df953d73b6a))
- Add shift-click menu swap (off by default)

Thanks @zmanowar!