### PR TITLE
Update item-retrieval-warning

### DIFF
--- a/plugins/item-retrieval-warning
+++ b/plugins/item-retrieval-warning
@@ -1,2 +1,2 @@
 repository=https://github.com/zodaz/item-retrieval-warning.git
-commit=78796c60db6f0a23a619ee0d8ee63e4312d3d9d0
+commit=7c8b98cd5e6ee2b96b5cb51c49e85b69f6474020


### PR DESCRIPTION
Fixes issue where the plugin incorrectly though players were deathbanked when opening the items kept on death interface while inside a poh or safe minigame etc.