### PR TITLE
Add Not Enough Runes plugin

### DIFF
--- a/plugins/not-enough-runes
+++ b/plugins/not-enough-runes
@@ -1,0 +1,2 @@
+repository=https://github.com/Hannah-GBS/notenoughrunes.git
+commit=8732aa7f450970abb92d9ee8347944c91f002a90


### PR DESCRIPTION
Shows sources and uses for in-game items using scraped wiki data (hosted on github and cached locally)

https://user-images.githubusercontent.com/7504779/160226998-2879ed72-2104-44b8-9a26-ef7a3580a011.mp4