### PR TITLE
Update dropsounds to v1.0.2

### DIFF
--- a/plugins/dropsounds
+++ b/plugins/dropsounds
@@ -1,2 +1,2 @@
 repository=https://github.com/MitzDK/DropSounds.git
-commit=02298e764a2b688283b2fcd4db4bceb958c5ceab
+commit=b65023428b63bf9dd52666479de16c5a8a3cd2f5


### PR DESCRIPTION
Fixed a minor bug found in the Untradeable Items section

Rewrote some of the plugin to be based off of the ingame Valueable drop notification rather than the Clan/Group chat system.
Removed the Enum configs for the chat selection
Added the option to change the threshold for the valuable drop notification to play.