### PR TITLE
Update Inferno Stats to v2.1.1

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=ae44e18caae82790e41fea944fb2b7f61401c0d9
+commit=ba99d3a8981e4304422f8c4eee2bfcf9fbe2bcdb


### PR DESCRIPTION
1. This PR fixes a bug where the first wave's initial time is set to the duration of the previous run as the wave creation in the snippet below is called before posting the new TimerStartedEvent that would set the current timer duration to 0.

```diff
Wave wave = new Wave(waveId, this.plugin.getRunDuration());

if (wave.getId() == 1) {
+  wave.setDuration(0);
  if (this.plugin.isInInferno()) {
    // The first wave message is 10 ticks after the timer starts
    eventBus.post(new TimerStartedEvent(10));
  } else if (this.plugin.isInFightCaves()) {
    // Fight caves does not have a delay on the timer
    eventBus.post(new TimerStartedEvent(0));
  }
} else if (config.tzhaarTimerState() == TimerHandler.TimerState.PAUSED) {
  eventBus.post(new TimerStartedEvent(0));
}
```

2. This PR also addresses some feedback that users preferred a shortened version of the "Delta" information in splits:

From:
```
Wave: 9, Split: 02:31, Delta: 02:31
Wave: 18, Split: 06:08, Delta: 03:36
Wave: 25, Split: 09:30, Delta: 03:22
Wave: 35, Split: 14:39, Delta: 05:08
Wave: 42, Split: 19:10, Delta: 04:31
Wave: 50, Split: 25:42, Delta: 06:32
Wave: 57, Split: 31:46, Delta: 06:03
Wave: 60, Split: 34:33, Delta: 02:46
Wave: 63, Split: 37:36, Delta: 03:03
Wave: 66, Split: 40:46, Delta: 03:10
Wave: 67, Split: 41:37, Delta: 00:51
Wave: 68, Split: 42:13, Delta: 00:35
Wave: 69, Split: 44:40, Delta: 02:27
Duration (Success): 48:23
```

To:
```
Wave: 9, Split: 02:31 (+02:31)
Wave: 18, Split: 06:08 (+03:36)
Wave: 25, Split: 09:30 (+03:22)
Wave: 35, Split: 14:39 (+05:08)
Wave: 42, Split: 19:10 (+04:31)
Wave: 50, Split: 25:42 (+06:32)
Wave: 57, Split: 31:46 (+06:03)
Wave: 60, Split: 34:33 (+02:46)
Wave: 63, Split: 37:36 (+03:03)
Wave: 66, Split: 40:46 (+03:10)
Wave: 67, Split: 41:37 (+00:51)
Wave: 68, Split: 42:13 (+00:35)
Wave: 69, Split: 44:40 (+02:27)
Duration (Success): 48:23
```