### PR TITLE
Add Nylo Death Indicators Plugin

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
+commit=ceab31637a3309f200c2badb4be171dff0573d22

--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=ceab31637a3309f200c2badb4be171dff0573d22
+commit=10657a6dc10d477afda201840241cd0b9847c4fa


### PR DESCRIPTION
Adds a plugin to set nylos to dead if the xp drop will kill them as they are unable to regenerate HP which removes them from your screen faster.