### PR TITLE
Create betteroverload

### DIFF
--- a/plugins/betteroverload
+++ b/plugins/betteroverload
@@ -1,0 +1,2 @@
+repository=https://github.com/tdb48/better-timers.git
+commit=e93b4c48071279c6bfc7375a15f5b486a24662cc


### PR DESCRIPTION
New plugin that is an improvement on the overload option from the 'timers' plugin. The plugin accounts for world lag so the timer will never be off.