### PR TITLE
Update aqp-finder

### DIFF
--- a/plugins/aqp-finder
+++ b/plugins/aqp-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/JamesShelton140/aqp-finder.git
-commit=0de90ddabd74c6c879497bc528fde11e85bca391
+commit=d77a0d0da373a0d650948221f69ffac03696dcc3


### PR DESCRIPTION
Notification message changed from `A q p opportunity!` to `A qp opportunity!` to prevent game freezing notification loop when "Game message notifications" is enabled in RuneLite settings.