### PR TITLE
Replace Startierindicator with star-info plugin / change ownership

### DIFF
--- a/plugins/startierindicator
+++ b/plugins/startierindicator
@@ -1,2 +1,2 @@
-repository=https://github.com/zodaz/StarTierIndicator.git
-commit=c270a68ba8a1a4307670bdc95c8cce903a1e1744
+repository=https://github.com/pwatts6060/star-info.git
+commit=75df4272d5ec768f50e7201e6d3462c94bcbc3ff


### PR DESCRIPTION
Star Info is a very large enhancement of the Star tier indicator plugin. I've coordinated with the original author @zodaz to replace the plugin with my version and he should comment his authorization below soon if all goes well.