### PR TITLE
update imbued-heart-notifier

### DIFF
--- a/plugins/imbued-heart-notifier
+++ b/plugins/imbued-heart-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/JuliusAF/imbued-heart-notifier.git
-commit=fa91eda9f75ab3cdcdfec6451aaf885b47387353
+commit=f9ce1627263b456ba3e74b479b7a1fcac407a0c4


### PR DESCRIPTION
Fixed heart highlighting not being removed when it's on cooldown, and stopped notifier from notifying if heart isn't in the inventory