### PR TITLE
Add meepspeak plugin

### DIFF
--- a/plugins/meepspeak
+++ b/plugins/meepspeak
@@ -1,2 +1,2 @@
 repository=https://github.com/Jarvinnn/meepspeak.git
-commit=4f0b0a92c3e24ba2e95a1151e2e47315510ee818
+commit=0223cb266741ac90fd6be08ae279b67af9503154

--- a/plugins/meepspeak
+++ b/plugins/meepspeak
@@ -1,2 +1,2 @@
 repository=https://github.com/Jarvinnn/meepspeak.git
-commit=ccbec125fdaa2b46594ddea82ebca8a8dd6edfd3
+commit=89ee8fa642a942c81a35b6ac2885cf6640460b5c

--- a/plugins/meepspeak
+++ b/plugins/meepspeak
@@ -1,0 +1,2 @@
+repository=https://github.com/Jarvinnn/meepspeak.git
+commit=ccbec125fdaa2b46594ddea82ebca8a8dd6edfd3

--- a/plugins/meepspeak
+++ b/plugins/meepspeak
@@ -1,2 +1,2 @@
 repository=https://github.com/Jarvinnn/meepspeak.git
-commit=89ee8fa642a942c81a35b6ac2885cf6640460b5c
+commit=4f0b0a92c3e24ba2e95a1151e2e47315510ee818


### PR DESCRIPTION
A plugin that changes NPC/item/widget names to "meepspeak" in the following:

- Official OSRS health bar (Chambers of Xeric, Inferno, etc)
- Menu option (right-click)
- Theatre of Blood widgets
- Combat Achievements/Collection Log interface

It also has an option to create your own custom names for both NPCs and items. You can do so by disabling the "Default" (the default being the meepspeak names) renames.