### PR TITLE
Update no-examine to v1.2

### DIFF
--- a/plugins/no-examine
+++ b/plugins/no-examine
@@ -1,3 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=ba1f9a7d6594e7db6fd9eba43442c88dfc11c381
-disabled=breaking core functionality
+commit=4850ddc5b075c278cb9e72b0db89b257f8d5ff7c


### PR DESCRIPTION
Properly fixes this plugin to work alongside the menu entry swapper. This is done by only removing the examine menu entry once both 1) the menu has been opened and 2) the menu entry swapper has added all its custom swaps.
And yes I have actually tested these changes now 😆 