### PR TITLE
Create discord_slayer_notifications

### DIFF
--- a/plugins/discord_slayer_notifications
+++ b/plugins/discord_slayer_notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/ngageIBI/Discord-Slayer-Notifications.git
+commit=5cb01b0f66cbc192b92fcaf0b2135f456c9a1ee9


### PR DESCRIPTION
A simple plugin that takes Slayer task info and sends it to a Discord channel. Created for Group Ironman that want to able to keep track of there friends Slayer progress.