### PR TITLE
Watchdog: Move TTS into an opt-in config and add debounce setting to Alerts

### DIFF
--- a/plugins/watchdog
+++ b/plugins/watchdog
@@ -1,2 +1,2 @@
 repository=https://github.com/adamk33n3r/runelite-watchdog.git
-commit=be7bfbcf129522af60bea08e49e5127ebe3be072
+commit=49b8c01e0b101f2b53aa0aecedc49884ad7795eb

--- a/plugins/watchdog
+++ b/plugins/watchdog
@@ -1,2 +1,2 @@
 repository=https://github.com/adamk33n3r/runelite-watchdog.git
-commit=229bb38bf2fc9800a1264fba1ff6929b56110bff
+commit=be7bfbcf129522af60bea08e49e5127ebe3be072

--- a/plugins/watchdog
+++ b/plugins/watchdog
@@ -1,3 +1,2 @@
 repository=https://github.com/adamk33n3r/runelite-watchdog.git
-commit=3387702c902e810aeccb0f6ea916866f44ece128
-warning=(For TTS) This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
+commit=229bb38bf2fc9800a1264fba1ff6929b56110bff


### PR DESCRIPTION
This update removes the install warning and instead puts it into an opt-in config setting.

It also adds the ability to debounce alerts so that you are not spammed with alerts for actions that happen quickly e.g. all of your herbs become ready to harvest.