### PR TITLE
Update seaweed-spore-notifier to v1.1.1

### DIFF
--- a/plugins/seaweed-spore-notifier
+++ b/plugins/seaweed-spore-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/rbbi/seaweed-spore-notifier.git
-commit=37c2e97c1fd27dd0dc8bb1e6190cb84ed608995d
+commit=b98eaac13a6b9eec1a3906c2d3f6090cae7bd3a2


### PR DESCRIPTION
Fixes critical issue (non-default plugin constructor) that prevents the plugin from loading.