### PR TITLE
Create maxhitalert

### DIFF
--- a/plugins/maxhitalert
+++ b/plugins/maxhitalert
@@ -1,0 +1,2 @@
+repository=https://github.com/doppy2023/maxhitalert.git
+commit=261b4ad36b89f9f2e5df15e8985d000121f5c5eb


### PR DESCRIPTION
This plugin allows you to receive a discord webhook whenever you get a max hit. You can input the discord webhook in the plugin settings.