### PR TITLE
Update nylo-death-indicators to version 1.0.5

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=0fecee43343fea27b07374f452aba3b793411f5b
+commit=c6df65d918f0735b58f316977a52eece0a2bbd92


### PR DESCRIPTION
Update to work with the new spawn/despawn code since Nylocas respawn every tick when walking into the room.