### PR TITLE
Update improved-tile-indicators

### DIFF
--- a/plugins/improved-tile-indicators
+++ b/plugins/improved-tile-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/LeikvollE/tileindicators.git
-commit=7259082e76c71d308fdc5853cb4787372a9b585e
+commit=6bb9069d41ebf62e24c17af060c8cc99b4177584


### PR DESCRIPTION
Remove code mimicking the official tile indicators plugin and increased the priority of the overlay.