### PR TITLE
update shattered-relic-xp to v1.5

### DIFF
--- a/plugins/shattered-relic-xp
+++ b/plugins/shattered-relic-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=ec81a121bab13922dd71afeaf64df9b785e20ab3
+commit=3dad3ade697302cb947db8f3051f438641a74a7c


### PR DESCRIPTION
Fixed the Larger Recharger tooltips breaking with descriptive tooltips