### PR TITLE
Update pvp-performance-tracker to v1.5.6

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=7ca3ba087661183e0a94641a36e02d7714aaff37
+commit=4af458eb070350627d11d731315e023a3d8df110


### PR DESCRIPTION
- Added DPS support for Osmuten's fang, both normal attacks & spec (thanks to Mazhar once again!)
- Adjust opal & diamond bolts(e) accuracy increase since they were using PvM values
- Support new LMS items introduced in August from the different skill builds (stats not automatically detected for most of these "item copies", so need to relate them with the "real item").
- Properly decide LMS skills/stats depending on build type, based on defence level when starting the fight. Previously it was always defaulting to MaxMed stats if in LMS. (Also fixed a bug relating to this)
- Migrates/updates data on StartUp so that previous fights can be kept while supporting the above change of "bool isAtLms" -> "enum FightType". Attempts to detect LMS style for older matches based on def lvl while isAtLms.