### PR TITLE
Create resting

### DIFF
--- a/plugins/resting
+++ b/plugins/resting
@@ -1,0 +1,2 @@
+repository=https://github.com/ScreteMonge/TestPlugin.git
+commit=16042d7eafd98e9e793c7812e09f4587bc4537c8

--- a/plugins/resting
+++ b/plugins/resting
@@ -1,2 +1,2 @@
 repository=https://github.com/ScreteMonge/TestPlugin.git
-commit=5acb823b092627fe104b1b55e290c77b14282e47
+commit=0c26e0f32a68552bf473e66fa53ffa2541ec84bb

--- a/plugins/resting
+++ b/plugins/resting
@@ -1,2 +1,2 @@
 repository=https://github.com/ScreteMonge/TestPlugin.git
-commit=0c26e0f32a68552bf473e66fa53ffa2541ec84bb
+commit=f5d4688457a3dfa8598196b80efe53cd1065f3e3

--- a/plugins/resting
+++ b/plugins/resting
@@ -1,2 +1,2 @@
 repository=https://github.com/ScreteMonge/TestPlugin.git
-commit=16042d7eafd98e9e793c7812e09f4587bc4537c8
+commit=5acb823b092627fe104b1b55e290c77b14282e47


### PR DESCRIPTION
Creates a "Resting" plugin that gives the player a resting idle, much like that in RS2/RS3, performed by either right-clicking the run orb or a player-made fire and selecting "rest." Also allows other players (using the plugin) to appear as resting as well if they use the spin emote.