### PR TITLE
Add one-click-tiles plugin, addon to tileman mode

### DIFF
--- a/plugins/one-click-tiles
+++ b/plugins/one-click-tiles
@@ -1,0 +1,2 @@
+repository=https://github.com/nath/one-click-tiles.git
+commit=e7271fa4a6c40a3a7e32e0744347cd80fe9d2d41


### PR DESCRIPTION
This is an addon to the [Tileman Plugin](https://github.com/ConorLeckey/Tileman-Mode) plugin. It highlights tiles that can be reached in one click without walking over any locked tiles.

Example Screenshots:
<img width="854" alt="screenshot1" src="https://user-images.githubusercontent.com/1922800/172080762-3de23cbe-c649-4c7b-a435-ab073cb415f4.png">
<img width="854" alt="screenshot2" src="https://user-images.githubusercontent.com/1922800/172080763-28aeecda-de75-4adf-b15d-b4c1aa9d7c17.png">
