### PR TITLE
Update nylo-death-indicators to version 1.0.4

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=192e5297fab64745d1fc5077cb383b8b76b4a815
+commit=0fecee43343fea27b07374f452aba3b793411f5b


### PR DESCRIPTION
Fix for Goblin Paint Cannon rename