### PR TITLE
Update Twitch Live Loadout Plugin to v1.0.1

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,3 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=374815959c36cef5d6366f1f07a001bd598f5fce
-disabled=unmaintained
+commit=866b83e22b789963311789370b2d829b94466d71


### PR DESCRIPTION
Summary of changes:
1) Fixed Twitch deprecation of their previous version of the PubSub service, resolved by migrating (see: https://dev.twitch.tv/docs/api/migration). 
2) Minor fix where the plugin could not be compiled properly anymore with the latest Runelite version (causing an unlisting in the Plugin Hub as well). 
3) The recent inventory system changes have also been tested and this looks to be working properly again.
4) Added some improvements to prevent concurrency errors and removed excessive logging.
