### PR TITLE
Add bank-menu-entry-swapper

### DIFF
--- a/plugins/bank-menu-entry-swapper
+++ b/plugins/bank-menu-entry-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/MarkHarms/bank-menu-entry-swapper.git
-commit=ee254de237fe4c02b97ac69e3e2cfb8711450f09
+commit=e4e8cc8170861d12b01fc36eb9fa83d916f75ced

--- a/plugins/bank-menu-entry-swapper
+++ b/plugins/bank-menu-entry-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/MarkHarms/bank-menu-entry-swapper.git
-commit=1781dd79311fcad31974c7ec468e4502c9d81148
+commit=129f6ff93883f8c43ba657061cf4214a1075553e

--- a/plugins/bank-menu-entry-swapper
+++ b/plugins/bank-menu-entry-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/MarkHarms/bank-menu-entry-swapper.git
-commit=129f6ff93883f8c43ba657061cf4214a1075553e
+commit=d04820009cf565f578e1d0c6dfe216b7aa5eeed6

--- a/plugins/bank-menu-entry-swapper
+++ b/plugins/bank-menu-entry-swapper
@@ -1,0 +1,2 @@
+repository=https://github.com/MarkHarms/bank-menu-entry-swapper.git
+commit=ee254de237fe4c02b97ac69e3e2cfb8711450f09

--- a/plugins/bank-menu-entry-swapper
+++ b/plugins/bank-menu-entry-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/MarkHarms/bank-menu-entry-swapper.git
-commit=e4e8cc8170861d12b01fc36eb9fa83d916f75ced
+commit=1781dd79311fcad31974c7ec468e4502c9d81148


### PR DESCRIPTION
Adds config for the new bank-menu-entry-swapper plugin which provides shift-right click menu config capabilities within the bank interface. This works in the same manner as the new npc/inventory shift-right click menu configuration.