### PR TITLE
Update shattered-religs-fragment-presets to 1.6

### DIFF
--- a/plugins/shattered-relics-fragment-presets
+++ b/plugins/shattered-relics-fragment-presets
@@ -1,2 +1,2 @@
 repository=https://github.com/SyntaxBlitz/osrs-shattered-relics-fragment-presets.git
-commit=14e05451b55952a963fd0b19529dbce80e74484c
+commit=45195da8ffe586a54e9fcf150e68e2fd26a64d8b


### PR DESCRIPTION
Apologies for the quick re-update. I introduced a bug in 1.5 that needed a one-line fix. Plugin crashes when there are zero presets configured (including on a fresh install...! whoops).