### PR TITLE
Disable daily-task-extensions

### DIFF
--- a/plugins/daily-task-extensions
+++ b/plugins/daily-task-extensions
@@ -1,2 +1,3 @@
 repository=https://github.com/Cyborger1/daily-task-extensions.git
 commit=3e0088ec1932ee2534b23329db6878aba3ee36c2
+disabled=true


### PR DESCRIPTION
The cap was removed for chronicle cards in a recent and there's never been any other daily task added to this plugin, so I'm disabling it for now I suppose.