### PR TITLE
Break reminder plugin

### DIFF
--- a/plugins/break-reminder
+++ b/plugins/break-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/LeeOkeefe/Break-reminder-plugin.git
+commit=45671cf455be2ec3e7792b41bc0685bd783a9e52


### PR DESCRIPTION
This plugin allows a user to set how frequently to take a break, then provides an overlay to show updates on when their break is due/overdue to help them stick to taking regular breaks.
