### PR TITLE
Update 117HD to v1.2.0

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=53391db8b90c44ec9314d53e6f459973e990e8cc
+commit=bc3f4f351b9346c4b98aa94c7c2ea0b76c3b15b9
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
[diff between previous release and this commit](https://github.com/117HD/RLHD/compare/v1.1.3..bc3f4f351b9346c4b98aa94c7c2ea0b76c3b15b9)

Note that the current release is a different branch.

Overview:
* Opt-in off-heap model caching
* Many TOA graphical improvements
* New graphical features (unused)
* General refactoring, cleanup, and bug fixes
* Dependency updates that are already in use by either core runelite or other plugin-hub plugins

Multiple users across Windows, Mac, and Linux have tested these changes extensively. 