### PR TITLE
Update Clan Events

### DIFF
--- a/plugins/elysiumevents-plugin
+++ b/plugins/elysiumevents-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/cmsu224/clan-events.git
-commit=1cb3d276bcdadab3287fb840ce5d710fc579664f
+commit=7d9d919e71dfc0235404cc0e4a147f24c16c7e83


### PR DESCRIPTION
Disables the plugin panel when not using a valid Google Sheet.