### PR TITLE
Fix naming clash with RuneLite slayer plugin

### DIFF
--- a/plugins/slayer-assistant
+++ b/plugins/slayer-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeOkeefe/slayer-assistant-plugin.git
-commit=49fd7896704421f34388c0165ffb67f574aff1e9
+commit=7a24e969347a4be178e67615bbd07b5687c9308f


### PR DESCRIPTION
The plugin class/filename for Slayer Assistant was matching the built-in RuneLite Slayer plugin name 'SlayerPlugin'. As both plugins had the same name, when enabling one of the plugins, it would enable both plugins at the same time.

**Some strange behaviour**

On the live RuneLite client:
- Both plugins are enabled when enabling RuneLite's Slayer Plugin, but not when enabling Slayer Assistant.
- Slayer Assistant toolbar icon is not appearing when enabling the plugin

On the local RuneLite client:
- Both plugins are enabled when enabling either RuneLite's Slayer Plugin or Slayer Assistant
- Slayer Assistant toolbar icon appears as expected when enabling the plugin

As I cannot replicate the toolbar icon not appearing on my local system, I'm unsure whether it's related to the naming conflict.