### PR TITLE
Worldping (Displayed name: Tile Ping)

### DIFF
--- a/plugins/worldping
+++ b/plugins/worldping
@@ -1,2 +1,2 @@
 repository=https://github.com/Conkerjoey/WorldPing.git
-commit=df9c414e782e21128b31fb3199a274cd5ebffc73
+commit=20704bc3d3fc7bab0def92e4c8e56fe82facfd1b

--- a/plugins/worldping
+++ b/plugins/worldping
@@ -1,0 +1,2 @@
+repository=https://github.com/Conkerjoey/WorldPing.git
+commit=df9c414e782e21128b31fb3199a274cd5ebffc73


### PR DESCRIPTION
A simple plugin that allows you to ping a tile to every member of the Chat-Channel. They need to have the Tile Ping plugin installed and enabled.

The basic behaviour:
1. Connect to my own Windows server running the World Ping Server in C# (found on my github)
2. Shift + Mouse Wheel Click gather Tile information (world position) and Chat-Channel players list
3. Send ping information to server
4. Server check who is connected and if they are on the CC players list of that ping
5. Send everyone (who was on the list at the time of the ping) the ping with world position and color information.