### PR TITLE
Add RuneProfile Plugin

### DIFF
--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,2 +1,3 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
 commit=619a549f5d898836662e4983610ecf68ea72e394
+warning=This plugin submits your player data and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=b3470f01f153464d0c47f0dfda5a2b2267fa0c18
+commit=6b0c77d1ee44627533e08a03c69739f6681d5753

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=d6de5f364d99a6c3adb65bf48936d309b2154bc8
+commit=0d6e946d7d34d20d4a26c7fb30e24ec344b42752

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=d1cc7d8c1e5b59a374094d18d93f9f7e343c33f4
+commit=b4515100b447a6c5a075d51e8daacf7bdbe45706

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=0d6e946d7d34d20d4a26c7fb30e24ec344b42752
+commit=619a549f5d898836662e4983610ecf68ea72e394

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=339b2b8f318681bac2827c343dcc5f90d38b8060
+commit=8e32aba6d3ea3dad7a6a0665861ed93c50fcc432

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,0 +1,2 @@
+repository=https://github.com/ReinhardtR/runeprofile-plugin.git
+commit=19b9e71c0135a06566e88b6d8ad96c0b86883c03

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=b4515100b447a6c5a075d51e8daacf7bdbe45706
+commit=d6de5f364d99a6c3adb65bf48936d309b2154bc8

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=19b9e71c0135a06566e88b6d8ad96c0b86883c03
+commit=b3470f01f153464d0c47f0dfda5a2b2267fa0c18

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=8e32aba6d3ea3dad7a6a0665861ed93c50fcc432
+commit=d1cc7d8c1e5b59a374094d18d93f9f7e343c33f4

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=6b0c77d1ee44627533e08a03c69739f6681d5753
+commit=339b2b8f318681bac2827c343dcc5f90d38b8060


### PR DESCRIPTION
**Plugin Description**
RuneProfile is a plugin that reads some of your account data and sends it to a server, which will store it in a database and generate a profile page on RuneProfile.com, displaying some of that data.
- Repository of the full-stack application: https://github.com/ReinhardtR/runeprofile
- Example profile page: https://www.runeprofile.com/u/PGN

---

**Account Data**
- Hashed account hash
- Username (e.g.: PGN)
- Account Type (e.g.: Ironman)
- 3D Player Model
- Combat Level
- Skill Experiences
- Achievement Diary progress
- Combat Achievements progress
- Quest List progress
- Collection Log data (tracked when the player opens their collection log)
- Hiscores (sourced from the Hiscores API)