### PR TITLE
Create shift remapping plugin

### DIFF
--- a/plugins/shift-remapping
+++ b/plugins/shift-remapping
@@ -1,0 +1,2 @@
+repository=https://github.com/WhatATopic/Shift-Remapping.git
+commit=5b85a2959b0b509889dab97c2467f2ae100e6bee


### PR DESCRIPTION
Allows the shift key to be remapped since key remapping doesn't have this feature.