### PR TITLE
add challenge-mode-indicator plugin

### DIFF
--- a/plugins/challenge-mode-indicator
+++ b/plugins/challenge-mode-indicator
@@ -1,0 +1,2 @@
+repository=https://github.com/robrichardson13/challenge-mode-indicator.git
+commit=a9caed3f4b9e3fb005375d9bb37aeb70e53a1d79


### PR DESCRIPTION
# Challenge Mode Indicator
##### A plugin for [RuneLite](https://runelite.net/)


Shows an indicator above the lever in the POH if challenge mode is on

Initially brought up in the Discussions page: https://github.com/runelite/runelite/discussions/15669

## Preview

![Demo](https://user-images.githubusercontent.com/9492530/192448046-107b15e1-4bea-4420-ab79-d282eb0a2be3.gif)