### PR TITLE
update combo-runes-only to v2.0.1

### DIFF
--- a/plugins/combo-runes-only
+++ b/plugins/combo-runes-only
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/combo-runes-only.git
-commit=145a3d4335d996aff276fc198d4eb1b7d5e98951
+commit=2634403ae2d9fc1e995be70af7145108fba96e12


### PR DESCRIPTION
Closes LlemonDuck/combo-runes-only#3