### PR TITLE
Update SoundSwapper Plugin

### DIFF
--- a/plugins/sound-swapper
+++ b/plugins/sound-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/petertalbanese/SoundSwapper.git
-commit=0e651520375bc9b12755ea39f6ad3a57ddf94d83
+commit=77127c6b21923cc82dbb09eaeed58300e9d7d112


### PR DESCRIPTION
Changed from Sound Names as input to directly using Sound IDs. This removes the need for the large map I was using before and allows people to directly use the Visual Sounds plugin to find and change ANY sound in game (not just the wiki list).