### PR TITLE
Add Bank Regex Search plugin

### DIFF
--- a/plugins/regex-bank-search
+++ b/plugins/regex-bank-search
@@ -1,0 +1,2 @@
+repository=https://github.com/majiru/regex-bank-search.git
+commit=185e73e507a5e0cd39dae2d30644ef155a753e39


### PR DESCRIPTION
This adds a plugin for searching bank using regular expressions.
Any search starting with a '/' and optionally ending with a '/' will do regex matching against the item's name.
There is a matching PR to add this feature to the stock bank plugin: https://github.com/runelite/runelite/pull/14823 but figured it may be too niche to be included within the base plugin.