### PR TITLE
Add clan-event-keyword plugin

### DIFF
--- a/plugins/clan-event-keyword
+++ b/plugins/clan-event-keyword
@@ -1,0 +1,2 @@
+repository=https://github.com/SieBRUM/clan-event-keyword.git
+commit=53c348747eb0ef94a901121f9766daaceb70f953


### PR DESCRIPTION
This is a very basic plugin that writes text and the date to an overlay.

Alot of clans have regular events like Bingo events. These events require you to have some kind of keyword on-screen, so the admins that host the event, know the received items were received during the clan event period.

People like me like to play without a chatbox, which results in having no option to have text inside the client. This plugin is a simple plugin that draws some text in a textbox (and the date if enabled) so you always have proof that you are not cheating in the event!