### PR TITLE
Add item-retrieval-warning

### DIFF
--- a/plugins/item-retrieval-warning
+++ b/plugins/item-retrieval-warning
@@ -1,0 +1,2 @@
+repository=https://github.com/zodaz/item-retrieval-warning.git
+commit=78796c60db6f0a23a619ee0d8ee63e4312d3d9d0


### PR DESCRIPTION
This plugin keeps track of whether a player has items stored in an item retrieval service or not and if they have, it warns the player when their health drops below a user-specified percentage by sending a notification, flashing the in-game screen red and displaying overlay message.
Warnings will not trigger in areas of the game where the items in an item retrieval service are not at risk. (Minigames, cox etc).