### PR TITLE
Update ba-minigame to v1.61

### DIFF
--- a/plugins/ba-minigame
+++ b/plugins/ba-minigame
@@ -1,2 +1,2 @@
 repository=https://github.com/BegOsrs/Ba-minigame.git
-commit=31979b0f093bc15297f1ced515a4d3a1d25453f4
+commit=15704dfd7b29570bf2d4723a47b9585953aca61e

--- a/plugins/ba-minigame
+++ b/plugins/ba-minigame
@@ -1,2 +1,2 @@
 repository=https://github.com/BegOsrs/Ba-minigame.git
-commit=15704dfd7b29570bf2d4723a47b9585953aca61e
+commit=be2ab32d165fbfb6ebb4a7bb90d5b1d39dab18a2


### PR DESCRIPTION
- Fix bug related to round tick timer not ticking outside a ba game
- Fix bug related to round/session points not increasing for wave 10
- Add option to hide call-to teammate role
- Disable some defaults such as highlight food/arrows/style/broken trap
- Start a new wave by detecting role horn on inventory
- Other minor bug fixes/changes