### PR TITLE
Create energy-info

### DIFF
--- a/plugins/energy-info
+++ b/plugins/energy-info
@@ -1,0 +1,2 @@
+repository=https://github.com:JacobLindelof/runelite-plugins.git
+commit=0672e76c2783c4986f508d2d8aedfbfb594a6a63

--- a/plugins/energy-info
+++ b/plugins/energy-info
@@ -1,2 +1,2 @@
-repository=https://github.com:JacobLindelof/runelite-plugins.git
+repository=https://github.com/JacobLindelof/runelite-plugins.git
 commit=0672e76c2783c4986f508d2d8aedfbfb594a6a63

--- a/plugins/energy-info
+++ b/plugins/energy-info
@@ -1,2 +1,2 @@
 repository=https://github.com/JacobLindelof/runelite-plugins.git
-commit=0672e76c2783c4986f508d2d8aedfbfb594a6a63
+commit=ca1f6206ee85765fdf92b3c9969ac3dabaeac96d

--- a/plugins/energy-info
+++ b/plugins/energy-info
@@ -1,2 +1,2 @@
 repository=https://github.com/JacobLindelof/runelite-plugins.git
-commit=ca1f6206ee85765fdf92b3c9969ac3dabaeac96d
+commit=ba0d76fe470624d43b7a582273982e250090dfba


### PR DESCRIPTION
Plugin to display run energy information as an info box. Useful for people with large screens who don't want to glance at the run orb during fights like Olm.