### PR TITLE
Update combo-runes-only to v2.0.0

### DIFF
--- a/plugins/combo-runes-only
+++ b/plugins/combo-runes-only
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/combo-runes-only.git
-commit=ea75dd3783cb71b41ce6a34108bda72783ddaa80
+commit=145a3d4335d996aff276fc198d4eb1b7d5e98951


### PR DESCRIPTION
A likely overcomplicated update of the plug-in, sorry for the 500 line diff.

Copied from LlemonDuck/combo-runes-only#1:

> Context from runelite/plugin-hub#2561:
> 
> Expansion of the plugin to hide the Craft-rune option on all altars, not just the fire altar, would be appreciated. With the release of Guardians of the Rift, this would cover a now-more-common use case of combination rune crafting at non-fire altars.
> 
> Added in 184d671a9dd4e19fe8b5e9f4ad1a4f1141850c21, which is a rewrite of the plugin, adding this and more. Full changelog:
> * Now includes all altars, and altars can be individually toggled in the config.
>   * Since this impacts existing behaviour at the air, water, and earth altars, I've added a version migration notifier on the first entry to an altar. Hopefully this should reduce confusion to users of the plugin wondering why their Craft-rune options may have suddenly disappeared.
> * `MenuEntry` instances are now filtered on the `MenuEntryAdded` event, rather than pruned every client tick.
> * Added a new config option to de-prioritize the Craft-rune `MenuEntry` rather than completely remove.