### PR TITLE
Update aqp-finder

### DIFF
--- a/plugins/aqp-finder
+++ b/plugins/aqp-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/JamesShelton140/aqp-finder.git
-commit=ad57c36d05f8a5c6eaf895d01f1c387f0a5374cc
+commit=0de90ddabd74c6c879497bc528fde11e85bca391


### PR DESCRIPTION
Fixes compatibility with RuneLite version 1.8.25.

- Change `getVar()` to `getVarcStrValue()`
- Remove call to deprecated method `chatMessageManager.update()`