### PR TITLE
Update gim-plugin to 2.5.0

### DIFF
--- a/plugins/gim-plugin
+++ b/plugins/gim-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/davidvorona/gim-plugin.git
-commit=1a1e572ed8d6bc6fcf6175e2ead4a9749b507fc3
+commit=be9ef232fd23736daf7af2564369b6adef5e7f91


### PR DESCRIPTION
- fixes a bug if client starts with empty server address
- adds online status dot to panel tabs