### PR TITLE
update dps-calculator to v1.5.0

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=408567d91d3d2c2ac0a417fea1bf7d5f33a915e8
+commit=7e1a5cfbe64b62dd9bd3b0e79154b1ba0a6729f2


### PR DESCRIPTION
In combination with today's change to LlemonDuck/runelite-wiki-scraper, this plugin now automatically pulls wiki changes weekly in order to stay up to date with game changes. This should reduce the amount of required plugin-hub updates, and provide users with more up-to-date stats/availability.