### PR TITLE
Update Twitch Live Loadout Plugin to v1.1.0

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=ceee3ca3f228343a2745cb98b9f3bd2a281bbf7d
+commit=586f9f87dd9b55063e8a9899456946912b1558aa

--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=b0f78bb0571f54d1be74690e4514e01cacbe564c
+commit=ceee3ca3f228343a2745cb98b9f3bd2a281bbf7d


### PR DESCRIPTION
Added syncing of ToA invocations, syncing of looting bag and many stability improvements.

Changelog:
- Tombs of Amascut Invocations can now be synced automatically when at the raid lobby and in the raid itself.
- You can now switch between dark and light theme for your viewers.
- All bank items are now synced to your viewers, rather than only the 200 most valuable items.
- The looting bag can now be synced to viewers.
- Items can now have 'special behaviours' for example the looting bag opens a new side-panel as one of the first items for this behaviour.
- Collection log can be filtered using keywords to chose what you want too sync.
- Added support and documentation links to the `Status` tab in the plugin tab.
- Added automatic detection which account should be synced when multi-logging. The plugin keeps track of which RuneLite window is focussed on for a minimum (configurable) time to determine which account to sync.
- Expanded the `Status` tab to be more transparent in which RuneLite window is currently synchronizing data.
- Enhanced the stability of the plugin by ignoring game events that are disabled by the streamer to sync anyways.