### PR TITLE
Update pvmtickcounter to 1.1

### DIFF
--- a/plugins/pvmtickcounter
+++ b/plugins/pvmtickcounter
@@ -1,2 +1,2 @@
 repository=https://github.com/Chrisioman/PvMTickCounter.git
-commit=85ad93e11fe34a1857e21bba4bc8176f2b638e82
+commit=18a21bc62f4e08f9af95ebe77e1134e497d9be99


### PR DESCRIPTION
1.1
Added Blisterwood Flail & Iban's blast to Tick Counter. Max Hit count will now also reset on instance
Zamorakian Hasta swipe action now counts correctly