### PR TITLE
update dps-calculator to v2.1.0

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=f5f57227013b8fb442d500adad2d918fbdcc5fe6
+commit=b427b9f97e1a5acfb90dec82ce979005e8e1120e


### PR DESCRIPTION
As with any large software update, there are bound to be release bugs ☹️ 

* LlemonDuck/dps-calculator@4fdff0edc31711ae0d5ab6ad15299c348e364ad4: `loadFromClient` used an immutable map that caused `PrayerPanel` to fail to write changes to the `PanelState`
* LlemonDuck/dps-calculator@fc24da5aa4ae0c5ec0cf0503841e9e4b1f75f98d: add defaultly enabled option to minimize the live dps overlay when dps cannot be calculated
* LlemonDuck/dps-calculator#56: Set effects like Dharok's were able to bypass max hit limiters
* Some misc. test harness changes