### PR TITLE
Add attacktimer plugin

### DIFF
--- a/plugins/attacktimer
+++ b/plugins/attacktimer
@@ -1,0 +1,3 @@
+repository=https://github.com/ngraves95/attacktimer.git
+commit=8d5373a5f7d2b12312765a2c612116773e1136ff
+


### PR DESCRIPTION
Adds a plugin to count ticks until your next attack. Displays a cooldown bar overhead and tick counter until next attack.