### PR TITLE
Add hue-ambiance plugin

### DIFF
--- a/package/verification-template/build.gradle
+++ b/package/verification-template/build.gradle
@@ -86,6 +86,7 @@ dependencies {
 	}
 	thirdParty("io.github.zeroone3010:yetanotherhueapi:2.3.0") {
 		because "phillip-hue-integration"
+		because "hue-ambiance"
 	}
 	thirdParty("com.h2database:h2:2.1.212") {
 		because "polywoof"

--- a/plugins/hue-ambiance
+++ b/plugins/hue-ambiance
@@ -1,0 +1,2 @@
+repository=https://github.com/Jallah123/hue-ambiance.git
+commit=9c87d81a6bb4b3515583648ef3edc06ee09683a5


### PR DESCRIPTION
This PR adds the hue-ambiance plugin.

The plugin will connect with Philips Hue lights and change them based on in-game events.

Currently supported features:
- Skybox
- Level up notifier
- Low hp notifier
- Low prayer notifier
- Drop notifier
  - Drops above X price
  - COX drops
  - CG drops
- Custom zulrah colors