### PR TITLE
Item stats banking

### DIFF
--- a/plugins/item-stats-banking
+++ b/plugins/item-stats-banking
@@ -1,2 +1,2 @@
-repository=https://github.com/Boredska/item-stats-banking.git
-commit=b546e3e62f7a78b1189737682c12aac2a9c7b55b
+repository=https://github.com/Boredska/bank-item-stats-toggle.git
+commit=b9d65c7472e59224895ff13b05bd459c81661a32

--- a/plugins/item-stats-banking
+++ b/plugins/item-stats-banking
@@ -1,0 +1,2 @@
+repository=https://github.com/Boredska/item-stats-banking.git
+commit=b546e3e62f7a78b1189737682c12aac2a9c7b55b


### PR DESCRIPTION
Plugin that toggles Item Stat plugins overlays when banking depending on user settings.
Plugin hub version of https://github.com/runelite/runelite/pull/15499