### PR TITLE
Add F2P Star Assist

### DIFF
--- a/plugins/f2p-star-assist
+++ b/plugins/f2p-star-assist
@@ -1,2 +1,2 @@
 repository=https://github.com/Jannyboy11/F2P-Star-Assist-PluginHub.git
-commit=69d1c17dc6bc84da0092c8a5aa0d6ac5dbe72bf3
+commit=56d50692a0f925b55ae4c2b4359579d52c9313ce

--- a/plugins/f2p-star-assist
+++ b/plugins/f2p-star-assist
@@ -1,2 +1,2 @@
 repository=https://github.com/Jannyboy11/F2P-Star-Assist-PluginHub.git
-commit=2ac2d6bb43bae297d1308dc37b84a98b404a14c8
+commit=16927242cff5eec158bb50140895057611e609a9

--- a/plugins/f2p-star-assist
+++ b/plugins/f2p-star-assist
@@ -1,2 +1,2 @@
 repository=https://github.com/Jannyboy11/F2P-Star-Assist-PluginHub.git
-commit=56d50692a0f925b55ae4c2b4359579d52c9313ce
+commit=2ac2d6bb43bae297d1308dc37b84a98b404a14c8

--- a/plugins/f2p-star-assist
+++ b/plugins/f2p-star-assist
@@ -1,0 +1,2 @@
+repository=https://github.com/Jannyboy11/F2P-Star-Assist-PluginHub.git
+commit=69d1c17dc6bc84da0092c8a5aa0d6ac5dbe72bf3


### PR DESCRIPTION
This plugin assists my clan and friends chat with keeping track of shooting stars.
It's feature list:
- Sidebar panel with a list of known crashed stars
- Hint arrow that points to a star location (togglable)
- Checks for star calls in chat (togglable)
- Communication with a web server to send/update/receive crashed stars (configurable, off by default)

The repo of the plugin-hub compatible gradle-project was generated from the example plugin template, and my own multi-module maven project located [here](https://github.com/jannyboy11/F2P-Star-Assist).