### PR TITLE
Create Shift remapping plugin

### DIFF
--- a/plugins/shift-remapping
+++ b/plugins/shift-remapping
@@ -1,2 +1,2 @@
 repository=https://github.com/WhatATopic/Shift-Remapping.git
-commit=5b85a2959b0b509889dab97c2467f2ae100e6bee
+commit=e41322d60c633719dad1744bd70688650ae2ee37

--- a/plugins/shift-remapping
+++ b/plugins/shift-remapping
@@ -1,0 +1,2 @@
+repository=https://github.com/WhatATopic/Shift-Remapping.git
+commit=5b85a2959b0b509889dab97c2467f2ae100e6bee


### PR DESCRIPTION
Allows the shift key to be remapped since key remapping doesn't have this functionality.