### PR TITLE
Update sandstone-buckets-counter to 1.1

### DIFF
--- a/plugins/sandstone-buckets-counter
+++ b/plugins/sandstone-buckets-counter
@@ -1,2 +1,2 @@
-repository=https://github.com/klisiu-net/sandstone-buckets-counter.git
-commit=a9aa599883bc2ca3f7740c1b2f1dcfd35ddf40d0
+repository=https://github.com/wookkeey/sandstone-buckets-counter.git
+commit=47e2cc78af9b77a6c38b26cc09121cd0e1f0a6ad


### PR DESCRIPTION
Updated the plugin to the latest release (1.1) and updated path to the repository (moved it from one organisation to another).

PS. Plugin originally submitted in https://github.com/runelite/plugin-hub/pull/957.