### PR TITLE
update contextual-cursor to v1.3.1

### DIFF
--- a/plugins/contextual-cursor
+++ b/plugins/contextual-cursor
@@ -1,2 +1,2 @@
 repository=https://github.com/Enriath/external-plugins.git
-commit=8b274d6f8ef5562118a82bad8070eea01fee7aa5
+commit=9b37717bd48359ced06bd08ee821d721f6cea53c


### PR DESCRIPTION
So this was an unexpected adventure.

To fix the overlapping issue, I made the overlay add a tooltip to the front. This meant that the layer had to be lowered, so it was added before tooltips were rendered, and after mouse tooltips added its tooltip. This caused the cursor to be rendered behind the minimenu, which is not good. 
Adding a tooltip to the front of the list *and* rendering over minimenus isn't something a single overlay can do. Reluctantly, there are now 2 overlays.

Also, Use options were accidentally being considered a spell and breaking, so that's now fixed.