### PR TITLE
Update purchase-progress to v1.1.1

### DIFF
--- a/plugins/purchase-progress
+++ b/plugins/purchase-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/BrastaSauce/purchase-progress.git
-commit=1b028149ddc2b1f46377ba2852b03d0021c153c7
+commit=3068d83d7e0530cabe0030c385985c5762b9d11c


### PR DESCRIPTION
**v1.1.0**
- Add ability to sort added items by price
- Add ability to manually move added items up or down through the list
- Add plugin hub icon

**v1.1.1**
- Fix a bug where platinum tokens weren't being added to value properly