### PR TITLE
update tombs-of-amascut to v2.0.1

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tombs-of-amascut.git
-commit=11fea97176c6d633f62961d12829925cc107854d
+commit=50e37e1fd41279bcf387808b45ce111b7c191c20


### PR DESCRIPTION
two bug fixes:
* prevent npe on scabaras overlay for off-screen tiles
* prevent config parse coersion error for deposit pickaxe option (was boolean, now enum)