### PR TITLE
Update c-engineer-completed to v1.0

### DIFF
--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=945d0499c26c6ccecbe9e83206eb6f0a98bd4012
+commit=d573e9d090bbd1a342870eb42b0fdcb3192dffb9


### PR DESCRIPTION
Manages sound files differently - downloads each file from GitHub to a `c-engineer-sounds` folder in the .runelite folder instead of baking them in to the .jar. This allows users to swap out sounds if desired (as some have requested), as well as allowing for more sounds to be added in the future without bloating the plugin jar.