### PR TITLE
Add Invocation Screenshot plugin

### DIFF
--- a/plugins/invocation-screenshot
+++ b/plugins/invocation-screenshot
@@ -1,0 +1,2 @@
+repository=https://github.com/TheStonedTurtle/invocation-screenshot.git
+commit=3f9214f5409bb6a98909037dcc0efe25ba905a1e


### PR DESCRIPTION
Adds a camera button to the Tombs of Amascut interface that will generate an image of the current invocations to the system clipboard.

![image](https://user-images.githubusercontent.com/29030969/186608284-3ce2b76f-43e1-477b-a954-c159397ceaa8.png)

![image](https://user-images.githubusercontent.com/29030969/186608337-eec5b3cb-2bfa-4e35-9130-5fdf89b97734.png)
