### PR TITLE
Add toa-mistake-tracker

### DIFF
--- a/plugins/toa-mistake-tracker
+++ b/plugins/toa-mistake-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/QuestingPet/ToaMistakeTracker.git
+commit=7f39560e66a79549610304d52c7d34207e6a63d1


### PR DESCRIPTION
Add the ToaMistakeTracker plugin, which tracks mistakes for all present raiders in the Tombs of Amascut.

This plugin is very similar to the TobMistakeTracker plugin, but with over 5x the number of tracked mistakes. The panel code is almost completely copied over from TobMistakeTracker.

View the [README](https://github.com/QuestingPet/ToaMistakeTracker/blob/master/README.md) for more details on what's being tracked: 