### PR TITLE
Update NeverScapeAlone to v2.21.0-alpha

### DIFF
--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=97526c4911f8bab681545fd09b95612d2c79c2c1
+commit=8e3e7857cb93782fcb780672e5772f32e2b407ed
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic

--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=8e3e7857cb93782fcb780672e5772f32e2b407ed
+commit=7e808c7c69490f1ade6405e15c1ef15a15d6f20b
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic

--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=638feb062aa9a567533e805d6575ef63ea77d73e
+commit=ef5847dc63b910d11098036ac7f405b2b2a0a376
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic

--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=a5958f4785581e1e67aa71772ff3e3d59e09bbbe
+commit=97526c4911f8bab681545fd09b95612d2c79c2c1
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic

--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=ef5847dc63b910d11098036ac7f405b2b2a0a376
+commit=b5275f72d4c835019431205bbacd50eb2eae31ba
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic

--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=a3a0e09f2d4ebe1bf57e5a74603f72753a7e8630
+commit=b0ceee7309236b71c69d13be098492f2cdedd144
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic

--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=b5275f72d4c835019431205bbacd50eb2eae31ba
+commit=9d9200b83380fb3443c04ec2b9ef3f6573fec23c
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic

--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=7e808c7c69490f1ade6405e15c1ef15a15d6f20b
+commit=638feb062aa9a567533e805d6575ef63ea77d73e
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic

--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=9d9200b83380fb3443c04ec2b9ef3f6573fec23c
+commit=a3a0e09f2d4ebe1bf57e5a74603f72753a7e8630
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic


### PR DESCRIPTION
Changelog:
+ Renames "Random" to "I'm feeling lucky"
+ Adds Herbiboar
+ Adds Tombs of Amascut (Entry, Normal, Expert)
+ Adds Entry Mode TOB
+ Adds MLM
+ Adds Money-making
+ Adds a link to RuneWatch in the links panel
+ Changes max ping rate to 10/second from 3/second
+ Adds Map Icons
+ Adds Map Names
+ Adds Map Stats
+ Adds Map Bars
+ Adds Minimap Icons
+ Adds Minimap Names
+ Adds LFG tag
+ Hides Authentication token
+ Add match reconnect on failure
+ File Structure Refactor


Bug Fixes:
+ Resolves permanent search panel spinning
+ Resolves long activity names running over the panel
+ Resolves Alert ping lasting 'forever'
+ Resolves Pop-up panels from being below RuneLite when RL is set "Always On Top"
+ Resolves Overlay bug
