### PR TITLE
Add F2P Star Hunt

### DIFF
--- a/plugins/f2p-starhunt
+++ b/plugins/f2p-starhunt
@@ -1,2 +1,2 @@
 repository=https://github.com/Jannyboy11/F2P-StarHunt-PluginHub.git
-commit=c55d24e86e1a65d79325dd214e6d3686655dd2b7
+commit=2fe5aac89f26e78bacdb93570bfb26c667f5b787


### PR DESCRIPTION
This plugin assists my clan and friends chat with keeping track of shooting stars.
It's feature list:
- Sidebar panel with a list of known crashed stars
- Hint arrow that points to a star location (togglable)
- Checks for star calls in chat (togglable)
- Communication with a web server to send/update/receive crashed stars (configurable, off by default)

The repo of the plugin-hub compatible gradle-project was generated from the example plugin template, and my own multi-module maven project located [here](https://github.com/jannyboy11/f2p-starhunt).