### PR TITLE
add collection-log-command plugin

### DIFF
--- a/plugins/collection-log-command
+++ b/plugins/collection-log-command
@@ -1,0 +1,3 @@
+repository=https://github.com/call-me-maple/collection-log-command.git
+commit=9ac1350f977847f648dddb51183713927f2f9254
+warning=This plugin submits your display name, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
This plugin displays collection log data using `!log` as a chat command. The collection log data is pulled from [collectionlog.net](https://collectionlog.net/).


