### PR TITLE
added altar-of-net plugin

### DIFF
--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,5 +1,5 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=2d8d3cc8940600a90e8a954eafe2ba03b626ebbb
+commit=d350a98cb76f6d64a6394034e6d88c9a62c433d9
 
 
 

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,2 +1,2 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=24c3ddbe881508aecc57744617e995c495036033
+commit=05a7bf6ac02eb06bddc659f4c7bb74646b2ee614

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,2 +1,2 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=a1aa52e200bfa6b314ca133bb76eb8080125222d
+commit=1fdd4042e799733784909de251ce72f5085b7326

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,6 +1,2 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=d350a98cb76f6d64a6394034e6d88c9a62c433d9
-
-
-
-
+commit=724eb2d7079fb2d493770e12852742a48cd3c0ef

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,4 +1,4 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=02fa6b3b8798297401fac2c6a25c90efc30770c8
+commit=8793d9546bbdbd026209ed1af5bd84e3f30834e8
 
 

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,2 +1,2 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=ac5531d7ed4017682ddb0e2b304f373adbc934e9
+commit=a1aa52e200bfa6b314ca133bb76eb8080125222d

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,0 +1,2 @@
+repository=https://github.com/GabrielReyes136/altar-of-net.git
+commit=ac5531d7ed4017682ddb0e2b304f373adbc934e9

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,4 +1,4 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=8793d9546bbdbd026209ed1af5bd84e3f30834e8
+commit=baabd721ccd64a71584c5a27f05483a43198e3cc
 
 

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,5 +1,5 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=3f8f9d5e9d00d51ed719ab1fbb484048af2b286a
+commit=2d8d3cc8940600a90e8a954eafe2ba03b626ebbb
 
 
 

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,4 +1,6 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=baabd721ccd64a71584c5a27f05483a43198e3cc
+commit=3f8f9d5e9d00d51ed719ab1fbb484048af2b286a
+
+
 
 

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,2 +1,4 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=05a7bf6ac02eb06bddc659f4c7bb74646b2ee614
+commit=02fa6b3b8798297401fac2c6a25c90efc30770c8
+
+

--- a/plugins/altar-of-net
+++ b/plugins/altar-of-net
@@ -1,2 +1,2 @@
 repository=https://github.com/GabrielReyes136/altar-of-net.git
-commit=1fdd4042e799733784909de251ce72f5085b7326
+commit=24c3ddbe881508aecc57744617e995c495036033


### PR DESCRIPTION
Clan plug in designed to "enhance the user's clan experience"
As of version 1.0.1 the following commands have been added:
!kill !event !slap !pre !bgs !help !ranks !greet !mute !beg !give !gratz

EDIT:
Originally the plugin checked to make sure that you are part of the "altar of net clan" in order to be used.

That is no longer the case, and anybody can use the features provided by the plugin regardless of whether they are in my clan or not.

In the future, members of my clan will receive unique features, but the plugin will always have features available the the general public as well as that of my clan