### PR TITLE
Update essence-running

### DIFF
--- a/plugins/essence-running
+++ b/plugins/essence-running
@@ -1,2 +1,2 @@
 repository=https://github.com/AaronPoon/essence-running.git
-commit=04b31000d49a80de950bcf2dc11602fcba4fed11
+commit=efa1df0dae20568ed72c1f7f35048e9d444529a1


### PR DESCRIPTION
Fix Highlight Binding Necklace because WidgetItems are now also children in Inventory Widget and Make Prevent Fire-Runes better