### PR TITLE
Update mlm-upper-level-markers to v1.3

### DIFF
--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=f2ca28bc21ea1ef3c52f0c50d37f5307eb28a961
+commit=e5a758c62d385c0bac8926d230c12c1e94750749

--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=e5a758c62d385c0bac8926d230c12c1e94750749
+commit=eebf4482339cd1f2c0706341ebc849d2b7d5802e


### PR DESCRIPTION
Added a config option to accommodate for the new ore respawn mechanics at Upper MLM.
By default, after 120 seconds of activating a marker, that marker will be deleted, now assuming the rock is fully respawned.