### PR TITLE
Update basqh

### DIFF
--- a/plugins/basqh
+++ b/plugins/basqh
@@ -1,2 +1,2 @@
 repository=https://github.com/BA-Services/queue-helper.git
-commit=8890ddf61475c1278b01cb54a0890bbe73618154
+commit=7a4c95143945e47d22094286b1b78605eec58b37


### PR DESCRIPTION
Notifies user when API Key field is empty, and doesn't send server requests with an empty API Key