### PR TITLE
Update profit-tracker to the latest runelite.

### DIFF
--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,3 +1,2 @@
-repository=https://github.com/nofatigue/runelite-profit-tracker.git
-commit=3ae33028a2ba84e2942b4cca1c28d1f8d4d866ff
-disabled=removed by author because unmaintaned
+repository=https://github.com/mrhappyasthma/runelite-profit-tracker.git
+commit=df9dfa08f57c1b4a6c86d3def565272199a3e69a

--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/mrhappyasthma/runelite-profit-tracker.git
-commit=df9dfa08f57c1b4a6c86d3def565272199a3e69a
+commit=4612018f678cf9ffc49470e0df876990878712bc


### PR DESCRIPTION
The original author appears to have abandoned this plugin (https://github.com/runelite/plugin-hub/pull/3257). The plugin is not perfect, but I still found it very useful. I updated the links to point to my repo which has the fixes (including the open PR from the original repo that I verified locally) to get the plugin working in the latest runelite.

If/when the author decides to merge in the PRs and revive their repo, we can update the references back to `https://github.com/nofatigue/runelite-profit-tracker.git`