### PR TITLE
Create Dragon WAHammer Plugin

### DIFF
--- a/plugins/dragon-wahammer-plugin
+++ b/plugins/dragon-wahammer-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/petertalbanese/DragonWAHammer.git
+commit=901616b1463116812f335d919f220c09b469561b


### PR DESCRIPTION
Allows the user to add custom sounds to hit/miss on the Dragon Warhammer special attack.

To use, place a custom `dwh_hit.wav` and `dwh_miss.wav` file in your root RuneLite folder and activate the plugin.