### PR TITLE
Update Calcusource Xp Tracker on Hop

### DIFF
--- a/plugins/calcusource-xp-updater
+++ b/plugins/calcusource-xp-updater
@@ -1,3 +1,3 @@
 repository=https://github.com/hessrs/calcusource-xp-updater.git
-commit=d216dfe889a73c8a3976232f7eba9aab766b898d
+commit=fd6b5fbe2d9c2c7bcc1d49bc521207fb005aa19e
 warning=This plugin submits your player data and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
- Updates the player if they are world hopping and have met the criteria to update, instead of **only** on logout.
- Removes the minimum xp requirement from 10k xp to whatever the configurable value is set to to allow lower xp gains to update as well.