### PR TITLE
Update ToG Crowdsourcing - Fix overlay always showing. 

### DIFF
--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=d613a4eb37aab98adf9b04c953c36f44b1e4732f
+commit=e12fd450d63ac455e48e086b0be310cac1e1b889
 warning=This plugin submits your current world number along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Overlay will no longer show up when outside of ToG area. Added icon. Simplified author name in runelite-plugin.properties.