### PR TITLE
Create pickpocket-helper

### DIFF
--- a/plugins/pickpocket-helper
+++ b/plugins/pickpocket-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/RDieleman/runelite-pickpocket-helper.git
-commit=fa19e9ec8c27e31dae77d1f2e4bc082153a7740e
+commit=8f866d8d9dc200a9fb397f27be8c8df7b4c8834b

--- a/plugins/pickpocket-helper
+++ b/plugins/pickpocket-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/RDieleman/runelite-pickpocket-helper.git
-commit=00a96ac77d6e4920c0467219214c02abd9e728c4
+commit=fb826b0a441bb15d6a8a32561bd1dd27fe50b9ac

--- a/plugins/pickpocket-helper
+++ b/plugins/pickpocket-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/RDieleman/runelite-pickpocket-helper.git
-commit=8f866d8d9dc200a9fb397f27be8c8df7b4c8834b
+commit=8e9acf1adc1cd7452226adb5e403c82a6a8ab112

--- a/plugins/pickpocket-helper
+++ b/plugins/pickpocket-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/RDieleman/runelite-pickpocket-helper.git
-commit=cd45a7080840318bc3bd6fddd773b4290d3dd87e
+commit=00a96ac77d6e4920c0467219214c02abd9e728c4

--- a/plugins/pickpocket-helper
+++ b/plugins/pickpocket-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/RDieleman/runelite-pickpocket-helper.git
+commit=fa19e9ec8c27e31dae77d1f2e4bc082153a7740e

--- a/plugins/pickpocket-helper
+++ b/plugins/pickpocket-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/RDieleman/runelite-pickpocket-helper.git
-commit=8e9acf1adc1cd7452226adb5e403c82a6a8ab112
+commit=cd45a7080840318bc3bd6fddd773b4290d3dd87e


### PR DESCRIPTION
This plugin offers some quality of life improvements for pickpocketing, for example:
- Idle notifier for the player
- Idle notifier for, if present, the splasher
- Muting specific game sounds
- Despawn timer and notifier
- Missing rogue gear notifier
- Breaking dodgy necklace notifier
- Some info overlays

And more. Additionally, it allows you to configure the way you receive alerts: chat messages, notifications, or speech audio.