### PR TITLE
add tombs-of-amascut

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,0 +1,2 @@
+repository=https://github.com/LlemonDuck/tombs-of-amascut.git
+commit=5eee0bfd6cb648c4d29aa4af0d4e97a4b0a30a5c


### PR DESCRIPTION
Creates tombs-of-amascut plugin, mostly still empty.

Currently has deposit-pickaxe swap for mirrors room, whether you have a pickaxe in inventory or not.