### PR TITLE
upgrade dps-calculator to v2.1.1

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=b427b9f97e1a5acfb90dec82ce979005e8e1120e
+commit=37961e7132cf56c08aa2f736fbb3eb29f86aabfa


### PR DESCRIPTION
Hopefully fixes a classloading issue when installing from the plugin hub:

```
java.lang.NoClassDefFoundError: com/google/inject/multibindings/Multibinder
    at com.duckblade.osrs.dpscalc.calc.DpsComputeModule.configure(DpsComputeModule.java:49)
```