### PR TITLE
Update Bossing Info to 1.8.5

### DIFF
--- a/plugins/kph-tracker
+++ b/plugins/kph-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Mrnice98/BossingInfo.git
-commit=0f5a5c6dd83d19b3c33521aa881c868c967a67de
+commit=37786f0783bdf4dc0fda6d899050b9b791e73622


### PR DESCRIPTION
Update Bossing Info to 1.8.5, Add option to output kph in chat each kill, fixed a bug with session data cache, fixed capitalization and adjusted timeout for a few bosses. just a few small changes. 