### PR TITLE
update slayer-assistant to v1.0.3

### DIFF
--- a/plugins/slayer-assistant
+++ b/plugins/slayer-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeOkeefe/slayer-assistant-plugin.git
-commit=301c93afc525fc11bbece6f07569c89375fcb3c7
+commit=42fcbfdf9f15700533027138fe9f5d1422430115


### PR DESCRIPTION
Renamed an image from 'Inventory.png' to 'inventory.png'.

The image failed to load due to case sensitivity, not sure how it ever worked when running a local copy of RuneLite 🤷‍♂️