### PR TITLE
Update loot-lookup to v1.1.2

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=200648c6fa3f2ac7a37cf2700de50ba711bee78a
+commit=fc3e42784f8376f32029004f2e40c80a067dae64


### PR DESCRIPTION
* Auto select tab corresponding to monster level on right click menu option where possible
      -  Ex: If the NPC is level 221 and the "Lookup Drops" menu option is selected, auto select the tab that corresponds to "Drops (Level 221)"
     

* Link to correct wiki page for TzHaar-Mej
      - "TzHaar-Mej (monster)" instead of "TzHaar-Mej"