### PR TITLE
Create pyramid-plunder-counter

### DIFF
--- a/plugins/pyramid-plunder-counter
+++ b/plugins/pyramid-plunder-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/adnapPanda/pyramid-plunder-counter.git
+commit=403ac74ceb008b8c381bde8d9b714e2f4afc4264


### PR DESCRIPTION
This plugin will track and display how many golden chests and sarcophagi you have successfully looted in your session.