### PR TITLE
Add ba-call-highlight plugin

### DIFF
--- a/plugins/ba-call-highlight
+++ b/plugins/ba-call-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/ba-call-highlight.git
-commit=bb6a2d87b7ae6904f32df17b503b52b6642f3e61
+commit=8b47dcea94e5ef915cad37314f9d7e81db1ff037

--- a/plugins/ba-call-highlight
+++ b/plugins/ba-call-highlight
@@ -1,0 +1,2 @@
+repository=https://github.com/rugg0064/ba-call-highlight.git
+commit=bb6a2d87b7ae6904f32df17b503b52b6642f3e61

--- a/plugins/ba-call-highlight
+++ b/plugins/ba-call-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/ba-call-highlight.git
-commit=8b47dcea94e5ef915cad37314f9d7e81db1ff037
+commit=21acfedf90291a6cfc5caf145fd734d347ecadca


### PR DESCRIPTION
A plugin that highlights the current barbarian assault call
![image](https://user-images.githubusercontent.com/35048262/173480775-476c2daa-941b-4a85-a710-04fbd433fcd3.png)
![image](https://user-images.githubusercontent.com/35048262/173481121-bd38e3e5-a1c0-4dea-915c-ceec0078e2f9.png)
