### PR TITLE
Update NeverScapeAlone to v2.11.1-alpha

### DIFF
--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=d7e5e5615627916ef11594c7ae63cc44549c991f
+commit=a5958f4785581e1e67aa71772ff3e3d59e09bbbe
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic


### PR DESCRIPTION
Changelog:
+ Adds match version checks

Bugfix:
+ Fixes zero length notes appearing as panel object

Line Changes: +109/-9