### PR TITLE
Update shortest-path to v1.7

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=66f5ad1866b6abb584a249d7dd27f565b012c2b0
+commit=69365bccde7804784c6c5d9ed4e6ef064d55a54a


### PR DESCRIPTION
Properly remove the target and path when triggering the target reached distance or near path distance.