### PR TITLE
Add seaweed-spore-notifier plugin

### DIFF
--- a/plugins/seaweed-spore-notifier
+++ b/plugins/seaweed-spore-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/rbbi/seaweed-spore-notifier.git
+commit=2628c32283098c35b8108313bc5537784bcd71c0


### PR DESCRIPTION
Notifies the user when [seaweed spores](https://oldschool.runescape.wiki/w/Seaweed_spore) spawn. 

Useful for gathering seaweed spores while playing on other accounts.

The "Ground Items" plugin is able to notify for _all_ highlighted drops, but not specific ones (like seaweed spores).