### PR TITLE
Update analogue-timestamps to 1.1

### DIFF
--- a/plugins/analogue-timestamps
+++ b/plugins/analogue-timestamps
@@ -1,2 +1,2 @@
 repository=https://github.com/Hannah-GBS/analogue-timestamps.git
-commit=0c3a4e45b48fd7b81fa37ad4916c2151ff3bd1ef
+commit=882f5cefca1a437a2d1c8542081c7f322bc50a92


### PR DESCRIPTION
Abex broke this 8 months ago by changing the core timestamps and _never thought to tell me_ 😭