### PR TITLE
Create Discord Notifications + Split Tracker Plugin

### DIFF
--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/discord-split-tracker-plugin.git
-commit=0b692b85ba9f90d00703a66c7e38c528d7aa4e43
+commit=f98a4aef35cc4eb6d3769bf4635b1b84255d96d8
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=8397b06d20d2da49c0212ad4331694f3015c04d1
+commit=8ec5e3679e3c4969602f88e166d672098f8a6b2e
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=d2d4fc17f86422c4c0af729d005eea9183759506
+commit=77c270d571852576673370647ccf38254bcf5828
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/discord-split-tracker-plugin.git
-commit=5980ddcd9a4a18ae08509e7c99abfee999c128f4
+commit=0b692b85ba9f90d00703a66c7e38c528d7aa4e43
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,3 @@
-repository=https://github.com/skyhawkgaming/discord-split-tracker-plugin.git
+repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
 commit=d2d4fc17f86422c4c0af729d005eea9183759506
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,3 @@
-repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=df98670bf852294705005597d6fa977a8d74132a
+repository=https://github.com/skyhawkgaming/discord-split-tracker-plugin.git
+commit=d2d4fc17f86422c4c0af729d005eea9183759506
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,3 @@
-repository=https://github.com/skyhawkgaming/discord-split-tracker-plugin.git
-commit=f98a4aef35cc4eb6d3769bf4635b1b84255d96d8
+repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
+commit=4e5064036721c8408b13d6ceff1c2a9ec67f47f8
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/skyhawkgaming/discord-split-tracker-plugin.git
+commit=5980ddcd9a4a18ae08509e7c99abfee999c128f4
+warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=77c270d571852576673370647ccf38254bcf5828
+commit=ff438774441fc5ea02c846881cd5368ec4b806d4
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=4e5064036721c8408b13d6ceff1c2a9ec67f47f8
+commit=df98670bf852294705005597d6fa977a8d74132a
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,0 @@
-repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=8ec5e3679e3c4969602f88e166d672098f8a6b2e
-warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discord-split-tracker
+++ b/plugins/discord-split-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=ff438774441fc5ea02c846881cd5368ec4b806d4
+commit=8397b06d20d2da49c0212ad4331694f3015c04d1
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discordnotificationsaio
+++ b/plugins/discordnotificationsaio
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=6a17f22d0dc8e328c65f4f46be5cb29f9e15d947
+commit=ecc5d860adcdeb7304c140df4853d18b9eaf837f
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discordnotificationsaio
+++ b/plugins/discordnotificationsaio
@@ -1,0 +1,3 @@
+repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
+commit=8ec5e3679e3c4969602f88e166d672098f8a6b2e
+warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discordnotificationsaio
+++ b/plugins/discordnotificationsaio
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=3b6f751da88e8e64b7f07da3e0efb725dfeb8460
-warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.
+commit=ec4c0ddc9b1773afd8a722406935426fb1561996
+warning=This plugin submits your username to wiseoldman.net.

--- a/plugins/discordnotificationsaio
+++ b/plugins/discordnotificationsaio
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=ecc5d860adcdeb7304c140df4853d18b9eaf837f
+commit=3b6f751da88e8e64b7f07da3e0efb725dfeb8460
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discordnotificationsaio
+++ b/plugins/discordnotificationsaio
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=8ec5e3679e3c4969602f88e166d672098f8a6b2e
+commit=0067d5c75f291adea337b7b1c04ec11ed70c1e4c
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discordnotificationsaio
+++ b/plugins/discordnotificationsaio
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=0067d5c75f291adea337b7b1c04ec11ed70c1e4c
+commit=9b39bf9d7811cc0bfa5f01031247a23bd5e726d6
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.

--- a/plugins/discordnotificationsaio
+++ b/plugins/discordnotificationsaio
@@ -1,3 +1,3 @@
 repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
-commit=9b39bf9d7811cc0bfa5f01031247a23bd5e726d6
+commit=6a17f22d0dc8e328c65f4f46be5cb29f9e15d947
 warning=This plugin sends your username to wiseoldman.net to give you a list of groups you're in.


### PR DESCRIPTION
- Side Panel for split/various loot submissions

- Simply set a valuable drop threshold, and open the panel when you get a drop worth sharing, it will pre-populate with item/npc information and a screenshot of the most recent valuable drop

- Wise Old Man API Integration to list out all members in your Clan/Group and add them to the Split Submission

- Particularly useful in clans and alongside specialized Discord bots
- Prompt for split information if applicable, which will display to track with your clan or friend group
- Configuration available for Bingo and Event strings to prevent fraudulent activity in clan events
- Can set a custom field such as "Clan: ", "Group", etc. to display in your Discord WebHook messages

- Automatic Discord WebHook output just like any other loot logger, but in a format that I thought was more appealing
- First of its kind to show realtime KC information on each valuable boss drop
- Also queries the OSRS wiki to show an item icon and an image of the npc you fought in Discord, if applicable