### PR TITLE
Create ScoutingStats

### DIFF
--- a/plugins/ScoutingStats
+++ b/plugins/ScoutingStats
@@ -1,0 +1,2 @@
+repository=https://github.com/OmbudRov/ScoutingStats.git
+commit=4f84482864e6adb31c1bcab24bd30c30cd0127ab

--- a/plugins/scouting-stats
+++ b/plugins/scouting-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/OmbudRov/ScoutingStats.git
-commit=4f84482864e6adb31c1bcab24bd30c30cd0127ab
+commit=02aeac608a8a5cb49d83eb05495727aa81e4907b

--- a/plugins/scouting-stats
+++ b/plugins/scouting-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/OmbudRov/ScoutingStats.git
-commit=02aeac608a8a5cb49d83eb05495727aa81e4907b
+commit=ab0bf5be28fc91812ac0de685ebb8cfe8767a5ed


### PR DESCRIPTION
The plugin keeps track of how many raids Scouters have entered and left, which might induce rage in them