### PR TITLE
Add GE Filters v1.0

### DIFF
--- a/plugins/ge-filters
+++ b/plugins/ge-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/GE-Filters.git
-commit=2aaaf971f42430ad18e061407463e3e95a9460e8
+commit=aa1d939cc69e57286c2f52dab467b11f571f2f1b

--- a/plugins/ge-filters
+++ b/plugins/ge-filters
@@ -1,0 +1,2 @@
+repository=https://github.com/salverrs/GE-Filters.git
+commit=2aaaf971f42430ad18e061407463e3e95a9460e8


### PR DESCRIPTION
Adds GE Filters v1.0.

GE Filters adds a set of item search filters to the Grand Exchange interface.

Filters:
Bank Tags - Filter by bank tags, requires the Bank Tags plugin to be enabled.
Inventory Items - Filter by current inventory or equipped items.
Recent Items - Filter by recently viewed items or recent buy/sell offers.