### PR TITLE
Update inventory-value-overlay

### DIFF
--- a/plugins/inventory-value-overlay
+++ b/plugins/inventory-value-overlay
@@ -1,3 +1,2 @@
 repository=https://github.com/wikiworm/InventoryValue.git
-commit=ef826c22c34d177ddd2e145e1538d7e82f32c80e
-disabled=unmaintained
+commit=0cb1f83fe35a53c0b4cd8f42032da3afc97793ea


### PR DESCRIPTION
User reported plugin inactive. New commit addresses old runelite-client and other outdated dependencies.
Removes disabled=unmaintained flag.