### PR TITLE
Add hue-ambiance plugin

### DIFF
--- a/plugins/phillip-hue-integration
+++ b/plugins/phillip-hue-integration
@@ -1,3 +1,2 @@
-repository=https://github.com/nganzalo/Hue_Implementation.git
-commit=f0aabcb8bc4ad53fdf6980adcee2414ed16cbec6
-disabled=unmaintained
+repository=https://github.com/Jallah123/hue-ambiance.git
+commit=c260c0fc3e4ce5cff13fed7052d92367dda01102


### PR DESCRIPTION
This PR adds the hue-ambiance plugin.

The plugin will connect with Philips Hue lights and change them based on in-game events.

Currently supported features:

- Skybox
- Level up notifier
- Low hp notifier
- Low prayer notifier
- Drop notifier
  - Drops above X price
  - COX drops
  - CG drops
- Custom zulrah colors