### PR TITLE
Update shortest-path to v1.9

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=724cf3ec6bcdd6da53e16ec08dc64be06c1d4858
+commit=b2889d948e22cc447766d41d946159188f16b565

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=b2889d948e22cc447766d41d946159188f16b565
+commit=9ee033ce834ec21f367ee323082dafe070101cf4

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=1bee4ba70644128263c24192da741b82245f8ebc
+commit=724cf3ec6bcdd6da53e16ec08dc64be06c1d4858


### PR DESCRIPTION
- Option to draw the path as a line instead of tiles.
- Fix transports not properly drawn on the world map.
- Small reorganization of the pathfinder and config usage.
- Preliminary fix to prevent paths with an unreachable target from causing client lag by limiting calculation to 2 seconds of no progress.