### PR TITLE
Update bot-detector to v1.3.9

### DIFF
--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,4 +1,4 @@
 repository=https://github.com/Bot-detector/bot-detector.git
-commit=b932f0b5124b5682c12ced67f75c77c31c7c36a5
+commit=5ffabc78ba6329cbf612cb7778257a7c57f33a08
 warning=This plugin submits the names, locations, and gear of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic,Cyborger1


### PR DESCRIPTION
* Patreon link updated on the README as well.
* Slight behind the scene changes with error logging when communicating with the Bot Detector API.
* Added hover tooltips to the Feedback and Flagging panel headers after an error occurred.
* Added a new sister feature to the `Predict` coloring settings. Users may now apply the coloring to the in-game `Report` option as well.
  * Useful for those who hide the `Predict` option and make use of `Predict on right-click Report` instead.
  * However, may cause unforeseen issues with other plugins if they rely on the `Report` option's text being unchanged. This is due to the way the color is applied, which is by adding a color tag in front of the option's text. An appropriate warning should display when trying to enable this option.