### PR TITLE
Update loot-lookup to v1.1.3

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=fc3e42784f8376f32029004f2e40c80a067dae64
+commit=0bd886df367a341d19992375a73120aedbb3ce07


### PR DESCRIPTION
* When right click menu option is selected, retrieve the wiki page based on the monster id using the [RSLookup extension](https://oldschool.runescape.wiki/w/RuneScape:Lookup)
      -  Ex: "Lookup Drops" is selected, and the plugin finds the wiki page via url [https://oldschool.runescape.wiki/w/Special:Lookup?type=npc&id=6448](https://oldschool.runescape.wiki/w/Special:Lookup?type=npc&id=6448) for Skeleton (Tarn's Lair) instead of the standard page for [Skeleton ](https://oldschool.runescape.wiki/w/Skeleton)
     