### PR TITLE
Slayer Assistant - Fix Bug Loading Specific Images

### DIFF
--- a/plugins/slayer-assistant
+++ b/plugins/slayer-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeOkeefe/slayer-assistant-plugin.git
-commit=42fcbfdf9f15700533027138fe9f5d1422430115
+commit=e0455a1f39b2da6261eed02caa2e0451ad4f9e12


### PR DESCRIPTION
Images for a monster are being loaded using the monster's name. There were a few instances where the naming had inconsistent casing between the monster name and the image filename, these are the ones that were failing to load.

I have made all the image filenames lowercased, then before we attempt to load an image using the monster name we convert the name to lowercase.

Not sure why the images were able to load when ran in a local environment but not in live.