### PR TITLE
Update NeverScapeAlone to v2.5.0-alpha

### DIFF
--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=bc43e9420fd1c90931fc510fcaeaeaf2b5a76cbc
+commit=56abc467b957875fb0abe8bc04b6c855049c3a81
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic


### PR DESCRIPTION
**Bug Fixes**
+ Resolves Discord NULL error

**Changes**
+ Allows for older pings to fade over time, default is 20s
+ Shows the number of players in each lobby
+ Adds a warning before joining a voice channel
+ Marks an initial Friend's Chat to join when participating in an activity, based upon the Party Leader
+ Adds Giants' Foundry
+ Renames Duel Arena -> PVP Arena
+ Client-Side Rate-Limits Pings to 1 per 350ms to complement server-side ping rate-limiter

+130/-30