### PR TITLE
Fix to quest-helper

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=6acd61f6f9ae103cec3b6f135b7a74d7807b111b
+commit=8dd29c3c61a0b8003a19294da11f4bba30269c1c

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=522d5f5602c14650d164ffb29fdba5b2853ea769
+commit=6acd61f6f9ae103cec3b6f135b7a74d7807b111b


### PR DESCRIPTION
Fixes the issue of the cheerer appearing when a quest hasn't been completed. This is done by using the QUEST_COMPLETE widget.

This also changes it to default to false, so as to avoid confusion.

Edit: Changed per feedback from Adam to use Chat Messages instead of the widget.