### PR TITLE
Update Inferno Stats to v2.1

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=a1ffa4c479cac213607db2386c103a536a7886d1
+commit=ae44e18caae82790e41fea944fb2b7f61401c0d9

--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=0e885d94023794977d0a91eb87511f11950d9870
+commit=c4435a3b80ccd8cf695e502696da29a7ae62167c

--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=c4435a3b80ccd8cf695e502696da29a7ae62167c
+commit=63a0a8b3b40754a1c35b591f83c8300f7d6e6b4b

--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=a9b90842161dab06173a840e1ae6b425b6cf76b8
+commit=a1ffa4c479cac213607db2386c103a536a7886d1

--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=63a0a8b3b40754a1c35b591f83c8300f7d6e6b4b
+commit=a9b90842161dab06173a840e1ae6b425b6cf76b8


### PR DESCRIPTION
This PR is a follow-up to the v2.0 rewrite to address additional feature requests and new bugs.

1. Fixes 0-anim chins from Arceuus spells not being tracked in the Tick Loss handler
2. Fixes the saved splits files not containing idle ticks
3. Adds the config option to save splits as a plain text file and not CSV for people who don't want to do analysis

Edit 1:

The updated commit adds a bugfix for some code copied from the timers plugin: https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java#L779

The line `TZHAAR_COMPLETED_MESSAGE.matcher(message).matches()` will never match as it does not match on the entire line (it is missing the KC), but changing this to `.find()` will work.

Other changes were somewhat structural to make sure that the panel is updated after the run is complete and that files are saved with the correct final state. One request regarding files was that CSVs output in HH:MM:SS format to avoid automatic excel formatting that makes anything 30 minutes or above change from MM:SS to HH:MM:SS.

Edit 2:

Prayer Drain is now tracked instead of staying at 0 the entire time: https://github.com/InfernoStats/InfernoStats/commit/a9b90842161dab06173a840e1ae6b425b6cf76b8

Edit 3:

A config option was misnamed causing an overlay to not be able to be removed: https://github.com/InfernoStats/InfernoStats/commit/a1ffa4c479cac213607db2386c103a536a7886d1

Edit 4:

Add support for fight caves splits. Users requested the "Splits Overlay" be shown during the fight caves as well as the ability to save splits: https://github.com/InfernoStats/InfernoStats/commit/ae44e18caae82790e41fea944fb2b7f61401c0d9