### PR TITLE
Re-enable and update spamfilter

### DIFF
--- a/plugins/spamfilter
+++ b/plugins/spamfilter
@@ -1,3 +1,2 @@
 repository=https://github.com/jackriccomini/spamfilter-plugin-runelite.git
-commit=9011f51302890a8d4c1b367522b2f73234039e78
-disabled=unstable
+commit=846413d594416195047e5d2ea233dce7a12fd85c


### PR DESCRIPTION
Single line change to spamfilter. [Discussed](https://discord.com/channels/301497432909414422/419891709883973642/1019416137861169202) in RL Discord development channel. Crash has been fixed, tested with rat catching and drinking a cup of tea. I'm unable to test in some other crash situations (e.g. Olm apparently) due to account progress.