### PR TITLE
Update stealing artefacts plugin

### DIFF
--- a/plugins/stealing-artefacts
+++ b/plugins/stealing-artefacts
@@ -1,2 +1,2 @@
 repository=https://github.com/Chris-Bitler/Runelite-StealingArtefacts.git
-commit=d4ccb8955208137981bf636121ba1c87ab453108
+commit=5db639332e27ba3238cfe2af8615fc1232c33733


### PR DESCRIPTION
This version has the following changes:
- No longer broken in general when loading the plugin
- Ability to disable highlights of patrolmen and the text saying the number of artefacts to next level
- Fixed an error where the plugin would break some other plugins' hint arrows