### PR TITLE
Update Mahogany Homes (v1.5)

### DIFF
--- a/plugins/mahogany-homes
+++ b/plugins/mahogany-homes
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Mahogany-Homes.git
-commit=a9e118c1a07df4f4bd07e259ec23b6bef5f26206
+commit=46f4a2c805640ee294bc755d5229855bb7d7da28


### PR DESCRIPTION
* Removed the `GameObjectChanged` subscriber
* Added tier based required materials