### PR TITLE
Create elysiumattendance-plugin

### DIFF
--- a/plugins/elysiumattendance-plugin
+++ b/plugins/elysiumattendance-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/Brianmm94/clan-attendance.git
+commit=b5a5f007ae202ce84b6b3d63d92f4c6ebe6f0e9b


### PR DESCRIPTION
Create Elysium's attendance plugin, which is an updated copy of the Clan Event Attendance plugin with added features that will be managed by Elysium along with their existing Clan Events plugin. I tried putting in a pull request to the existing Clan Event Attendance plugin, but they were unresponsive to it, so it seemed easier to just add it as a new plugin that our clan manages.