### PR TITLE
Updated to later version of the plugin that allows notifications when…

### DIFF
--- a/plugins/blast-furnace-trainer
+++ b/plugins/blast-furnace-trainer
@@ -1,2 +1,2 @@
 repository=https://github.com/jmfallecker/blast-furnace-trainer.git
-commit=9a895a3f6c0601bb9616b0fefcd51785aeddef43
+commit=60f7b99f9f2511d8ab34aea4c181a2e4d805ae12


### PR DESCRIPTION
… the blast furnace stove is low on coke.

It's helpful to notify people who are running the stove as to when the furnace is low on coke. Also reorganized the settings a bit so that it is more user friendly.