### PR TITLE
Add ToG Crowdsourcing

### DIFF
--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=ea0b9bcfc55571df303346ee1414052ed00ebedc
+commit=4e7b7a9cd019e10f5963886bdc63f446791706cf

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,2 +1,3 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
 commit=4e7b7a9cd019e10f5963886bdc63f446791706cf
+warning=This plugin submits your current world number along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=85f4ddd59e341ec5d9bcfb11e19c7a6bdd00cb32
+commit=88f9a125fdea29a6f980c602a25c407150b0fba4

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,0 +1,2 @@
+repository=https://github.com/jcarbelbide/tog-crowdsourcing
+commit=322d137bae4afa5fb0d6359b137e24c45cb48496

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=4e7b7a9cd019e10f5963886bdc63f446791706cf
+commit=d613a4eb37aab98adf9b04c953c36f44b1e4732f
 warning=This plugin submits your current world number along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,2 +1,2 @@
-repository=https://github.com/jcarbelbide/tog-crowdsourcing
+repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
 commit=322d137bae4afa5fb0d6359b137e24c45cb48496

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=322d137bae4afa5fb0d6359b137e24c45cb48496
+commit=f326ec40fd87fa295efe50bf326e84d9ff9ca6ac

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=88f9a125fdea29a6f980c602a25c407150b0fba4
+commit=ea0b9bcfc55571df303346ee1414052ed00ebedc

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,2 +1,2 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=f326ec40fd87fa295efe50bf326e84d9ff9ca6ac
+commit=85f4ddd59e341ec5d9bcfb11e19c7a6bdd00cb32


### PR DESCRIPTION
Tears of Guthix Crowdsourcing. 

This plugin aims to crowdsource the stream orders for each world. For example "gggbbb". Some stream orders are more efficient to use than others. 

This talks to an external web server created by me. The code for that cane be found [here](https://github.com/jcarbelbide/tog-crowdsourcing-server). 

The server monitors the osrs servers through a JS5 socket connection. When it detects the weekly reset, the database is wiped, and the new week's data must be gathered, The JS5 monitor can be found [here](https://github.com/jcarbelbide/js5-monitor). 

Please let me know if there are any questions or anything I need to change. 

Thank you for your time!