### PR TITLE
Create recently-killed-highlight

### DIFF
--- a/plugins/recently-killed-highlight
+++ b/plugins/recently-killed-highlight
@@ -1,0 +1,2 @@
+repository=https://github.com/DrJam/recently-killed-highlight.git
+commit=d5b2b28f41f7bb79847ff8f61360366855069e8c

--- a/plugins/recently-killed-highlight
+++ b/plugins/recently-killed-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/DrJam/recently-killed-highlight.git
-commit=981ab2b897af54d52cdb247813e681cff4ada8f7
+commit=4e485c35b0e0112b6588acdfb178c6de15d7169e

--- a/plugins/recently-killed-highlight
+++ b/plugins/recently-killed-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/DrJam/recently-killed-highlight.git
-commit=7aa1cd157cdc51422fc98318eae046954d49d276
+commit=981ab2b897af54d52cdb247813e681cff4ada8f7

--- a/plugins/recently-killed-highlight
+++ b/plugins/recently-killed-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/DrJam/recently-killed-highlight.git
-commit=d5b2b28f41f7bb79847ff8f61360366855069e8c
+commit=054a6005b8bfe238b135b978aaa408fbdb0dc687

--- a/plugins/recently-killed-highlight
+++ b/plugins/recently-killed-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/DrJam/recently-killed-highlight.git
-commit=054a6005b8bfe238b135b978aaa408fbdb0dc687
+commit=7aa1cd157cdc51422fc98318eae046954d49d276


### PR DESCRIPTION
Highlights the last N enemies you have killed recently, until they target you. Re-highlights remembered enemies if they stop targeting you.

Intended for multi-combat slayer tasks, to indicate which mobs need to be tagged.

Example videos
https://i.imgur.com/7rrHoQt.gifv
https://i.imgur.com/VlpL66Y.gifv