### PR TITLE
rs3-music plugin

### DIFF
--- a/plugins/rs3-music
+++ b/plugins/rs3-music
@@ -1,0 +1,3 @@
+repository=https://github.com/Frunkh/rl-rs3-music.git
+commit=4c33ebfff3233663d1afd1dbd3b6b734c9014602
+warning=This plugin retrieves the RS3 music from an external source


### PR DESCRIPTION
This plugin detects the current playing music within OSRS and replaces them with the RS3 variant if available. If it's not available it will fall back on the OSRS variant. It connects to an external source to retrieve the music files.