### PR TITLE
update tombs-of-amascut to v2.2.1

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tombs-of-amascut.git
-commit=8d78ae756daef6955d887d98181436aa509d9ec9
+commit=24c5fcfc5403cd4f9bf993f650e5008689d4f45d


### PR DESCRIPTION
* fixes bug causing unique % to be calculated on 0 raid level even on higher levels
* adds puzzle room mvp points estimate
* fixes p1->p2 warden transition giving ~2k unearned points