### PR TITLE
[IRC] Move away from NOTICE to RAW

### DIFF
--- a/plugins/irc
+++ b/plugins/irc
@@ -1,2 +1,2 @@
 repository=https://github.com/ryanwohara/irc-plugin.git
-commit=3a23633d91cc1efcb9e1acefab30f2e6779def9a
+commit=574bfd3e1f00a7b3aaad9ef182d0fdbc179c66bc


### PR DESCRIPTION
This move ensures we identify at the right time and only once: on connect. This is both for security and functionality, including a fix for a bug that persisted yesterday's update.