### PR TITLE
addition gamesense plugin file

### DIFF
--- a/plugins/gamesense
+++ b/plugins/gamesense
@@ -1,2 +1,2 @@
 repository=https://github.com/LowieN-1848537/SteelseriesGamesense.git
-commit=a04c8bc6994e2663bd31a9559ab4f2dfb07d97d7
+commit=5bdb4dd5789a13bc3ee5da99b5d3a9b8eb528572

--- a/plugins/gamesense
+++ b/plugins/gamesense
@@ -1,2 +1,2 @@
 repository=https://github.com/LowieN-1848537/SteelseriesGamesense.git
-commit=d45025d8995472f11dadc1d9baaa273a2a222b59
+commit=efd084c68b2e8ad30b59fcb9c80fb8901df741dd

--- a/plugins/gamesense
+++ b/plugins/gamesense
@@ -1,2 +1,2 @@
 repository=https://github.com/LowieN-1848537/SteelseriesGamesense.git
-commit=efd084c68b2e8ad30b59fcb9c80fb8901df741dd
+commit=e3e73a23ce10dc0178ded1320b53218fab68d6ec

--- a/plugins/gamesense
+++ b/plugins/gamesense
@@ -1,2 +1,2 @@
 repository=https://github.com/LowieN-1848537/SteelseriesGamesense.git
-commit=5bdb4dd5789a13bc3ee5da99b5d3a9b8eb528572
+commit=51453dd595f18220aeea2799c7299471c21c16cb

--- a/plugins/gamesense
+++ b/plugins/gamesense
@@ -1,2 +1,2 @@
 repository=https://github.com/LowieN-1848537/SteelseriesGamesense.git
-commit=04c507ee6ff1f5d8700766f68e51ef65e926b9a6
+commit=d45025d8995472f11dadc1d9baaa273a2a222b59

--- a/plugins/gamesense
+++ b/plugins/gamesense
@@ -1,2 +1,2 @@
 repository=https://github.com/LowieN-1848537/SteelseriesGamesense.git
-commit=7f9ce9f016ec3a5e67d2da338c78e7b8cda55486
+commit=04c507ee6ff1f5d8700766f68e51ef65e926b9a6

--- a/plugins/gamesense
+++ b/plugins/gamesense
@@ -1,2 +1,2 @@
 repository=https://github.com/LowieN-1848537/SteelseriesGamesense.git
-commit=51453dd595f18220aeea2799c7299471c21c16cb
+commit=7f9ce9f016ec3a5e67d2da338c78e7b8cda55486

--- a/plugins/gamesense
+++ b/plugins/gamesense
@@ -1,0 +1,2 @@
+repository=https://github.com/LowieN-1848537/SteelseriesGamesense.git
+commit=2f3bfc8239c6acb3a4f72a646b54e806bfb09023

--- a/plugins/gamesense
+++ b/plugins/gamesense
@@ -1,2 +1,2 @@
 repository=https://github.com/LowieN-1848537/SteelseriesGamesense.git
-commit=2f3bfc8239c6acb3a4f72a646b54e806bfb09023
+commit=a04c8bc6994e2663bd31a9559ab4f2dfb07d97d7


### PR DESCRIPTION
The plugin makes it possible to send game related data (Hp,Prayer, last trained skill xp) to the steelseries gamesense client. This enables users to display in game stats on the keyboard (such as a bar correlating to your HP)

A short example of the result in the event of prayer is shown in the attached file.

https://user-images.githubusercontent.com/60964789/172820111-955e135a-edcc-427a-8b9d-73b3455e7464.mp4

