### PR TITLE
Add touch-bar plugin

### DIFF
--- a/plugins/touch-bar
+++ b/plugins/touch-bar
@@ -1,0 +1,2 @@
+repository=https://github.com/PatrickKocken/runelite-touch-bar.git
+commit=8ed8131a325bdd9266546d4a08c0e8dbd92ce38c


### PR DESCRIPTION
(If you have any questions about this plugin feel free to ask them)

Runelite Touch Bar
=============

A plugin that adds Macbook Pro Touch Bar support for Runelite.

Screenshots
-----------

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/36711947/179292816-69e1ecd2-90f6-4e50-8f6d-f1696fff9955.png">
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/36711947/179292890-a452164a-e359-446e-be20-d2b3a067abf5.png">

Config 
------

Make sure the keybinds in Runescape and in the Touch Bar Plugin config match.

![image](https://user-images.githubusercontent.com/36711947/179294950-1d1cb0a6-e4dd-4018-b114-bab5a4bb64b7.png)

Native Library
--------------

This plugin uses a Dynamic Link Library in order to use the Macbook's Touch Bar. The source code of the native library can be found [here](https://github.com/PatrickKocken/runelite-touch-bar-native-library).