### PR TITLE
Create prayer-volume-control

### DIFF
--- a/plugins/prayer-volume-control
+++ b/plugins/prayer-volume-control
@@ -1,0 +1,2 @@
+repository=https://github.com/ruttie3/prayer-volume-control.git
+commit=e036289b99201f922015f1137797ac51aa049664


### PR DESCRIPTION
A plugin which allows you to individually control the volume for each prayer or a global volume for every prayer.

Lets you keep your sound effect volume at the same level while only changing the volume for prayers. Useful for when you're one-tick flicking.