### PR TITLE
Add OSRS player count plugin

### DIFF
--- a/plugins/osrs-player-count
+++ b/plugins/osrs-player-count
@@ -1,2 +1,2 @@
 repository=https://github.com/protje/runelite-osrs-player-count.git
-commit=d31721c2447c111af9253c236f6bbfaca9f15ef7
+commit=33d9c7e4f4e276f0544ffbdd575c808e15dc9baa

--- a/plugins/osrs-player-count
+++ b/plugins/osrs-player-count
@@ -1,2 +1,2 @@
 repository=https://github.com/protje/runelite-osrs-player-count.git
-commit=de51b65a1bdb6a7e7c219b096b1224c4b90b0e2e
+commit=3c27cfd6eafaba693331245924bad55040ead8b7

--- a/plugins/osrs-player-count
+++ b/plugins/osrs-player-count
@@ -1,0 +1,2 @@
+repository=https://github.com/protje/runelite-osrs-player-count.git
+commit=de51b65a1bdb6a7e7c219b096b1224c4b90b0e2e

--- a/plugins/osrs-player-count
+++ b/plugins/osrs-player-count
@@ -1,2 +1,2 @@
 repository=https://github.com/protje/runelite-osrs-player-count.git
-commit=3c27cfd6eafaba693331245924bad55040ead8b7
+commit=e9a5d9b552e0453d17a200e36f5628dd3ad0672c

--- a/plugins/osrs-player-count
+++ b/plugins/osrs-player-count
@@ -1,2 +1,2 @@
 repository=https://github.com/protje/runelite-osrs-player-count.git
-commit=e9a5d9b552e0453d17a200e36f5628dd3ad0672c
+commit=d31721c2447c111af9253c236f6bbfaca9f15ef7


### PR DESCRIPTION
This is a simple plugin that shows the amount of players currently in the game (OSRS only):

![image](https://user-images.githubusercontent.com/117227329/199975364-8eea4df3-f208-4efc-ad0e-50f671833966.png)

To retrieve the amount of players it does the following:
- Checks if the amount of players were already fetched within the pre-defined refresh interval.
  - Minimum and default is 60 seconds, can be changed to a maximum of 3600 seconds (1 hour).
- If enough time has passed, it fetches the OSRS homepage (async) to retrieve the player count.
  - Does some web scraping to retrieve the correct amount of players.
  - Stores this amount of players in memory
- If not, it simply retrieves what is currently stored in memory.
- Shows this in-game.