### PR TITLE
Update improved-tile-indicators

### DIFF
--- a/plugins/improved-tile-indicators
+++ b/plugins/improved-tile-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/LeikvollE/tileindicators.git
-commit=6bb9069d41ebf62e24c17af060c8cc99b4177584
+commit=440899183e10821406da4f2c195ea1235526ed97


### PR DESCRIPTION
Unfortunately in my last update, I removed some features that it turns out people actually use so this update largely reverts that update(sorry about this), while still not mimicking the official tile indicator plugin in its entirety. 

Also fixed is making sure the overlay is always drawn as the last element with MED overlay priority and before all elements with HIGH overlay priority.