### PR TITLE
Add Iron Value Plugin

### DIFF
--- a/plugins/iron-value
+++ b/plugins/iron-value
@@ -1,0 +1,2 @@
+repository=https://github.com/hawkins/hawkins-external-plugins.git
+commit=aed9f0a38df3bc6f4661f076a1a3f0448f375eb3


### PR DESCRIPTION
This pr adds a plugin meant resemble the Item Prices plugin (and based off it, hence the copyright credit) but catered to iron players instead.

Right now, there are two features. A blood rune value tooltip: 
![image](https://user-images.githubusercontent.com/9123458/171524114-c70bfb82-950e-49b6-9fdc-00fea19fbb75.png)
... and the same tooltip for minnows and their equivalent shark value (i.e., 10000 minnows = 250 sharks).

This plugin is useful where Item Prices's tooltip might show you the High Alch price of 240 GP for a blood rune, but an Iron player won't usually value the rune that way; they'll instead value it at 200 GP for selling to Ali Morrisane, so this plugin shows a value based on that math instead.

I intend to expand this for other items later on as I encounter the need, such as Chaos Runes for tokkul, This is my first RuneLite plugin of my own though, so apologies if it's overly simple or if I'm missing a step. I've wanted this particular feature ever since my UIM unlocked blood runecrafting though, so I wanted to start here and see if this is something that could be accepted before I sink too much time into it since I'm so new to RuneLite.