### PR TITLE
update shortest-path to v1.6

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=2f546ed4a7eff861d8ffec01b4790cc5c0205f6e
+commit=9fac9a4b4c8c8b38231f06deab5fb61799e64013

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=b42eda0a60920add7a7f6d3c91eab649bdcba26e
+commit=2f546ed4a7eff861d8ffec01b4790cc5c0205f6e


### PR DESCRIPTION
**Persistent start position and world map bug fix**
- A manually selected path start position will now be re-used when changing the path target position instead of always defaulting to the current player location.
- Transport lines drawn on the world map will no longer be visible outside the world map widget view.
- Updated the support URL.