### PR TITLE
Add crop-circle-tracker plugin

### DIFF
--- a/plugins/crop-circle-tracker
+++ b/plugins/crop-circle-tracker
@@ -1,2 +1,3 @@
 repository=https://github.com/mattjrumble/crop-circle-tracker-plugin.git
-commit=d1ef0dcd56629cd3bf5ecb5980dd0c85a1e9dd22
+commit=a7f9820ff03187f548fc26435a159b0c10380096
+warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/crop-circle-tracker
+++ b/plugins/crop-circle-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/mattjrumble/crop-circle-tracker-plugin.git
+commit=d1ef0dcd56629cd3bf5ecb5980dd0c85a1e9dd22


### PR DESCRIPTION
This plugin crowdsources crop circle tracking. Nearby crop circles are detected and reported to a backend server (default server: https://github.com/mattjrumble/crop-circle-tracker-server). The server combines sightings to calculate the location of crop circles in different worlds. The plugin gets these locations from the server and displays them in a panel so users can quick-hop to a world where a crop circle is present. Mainly useful for area-locked/snowflake accounts.