### PR TITLE
Update copy-clan-usernames

### DIFF
--- a/plugins/copy-clan-usernames
+++ b/plugins/copy-clan-usernames
@@ -1,2 +1,2 @@
-repository=https://github.com/stevenkaan/clan-users.git
-commit=85911f5edb29fbfdb61ee786cdf2aae1904f7ee8
+repository=https://github.com/solowanna/runelite_plugins.git
+commit=597cb1a193718b7ff1639619c5559a6a08de84b8


### PR DESCRIPTION
Added a JTextArea to the plugin, because the names didn't always get copied towards the users clipboard.

Changed my username on github a few weeks ago, thats why the username is different.