### PR TITLE
Add Discord Split Tracker Plugin

### DIFF
--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/skyhawkgaming/discord-split-tracker.git
-commit=064f0a82a9ca043c65a3231396c7b3783ae8eafb
+commit=95d794b95721578f7fbb2bbdebe3e36649f4998f

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/skyhawkgaming/discord-split-tracker.git
-commit=95d794b95721578f7fbb2bbdebe3e36649f4998f
+commit=f3674519c9f34b80db42f1812ff93c26c123f3a1

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/skyhawkgaming/discord-split-tracker.git
+commit=fd0c872646b81090fdb6e6041baaa175608bc1f1

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/skyhawkgaming/discord-split-tracker.git
-commit=45a46fede42792077c3eec3d663bf9b216d75b5d
+commit=064f0a82a9ca043c65a3231396c7b3783ae8eafb

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/skyhawkgaming/discord-split-tracker.git
-commit=1b721589120d91c0b2f950e60ebb88ec82925dab
+commit=45a46fede42792077c3eec3d663bf9b216d75b5d

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/skyhawkgaming/discord-split-tracker.git
-commit=fd0c872646b81090fdb6e6041baaa175608bc1f1
+commit=1b721589120d91c0b2f950e60ebb88ec82925dab


### PR DESCRIPTION
- Side Panel for split/various loot submissions

- Simply set a valuable drop threshold, and open the panel when you get a drop worth sharing, it will pre-populate with item/npc information and a screenshot of the most recent valuable drop
- Wise Old Man API Integration to list out all members in your Clan/Group and add them to the Split Submission
- Particularly useful in clans and alongside specialized Discord bots
- Prompt for split information if applicable, which will display to track with your clan or friend group
- Configuration available for Bingo and Event strings to prevent fraudulent activity in clan events
- Can set a custom field such as "Clan: ", "Group", etc. to display in your Discord WebHook messages

- Automatic Discord WebHook output just like any other loot logger, but in a format that I thought was more appealing
- First of its kind to show realtime KC information on each valuable boss drop
- Also queries the OSRS wiki to show an item icon and an image of the npc you fought in Discord, if applicable