### PR TITLE
Updated godbook to v1.0.1

### DIFF
--- a/plugins/godbook
+++ b/plugins/godbook
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/godbook.git
-commit=eec041d78d31b1f135720477a4ac0490f7cb490b
+commit=d9cbb08c863b59fb2d26792e92e72e8f16e565bd


### PR DESCRIPTION
This update changes the list of players to use a LinkedHashMap instead of a HashMap so that the iteration order matches the order of insertion. This will make the display of players more uniform instead of listing older players both under and over newer players in the overlay.