### PR TITLE
Update 117HD to v1.2.1.2

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=02f6483e49b3507fc1380eb7d05e9980dcde2289
+commit=9d39696931fb34aeef34662bd7e021411c0e7389
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This fixes yet another issue with Apple M1/M2 which was causing the driver to fall back to software rendering, printing the following messages:

```
FALLBACK (log once): Fallback to SW vertex processing for VERT_BUF_REQ
FALLBACK (log once): Fallback to SW vertex processing for GEOM_BUF_REQ
FALLBACK (log once): Fallback to SW fragment processing for FRAG_BUF_REQ
FALLBACK (log once): Fallback to SW vertex processing, m_disable_code: 9
FALLBACK (log once): Fallback to SW fragment processing, m_disable_code: 10000
FALLBACK (log once): Fallback to SW vertex processing in drawCore, m_disable_code: 9
FALLBACK (log once): Fallback to SW fragment processing in drawCore, m_disable_code: 10000
```

Also included in the patch is a fix for overly bright textures.