### PR TITLE
Update 117HD to 1.1.2

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=a4dbb46889982da18f85f3a6d094e0cda51e2465
-authors=RS117,sosodev
+commit=87b8309a8bd67c90d3148e0d284cf4e0e3c65ef3
+authors=RS117,sosodev,ahooder

--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=87b8309a8bd67c90d3148e0d284cf4e0e3c65ef3
+commit=abb7b17781d539c8e6d0a9233585aab2e9e5434c
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This update primarily consists of miscellaneous fixes, and porting to LWJGL + rlawt. We're hoping to get this update out of the way so that we're caught up with master and can start doing smaller, more frequent updates. The last proper update was back in early May (PR #2654).

- The gradle wrapper matches the sha256 sum for [v7.4.2 listed here](https://gradle.org/release-checksums/).
- The support URL was changed to our Discord server. The URL matches the one in the [original repo's readme](https://github.com/RS117/RLHD).