### PR TITLE
Update Sotetseg defence, add more spec weps

### DIFF
--- a/plugins/party-defence-tracker
+++ b/plugins/party-defence-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/MoreBuchus/buchus-plugins.git
-commit=39e1f88c0722bd53e32cd4a880c919d482b262b4
+commit=2ab3c4211754a9f51a94cf89b0afe64ab6fe7193


### PR DESCRIPTION
Changes:
+ Updates Sotetseg's defence to be 200 base and does not fall beneath 100
+ Added barrelchest anchor, bone dagger, and bone cbow