### PR TITLE
Update 117HD to v1.2.3

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=720957fc92dd0232550a0b539915e7d09bb9e75f
+commit=db88c7b616588b5915ab96a461754e0015f21464
 authors=RS117,sosodev,ahooder

--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=db88c7b616588b5915ab96a461754e0015f21464
+commit=2e7861aa690c0b0c414475731f18fb2bc4f4bf77
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Update summary:
- Fix model cache allocation issues:
  - Only allocate memory if caching is actually enabled.
  - Allocate memory in large chunks, and ensure memory is freed right away if allocation fails at any point. This should ensure that allocation can no longer indirectly crash the JVM by using up all of the available memory, causing OOMs elsewhere.
- Fix random snow tile bug introduced by overlay & underlay IDs changing from `byte` to `short`.
- Apply anisotropic filtering setting changes without requiring a plugin restart.
- Synchronize heuristic scene reloads with game ticks so they reload reliably at the intended time.
- Fix monkey skull visibility issue with lights in Tombs of Amascut's Path of Apmeken room.
- Fix Tombs of Amascut's Crondis boss battle room. It now has more of a HD look, while staying true to vanilla.
- Minor tweaks to lights for Tombs of Amascut's Warden special attacks and Akkha's orbs during the final phase.