### PR TITLE
Updated Emote Clue Items to v3.4.0.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
-repository=https://github.com/Adam-/runelite-plugins.git
-commit=b50480ef2d7a87ec116ac2fc9ecbb2cf9c4929fc
+repository=https://github.com/larsvansoest/emote-clue-items.git
+commit=abea650fae9bccb8426e0fa73e66337d940d652c


### PR DESCRIPTION
### 3.4.0 Patch notes

This update of Emote Clue Items features the following updates.
- Fixed typos in STASHUnit names. (see [emote-clue-items/pull40](https://github.com/larsvansoest/emote-clue-items/pull/40))
- Updated to RuneLite version 1.18.17. (see [emote-clue-items/pull44](https://github.com/larsvansoest/emote-clue-items/pull/44))
- Overhauled nested item requirement status display. (see [emote-clue-items#39](https://github.com/larsvansoest/emote-clue-items/issues/39))
- Added overlay for group iron man storage. (see [emote-clue-items#41](https://github.com/larsvansoest/emote-clue-items/issues/41))
- Update emote clue data base up to [d129c49](https://github.com/runelite/runelite/commits/master/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java). (see [emote-clue-items/pull45](https://github.com/larsvansoest/emote-clue-items/pull/45))
