### PR TITLE
update easy-pharaoh-sceptre to v2.0.0

### DIFF
--- a/plugins/easy-pharaoh-sceptre
+++ b/plugins/easy-pharaoh-sceptre
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/easy-pharaoh-sceptre.git
-commit=244dcf9ce2925994286645815927572fd3bb6ed9
+commit=28305ea8e64e65881c8e884398e3e35a4f273430


### PR DESCRIPTION
Expands the plugin to be called "Easy Teleports" since it now encompasses other items as well.

I'd like to also rename the repository afterward, but I'll wait until this is merged to not break the bot.