### PR TITLE
Update Hub Party Panel (v3.2)

### DIFF
--- a/plugins/party-panel
+++ b/plugins/party-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/party-panel.git
-commit=5edf8ace277740af96c88a250f343203203a1937
+commit=e49f85ef104cbe00d84aa47fd008962f0ad32002


### PR DESCRIPTION
* Removed skill experience from the plugin to further reduce server load
* Updated the skills tab to default to starting levels for logged out users