### PR TITLE
move easy-pharaoh-sceptre repository

### DIFF
--- a/plugins/easy-pharaoh-sceptre
+++ b/plugins/easy-pharaoh-sceptre
@@ -1,2 +1,2 @@
-repository=https://github.com/LlemonDuck/easy-pharaoh-sceptre.git
+repository=https://github.com/LlemonDuck/easy-teleports.git
 commit=28305ea8e64e65881c8e884398e3e35a4f273430


### PR DESCRIPTION
Plugin was renamed, this points the plugin file to the new repository for whenever the next update is.