### PR TITLE
Tombs of Amascut Puzzle Helper

### DIFF
--- a/plugins/tombs-of-amascut-puzzle-helper
+++ b/plugins/tombs-of-amascut-puzzle-helper
@@ -1,0 +1,3 @@
+repository=https://github.com/BoydHarold/Tombs-of-Amascut-Puzzle-Helper.git
+commit=cdabb2b398a88cc75895863341fce8c5088b9b2d
+authors=Crystal Bofa


### PR DESCRIPTION
Added a plugin that utilizes labelled tile overlays to make the Scarab Puzzle Room in Tombs of Amascut more brain-dead than it already is.