### PR TITLE
Create ClientAntiDrag Plugin

### DIFF
--- a/plugins/client-anti-drag
+++ b/plugins/client-anti-drag
@@ -1,0 +1,2 @@
+repository=https://github.com/1Defence/client-anti-drag.git
+commit=d35dfeaa2a13a75809f8002b0bbd39e3b956b727

--- a/plugins/client-anti-drag
+++ b/plugins/client-anti-drag
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/client-anti-drag.git
-commit=d35dfeaa2a13a75809f8002b0bbd39e3b956b727
+commit=2081a9ed8e02378d6cfe7425517ff5f6da476d6a


### PR DESCRIPTION
Prevents moving the client unintentionally

Set Drag delay in the config to the duration in milliseconds(1000=1 second), in which you need to be moving the client for it to successfully drag.

https://user-images.githubusercontent.com/63735241/174520622-78aef64f-0048-4618-a393-885e78b6753c.mp4

