### PR TITLE
Update Discord rare drop notificator to 1.4.0

### DIFF
--- a/plugins/discord-rare-drop-notificater
+++ b/plugins/discord-rare-drop-notificater
@@ -1,2 +1,2 @@
 repository=https://github.com/BossHuso/discord-rare-drop-notificater.git
-commit=54dc0daa911efed0f1114d6249e40e66cf674324
+commit=036556997be626068bcefaa789cde73490eb4bee

--- a/plugins/discord-rare-drop-notificater
+++ b/plugins/discord-rare-drop-notificater
@@ -1,3 +1,2 @@
 repository=https://github.com/BossHuso/discord-rare-drop-notificater.git
-commit=3527e7fe67db4826a6dcce5fab3f4d6aa5f332cd
-warning=This plugin submits the ID of monsters you kill, items you receive, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
+commit=54dc0daa911efed0f1114d6249e40e66cf674324


### PR DESCRIPTION
* No more Osrsbox API
* Only api used is osrs wiki
* Sent to discord using user set endpoints
* **Removed warning,** _please advise_
* Cache a JSON on startup