### PR TITLE
Add star calling assist

### DIFF
--- a/plugins/star-calling-assist
+++ b/plugins/star-calling-assist
@@ -1,0 +1,3 @@
+repository=https://github.com/zodaz/star-calling-assist.git
+commit=1efa782d30d9e302aa5fe00fe595b0d2179d7523
+warning=This plugin submits your current world number and in game name along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/star-calling-assist
+++ b/plugins/star-calling-assist
@@ -1,3 +1,3 @@
 repository=https://github.com/zodaz/star-calling-assist.git
-commit=202bcf484cc3b0d8f1062da173924a03ba1141c3
+commit=172258cdb0099ee51127e4e30aa34a35dd178a15
 warning=This plugin submits your current world number and in game name along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/star-calling-assist
+++ b/plugins/star-calling-assist
@@ -1,3 +1,3 @@
 repository=https://github.com/zodaz/star-calling-assist.git
-commit=1efa782d30d9e302aa5fe00fe595b0d2179d7523
+commit=202bcf484cc3b0d8f1062da173924a03ba1141c3
 warning=This plugin submits your current world number and in game name along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
This plugin allows for crashed stars found around the game to be posted to a remote endpont when found.