### PR TITLE
Update osrs-wiki-crowdsourcing

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=886e98ad1bfc52aebd04467203e902499e825f07
+commit=3e74d23f5caeabb916373d2de54b27356790ffa8
 authors=leejt,andmcadams


### PR DESCRIPTION
- remove Nex so it builds after HitsplatType API changes
- fix bug in XP crowdsourcing lastClick