### PR TITLE
[Taskman] added website support

### DIFF
--- a/plugins/taskman
+++ b/plugins/taskman
@@ -1,3 +1,3 @@
 repository=https://github.com/remcowesterhoud/taskman-plugin.git
-commit=50266dd9b9f52bd888c32efe072d86a425406cd8
-warning=This plugin submits your Taskman spreadsheet key and passphrase, and your IP address to a server not controlled or verified by the RuneLite developers.
+commit=3aaca1a2745c8ea899467ac8fbc3a5dd243596c7
+warning=This plugin submits your Taskman credentials, and your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
The taskman plugin currently only works with a google spreadsheet. Part of the community is using a website for their adventures (https://www.osrstaskapp.com/dashboard/). In this new version website support has been addded.