### PR TITLE
update tombs-of-amascut to v1.5.1

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tombs-of-amascut.git
-commit=b31e4eea9083b0036c63d64847bcfd32023ff628
+commit=b6975daae8dcbc1428b47d7891ae6efd6ed6e594


### PR DESCRIPTION
* prevents inconsistent NPE on plugin startup
* don't render null target time when no time limit is selected
* add new quick-* entries for teleport crystals, doorways, etc