### PR TITLE
Change ownership of discord-notifications

### DIFF
--- a/plugins/discord-notifications
+++ b/plugins/discord-notifications
@@ -1,2 +1,2 @@
-repository=https://github.com/WilliamWinterDev/Discord-Notifications.git
-commit=837a5c58d3e00bf0f903555e03a5753af4192561
+repository=https://github.com/cepawiel/RuneLite-Discord-Notifications.git
+commit=ea15bb3468fecca0999da375ef55855aa9494ca7


### PR DESCRIPTION
I opened a pull request (https://github.com/WilliamWinterDev/Discord-Notifications/pull/12) on the existing plugin's repo but the author doesn't seem to have touched the project in a few months. I asked in discord and was told to open a PR so that the runelite team would attempt to reach out to the author. I'm willing to maintain the plugin going forward should the original developer not be interested.