### PR TITLE
Add RS3 Music

### DIFF
--- a/plugins/rs3-music
+++ b/plugins/rs3-music
@@ -1,3 +1,3 @@
 repository=https://github.com/Frunkh/rl-rs3-music.git
 commit=bfecfd5e0f849772abd121672ac8d04a48c7a519
-warning=This plugin retrieves the RS3 music from an external source
+warning=This plugin retrieves the RS3 music from rs3.frunk.ovh, a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/rs3-music
+++ b/plugins/rs3-music
@@ -1,3 +1,3 @@
 repository=https://github.com/Frunkh/rl-rs3-music.git
-commit=1fe58d8ac1ba1244b1a78a9c55d0e40ac743b4d8
+commit=714228a0be3a724fa4f54c250d2c045b477d9a2f
 warning=This plugin retrieves the RS3 music from an external source

--- a/plugins/rs3-music
+++ b/plugins/rs3-music
@@ -1,3 +1,3 @@
 repository=https://github.com/Frunkh/rl-rs3-music.git
-commit=348a18a98f7a7582074164add66671df3e6c522a
+commit=9da4cf65a0613f76d0d8bb04444da91c8c311fd7
 warning=This plugin retrieves the RS3 music from an external source

--- a/plugins/rs3-music
+++ b/plugins/rs3-music
@@ -1,3 +1,3 @@
 repository=https://github.com/Frunkh/rl-rs3-music.git
-commit=9da4cf65a0613f76d0d8bb04444da91c8c311fd7
+commit=bfecfd5e0f849772abd121672ac8d04a48c7a519
 warning=This plugin retrieves the RS3 music from an external source

--- a/plugins/rs3-music
+++ b/plugins/rs3-music
@@ -1,0 +1,3 @@
+repository=https://github.com/Frunkh/rl-rs3-music.git
+commit=4c33ebfff3233663d1afd1dbd3b6b734c9014602
+warning=This plugin retrieves the RS3 music from an external source

--- a/plugins/rs3-music
+++ b/plugins/rs3-music
@@ -1,3 +1,3 @@
 repository=https://github.com/Frunkh/rl-rs3-music.git
-commit=4c33ebfff3233663d1afd1dbd3b6b734c9014602
+commit=1fe58d8ac1ba1244b1a78a9c55d0e40ac743b4d8
 warning=This plugin retrieves the RS3 music from an external source

--- a/plugins/rs3-music
+++ b/plugins/rs3-music
@@ -1,3 +1,3 @@
 repository=https://github.com/Frunkh/rl-rs3-music.git
-commit=714228a0be3a724fa4f54c250d2c045b477d9a2f
+commit=348a18a98f7a7582074164add66671df3e6c522a
 warning=This plugin retrieves the RS3 music from an external source


### PR DESCRIPTION
Replaces the ingame music with its RS3 variant when available. When a soundtrack is not available it will fallback to its OSRS variant.  

Note: the music is fetched from an external source