### PR TITLE
Revert to key listener

### DIFF
--- a/plugins/toggle-chat
+++ b/plugins/toggle-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/MoreBuchus/buchus-plugins.git
-commit=6cc1c9db026215bce68e78e81430558e37c9302c
+commit=6529a80856c58dbc9b916e710b7297d85aae4d98


### PR DESCRIPTION
Hotkey listener was consuming the key pressed and not allowing Esc to close interfaces when the hotkey was set to Esc