### PR TITLE
Hotkeyable menu swaps 2.0 - custom swaps.

### DIFF
--- a/plugins/hotkeyable-menu-swaps
+++ b/plugins/hotkeyable-menu-swaps
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/More-menu-entry-swaps.git
-commit=b3e36e75c89c2bc367f0f499980af349ad9be756
+commit=181915fe73098f88a932aa1556f94ab6f200d18d

--- a/plugins/hotkeyable-menu-swaps
+++ b/plugins/hotkeyable-menu-swaps
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/More-menu-entry-swaps.git
-commit=da8d6976e2d3881d56d372ee89df7fae46cfa092
+commit=b3e36e75c89c2bc367f0f499980af349ad9be756

--- a/plugins/hotkeyable-menu-swaps
+++ b/plugins/hotkeyable-menu-swaps
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/More-menu-entry-swaps.git
-commit=3b7cf72d325ffe7a085f12f3a63aecbee3ff907c
+commit=ffc00557c13531f2498597a3fa218067c06a963b

--- a/plugins/hotkeyable-menu-swaps
+++ b/plugins/hotkeyable-menu-swaps
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/More-menu-entry-swaps.git
-commit=ffc00557c13531f2498597a3fa218067c06a963b
+commit=e31af8a834b856dc1fdb2c2267d6346baf5fa676

--- a/plugins/hotkeyable-menu-swaps
+++ b/plugins/hotkeyable-menu-swaps
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/More-menu-entry-swaps.git
-commit=181915fe73098f88a932aa1556f94ab6f200d18d
+commit=3b7cf72d325ffe7a085f12f3a63aecbee3ff907c


### PR DESCRIPTION
Initial version, feedback appreciated. This is a text-based menu swapper similar to those on other clients. It tries to be jagex-compliant by doing the following:

Make sure that the top option (defined as the first option in the menuentry list with MenuAction id < 1000, and if there are no such options, the top option in the list) is not a blackjacking or construction option.
Never swap when the swapped option OR the top option is one of the following: A player option, a spellcast option, or a blackjack/construction option.
