### PR TITLE
Added Guardians of the Rift Helper

### DIFF
--- a/plugins/guardians-of-the-rift-helper
+++ b/plugins/guardians-of-the-rift-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/DatBear/Guardians-of-the-Rift-Helper.git
-commit=43018ffe0e3ee65fb6d791759a17fc9653bec9bb
+commit=9cf061000918d02b2dd407b0d48e2ae1361b34f5

--- a/plugins/guardians-of-the-rift-helper
+++ b/plugins/guardians-of-the-rift-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/DatBear/Guardians-of-the-Rift-Helper.git
+commit=faae98448879c536ed86897d83889daf264945f9

--- a/plugins/guardians-of-the-rift-helper
+++ b/plugins/guardians-of-the-rift-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/DatBear/Guardians-of-the-Rift-Helper.git
-commit=178417e293b09f769c4bc6308136e78d2fa3ff02
+commit=94c8faa8185538a0dfdb915d4047e513e6754258

--- a/plugins/guardians-of-the-rift-helper
+++ b/plugins/guardians-of-the-rift-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/DatBear/Guardians-of-the-Rift-Helper.git
-commit=9cf061000918d02b2dd407b0d48e2ae1361b34f5
+commit=c16d649cb3bdb3731b562df2eeaa6f9776302022

--- a/plugins/guardians-of-the-rift-helper
+++ b/plugins/guardians-of-the-rift-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/DatBear/Guardians-of-the-Rift-Helper.git
-commit=c16d649cb3bdb3731b562df2eeaa6f9776302022
+commit=178417e293b09f769c4bc6308136e78d2fa3ff02

--- a/plugins/guardians-of-the-rift-helper
+++ b/plugins/guardians-of-the-rift-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/DatBear/Guardians-of-the-Rift-Helper.git
-commit=faae98448879c536ed86897d83889daf264945f9
+commit=43018ffe0e3ee65fb6d791759a17fc9653bec9bb


### PR DESCRIPTION
# Guardians of the Rift Helper
* Adds outlines to the currently active elemental + catalytic runes.
* Adds rune icons + timers above the active runes.
* Highlights the Great Guardian when you have catalytic or elemental essence to give to him.
* Highlights the Cell table when you have no Cells left.
* Highlights the Essence piles when you have an Overcharged cell and there is a free guardian slot.
* Adds a timer showing how long the current portal will last.
* Overlay panel shows: Time since last portal, time until next game, and reward points.