### PR TITLE
Add Group Ironmen Tracker plugin

### DIFF
--- a/plugins/group-ironmen-tracker
+++ b/plugins/group-ironmen-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/christoabrown/group-ironmen-tracker.git
-commit=027bb16b756fd70862504bbf29e3d3a85e83a94b
+commit=f61c6aa5454616145ea2796e028e90a71cc48fbb
 warning=This plugin pushes data about your character to an external server.<br>This data is encrypted and is only viewable by people you share the credentials with.

--- a/plugins/group-ironmen-tracker
+++ b/plugins/group-ironmen-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/christoabrown/group-ironmen-tracker.git
-commit=d8cdd5ce253cbfdbfa2da715cb06814221d7a256
+commit=3bbfeaee11a00b63db65ffa6facd7315ed16a8c0

--- a/plugins/group-ironmen-tracker
+++ b/plugins/group-ironmen-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/christoabrown/group-ironmen-tracker.git
+commit=b28b2314f035776d25827b929b3a08c3998ec1d7
+warning=This plugin pushes data about your character to an external server.<br>This data is encrypted and is only viewable by people you share the credentials with.

--- a/plugins/group-ironmen-tracker
+++ b/plugins/group-ironmen-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/christoabrown/group-ironmen-tracker.git
-commit=63233873c61cc06779fdfe82d26e26adeebaacf9
+commit=027bb16b756fd70862504bbf29e3d3a85e83a94b
 warning=This plugin pushes data about your character to an external server.<br>This data is encrypted and is only viewable by people you share the credentials with.

--- a/plugins/group-ironmen-tracker
+++ b/plugins/group-ironmen-tracker
@@ -1,3 +1,2 @@
 repository=https://github.com/christoabrown/group-ironmen-tracker.git
-commit=f61c6aa5454616145ea2796e028e90a71cc48fbb
-warning=This plugin pushes data about your character to an external server.<br>This data is encrypted and is only viewable by people you share the credentials with.
+commit=d8cdd5ce253cbfdbfa2da715cb06814221d7a256

--- a/plugins/group-ironmen-tracker
+++ b/plugins/group-ironmen-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/christoabrown/group-ironmen-tracker.git
-commit=b28b2314f035776d25827b929b3a08c3998ec1d7
+commit=63233873c61cc06779fdfe82d26e26adeebaacf9
 warning=This plugin pushes data about your character to an external server.<br>This data is encrypted and is only viewable by people you share the credentials with.


### PR DESCRIPTION
Sends character information for group ironmen where other members can view. Groups will need to go to the site to create a new group and are provided with credentials for login and sending the data.

[groupiron.men](https://groupiron.men/)  
Demo of what it looks like logged in is also available: [Demo](https://groupiron.men/demo)

This version sends the following information, all of it is encrypted before being stored:
* Inventory, bank, equipment, and shared bank
* HP, prayer, energy, and world
* World position
* Skill XP
* Quest states  

Source code for the server and frontend is here:
[https://github.com/christoabrown/group-ironmen](https://github.com/christoabrown/group-ironmen)

It seems somewhat similar to the other tracker plugins, although I believe having a public server with a DB and login credentials sets it apart. I do also intend to add more features like more inventories, achievement diaries, etc.