### PR TITLE
Update Party Panel (v2.1)

### DIFF
--- a/plugins/party-panel
+++ b/plugins/party-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/party-panel.git
-commit=27affa6ec99fe201e8a211ec76cdc0d8776ab192
+commit=07738aaed693170ecbef741ff26509ceae4c3b15


### PR DESCRIPTION
Updated imports based on recent Party changes and rebranded plugin to `Hub Party Panel` since this no longer uses discord.