### PR TITLE
Update thrall-helper to 1.4

### DIFF
--- a/plugins/thrall-helper
+++ b/plugins/thrall-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/PortAGuy/thrall-helper.git
-commit=a57224b4ba3016a3fffc2b92ad3fcb01f3d0c407
+commit=ca5948987c0e8a01d49e55b926ba7e5182f3c198


### PR DESCRIPTION
- Added functionality to only show reminder box while on Arceuus spellbook
- Added functionality to allow a hotkey to remove the reminder box
- Fixed various typos