### PR TITLE
Add zom-ignore-list-updater

### DIFF
--- a/plugins/zom-ignore-list-updater
+++ b/plugins/zom-ignore-list-updater
@@ -1,0 +1,2 @@
+repository=https://github.com/JZomerlei/zom-external-plugins.git
+commit=7dd12f22f351c8d0122f7f9774a73bfb9007abd8


### PR DESCRIPTION
Ignore List Alerter uses friend note plugin's notes on ignore list to alert chat box when they are nearby