### PR TITLE
Update quest-helper to v2.8.3

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=f5067ed9ed16a458b291bfd80314e4702d3424f7
+commit=698ecbad965d91c9cfcc39d47cf982643c1290c7


### PR DESCRIPTION
A few small fixes, including making quest-helper compatible with the most recent version of Runelite