### PR TITLE
Add Easy Unnote plugin

### DIFF
--- a/plugins/easy-unnote
+++ b/plugins/easy-unnote
@@ -1,0 +1,2 @@
+repository=https://github.com/mad-s/easy-unnote.git
+commit=c3445bdbc27adcff666ea5e7a04e20688bd1769f


### PR DESCRIPTION
This plugin removes the option of using banknotes on anything that can't unnote the banknotes. Never again will you accidentally use your banknotes on a player or the Farming Guild rabbits.

It still allows using them on other items within your inventory, so charging a ring of suffering or a bottomless bucket should still work.