### PR TITLE
Updated native-mac-notifications

### DIFF
--- a/plugins/native-mac-notifications
+++ b/plugins/native-mac-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/fatfingers23/mac-runelite-native-notifications.git
-commit=733ffb5a64e96d36bedecfe526ce3ebeafd18867
+commit=d25e6225f76aadda36ee6d8493c97d8069edec8e


### PR DESCRIPTION
* Updated to honor RuneLite's send notifications when focused option. Closing an issue on [my repo ](https://github.com/fatfingers23/mac-runelite-native-notifications/issues/4) 
* Changed OS check to when a notification fires instead of on start up instead of just turning off if it is not a mac OS.
* Also added the ability to attempt to control the tray notification if the OS is Mac, since it is not needed. Should help with those who play on two different operating systems. Also closes this [issue](https://github.com/fatfingers23/mac-runelite-native-notifications/issues/2).