### PR TITLE
Update blindfold

### DIFF
--- a/plugins/blindfold
+++ b/plugins/blindfold
@@ -1,2 +1,2 @@
 repository=https://github.com/stevenwaterman/runelite-plugins.git
-commit=616aaabef3411f1d2f312b2c637d831dff25824b
+commit=5a7988b898d8dc98d857c3a02d95174d9ffb5fa1

--- a/plugins/blindfold
+++ b/plugins/blindfold
@@ -1,2 +1,2 @@
 repository=https://github.com/stevenwaterman/runelite-plugins.git
-commit=a18c14b8783d36ea003ba4f1e08d7a35590e859e
+commit=616aaabef3411f1d2f312b2c637d831dff25824b


### PR DESCRIPTION
JOGL was removed as a dependency. Updated to use the code from the newer version of the GPU plugin and to split the blindfold functionality into 3 sections so you can hide terrain / scenery / objects independently