### PR TITLE
Alone man mode bug fix

### DIFF
--- a/plugins/alone-man-mode
+++ b/plugins/alone-man-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/OnDEK/runelite-plugins.git
-commit=798d2a0b26eb2dcec3a79a806c07e5d35f4c68c5
+commit=3773a68e3f90d166ebc1c82e20095cd328463a5f


### PR DESCRIPTION
Fixed bug caused by initializing executor service outside of StartUp which caused the plugin to throw exceptions if toggled off then back on.