### PR TITLE
Add qsr-auto-splitter plugin

### DIFF
--- a/plugins/qsr-auto-splitter
+++ b/plugins/qsr-auto-splitter
@@ -1,2 +1,2 @@
 repository=https://github.com/muffyn/quest-speedrunning-auto-splitter.git
-commit=9e2c31375b0f0a2c808862d5f1cef5cb8e8ea908
+commit=7c28a755e10cd4f51d6f86bc4222de3ed8656226

--- a/plugins/qsr-auto-splitter
+++ b/plugins/qsr-auto-splitter
@@ -1,0 +1,2 @@
+repository=https://github.com/muffyn/quest-speedrunning-auto-splitter.git
+commit=9e2c31375b0f0a2c808862d5f1cef5cb8e8ea908


### PR DESCRIPTION
For quest speedrunning worlds. Communicates with livesplit via livesplit-server to provide configurable auto splits on item collection and varb/varp changes. Has splits for the first 7 quests already filled in, along with accompanying .lss split files and a .lsl layout

Notably similar to https://github.com/runelite/plugin-hub/pull/3574 , but I've been working on this for a while to make a much more versatile program