### PR TITLE
Update shortest-path to v1.6

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=87897af6b5d15241685eacd3c12c5d574b857f71
+commit=9089d64edf80b98bf02a2990fb95b9c884057d71

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=9089d64edf80b98bf02a2990fb95b9c884057d71
+commit=2143fb1570cc19d30224df037232b472b0fbea7b

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=9fac9a4b4c8c8b38231f06deab5fb61799e64013
+commit=87897af6b5d15241685eacd3c12c5d574b857f71

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=2143fb1570cc19d30224df037232b472b0fbea7b
+commit=42e0e6d16ca56db40749031e0f027302146616e3


### PR DESCRIPTION
- Fix transport line clipping
  - Transport line clipping was performed inside a loop which made the map slow
- Include the z-plane in the distance calculation
  - Unreachable target destinations should now prioritize pathing on the current z-plane
- Fix bug in recalculation distance check
  - Unreachable target destinations should no longer cause an infinite recalculation distance check
- Added a clear path option on the minimap
  - The minimap now has a right-click `Clear Path` option, similar to in the scene and on the world map