### PR TITLE
Update startierindicator to v1.1.1

### DIFF
--- a/plugins/startierindicator
+++ b/plugins/startierindicator
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
-commit=05a88cf80c10efc6655c844dd23c45c7ad3d446a
+commit=55e80a378745a0b828d4d66fd1219b22db5badd8

--- a/plugins/startierindicator
+++ b/plugins/startierindicator
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
-commit=55e80a378745a0b828d4d66fd1219b22db5badd8
+commit=2e7f04e27d11fc748be3f2f22edb8d78b0ccd8da

--- a/plugins/startierindicator
+++ b/plugins/startierindicator
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
-commit=8734881551261de6161f61b0b3d76489c3861862
+commit=05a88cf80c10efc6655c844dd23c45c7ad3d446a


### PR DESCRIPTION
Fix some statistics for f2p stars
-Half xp on f2p
-Prospector / Celestial ring doesn't work on f2p

Add configuration for star health bar. Health bar is always hidden, and a new health bar is drawn manually with configs for its width/height/colors. Toggle to hide the manual health bar too. (Vanilla health bar is hidden as it overlaps with the text).