### PR TITLE
Update Twitch Live Loadout Plugin to v1.0.3

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=82ff9f364b4350339b327049a3d44cb84118e5d7
+commit=b0f78bb0571f54d1be74690e4514e01cacbe564c


### PR DESCRIPTION
This updates the plugin to be compatible with the recent hitsplat API changes. The plugin uses the hitsplat types to categorize different types of damages and show them separately to Twitch viewers. 

With the deprecation of `Hitsplat.HitsplatType` we now moved to an `integer` based approach where we keep track of the hitsplat types ourselves to ensure no breaking changes in the future.