### PR TITLE
Disable action-progress

### DIFF
--- a/plugins/action-progress
+++ b/plugins/action-progress
@@ -1,2 +1,3 @@
 repository=https://github.com/CalebWhiting/runelite-plugin-action-progress.git
 commit=1f51a794d38c94273ce415f62c5fc2a4d8d69cb4
+disabled=true


### PR DESCRIPTION
Temporarily disable the plugin until such a time as the update can be approved.