### PR TITLE
Update CoX Additions to 1.1.0

### DIFF
--- a/plugins/cox-qol
+++ b/plugins/cox-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/MoreBuchus/buchus-plugins.git
-commit=a641dc2b925eb0757849730654d0aaf6c04a3145
+commit=ae3177a9a520ed022fafbddcc9b2a9a7659641da


### PR DESCRIPTION
+ Added vanguard overload counter (works with party)
+ Added Ice Demon, Small Muttadile, and Olm hand HP overlays
+ More customization with overlay and infobox fonts
+ Replace Olm orbs with Warden attacks (blue orb, white arrow, red sword - for colorblind people)
+ Phase panel/highlight (uses the phase in-game message displayed in the chat box - for chat closed gamers)