### PR TITLE
Add In Game Timer Plugin

### DIFF
--- a/plugins/in-game-timer
+++ b/plugins/in-game-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/IdylRS/in-game-timer.git
-commit=347da8e5a96b580eebaf54ab79ccffdede741ec1
+commit=f675e902b00ddd2168679f27954473bcfea950cd

--- a/plugins/in-game-timer
+++ b/plugins/in-game-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/IdylRS/in-game-timer.git
+commit=347da8e5a96b580eebaf54ab79ccffdede741ec1

--- a/plugins/in-game-timer
+++ b/plugins/in-game-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/IdylRS/in-game-timer.git
-commit=f675e902b00ddd2168679f27954473bcfea950cd
+commit=ddb7993b3bb1003f5b3e57c22195ea4e4b1a766d

--- a/plugins/inventory-value-overlay
+++ b/plugins/inventory-value-overlay
@@ -1,3 +1,2 @@
 repository=https://github.com/wikiworm/InventoryValue.git
-commit=ef826c22c34d177ddd2e145e1538d7e82f32c80e
-disabled=unmaintained
+commit=13891dd769de9fbfba885968847f9916171af486


### PR DESCRIPTION
The In Game Timer plugin functions like the built in Timer plugin's "Timer" function. However, it only counts down when logged into the game, thereby only counting "in game" time. This plugin's primary use is for an upcoming youtube series.