### PR TITLE
customizable-xp-drops to v1.6.1.2

### DIFF
--- a/plugins/customizable-xp-drops
+++ b/plugins/customizable-xp-drops
@@ -1,2 +1,2 @@
 repository=https://github.com/l2-/template-plugin.git
-commit=c28380386cf3ac61ddb4578382b7776299f11373
+commit=5a19d0d4c0be8a53df7cf22d9ed8c971e2933010


### PR DESCRIPTION
Bugfix for customizable xp drops not rendering or rendering with incorrect colors when using non empty prefix and or suffix settings.