### PR TITLE
Default Tab - Release

### DIFF
--- a/plugins/defaulttab
+++ b/plugins/defaulttab
@@ -1,0 +1,2 @@
+repository=https://github.com/damencs/default-tab.git
+commit=675b80e634ef049f568e4b6db7e3bea1bec31cd1


### PR DESCRIPTION
**Repository:** https://github.com/damencs/default-tab

Default Tab allows you to select what interface you would like to open when logging in or when world hopping. This is a restricted feature to not provide any PvP advantage, therefore you are **unable** to use the feature in **PvP/Deadman** worlds and **within the wilderness**.