### PR TITLE
revert transmog to v1.2.6

### DIFF
--- a/plugins/transmog
+++ b/plugins/transmog
@@ -1,3 +1,2 @@
 repository=https://github.com/Enriath/external-plugins.git
-commit=4ca4181183020b91081f879fba4a7669e3b333b2
-disabled=true
+commit=d46d0022d527ab9000a9c5b05d197416437cb12e


### PR DESCRIPTION
While the party situation is being resolved, this is the pre-party transmog plugin.

Branch is here, only extra thing included is the author update
https://github.com/Enriath/external-plugins/commits/transmog-temp