### PR TITLE
Create group-tilemanmode-addon

### DIFF
--- a/plugins/group-tilemanmode-addon
+++ b/plugins/group-tilemanmode-addon
@@ -1,0 +1,2 @@
+repository=https://github.com/Flexz9/Tileman-GroupMode.git
+commit=88710c6e038ef04f427a3280c99854fbb2dc2cdf


### PR DESCRIPTION
Currently there is no way for the tileman plugin to export and share tiles for group ironman.
This plugin has the goal to add an export/import like ground tiles does. But for sharing tiles between your group.