### PR TITLE
Update Time Tracking Reminder to 1.4.0

### DIFF
--- a/plugins/time-tracking-reminder
+++ b/plugins/time-tracking-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/queicherius/runelite-time-tracking-reminder.git
-commit=9207d27061751a437c226afdad74633b50baa188
+commit=3452ece98af8b20979522ef565e70878dc1f1b71


### PR DESCRIPTION
- Added config option to hide infoboxes in instances
- Added support for additional infoboxes: giant compost bin, hardwood, calquat, redwood, hops & cactus
- Improved configuration