### PR TITLE
Add the Group Iron Panel plugin

### DIFF
--- a/plugins/group-iron-panel
+++ b/plugins/group-iron-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/toasty-toast/runelite-group-iron-panel.git
-commit=66ee166267a10db52ae5be1a2ecf0b7736625c2a
+commit=646c92db4f9f249603ec2cab0808afbcb7db0cd5

--- a/plugins/group-iron-panel
+++ b/plugins/group-iron-panel
@@ -1,0 +1,2 @@
+repository=https://github.com/toasty-toast/runelite-group-iron-panel.git
+commit=66ee166267a10db52ae5be1a2ecf0b7736625c2a


### PR DESCRIPTION
The Group Iron Panel plugin adds a new panel in the RuneLite sidebar to show the skills/hiscores for all members of a Group Ironman group. This is similar to the Hiscore panel except for that it shows multiple players next to each other to easily compare skills between members of your group. The plugin can auto-detect the group members from the in-game group ironman tab or they can be entered in the config by hand.