### PR TITLE
Create item-stats-banking

### DIFF
--- a/plugins/item-stats-banking
+++ b/plugins/item-stats-banking
@@ -1,0 +1,2 @@
+repository=https://github.com/Boredska/item-stats-banking.git
+commit=b546e3e62f7a78b1189737682c12aac2a9c7b55b


### PR DESCRIPTION
Plugin that toggles Item Stats equipment and consumable overlays (depending on config) when banking