### PR TITLE
Add Jungle Japes Indicator plugin

### DIFF
--- a/plugins/jungle-japes-indicator
+++ b/plugins/jungle-japes-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/TheKlodster/jungle-japes-indicator.git
-commit=34fbaf7d4d462bad7ea813cf50aec570c422dd1a
+commit=0a456fecb41b9a5314fc67a4c78310a8993d503c

--- a/plugins/jungle-japes-indicator
+++ b/plugins/jungle-japes-indicator
@@ -1,0 +1,2 @@
+repository=https://github.com/TheKlodster/jungle-japes-indicator.git
+commit=34fbaf7d4d462bad7ea813cf50aec570c422dd1a


### PR DESCRIPTION
Indicates when the banana peels have spawned and when a player steps on a banana peel during the Ba-Ba fight in the Tombs of Amascut, by playing a sound effect. There are two sound effects that are played, one is for when the banana peels spawn, and one is for when a player steps on a banana peel.