### PR TITLE
Update inferno-autosplitter

### DIFF
--- a/plugins/inferno-autosplitter
+++ b/plugins/inferno-autosplitter
@@ -1,2 +1,2 @@
 repository=https://github.com/molgoatkirby/InfernoAutoSplitter.git
-commit=1986992a9eb60a53866e3bf130f91a3a2ec36d90
+commit=f7c351b9f36baf210aeef3034bc6155177a326b9


### PR DESCRIPTION
The description was still the default text saying it's an example greeter plugin, so I fixed that to say it's an inferno auto splitter.