### PR TITLE
Update high alc plugin to 1.1.2

### DIFF
--- a/plugins/high-alc-highlight
+++ b/plugins/high-alc-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/bloogeyz/high-alc-value.git
-commit=82c9cc29d7d6ef3b4fa05a29370c1c912bf2f394
+commit=aa069f9bf7ad5e8c38196415c087dadca55ca3d4


### PR DESCRIPTION
- Handle GE Tax
- Allow highlighting of just bank/inventory
- Gradient highlighting
- GE overriding for ironmen