### PR TITLE
Update cox-clipboard

### DIFF
--- a/plugins/cox-clipboard
+++ b/plugins/cox-clipboard
@@ -1,2 +1,2 @@
 repository=https://github.com/Maurits825/cox-clipboard.git
-commit=f4fc79edbf916a6b3b896bd53eb5822c0f5fb700
+commit=ce97d7fe5e646248b473384415a63797f6801f50


### PR DESCRIPTION
Fixed double clipboard text and missing toa raid type