### PR TITLE
Update bot-detector to v1.3.8.3

### DIFF
--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,4 +1,4 @@
 repository=https://github.com/Bot-detector/bot-detector.git
-commit=b5d794dd1d62f82699b31c8dd1f6c95da807fe9c
+commit=65a1295da7c181d6f4064512b3db34e6c7cbf612
 warning=This plugin submits the names, locations, and gear of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic,Cyborger1


### PR DESCRIPTION
Fixed `Stats Too Low` not letting you specify a bot type in the Feedback box when the option to show the Prediction Breakdown in such cases is disabled.