### PR TITLE
Updated Clan Spam Filter to version 1.1

### DIFF
--- a/plugins/guild-spam-filter
+++ b/plugins/guild-spam-filter
@@ -1,3 +1,3 @@
 repository=https://github.com/andreasx23/GuildSpamFilter.git
-commit=107c30d8e85562519e8610d50609b72c6e2cdacf
+commit=3403260e51740892a330ead41f8adb0e2e83c5e2
 authors=andreasx23

--- a/plugins/guild-spam-filter
+++ b/plugins/guild-spam-filter
@@ -1,3 +1,3 @@
 repository=https://github.com/andreasx23/GuildSpamFilter.git
-commit=1f7a757d1a305c4566fc89d6ef8ca1087aaaa8df
+commit=107c30d8e85562519e8610d50609b72c6e2cdacf
 authors=andreasx23

--- a/plugins/guild-spam-filter
+++ b/plugins/guild-spam-filter
@@ -1,3 +1,3 @@
 repository=https://github.com/andreasx23/GuildSpamFilter.git
-commit=348e2cf723bcb39993bfd86215f15bfa4fdea481
+commit=039e9ef9cd3f37a4726bda7957fd8ec02aba22fe
 authors=andreasx23

--- a/plugins/guild-spam-filter
+++ b/plugins/guild-spam-filter
@@ -1,3 +1,3 @@
 repository=https://github.com/andreasx23/GuildSpamFilter.git
-commit=3335f26ef239a96bcf4d79e7fb5cef391c1feafe
+commit=2cfde5886c569bb6ca03d54cd088bc359c909ecb
 authors=andreasx23

--- a/plugins/guild-spam-filter
+++ b/plugins/guild-spam-filter
@@ -1,3 +1,3 @@
 repository=https://github.com/andreasx23/GuildSpamFilter.git
-commit=3403260e51740892a330ead41f8adb0e2e83c5e2
+commit=3335f26ef239a96bcf4d79e7fb5cef391c1feafe
 authors=andreasx23

--- a/plugins/guild-spam-filter
+++ b/plugins/guild-spam-filter
@@ -1,3 +1,3 @@
 repository=https://github.com/andreasx23/GuildSpamFilter.git
-commit=107c30d8e85562519e8610d50609b72c6e2cdacf
+commit=1f7a757d1a305c4566fc89d6ef8ca1087aaaa8df
 authors=andreasx23

--- a/plugins/guild-spam-filter
+++ b/plugins/guild-spam-filter
@@ -1,3 +1,3 @@
 repository=https://github.com/andreasx23/GuildSpamFilter.git
-commit=039e9ef9cd3f37a4726bda7957fd8ec02aba22fe
+commit=107c30d8e85562519e8610d50609b72c6e2cdacf
 authors=andreasx23

--- a/plugins/guild-spam-filter
+++ b/plugins/guild-spam-filter
@@ -1,3 +1,3 @@
 repository=https://github.com/andreasx23/GuildSpamFilter.git
-commit=2cfde5886c569bb6ca03d54cd088bc359c909ecb
+commit=c49447341cb9ddd0896f0f9e26a0d963faf37366
 authors=andreasx23


### PR DESCRIPTION
Clan Spam Filter now has an option to set a personal best mode. The modes exists of include all pb's except and exclude all pb's except based on a CSV list the user can enter. We now also support to exclude self which always includes own player in broadcasts. Also added an option for custom filtering in CSV format