### PR TITLE
Update loot-lookup to v1.1.6

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=bd93c4fc56030d55fd8e0b10a030de9e22df899a
+commit=819ba1c5fb480ff63aa96bcc9ff43dc09b5bad96


### PR DESCRIPTION
* Fix alignment in noted images
* Handle edge case for Grotesque Guardians
* Check menu type `MenuAction.NPC_FIFTH_OPTION` for attackable NPCs