### PR TITLE
Update Twitch Live Loadout Plugin to v0.0.6

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=374815959c36cef5d6366f1f07a001bd598f5fce
+commit=1c6c0ba92dca19e9a9006ceb7b4a099257df06cd


### PR DESCRIPTION
Fixed Twitch deprecation of various functionalities, resolved by migrating (see: https://dev.twitch.tv/docs/api/migration). Along with this a minor fix where the plugin could not be compiled properly anymore with the latest Runelite version (causing an unlisting in the Plugin Hub as well). The recent inventory system changes have also been tested and this looks to be working properly.