### PR TITLE
Update to v1.3.0: re-map tabs if F-key is set as bind properly

### DIFF
--- a/plugins/global-f-keys
+++ b/plugins/global-f-keys
@@ -1,2 +1,2 @@
 repository=https://github.com/SirGirion/GlobalFKeys.git
-commit=b37cb7d274b2bf8218395dbb130badcff2212067
+commit=3ce1c6c52a0e3e6f45e9c43b020429f48126a880


### PR DESCRIPTION
If a user has a tab set to an F key, the dialogue checks copied from the core key remap plugin were preventing the right F key from being sent. This update will allow remaps to happen IIF the tab is set to an F key or escape.