### PR TITLE
Updated Dropsounds

### DIFF
--- a/plugins/dropsounds
+++ b/plugins/dropsounds
@@ -1,0 +1,2 @@
+repository=
+commit=

--- a/plugins/dropsounds
+++ b/plugins/dropsounds
@@ -1,2 +1,2 @@
 repository=https://github.com/MitzDK/DropSounds.git
-commit=109bf0d47e4e7779d0b4992f0f70fc3cce21afe5
+commit=037ec6f7b810664a622ce28f2026a3b50597d43a

--- a/plugins/dropsounds
+++ b/plugins/dropsounds
@@ -1,2 +1,2 @@
 repository=https://github.com/MitzDK/DropSounds.git
-commit=02298e764a2b688283b2fcd4db4bceb958c5ceab
+commit=b65023428b63bf9dd52666479de16c5a8a3cd2f5

--- a/plugins/dropsounds
+++ b/plugins/dropsounds
@@ -1,2 +1,2 @@
 repository=https://github.com/MitzDK/DropSounds.git
-commit=dec4a5553f26841b882f2d405bfba13c0b67ba5a
+commit=109bf0d47e4e7779d0b4992f0f70fc3cce21afe5

--- a/plugins/dropsounds
+++ b/plugins/dropsounds
@@ -1,2 +1,2 @@
-repository=
-commit=
+repository=https://github.com/MitzDK/DropSounds.git
+commit=16ca1593981ebf8f0616bbed1db5d559bf7be4ec

--- a/plugins/dropsounds
+++ b/plugins/dropsounds
@@ -1,2 +1,2 @@
 repository=https://github.com/MitzDK/DropSounds.git
-commit=037ec6f7b810664a622ce28f2026a3b50597d43a
+commit=02298e764a2b688283b2fcd4db4bceb958c5ceab

--- a/plugins/dropsounds
+++ b/plugins/dropsounds
@@ -1,2 +1,2 @@
 repository=https://github.com/MitzDK/DropSounds.git
-commit=16ca1593981ebf8f0616bbed1db5d559bf7be4ec
+commit=dec4a5553f26841b882f2d405bfba13c0b67ba5a


### PR DESCRIPTION
Fixed a bug within the Untradeable drop feature

Redid the entire Clan chan / Group chat mentality into working from the Runescape "valuable drop" notification system,
added a threshold option, and removed the enum option for chatselection.