### PR TITLE
Update Bot Detector to v1.3.8

### DIFF
--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,4 +1,4 @@
 repository=https://github.com/Bot-detector/bot-detector.git
-commit=4970a15d0ea5103378f11bb69e1204a8b1057b13
+commit=978770a8fdd52088f36b7836ed6c9da35f47b634
 warning=This plugin submits the names, locations, and gear of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic,Cyborger1


### PR DESCRIPTION
* Now using `RuneScapeProfileType` API to determine allowed world types more effectively.
* Removed deprecated call to `chatMessageManager.update()`.
* Moved the plugin to a newer version of the Bot Detector API.

Also generally some little polishes, like making sure all code files have a trailing new-line.