### PR TITLE
Added UniversalDiscordNotifications

### DIFF
--- a/plugins/universal-discord-notifications
+++ b/plugins/universal-discord-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/MidgetJake/UniversalDiscordNotifier.git
+commit=50b2b7dc8444e30ecb569fdc1eef2a5d2fd5635a


### PR DESCRIPTION
Universal Discord Notifications enables a discord webhook to be added to a single plugin and send messages when various events happen. These events are currently: on loot, on level up, on death, on obtaining a collection log item, on obtaining a pet. I know there are probably far too many of these already, but they are all so segmented and really don't allow for message customisation at the very least. The aim of this is to just bring multiple of these webhook plugins into a single one instead of multiple different ones