### PR TITLE
Changing repo ownership

### DIFF
--- a/plugins/ba-minigame
+++ b/plugins/ba-minigame
@@ -1,2 +1,2 @@
-repository=https://github.com/BegOsrs/Ba-minigame.git
-commit=19356a5d8563072653de2cc29aedf5a88a04a1f9
+repository=https://github.com/SkylerPIlot/Ba-Minigame.git
+commit=3e6bd9b782c17b8e75ff694b4cec266732b74479


### PR DESCRIPTION
Reupload of latest plugin version from source found here "http://repo.runelite.net/plugins/1.8.16/ba-minigame/19356a5d8563072653de2cc29aedf5a88a04a1f9-sources.zip". This is after the plugin's original owner removed the code/repo following community drama so changing ownership to other community members.