### PR TITLE
Update 117HD to v1.2.2

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=9d39696931fb34aeef34662bd7e021411c0e7389
+commit=ca7e7f8cffd6a1f3ad77886ea4e66ec0552ef287
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Brief summary of what's included in this update:
- Fix incorrect tile colors along the shore:
![image](https://user-images.githubusercontent.com/831317/194779522-e679471f-db88-45cf-a0df-60fa3adf4a5c.png)
- Reduce the max model cache size to 512MiB when using the 32-bit launcher, to hopefully prevent an OOM plugin crash that has been reported twice.
- Add the following popup notice to inform users of the recent change to opt-in model caching:
![image](https://user-images.githubusercontent.com/831317/194779673-0ae20fbb-1331-4ee0-8e0d-85b09b2cbfa4.png)
- Add config option to apply the old max brightness code which results in most white colors looking grey, as some users preferred the old look.
- More tile blending fixes.
- Add a new texture for the pyramids in Sophanem and the Desert Treasure pyramid.
- Fix loading of HD while developing other plugins (running from an IDE).