### PR TITLE
update shattered-relic-xp to v1.10

### DIFF
--- a/plugins/shattered-relic-xp
+++ b/plugins/shattered-relic-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=04fbb271864b057a5ec56d62aad82ca1ddc571c5
+commit=eb901cf3e2a5596fa3fae21878a04c7e0ec9e4e4


### PR DESCRIPTION
Didn't notice Jagex had removed one of the text widgets with the update, so this fixes the overlay text positions.