### PR TITLE
Update Loot Logger (v.3.2.2)

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=9a3715104c9a0b08fd54f8a03bb474a327528dbc
+commit=43493ded00d221da69829baba7313b119981dd47


### PR DESCRIPTION
Ensures the main `Loot Tracker` plugin is enabled on start up