### PR TITLE
Updated Nylo Death Indicators to v1.0.2

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=176c304be15fd07f992231d388aea2c8f1adfa8b
+commit=29cc79d8636992babcbbdc631a238d76274c8b83


### PR DESCRIPTION
Fix the Nylo Death Indicators plugin breaking from v1.8.30 Hitsplat API changes