### PR TITLE
Add purchase progress plugin

### DIFF
--- a/plugins/purchase-progress
+++ b/plugins/purchase-progress
@@ -1,0 +1,2 @@
+repository=https://github.com/BrastaSauce/purchase-progress.git
+commit=33c7ebeb5be6a7a4c1ed7be3c4e56af5aca75b7e

--- a/plugins/purchase-progress
+++ b/plugins/purchase-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/BrastaSauce/purchase-progress.git
-commit=33c7ebeb5be6a7a4c1ed7be3c4e56af5aca75b7e
+commit=9b32d1571ebed8e903dc5b41f279406fc5f6b6c8


### PR DESCRIPTION
A plugin to track how close you are to affording an item. Search for items to add from the Grand Exchange. Track your progress using only GP or include a loot tab.