### PR TITLE
update dps-calculator to v2.3.0

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=d1b61f3821915619a5fc613c2d27d41126e0a4e5
+commit=6d4e4b7deeb942df7b954fcaa07f8c53ceca6e57


### PR DESCRIPTION
* LlemonDuck/dps-calculator@2f4eaae0: fixes a bug in which some npc ids were not recognized during on-slayer-task checks
* LlemonDuck/dps-calculator#68: Fixes side-panel powered staff requiring non-existent spells
* LlemonDuck/dps-calculator@f184fb84: More autocast varbit recognition
* LlemonDuck/dps-calculator#71: Support for ToB