### PR TITLE
Added Mage Arena 2 Memory Plugin

### DIFF
--- a/plugins/mage-arena-2-memory
+++ b/plugins/mage-arena-2-memory
@@ -1,0 +1,2 @@
+repository=https://github.com/HerbsIO/ma2-memory.git
+commit=3b2841aacd2827c138a69358907c9821f201647a

--- a/plugins/mage-arena-2-memory
+++ b/plugins/mage-arena-2-memory
@@ -1,2 +1,2 @@
 repository=https://github.com/HerbsIO/ma2-memory.git
-commit=3b2841aacd2827c138a69358907c9821f201647a
+commit=d8db570ad0059e2173e72e11a602b2c469e3688b


### PR DESCRIPTION
For each user account: draws the locations of the mage arena 2 opponents on the world map after being discovered once.
Not fully tested