### PR TITLE
Create toa-het-puzzle

### DIFF
--- a/plugins/toa-het-puzzle
+++ b/plugins/toa-het-puzzle
@@ -1,0 +1,2 @@
+repository=https://github.com/JoostPerdok/toa-het-puzzle-countdown.git
+commit=b568a00376f2da7f135073690a08a82b96a04537


### PR DESCRIPTION
This plugin displays a countdown on the statue in Path of Het puzzle room in Tombs of Amascut.
The countdown starts at 8, and goes down by one each tick.
Clicking the statue when the timer hits 1 will allow the player to always perform a 'step-in', that allows for destroying the statue while removing its protective seal only once.