### PR TITLE
Update quest-helper to 3.1.3

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=2a63a3220008fefa46e17e66d1e05f6e8a20d140
+commit=522d5f5602c14650d164ffb29fdba5b2853ea769

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=3dedb5a29c8e0443b9b9d821e6807e059d05f121
+commit=0eea903e6559500e9c909ee007918e09b31982e5

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=0eea903e6559500e9c909ee007918e09b31982e5
+commit=2a63a3220008fefa46e17e66d1e05f6e8a20d140


### PR DESCRIPTION
- ~~Removes QH from speedrunning worlds~~
- Allows for highlights on skill reqs to consider possible boosts
- A few small typo and bug fixes

Edit: Following a chat with Adam, I've removed the removal of QH from speedrunning worlds due to the issues it may introduce.