### PR TITLE
Re-enable Party Panel plugin

### DIFF
--- a/plugins/party-panel
+++ b/plugins/party-panel
@@ -1,3 +1,2 @@
 repository=https://github.com/TheStonedTurtle/party-panel.git
-commit=7af745117e8400175d437b92b60e89fc91cb5d15
-disabled=true
+commit=fb4f7f061529e62ff4265d32d95fff514b47566e


### PR DESCRIPTION
* Updates the plugin to be compatible with gradle 7.3.2
* Renames the plugin to `Discord Party Panel` to try and avoid confusion
