### PR TITLE
Update gim-plugin to v2.2

### DIFF
--- a/plugins/gim-plugin
+++ b/plugins/gim-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/davidvorona/gim-plugin.git
-commit=c777cd161704d5000040be3b2095299a96585b89
+commit=7cd16da5ff4af5c434b07dcc1fa58e8968f337dc


### PR DESCRIPTION
- implements patch for breaking behavior if gimp usernames have spaces