### PR TITLE
Update Mahogany Homes (v1.5.1)

### DIFF
--- a/plugins/mahogany-homes
+++ b/plugins/mahogany-homes
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Mahogany-Homes.git
-commit=46f4a2c805640ee294bc755d5229855bb7d7da28
+commit=1eca0c671535f71fb06c2488d49d5833006b8002


### PR DESCRIPTION
Fixes an issue where after being timed out every hotspot update would cause the plugin to think the contract was done