### PR TITLE
Update NeverScapeAlone to v1.0.2-alpha

### DIFF
--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=7118145fc6dc2ca4b743959e19b52fce27f63a01
+commit=d3caefcd7154153e4d38caf13271f133f60de7ba
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic


### PR DESCRIPTION
+ Fixes image and reduces size to 48x48px
+ Updates Function Descriptions
+ Updates Readme
+ Adds plugin versioning for side-panel