### PR TITLE
Update action-progress to 1.04

### DIFF
--- a/plugins/action-progress
+++ b/plugins/action-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/CalebWhiting/runelite-plugin-action-progress.git
-commit=af090f471aabb44decebcb033d881758a39eb7b4
+commit=c13d6723cf787e96d2c1354c35f798ca4c637d0b

--- a/plugins/action-progress
+++ b/plugins/action-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/CalebWhiting/runelite-plugin-action-progress.git
-commit=519ecc9fa6f1857f5f6ace6f9b2a176bba86011b
+commit=af090f471aabb44decebcb033d881758a39eb7b4


### PR DESCRIPTION
- `1.04`
    - Added interruption when hit.
    - Added interruption when pest control portals drop.
  	- Updated for RuneLite version 1.8.30.