### PR TITLE
add butler-info plugin

### DIFF
--- a/plugins/butler-info
+++ b/plugins/butler-info
@@ -1,2 +1,2 @@
 repository=https://github.com/NickMckloski/butler-info-plugin.git
-commit=35d7c340ee424932c9f82b3ba8c8c598846b55f1
+commit=bd88c20cfbfadf7d10ca7eb2e88c972281503f43

--- a/plugins/butler-info
+++ b/plugins/butler-info
@@ -1,0 +1,2 @@
+repository=https://github.com/NickMckloski/butler-info-plugin.git
+commit=35d7c340ee424932c9f82b3ba8c8c598846b55f1


### PR DESCRIPTION
This plugin helps keep track of information relating to a POH butler/servant. It tracks things like the items the butler is holding, time until butler returns from bank, and number of trips until payment is required again.