### PR TITLE
Add Unpotted Reminder 1.0.1

### DIFF
--- a/plugins/unpotted-reminder
+++ b/plugins/unpotted-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/AnkouOSRS/unpotted-reminder.git
+commit=417de22ef478093612721ae3e9f9f24943f4a7fa


### PR DESCRIPTION
A plugin that reminds you to drink your boost potions when you have them in your inventory and your boost falls below a given threshold.