### PR TITLE
dead traps plugin

### DIFF
--- a/plugins/dead-traps
+++ b/plugins/dead-traps
@@ -1,2 +1,2 @@
 repository=https://github.com/oceijt/DeadTraps.git
-commit=7fb26d43a1a06044625aeeb873334aae22838da6
+commit=39febf041fdd2d43f8d82775326a5d709699d1a1

--- a/plugins/dead-traps
+++ b/plugins/dead-traps
@@ -1,2 +1,2 @@
 repository=https://github.com/oceijt/DeadTraps.git
-commit=bc6799703b5383030a94220788f0f332edb7dd22
+commit=7fb26d43a1a06044625aeeb873334aae22838da6

--- a/plugins/dead-traps
+++ b/plugins/dead-traps
@@ -1,0 +1,2 @@
+repository=https://github.com/oceijt/DeadTraps.git
+commit=bc6799703b5383030a94220788f0f332edb7dd22


### PR DESCRIPTION
Adds an extra "dead" state for box traps that can no longer catch any chins based off interaction