### PR TITLE
Update shattered-relics-fragment-presets (v1.2)

### DIFF
--- a/plugins/shattered-relics-fragment-presets
+++ b/plugins/shattered-relics-fragment-presets
@@ -1,2 +1,2 @@
 repository=https://github.com/SyntaxBlitz/osrs-shattered-relics-fragment-presets.git
-commit=4c24002769409537f75f335a72fca4ed7f96cbd7
+commit=8e3bba553b3d8a6dc1b303ac89d0622390343655


### PR DESCRIPTION
Shift-click equip and unequip work now, thanks to @Memebeams