### PR TITLE
Added kephri-number-puzzle-solver plugin

### DIFF
--- a/plugins/kephri-number-puzzle-solver
+++ b/plugins/kephri-number-puzzle-solver
@@ -1,0 +1,2 @@
+repository=https://github.com/EliasLahham/kephri-number-puzzle-solver.git
+commit=ae80d2cefdfddca6020da284d889817dcffb5baf

--- a/plugins/kephri-number-puzzle-solver
+++ b/plugins/kephri-number-puzzle-solver
@@ -1,2 +1,2 @@
 repository=https://github.com/EliasLahham/kephri-number-puzzle-solver.git
-commit=ae80d2cefdfddca6020da284d889817dcffb5baf
+commit=09da81e58879eae0fbf5583af634bb8ac5521d49


### PR DESCRIPTION
Description:
https://github.com/EliasLahham/kephri-number-puzzle-solver

This plugin utilizes a commonly used set of tile markers for the Kephri number puzzle in the new raid and provides a solution in the chat window. Most people, including myself, have the solutions listed in a notepad/Runelite notes, so this plugin makes it a bit easier to see the solution without looking at another monitor/window.

![image](https://user-images.githubusercontent.com/17418745/187564470-c6b4f158-0fdf-4e8b-8c08-280e7be739c1.png)

![image](https://user-images.githubusercontent.com/17418745/187564031-f8847033-f126-442a-bca9-682e283aa60e.png)

