### PR TITLE
Update jungle-japes-indicator to v1.1

### DIFF
--- a/plugins/jungle-japes-indicator
+++ b/plugins/jungle-japes-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/TheKlodster/jungle-japes-indicator.git
-commit=7bd344f74b75d82711affa1ad6bf989ac28aac1a
+commit=84dd2dedb982e70e0ada4d0ce05200823c0d3fdf

--- a/plugins/jungle-japes-indicator
+++ b/plugins/jungle-japes-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/TheKlodster/jungle-japes-indicator.git
-commit=e4cd205b3a1660aa1999673bac82ae97beaebf3a
+commit=7bd344f74b75d82711affa1ad6bf989ac28aac1a

--- a/plugins/jungle-japes-indicator
+++ b/plugins/jungle-japes-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/TheKlodster/jungle-japes-indicator.git
-commit=7141265734717376294b6212987f138dc1ce3d08
+commit=9e9f22a1f7e325475a93256eb4f26417490c3600

--- a/plugins/jungle-japes-indicator
+++ b/plugins/jungle-japes-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/TheKlodster/jungle-japes-indicator.git
-commit=9e9f22a1f7e325475a93256eb4f26417490c3600
+commit=86bcb4c24027adb318ea5fa2ded9a779a3fa0268

--- a/plugins/jungle-japes-indicator
+++ b/plugins/jungle-japes-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/TheKlodster/jungle-japes-indicator.git
-commit=0a456fecb41b9a5314fc67a4c78310a8993d503c
+commit=7141265734717376294b6212987f138dc1ce3d08

--- a/plugins/jungle-japes-indicator
+++ b/plugins/jungle-japes-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/TheKlodster/jungle-japes-indicator.git
-commit=6c15e3a5a846f9c9fa0628f57eb7b21db0b697ca
+commit=e4cd205b3a1660aa1999673bac82ae97beaebf3a

--- a/plugins/jungle-japes-indicator
+++ b/plugins/jungle-japes-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/TheKlodster/jungle-japes-indicator.git
-commit=86bcb4c24027adb318ea5fa2ded9a779a3fa0268
+commit=6c15e3a5a846f9c9fa0628f57eb7b21db0b697ca


### PR DESCRIPTION
Fixed the sound not playing when the plugin is distributed as a jar file.
Fixes [TheKlodster/jungle-japes-indicator](https://github.com/TheKlodster/jungle-japes-indicator/issues/1)