### PR TITLE
update transmog to v1.3.4

### DIFF
--- a/plugins/transmog
+++ b/plugins/transmog
@@ -1,2 +1,2 @@
 repository=https://github.com/Enriath/external-plugins.git
-commit=d46d0022d527ab9000a9c5b05d197416437cb12e
+commit=a2284054a9c4968270c1a86eecbedee18c28dfe9


### PR DESCRIPTION
I'm back!

So with a recent issue, it turns out the code scaled *really* badly with large parties that were badly configured. To this end, the plugin has taken some time, gone to university, and gotten a degree in data merging.

In all seriousness, the plugin now just doesn't care about empty states for other members of your party, instead merging that into the transmog it shares. Since empty state will rarely ever change, this cuts out a lot of extra data; it would not make sense to do the same with current state, as that's known to other clients generally and changes often.
I've also added a rate limit of 1 message per tick, so no flickering your transmog ultra fast for other people.