### PR TITLE
Add Type to Hop plugin

### DIFF
--- a/plugins/typetohop
+++ b/plugins/typetohop
@@ -1,0 +1,2 @@
+repository=https://github.com/mlgudi/rl-plugins.git
+commit=635964a74e15013ff52c779fc66f8336a8b6d459


### PR DESCRIPTION
Adds a plugin that allows you to hop worlds by sending a chat message. A message containing :: followed by a world number initiates a world hop.