### PR TITLE
Update Iron Value to 1.1

### DIFF
--- a/plugins/iron-value
+++ b/plugins/iron-value
@@ -1,2 +1,2 @@
 repository=https://github.com/hawkins/hawkins-external-plugins.git
-commit=aed9f0a38df3bc6f4661f076a1a3f0448f375eb3
+commit=beaf057be3b19b487bd5be3401ecc5c4132a4900


### PR DESCRIPTION
Sorry for sending an update so soon after 1.0 was merged - wanted to add an icon once I realized it would show up in the plugin hub list, and the next feature turned out simpler than I anticipated, so here's an update whenever convenient :)

- Adds icon
- Adds tokkul prices for chaos, death runes
- Adds gold price for death runes