### PR TITLE
Added no blue chat categories plugin

### DIFF
--- a/plugins/no-blue-chat-categories
+++ b/plugins/no-blue-chat-categories
@@ -1,0 +1,2 @@
+repository=https://github.com/GraysonSpencer/no-blue-chat-categories.git
+commit=3da8fc00bc5f4f5e7c870d246da3b30b9e748482


### PR DESCRIPTION
Stops the chat categories from turning blue when chat is hidden and new messages appear.
Provides options to allow users to decide which chat categories to hide.