### PR TITLE
Update NeverScapeAlone to v2.6.0-alpha

### DIFF
--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=56abc467b957875fb0abe8bc04b6c855049c3a81
+commit=149a09d6577f5cb781c7143981af6d072cdb798f
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic


### PR DESCRIPTION
PR Reference: https://github.com/NeverScapeAlone/never-scape-alone/pull/114

Changelog:
+ Adds Human-Readable conversion to player location using current DiscordEnum with citations
+ Adds Group ID to clipboard on click
+ Adds Player Name to clipboard on click
+ Adds Group Descriptions/Notes section with server-side censoring

![image](https://user-images.githubusercontent.com/5789682/184048774-94160536-3167-49c8-b30e-8bb1696a253f.png)
