### PR TITLE
Update Default Tab - v1.0.1

### DIFF
--- a/plugins/defaulttab
+++ b/plugins/defaulttab
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/default-tab.git
-commit=675b80e634ef049f568e4b6db7e3bea1bec31cd1
+commit=08d592e92c85ac724cb4ec4e700275e10b35ab8e

--- a/plugins/defaulttab
+++ b/plugins/defaulttab
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/default-tab.git
-commit=71f5ad9317fbd8acebe771dca2701529fe2c661a
+commit=c9abf4bda75efd058e2d60dddcc74484f19783e3

--- a/plugins/defaulttab
+++ b/plugins/defaulttab
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/default-tab.git
-commit=08d592e92c85ac724cb4ec4e700275e10b35ab8e
+commit=71f5ad9317fbd8acebe771dca2701529fe2c661a


### PR DESCRIPTION
- allows plugin functionality in the wilderness ... still restricted for PvP worlds