### PR TITLE
Remove Tracker Update Minimums

### DIFF
--- a/plugins/calcusource-xp-updater
+++ b/plugins/calcusource-xp-updater
@@ -1,3 +1,3 @@
 repository=https://github.com/hessrs/calcusource-xp-updater.git
-commit=d216dfe889a73c8a3976232f7eba9aab766b898d
+commit=8847ac6eb5c7ea937cf0e06d23f6f78f8509a24f
 warning=This plugin submits your player data and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Removes the minimum xp requirement from 10k xp to whatever the configurable value is set to to allow lower xp gains to update as well.