### PR TITLE
Add League Chat Broadcasts plugin

### DIFF
--- a/plugins/league-chat-broadcasts
+++ b/plugins/league-chat-broadcasts
@@ -1,0 +1,2 @@
+repository=https://github.com/Memebeams/league-chat-broadcasts.git
+commit=37256b842c729f8a5393cccf4f226854c8939188

--- a/plugins/league-chat-broadcasts
+++ b/plugins/league-chat-broadcasts
@@ -1,2 +1,2 @@
 repository=https://github.com/Memebeams/league-chat-broadcasts.git
-commit=37256b842c729f8a5393cccf4f226854c8939188
+commit=ac12ca768ca0314619ccc7dd1c2772ed88aab544


### PR DESCRIPTION
To help alleviate confusion, this plugin adds the small League icon to loot broadcasts in clan/group chats when that loot is obtained on a League world.

![image](https://user-images.githubusercontent.com/5132037/152624463-d5eb3736-afce-4001-8b77-1f576211f0b2.png)
