### PR TITLE
add alch-blocker plugin

### DIFF
--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/robrichardson13/alch-blocker.git
-commit=be2c3fbbaf7853d6bc67690f65c53b08751c3cda
+commit=f37c6a374debf6aa62579dfc00c8d35999d5a0ce

--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/robrichardson13/alch-blocker.git
-commit=d4999c8e5e266e74c8cbbb37a5de0784e83a1e59
+commit=a6cde22f30e9a3912dfe4e8fbfa5b7ae4dc1dcae

--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/robrichardson13/alch-blocker.git
-commit=fef10c3ce52ba9316c927798f8b0450ec476872b
+commit=be2c3fbbaf7853d6bc67690f65c53b08751c3cda

--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,0 +1,2 @@
+repository=https://github.com/robrichardson13/alch-blocker.git
+commit=d4999c8e5e266e74c8cbbb37a5de0784e83a1e59

--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/robrichardson13/alch-blocker.git
-commit=a6cde22f30e9a3912dfe4e8fbfa5b7ae4dc1dcae
+commit=fef10c3ce52ba9316c927798f8b0450ec476872b


### PR DESCRIPTION
# Alch Blocker
##### A plugin for [RuneLite](https://runelite.net/)


Allows you to block items from being alched

## Notes
- The plugin just checks the list of items configured and hides the item widgets when alching. It then unhides them after the alch cancels or completes.
- Adds quality of life (especially for UIM players), who always have near full inventories.
- This plugin can be used as a safeguard to ensure you never alch specific items. (The warning dialog doesn't have the fine controls to warn in all cases, where this plugin solves that.)



## Preview

![Demo](https://i.imgur.com/Amf3CEZ.gif)


