### PR TITLE
add godwars-protection-overlay plugin

### DIFF
--- a/plugins/godwars-protection-overlay
+++ b/plugins/godwars-protection-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/UnExploration/godwars-prot.git
+commit=854ba31adf0523cfc520433d1593cd87fb98531f


### PR DESCRIPTION
This plugin adds an overlay that shows your current protections in the God Wars Dungeon based on equipment. 
