### PR TITLE
Update set-timer to version 2.0.0

### DIFF
--- a/plugins/set-timer
+++ b/plugins/set-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/SetTimer.git
-commit=a8134cf6ee8c0f548a0d47896a50194a93b4b081
+commit=45a47eb32763087006459e43e865975fdace68fe


### PR DESCRIPTION
There was a bug where hotkeys would call button.doClick which has a thread.sleep call so if a user were to hold the hotkey button they'd DoS their client.

I decided to mostly rewrite the plugin to avoid this but none of the functionality has changed.