### PR TITLE
Create custom-xp-drops

### DIFF
--- a/plugins/custom-xp-drops
+++ b/plugins/custom-xp-drops
@@ -1,0 +1,2 @@
+repository=https://github.com/TylerHarding/custom-xp-drops.git
+commit=f758030d27ac403fa1256d84ddfe82cdedf35591


### PR DESCRIPTION
This plugin overrides the default OSRS XP Drops, and gives the player more customization options.

Features:

More customizable font options including - Font Name, size, color
Custom move speeds and fade out speed, can turn fade out off
Removal of default XP Tracker, replaced with a Custom XP Tracker dimension, allowing for it to be moved more freely, as well as greater control over the size of the XP Tracker
Addition of custom prefixes to the xp drop