### PR TITLE
Update loot-lookup to v1.1.5

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=b374c638da7a8a64bb648b9ba2ec072ab74348d8
+commit=bd93c4fc56030d55fd8e0b10a030de9e22df899a


### PR DESCRIPTION
- Add price type option to display Grand Exchange price or High Alchemy price for items