### PR TITLE
update tombs-of-amascut to v2.2.2

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tombs-of-amascut.git
-commit=24c5fcfc5403cd4f9bf993f650e5008689d4f45d
+commit=245508e5a660c8955ec6b6e66477303013982328


### PR DESCRIPTION
fixes
* target time not working for non-precise timers
* party points from previous parties not clearing