### PR TITLE
osrs-events: Fix bank item bug sending bad quantity for placeholder PT 2

### DIFF
--- a/plugins/osrs-events
+++ b/plugins/osrs-events
@@ -1,2 +1,2 @@
 repository=https://github.com/llamaXc/osrs-events.git
-commit=8d46be29bfe5da671e4a06e135b55a8bad9b9cd0
+commit=73e7d33513b9745ced74a6c164b7b1b19ea88f66


### PR DESCRIPTION
This commit is a continuation of the issue for a user who was getting 1 as the place holder quantity. This PR resolves that by sending over a BankItem with the proper values for a placeholder item.