### PR TITLE
Update to version 1.1.1; escape closes interfaces properly now

### DIFF
--- a/plugins/global-f-keys
+++ b/plugins/global-f-keys
@@ -1,2 +1,2 @@
 repository=https://github.com/SirGirion/GlobalFKeys.git
-commit=007471959c503d38a3a2a43fed9eacd139a96445
+commit=080d20700bb67554f95dab0c2543eee0c65b6ec2

--- a/plugins/global-f-keys
+++ b/plugins/global-f-keys
@@ -1,2 +1,2 @@
 repository=https://github.com/SirGirion/GlobalFKeys.git
-commit=07c6700adc18a393b9dcacdf341a95a18f991efa
+commit=007471959c503d38a3a2a43fed9eacd139a96445

--- a/plugins/global-f-keys
+++ b/plugins/global-f-keys
@@ -1,2 +1,2 @@
 repository=https://github.com/SirGirion/GlobalFKeys.git
-commit=080d20700bb67554f95dab0c2543eee0c65b6ec2
+commit=10911fb70e37316bb7b77e157bbfa6110dbb001e


### PR DESCRIPTION
I don't normally have escape bound to anything but closing inventory, friend noticed if escape is mapped in the plugin config, it will not close modal interfaces since it will remap to another F-Key. Confirmed plugin works as expected with myself and friend who noticed