### PR TITLE
Add turael skipping plugin

### DIFF
--- a/plugins/turael-skipping
+++ b/plugins/turael-skipping
@@ -1,2 +1,2 @@
 repository=https://github.com/BrastaSauce/turael-skpping.git
-commit=66b61a91010d62e1b1f632a98829dd9605037e30
+commit=faf198608543379c3934bc827dbc94559bf141c4

--- a/plugins/turael-skipping
+++ b/plugins/turael-skipping
@@ -1,0 +1,2 @@
+repository=https://github.com/BrastaSauce/turael-skpping.git
+commit=a76ec1931abef61558b471927182fdeebeca21fa

--- a/plugins/turael-skipping
+++ b/plugins/turael-skipping
@@ -1,2 +1,2 @@
 repository=https://github.com/BrastaSauce/turael-skpping.git
-commit=faf198608543379c3934bc827dbc94559bf141c4
+commit=75d4f6d22517e1d74027f26dbbf0f7e980a5a588

--- a/plugins/turael-skipping
+++ b/plugins/turael-skipping
@@ -1,2 +1,2 @@
 repository=https://github.com/BrastaSauce/turael-skpping.git
-commit=a76ec1931abef61558b471927182fdeebeca21fa
+commit=66b61a91010d62e1b1f632a98829dd9605037e30


### PR DESCRIPTION
A plugin that provides the best location and information on a Turael task when received. All related information came from the OSRS Gear Discord.

- Can display an overlay containing location and information.
- Can display a world map icon on top of the location


https://user-images.githubusercontent.com/12422316/200150239-d42418ca-9ee6-402f-9bad-5ff1002664a1.mp4