### PR TITLE
Added Offline Chat Icon Plugin

### DIFF
--- a/plugins/offline-chat-icon
+++ b/plugins/offline-chat-icon
@@ -1,0 +1,2 @@
+repository=https://github.com/fatfingers23/RuneliteOfflineChatIcon.git
+commit=2e126eabddbc7d442c5690396b5bce41d16fae34


### PR DESCRIPTION
This plugin displays an offline icon if a player logs out or leaves the chat next to their name.