### PR TITLE
Update Nylo Death Indicators to v1.0.1 - One Line Change

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=10657a6dc10d477afda201840241cd0b9847c4fa
+commit=176c304be15fd07f992231d388aea2c8f1adfa8b


### PR DESCRIPTION
* Fixes a bug where players with 200m xp would not get a stat delta and have the plugin not process their damage. The fix is to bypass the stat delta check by changing `preProcessXpDrop` to `processXpDrop`.