### PR TITLE
Added Godbook Plugin

### DIFF
--- a/plugins/godbook
+++ b/plugins/godbook
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/godbook.git
-commit=6b99a3367a4097538ea7c697c8550765a7fbca23
+commit=bafdd74322b0e1a69215dd04076a354bdaa83478

--- a/plugins/godbook
+++ b/plugins/godbook
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/godbook.git
-commit=bafdd74322b0e1a69215dd04076a354bdaa83478
+commit=eec041d78d31b1f135720477a4ac0490f7cb490b

--- a/plugins/godbook
+++ b/plugins/godbook
@@ -1,0 +1,2 @@
+repository=https://github.com/InfernoStats/godbook.git
+commit=6b99a3367a4097538ea7c697c8550765a7fbca23


### PR DESCRIPTION
This plugin displays an overlay with the amount of time in game ticks that a player last used the "Preach" option on a god book.

This is predominantly used in the Theatre of Blood to line up spec cycles in Verzik P1.