### PR TITLE
Update transcriber to v1.1

### DIFF
--- a/plugins/transcriber
+++ b/plugins/transcriber
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=31501ade9626e4b0142dad0d997434ec8582d0cd
+commit=263575a80e4f9fef496864ac9df23faaf09f7e82


### PR DESCRIPTION
- Fix certain books and scrolls not transcribing, e.g. `Intel report` and `Pirate message`
- Add option to transcribe item IDs and sprite IDs