### PR TITLE
Update quest-helper to 3.0.6

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=4995d84d350a328f1786e794b2f1e42362077891
+commit=116b8db37ba837fd0cac06075d52183766fa5dc3

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=116b8db37ba837fd0cac06075d52183766fa5dc3
+commit=9858dfe674412beb68e6c2b600b1bdd94e4d19be


### PR DESCRIPTION
Adds a fix to work with the upcoming Runelite version (1.8.25) to do with getVar usage. Don't merge until release.

Adds Sleeping Giants, as well as various other small fixes.