### PR TITLE
Update ba-minigame to 1.66

### DIFF
--- a/plugins/ba-minigame
+++ b/plugins/ba-minigame
@@ -1,2 +1,2 @@
 repository=https://github.com/SkylerPIlot/Ba-Minigame.git
-commit=67e26acf276b60881871321eef41ce81fbe7fd48
+commit=f18e30d958782fe2fc5425c0b53f6e2346ac280f

--- a/plugins/ba-minigame
+++ b/plugins/ba-minigame
@@ -1,2 +1,3 @@
 repository=https://github.com/SkylerPIlot/Ba-Minigame.git
 commit=f18e30d958782fe2fc5425c0b53f6e2346ac280f
+authors=SkylerPIlot,ransty,equirs


### PR DESCRIPTION
Fixes the currently broken menu entry reorder for the "tell-defensive" option on the collector horn.