### PR TITLE
Create RemoveSteps

### DIFF
--- a/plugins/RemoveSteps
+++ b/plugins/RemoveSteps
@@ -1,0 +1,2 @@
+repository=https://github.com/iffy-1/RemoveSteps.git
+commit=5e1550b9b643d38f7604bc92388543917055c9a0

--- a/plugins/StepRemover
+++ b/plugins/StepRemover
@@ -1,0 +1,2 @@
+repository=https://github.com/iffy-1/RemoveSteps.git
+commit=69724ec695363782b18cd0b19f40ab4e4b8e10df


### PR DESCRIPTION
Removes the right click menu in the Chambers of Xeric steps so that UIMs are less likely to wipe items that are in the Olm prep room.