### PR TITLE
Update runedoku-helper plugin repo and fix build issue

### DIFF
--- a/plugins/runedoku-helper
+++ b/plugins/runedoku-helper
@@ -1,2 +1,2 @@
-repository=https://github.com/adituv/runedoku-plugin.git
-commit=abc69adc6f6e1309e045512b5cf3df0d78a93718
+repository=https://github.com/robmonte/runedoku-plugin.git
+commit=f2d3b899048e45af1dfde328106e431dd47bcda7


### PR DESCRIPTION
I am taking ownership of this plugin to attempt to keep it working in Runelite. This PR fixes a build issue stopping it from working, and also moves the plugin location to my forked repo.

You can see in the below link that the author has given me permission to do this as he no longer wishes to maintain it and does not play Runescape anymore:
https://github.com/adituv/runedoku-plugin/pull/6