### PR TITLE
Update clan-activity-tracker

### DIFF
--- a/plugins/clan-activity-tracker
+++ b/plugins/clan-activity-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Phobos97/clan-activity-tracker.git
-commit=b0844de900498563ba86d8d7fbea26290b31c7ee
+commit=be06ca10b63339c8871ce8db46d05e27f678351e


### PR DESCRIPTION
Fixed dependency for apache commons csv and probable bug fix for clearing of tracked data when file reaches > 10kb