### PR TITLE
Update fashionscape to 1.1.16

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=919149e1c74e82fd29c8a896a2f1bfe21e3dcaeb
+commit=980749dd68cac290887494af0af1472cc5e25d77


### PR DESCRIPTION
Failed to build due to Jagex changing how the pharaoh's scepter works. Added support for keris partisan.