### PR TITLE
Add Giants' Foundry Mould Helper plugin

### DIFF
--- a/plugins/giants-foundry-mould-helper
+++ b/plugins/giants-foundry-mould-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Lawst96/giants-foundry-mould-helper.git
-commit=b0c1a23b4391af3963c1f06a8b5c22430e752141
+commit=23efd5cdb5c56747265712cd73ba9b841611b22e

--- a/plugins/giants-foundry-mould-helper
+++ b/plugins/giants-foundry-mould-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Lawst96/giants-foundry-mould-helper.git
+commit=b0c1a23b4391af3963c1f06a8b5c22430e752141


### PR DESCRIPTION
A plugin that highlights the name of the best moulds for a given commission at Giants' Foundry.

Would ideally make it actually calculate the best mould based on your level and what moulds you have available. But this is just a simple version that looks for a string match, for now.

![](https://i.imgur.com/ttI3Oe1.png)