### PR TITLE
Update Hub Party Panel (v3.0.1)

### DIFF
--- a/plugins/party-panel
+++ b/plugins/party-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/party-panel.git
-commit=405f342e904ea7e9ddd1af4867431c00889f4651
+commit=0b947894f938d06c92ddcef13abc1ff650da2441


### PR DESCRIPTION
Ensures the main `Party` plugin is enabled upon startup.