### PR TITLE
Update temple-osrs to v1.1.0

### DIFF
--- a/plugins/temple-osrs
+++ b/plugins/temple-osrs
@@ -1,3 +1,3 @@
 repository=https://github.com/SMaloney2017/Temple-OSRS-Plugin.git
-commit=a96b81d012a713620fb28b6051748d940d4e2a66
+commit=d05cb882de88ee48814ec7ca9145c4c55f3f96f7
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
1. Edit README.md
2. Add config options for `default-clan` and `default-competition` which are fetched, *given a default ID is set*, on:
    -  plugin startup
    - double-clicking the tab's search-icon