### PR TITLE
Update tob-hm-timer to v1.0.2

### DIFF
--- a/plugins/tob-hm-timer
+++ b/plugins/tob-hm-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/Loze-Put/tob-hm-timer.git
-commit=508483b878226811bb4114e3afdc63690d589538
+commit=7fd2248690020eaf64a328e0455eb75ab0ac3380


### PR DESCRIPTION
Fixes an issue where the overlay would still display outside the TOB lobby.