### PR TITLE
Add House Advertisement Plus plugin

### DIFF
--- a/plugins/house-advertisement-plus
+++ b/plugins/house-advertisement-plus
@@ -1,0 +1,2 @@
+repository=https://github.com/salverrs/House-Advertisement-Plus.git
+commit=2ffb4328af2465224c83c21c90c264b935885797

--- a/plugins/house-advertisement-plus
+++ b/plugins/house-advertisement-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/House-Advertisement-Plus.git
-commit=2ffb4328af2465224c83c21c90c264b935885797
+commit=290782332fafba319ffa95137ad9dd4cc338159e


### PR DESCRIPTION
Add House Advertisement Plus plugin.

Plugin Features:
- Filters config that will hide advertisements that don't meet certain requirements.
- Add houses to favourites so that they can be pinned to the top of the list and/or highlighted.
- Add houses to a blacklist so that they are always hidden from the list of houses.
- Show a preview of the last visited house name on the Visit-Last menu option (when a house has been visited in that session).
