### PR TITLE
add system tray inventory count plugin

### DIFF
--- a/plugins/system-tray-inventory-count
+++ b/plugins/system-tray-inventory-count
@@ -1,0 +1,2 @@
+repository=https://github.com/delps1001/system-tray-inventory.git
+commit=a1b03f432883cbcf7302a795f99a1584f323a9d2


### PR DESCRIPTION
adds system tray icon that displays the number of items in your inventory