### PR TITLE
Update quest-helper to v3.1.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=7005f5b74bb7cca2d3ef9e641abe483815ee706b
+commit=30011e7063d0b81d6990d97bdeef3ab008884d40


### PR DESCRIPTION
- Adds right-click link to the wiki to items in the sidebar
  - This also involved a change of the ItemCollection into an enum
- Changes the config for bank items from being a list of Item to an int[]