### PR TITLE
Add alone-man-mode plugin to hub

### DIFF
--- a/plugins/alone-man-mode
+++ b/plugins/alone-man-mode
@@ -1,0 +1,2 @@
+repository=https://github.com/OnDEK/runelite-plugins.git
+commit=798d2a0b26eb2dcec3a79a806c07e5d35f4c68c5


### PR DESCRIPTION
Adds a plugin which is intended to be used for an addition to normal Ironman gameplay. By default the plugin will completely blacken your screen whenever another player is nearby.