### PR TITLE
Add plugin info for Blast Furnace Trainer. 

### DIFF
--- a/plugins/blast-furnace-trainer
+++ b/plugins/blast-furnace-trainer
@@ -1,2 +1,2 @@
 repository=https://github.com/jmfallecker/blast-furnace-trainer.git
-commit=7c638fb8adf6674fd76193c2a3e9533540c6e49c
+commit=aa71ce23e585275c402302497f9f7859184f3f90

--- a/plugins/blast-furnace-trainer
+++ b/plugins/blast-furnace-trainer
@@ -1,2 +1,2 @@
 repository=https://github.com/jmfallecker/blast-furnace-trainer.git
-commit=e3246693f8be65e2ebabe47b681b51937003d4df
+commit=7c638fb8adf6674fd76193c2a3e9533540c6e49c

--- a/plugins/blast-furnace-trainer
+++ b/plugins/blast-furnace-trainer
@@ -1,0 +1,2 @@
+repository=https://github.com/jmfallecker/blast-furnace-trainer.git
+commit=e3246693f8be65e2ebabe47b681b51937003d4df


### PR DESCRIPTION
A plugin used to highlight Crafting, Firemaking and Strength training methods within the blast furnace.

Pipes, Cogs and Drive belt will be highlighted in Green if they are "fixed" (no actions available) and Red if they are "broken" (actions available).

The Stove will be highlighted in Red if it is empty or nearly empty, Yellow if it is neither full nor empty, Green if it is full or nearly full.

The Pump will be highlighted in Green whenever it is available for use.