### PR TITLE
customizable-xp-drops to v1.6.1.1

### DIFF
--- a/plugins/customizable-xp-drops
+++ b/plugins/customizable-xp-drops
@@ -1,2 +1,2 @@
 repository=https://github.com/l2-/template-plugin.git
-commit=63a66ca60643d31316449ba9109e73213e6579b1
+commit=c28380386cf3ac61ddb4578382b7776299f11373


### PR DESCRIPTION
Fixes the bug with the color encoding in the xp drop