### PR TITLE
Update osrs-wiki-crowdsourcing

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=bdb514ef68082e673ecbd2239c072212e4e2f0cc
+commit=64fedb9634dcaa5b8d2ef75b23d12aa267f53b6c
 authors=leejt,andmcadams

--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=3e74d23f5caeabb916373d2de54b27356790ffa8
+commit=bdb514ef68082e673ecbd2239c072212e4e2f0cc
 authors=leejt,andmcadams


### PR DESCRIPTION
- Add metadata to certain message crowdsourcing to make guessing certain stat_randoms easier, and to determine how Master Farmer loot scales with Farming level (andmcadams)
- Fix varbit crowdsourcing on disconnects (andmcadams)
- Add crowdsourcing for ToA supplies to determine boost formulas (Pharros)
- Track invisible impling spawn locations and change probabilities (Cook)
- Fix clue widget clicks (andmcadams)