### PR TITLE
Update no-examine to v1.4

### DIFF
--- a/plugins/no-examine
+++ b/plugins/no-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=d4c348cdc5cbd8ed57b6a953fd2b49c484115979
+commit=50218644fd8d9c8c5edfe1db0d0e7c1eda27e10b


### PR DESCRIPTION
- Option to remove PoH remove menu options when building mode is **off**.
- Option to remove walk here menu options.