### PR TITLE
Adding Ranking System plugin

### DIFF
--- a/plugins/ranking-system
+++ b/plugins/ranking-system
@@ -1,2 +1,2 @@
 repository=https://github.com/Landathradon/Ranking-System.git
-commit=3f92eb576227c7afe3808a64f38711ff40aba023
+commit=0bdcf7ac747336ae7c56b31e0ef068b387a96119

--- a/plugins/ranking-system
+++ b/plugins/ranking-system
@@ -1,0 +1,2 @@
+repository=https://github.com/Landathradon/Ranking-System.git
+commit=3f92eb576227c7afe3808a64f38711ff40aba023

--- a/plugins/ranking-system
+++ b/plugins/ranking-system
@@ -1,4 +1,4 @@
 repository=https://github.com/Landathradon/Ranking-System.git
 commit=db5d0939aab6cd12c2ec61d19ddf470dcad1936b
 warning=This plugin submits the name of your clan and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
-authors=Lore Bot
+authors=Landathradon

--- a/plugins/ranking-system
+++ b/plugins/ranking-system
@@ -1,2 +1,4 @@
 repository=https://github.com/Landathradon/Ranking-System.git
-commit=0bdcf7ac747336ae7c56b31e0ef068b387a96119
+commit=db5d0939aab6cd12c2ec61d19ddf470dcad1936b
+warning=This plugin submits the name of your clan and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
+authors=Lore Bot

--- a/plugins/ranking-system
+++ b/plugins/ranking-system
@@ -1,4 +1,3 @@
 repository=https://github.com/Landathradon/Ranking-System.git
 commit=db5d0939aab6cd12c2ec61d19ddf470dcad1936b
 warning=This plugin submits the name of your clan and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
-authors=Landathradon


### PR DESCRIPTION
This plugin will show players if they can rank up in their clan according to ranks that have been setup by the clan admins.

It will check through the Inventory, bank, equipment, collection logs, combat achievements and prayers to know if they can be ranked up. Collection logs are also saved on disk.

Currently only my clan will use it but I'll work on making it available for everyone.