### PR TITLE
add alch-blocker plugin

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,17 @@
 BSD 2-Clause License
 
-Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+Copyright (c) 2022, robrichardson13
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,0 +1,2 @@
+repository=https://github.com/robrichardson13/alch-blocker.git
+commit=fec8c1d9d1b75b7c5801e693ab757dbd32043e7f


### PR DESCRIPTION
# Alch Blocker
##### A plugin for [RuneLite](https://runelite.net/)


Allows you to block items from being alched

## Notes
- The plugin just checks the list of items configured and hides the item widgets when alching. It then unhides them after the alch cancels or completes.
- Adds quality of life (especially for UIM players), who always have near full inventories.
- This plugin can be used as a safeguard to ensure you never alch specific items. (The warning dialog doesn't have the fine controls to warn in all cases, where this plugin solves that.)



## Preview

![Demo](https://i.imgur.com/Amf3CEZ.gif)


