### PR TITLE
Update 117hd to v1.0.14

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,2 +1,2 @@
 repository=https://github.com/RS117/RLHD.git
-commit=7c6f9909a929517c6994772963971c64b2f35f96
+commit=965fe76320d329dcbb65dd19f5079c8d0fbddbff


### PR DESCRIPTION
- improve performance in The Gauntlet by forcing scene reload when opening rooms
- reduce CPU usage by caching a bunch of model data
- fix macOS resized FBO bug (port from GPU plugin)
- fix stretched geometry bug by replacing count_prio_offset's switch with a loop
- adjust shadow threshold to prevent some flickering shadows
- make light flickering effect visually consistent regardless of performance
- log client information (32/64-bit) for debugging purposes
- increase MAX_TRIANGLE to account for higher tri count models
- remove remaining Christmas environment properties