### PR TITLE
Update the-gauntlet to v1.2.1

### DIFF
--- a/plugins/the-gauntlet
+++ b/plugins/the-gauntlet
@@ -1,2 +1,2 @@
 repository=https://github.com/rdutta/runelite-gauntlet.git
-commit=b1157c817dd2c6a4363b99db87230202b501a41a
+commit=d0dada5ee22a91ddeeb5b36e1af9baa8477081c6


### PR DESCRIPTION
This fixes a bug where players with a no-break space `\u00A0` in their name would not have tracked resources updated.