### PR TITLE
added plugin file for salve-amulet-checker

### DIFF
--- a/plugins/salve-amulet-checker
+++ b/plugins/salve-amulet-checker
@@ -1,0 +1,2 @@
+repository=https://github.com/Zabith4/Salve-Amulet-Checker.git
+commit=9b2027315a1218ecc2e5fcab5bd10ed1eddf501d

--- a/plugins/salve-amulet-checker
+++ b/plugins/salve-amulet-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/Zabith4/Salve-Amulet-Checker.git
-commit=9b2027315a1218ecc2e5fcab5bd10ed1eddf501d
+commit=c5caf202df73e5c4f2ddf6e7ca4c2eba6444c6db


### PR DESCRIPTION
This plugin tells you which players are wearing their salve amulets in Cox's Mystic and Tob's Bloat room.  It also has a feature to overlay which room you are currently in in TOB and Cox.  The last feature is to call out players in the chat box who are not wearing their salve amulet in the rooms.