### PR TITLE
Create more-bank-fillers

### DIFF
--- a/plugins/more-bank-fillers
+++ b/plugins/more-bank-fillers
@@ -1,0 +1,2 @@
+repository=https://github.com/UnExploration/more-bank-fillers.git
+commit=22e94c29c2184a57ab92827aebd2d7b24de924ac

--- a/plugins/more-bank-fillers
+++ b/plugins/more-bank-fillers
@@ -1,2 +1,2 @@
 repository=https://github.com/UnExploration/more-bank-fillers.git
-commit=22e94c29c2184a57ab92827aebd2d7b24de924ac
+commit=e79f9ffce5f993f0613a48caf3b20b65b1259419

--- a/plugins/more-bank-fillers
+++ b/plugins/more-bank-fillers
@@ -1,2 +1,2 @@
 repository=https://github.com/UnExploration/more-bank-fillers.git
-commit=e79f9ffce5f993f0613a48caf3b20b65b1259419
+commit=1b3daf74b901160086a8c792595fce68c71520eb

--- a/plugins/more-bank-fillers
+++ b/plugins/more-bank-fillers
@@ -1,2 +1,2 @@
 repository=https://github.com/UnExploration/more-bank-fillers.git
-commit=1b3daf74b901160086a8c792595fce68c71520eb
+commit=157135bad533332c0f21dbc77778740b57b69b8b


### PR DESCRIPTION
Adds a new plugin called More Bank Fillers.
Adds options for overlays for bank fillers to make your bank easier to look at if you use bank fillers for organization.

There is bank tags but I much prefer using fillers and having my sorted tabs so I created this

Video of all the current overlay options available on the readme.
All images were made by the linked artist's Instagram for use with this plugin.



File is in the correct place this time 😅, had to make a new PR because the last PR could not be reopened. 
