### PR TITLE
[HotFix] Updated Emote Clue Items to v4.0.2.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=cd82a7dd65515eb29a84e67d13f25753013b1e0c
+commit=b039446bea8f79e028cccecba247a96ba83c6698


### PR DESCRIPTION
# 4.0.2. Patch Notes

This patch features the following updates.
- Refactored references to the duel arena. (see https://github.com/larsvansoest/emote-clue-items/issues/70)
- Updated to RuneLite version 1.8.27.