### PR TITLE
disable zalcano for breaking core functionality

### DIFF
--- a/plugins/zalcano
+++ b/plugins/zalcano
@@ -1,3 +1,3 @@
 repository=https://github.com/Tjieco/Zalcano.git
 commit=e7fde4576c9dbeb76efe5796f656dfe66f3d6fcb
-
+disabled=breaks core zalcano plugin overlay position


### PR DESCRIPTION
the overlay names for this hub plugin and the core zalcano plugin are the same, so changes to overlay position effect both, breaking dynamic markings for the core overlay