### PR TITLE
Update Inferno Stats to v2.0

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=d961645dedfb35fea9b0b463e02a61d0efd5904d
+commit=0e885d94023794977d0a91eb87511f11950d9870


### PR DESCRIPTION
This is a complete rewrite of Inferno Stats to make it significantly more maintainable. The previous version was a mess with the main InfernoStatsPlugin file containing almost 1k lines.

Issues addressed in the rewrite:

1) Used RL's LinkBrowser to support Linux users
2) Added a separate Fight Caves timer
3) Added `Delta`, time between splits, to split data
4) Fixed zero-anim chins and ghost barrages being missed by the Tick Loss tracker
5) Added toggle between Line-of-Sight and Inferno Trainer links
6) Fixed a bug where leaving the caves prematurely would not save your splits