### PR TITLE
Update wiki-sync to 2.0

### DIFF
--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/WikiSync.git
-commit=4ccdf66e0b4c4ebfa8369bac3063fdd5bd86984a
+commit=857e38bb5601e25620f9cd71cae60e314e3554da
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.

--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/WikiSync.git
-commit=0d15602b786b0062f8835002a610978add708197
+commit=4ccdf66e0b4c4ebfa8369bac3063fdd5bd86984a
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.

--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/WikiSync.git
-commit=857e38bb5601e25620f9cd71cae60e314e3554da
+commit=0b04a53c02264ef305b150ce1f42ecb127137820
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.

--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/WikiSync.git
-commit=0b04a53c02264ef305b150ce1f42ecb127137820
+commit=8246ef597be7554010737e8c47559b23d689410f
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.

--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/WikiSync.git
-commit=65f928ec5b7448597c32866a5b696f7925f969bb
+commit=0d15602b786b0062f8835002a610978add708197
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.


### PR DESCRIPTION
This is a core rewrite to the plugin and replaces the change-based approach into something that periodically just dumps all the relevant data for the user, computes the delta versus what has already been sent, and sends that to the server.

This gives us automatic retries (no changes get dropped if the server 500s), and less confusing logic if player name or profile change. It's also about 65% less code.