### PR TITLE
Added Memoir Charges plugin

### DIFF
--- a/plugins/Memoir-Charges
+++ b/plugins/Memoir-Charges
@@ -1,0 +1,2 @@
+repository=https://github.com/IvanKrivacka/MemoirCharges.git
+commit=14b184b3158f32b87279961746dabde152d77d70


### PR DESCRIPTION
This plugin takes the number of charges inside your Kharedst's memoirs or Book of the Dead from the chat and displays them in an info box. It will also push a notification if your charges reach 0. 
