### PR TITLE
Update Animation Transmog (v1.3.3)

### DIFF
--- a/plugins/animation-transmog
+++ b/plugins/animation-transmog
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtimosPenguidor/animation-transmog.git
-commit=39f255c4796eb1a9232265b9669390d1baf678eb
+commit=d3bd75aea96ff18c6947a4c19452724dfa3085d8


### PR DESCRIPTION
With the release of ToA, my plugin was causing a bug that triggers the player's custom teleport animation set within the plugin when a Blessed crystal scarab is broken.

This update essentially disables the plugin within ToA by blacklisting the regions found within the raid.