### PR TITLE
Update osrs-events: Allow placeholder items in bank notification to have 0 as quantity

### DIFF
--- a/plugins/osrs-events
+++ b/plugins/osrs-events
@@ -1,2 +1,2 @@
 repository=https://github.com/llamaXc/osrs-events.git
-commit=7de5e94394f0e216f0f8eda11fa018b519ecf25a
+commit=8d46be29bfe5da671e4a06e135b55a8bad9b9cd0


### PR DESCRIPTION
This PR is addressing the following [issue](https://github.com/llamaXc/osrs-events/issues/1). 

The Bank notification was updated so if an item is a placeholder the quantity of the item is 0. Prior, all placeholders has 1 as their quantity which was incorrect.