### PR TITLE
update shattered-relic-xp to v1.6

### DIFF
--- a/plugins/shattered-relic-xp
+++ b/plugins/shattered-relic-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=3dad3ade697302cb947db8f3051f438641a74a7c
+commit=b24950a21f14281f182e4220cb86df2e2cfe22fb


### PR DESCRIPTION
* Add support for showing effects of sets in their tooltips
	* This fixes the plugin complaining when hovering over set boxes
* Moved the tooltips to never cover the fragment boxes. This also allows extra lines to be used for the really long ones.