### PR TITLE
Add Global F Keys plugin

### DIFF
--- a/plugins/global-f-keys
+++ b/plugins/global-f-keys
@@ -1,0 +1,2 @@
+repository=https://github.com/SirGirion/GlobalFKeys.git
+commit=dfaf92d0a8b745c360309101be83681d17699878


### PR DESCRIPTION
Allows users to remap the F-Keys associated with the UI tabs independent of which account they're playing on