### PR TITLE
Add 'blindfold' plugin

### DIFF
--- a/plugins/blindfold
+++ b/plugins/blindfold
@@ -1,2 +1,2 @@
 repository=https://github.com/stevenwaterman/runelite-plugins.git
-commit=b95db9610359d13a17ac8678a9948cc9a5dd2997
+commit=a18c14b8783d36ea003ba4f1e08d7a35590e859e

--- a/plugins/blindfold
+++ b/plugins/blindfold
@@ -1,0 +1,2 @@
+repository=https://github.com/stevenwaterman/runelite-plugins.git
+commit=bf58055e8ffa881a9c0443edd50f71193fb68fe2

--- a/plugins/blindfold
+++ b/plugins/blindfold
@@ -1,2 +1,2 @@
 repository=https://github.com/stevenwaterman/runelite-plugins.git
-commit=bf58055e8ffa881a9c0443edd50f71193fb68fe2
+commit=b95db9610359d13a17ac8678a9948cc9a5dd2997


### PR DESCRIPTION
The blindfold plugin is a fork of the core GPU plugin which disables rendering for everything except your character and the UI layer. Created as a replacement for the greenscreen plugin for [Hanannie's YT series](https://www.youtube.com/watch?v=ifqgPJ8LhzQ). Compared to the greenscreen plugin, it provides anti-aliased edges, significantly improved performance, and allows tile markers, user chat, and other interfaces to still be shown.

![image](https://user-images.githubusercontent.com/23333247/170841392-81aa15bc-a484-4c7c-9695-c62e62c2a222.png)
