### PR TITLE
Hotfix 117HD to v1.2.1.1

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=a26b7068957cf733068516e185740727ec1ae253
+commit=02f6483e49b3507fc1380eb7d05e9980dcde2289
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This should fix an issue with an unavailable class on M1 Macs:

![image](https://user-images.githubusercontent.com/831317/193971964-28741b3e-d8c6-4c57-9ff6-9bdd86db53ad.png)
