### PR TITLE
Update Hub Party Panel (v3.1)

### DIFF
--- a/plugins/party-panel
+++ b/plugins/party-panel
@@ -1,3 +1,2 @@
 repository=https://github.com/TheStonedTurtle/party-panel.git
-commit=377be8785f50eeab5435b00792c2da54d474abc1
-disabled=true
+commit=4d7b5632dfb7e1b092baa71e4d7e8343739bf23a


### PR DESCRIPTION
No longer sends `PartyPlayer` over websocket and adds other packet size optimizations