### PR TITLE
Update no-examine

### DIFF
--- a/plugins/no-examine
+++ b/plugins/no-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=50218644fd8d9c8c5edfe1db0d0e7c1eda27e10b
+commit=f97c0ea114e7a570c0e1857c1598999ee3d0c044


### PR DESCRIPTION
- The remove menu option is now only removed for game objects and not in the equipment tab while inside the player-owned house