### PR TITLE
[HotFix] Updated Emote Clue Items to v4.0.1.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=f9e91d9570641f2f03fc5ed4a717850673125b87
+commit=cd82a7dd65515eb29a84e67d13f25753013b1e0c


### PR DESCRIPTION
Hotfix: RuneLite update [1.8.18.4](https://runelite.net/#news) introduced different itemID references for the pharao's scepter. As a result, as the plugin uses these references, the Emote Clue Items plugin broke, and it is currently missing from the plugin hub.

This update of Emote Clue Items features the following updates.
- Updated RuneLite version to 1.8.18.4.
- Updated Pharao's scepter references. (see [emote-clue-items#68](https://github.com/larsvansoest/emote-clue-items/issues/68))