### PR TITLE
Add alone-man-mode plugin to hub

### DIFF
--- a/plugins/alone-man-mode
+++ b/plugins/alone-man-mode
@@ -1,2 +1,2 @@
-repository=https://github.com/OnDEK/runelite-plugins/tree/alone-man-mode
+repository=https://github.com/OnDEK/runelite-plugins.git
 commit=8a368d304a0eb92c62538e61db4fba0e8e10a446

--- a/plugins/alone-man-mode
+++ b/plugins/alone-man-mode
@@ -1,0 +1,2 @@
+repository=https://github.com/OnDEK/runelite-plugins/tree/alone-man-mode
+commit=8a368d304a0eb92c62538e61db4fba0e8e10a446


### PR DESCRIPTION
Adds a plugin which is intended to be used for an addition to normal Ironman gameplay. By default the plugin will completely blacken your screen whenever another player is nearby.