### PR TITLE
Update osrs-wiki-crowdsourcing

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=3126eb83588f89e01e34f14080519ab311d28a25
+commit=886e98ad1bfc52aebd04467203e902499e825f07
 authors=leejt,andmcadams


### PR DESCRIPTION
Fixes issue where we reported instance coords instead of world coords for XP tracking. Also removes sample-based rejection, since it appears, after sampling, that the total amount of data is not that significant.