### PR TITLE
Update 117HD to v1.2.4

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=2e7861aa690c0b0c414475731f18fb2bc4f4bf77
+commit=d5b2409f0fb46dcd70011c6280993e359a8f874f
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This update reduces our minimum GPU requirements to support [this list of GPUs](https://opengl.gpuinfo.org/listreports.php?capability=GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS&value=8) (excluding less than OpenGL 4.3 & we may see shader bugs on some of these cards). I've also marked the experimental model caching options as stable and moved them into their own section, and enabled them by default like with the previous model caching implementation. Scene loading times were also improved a decent amount. The rest I hope is clear from commit messages :slightly_smiling_face:

One thing to note is that this does not include a patch for the API changes in https://github.com/runelite/runelite/commit/f4a1ef09a99d94af1b6afd0200d4e95aa1bc5c72. There is a PR for it waiting to be merged: https://github.com/117HD/RLHD/pull/99.