### PR TITLE
Update 117HD to v1.2.2.1

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=ca7e7f8cffd6a1f3ad77886ea4e66ec0552ef287
+commit=720957fc92dd0232550a0b539915e7d09bb9e75f
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This fixes issues with us using negative IDs instead of unsigned bytes after Jagex's change to shorts.