### PR TITLE
update tombs-of-amascut to v2.0.4

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tombs-of-amascut.git
-commit=20d7ffd5267a96330997f3bcc6c3078ab863efa7
+commit=da4f0ad20e903ff75ce92bd278ccb199611ab748


### PR DESCRIPTION
fixes an update regression for invocation screenshots when including the rewards section which was introduced during jagex' invocation preset update

thanks @TheStonedTurtle 