### PR TITLE
Update shortest-path to v1.9.1

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=ae3a46084286047fa3e0a2eb2cfa29b3130b15cf
+commit=108cdcddeca37665b03f33b7ac11b75087b225bd

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=505c68175fad97410860a31575bfac1526a5cd0f
+commit=bba4b8097b6c9490d8109a7cd9766229ad1338be

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=bba4b8097b6c9490d8109a7cd9766229ad1338be
+commit=235b2de1a6b386f2a1a8a90a8fce19f98a25d6ea

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=108cdcddeca37665b03f33b7ac11b75087b225bd
+commit=505c68175fad97410860a31575bfac1526a5cd0f


### PR DESCRIPTION
- Add option to toggle fairy rings
- Add option to toggle boats, ships and canoes
- Add option to toggle teleportation portals and levers
- Add some missing crossbow grapple shortcuts
- Update the collision map to the Beneath Cursed Sands release
- Reduce lag in connection with recalculate distance setting
- Display transports used in the path as a dashed line
- Only use transports if the required quests are completed