### PR TITLE
Add easy-pharaoh-sceptre

### DIFF
--- a/plugins/easy-pharaoh-sceptre
+++ b/plugins/easy-pharaoh-sceptre
@@ -1,0 +1,2 @@
+repository=https://github.com/LlemonDuck/easy-pharaoh-sceptre.git
+commit=244dcf9ce2925994286645815927572fd3bb6ed9


### PR DESCRIPTION
Small plugin to rename teleport options on the pharaoh's sceptre, now that it's going to be used more frequently