### PR TITLE
Add easy-blastfurnace plugin

### DIFF
--- a/plugins/easy-blastfurnace
+++ b/plugins/easy-blastfurnace
@@ -1,0 +1,2 @@
+repository=https://github.com/Toofifty/easy-blastfurnace.git
+commit=116536e2fb1a35882281d6871a54f0e4de699343


### PR DESCRIPTION
Adds a plugin to help in training smithing at blast furnace, by highlighting what to click next for certain methods.

btw is there anything else I need to do to add an icon? Or just dump an icon.png in there 🤔 