### PR TITLE
Update loot-lookup to v1.1.4

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=0bd886df367a341d19992375a73120aedbb3ce07
+commit=b374c638da7a8a64bb648b9ba2ec072ab74348d8


### PR DESCRIPTION
- Display noted drops with a note image
- Include "(noted)" text in quantity in some cases 