### PR TITLE
Plank Alerts Plugin

### DIFF
--- a/plugins/plank-alerts
+++ b/plugins/plank-alerts
@@ -1,2 +1,2 @@
 repository=https://github.com/ANWAQ/Plank-Alerts.git
-commit=48f82c8c21b71e870db569c9719fe553703f5a60
+commit=38ca686f37aaf5f3672d2b7dcd913919897ce29d

--- a/plugins/plank-alerts
+++ b/plugins/plank-alerts
@@ -1,2 +1,2 @@
 repository=https://github.com/ANWAQ/Plank-Alerts.git
-commit=5738c8cfe1b04060a0b67c8690d07e8153586d1d
+commit=48f82c8c21b71e870db569c9719fe553703f5a60

--- a/plugins/plank_alerts
+++ b/plugins/plank_alerts
@@ -1,0 +1,2 @@
+repository=https://github.com/ANWAQ/Plank-Alerts.git
+commit=5738c8cfe1b04060a0b67c8690d07e8153586d1d


### PR DESCRIPTION
Plugin to screenshot deaths during COX / TOB raids and post them to a discord webhook.