### PR TITLE
Update nylo-death-indicators to version 1.0.3

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=29cc79d8636992babcbbdc631a238d76274c8b83
+commit=192e5297fab64745d1fc5077cb383b8b76b4a815


### PR DESCRIPTION
Fixes multiple bugs:

1. Dead nylos were being unhidden in the failsafe due to projectile distance + death animation being longer than 5 ticks
2. Party messages were sent regardless of the user being in a party
3. Queued damage was _always_ subtracted from an NPC on hitslpat, even if the damage wasn't queued resulting in the value being negative