### PR TITLE
update shattered-relic-xp to v1.12

### DIFF
--- a/plugins/shattered-relic-xp
+++ b/plugins/shattered-relic-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/Hydrox6/external-plugins.git
-commit=53aadee81bd6022261a3a3daa46761e7e62c7ae3
+commit=49c13e7a125bee291157e9be5199f02f89b0b6ea


### PR DESCRIPTION
Fixed the overlay not updating when gaining fragment xp (oops)