### PR TITLE
Create clan-activity-tracker

### DIFF
--- a/plugins/clan-activity-tracker
+++ b/plugins/clan-activity-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Phobos97/clan-activity-tracker.git
+commit=a5c6e68bae9a3ed9d44a01045c3315f82bff2992


### PR DESCRIPTION
New plugin to track some clan data and save to .csv file. This tracks when a player was last seen online and how many messages the player has send in the clan chat. This was mainly made for use in my own clan but im sure some more people could get use out of it. Also has an option to track FriendsChat instead of Clan. See readme for image example.