### PR TITLE
Update Plugin Presets to v2.1

### DIFF
--- a/plugins/plugin-presets
+++ b/plugins/plugin-presets
@@ -1,2 +1,2 @@
 repository=https://github.com/antero111/plugin-presets.git
-commit=3ba95002375696db3b09e7fcaab02457f4247d70
+commit=d0d6326fa5ae197151a0578f70953c3528717b7d


### PR DESCRIPTION
Fixed volume sliders not working with presets.
Added invalid preset plugin setting configurations warning label and updated preset comparing logic so that preset switches turn on if preset contain invalid configuration. 

Fixes https://github.com/antero111/plugin-presets/issues/19 and https://github.com/antero111/plugin-presets/discussions/18