### PR TITLE
Update turael-skipping to v1.0.4

### DIFF
--- a/plugins/turael-skipping
+++ b/plugins/turael-skipping
@@ -1,2 +1,2 @@
 repository=https://github.com/BrastaSauce/turael-skpping.git
-commit=75d4f6d22517e1d74027f26dbbf0f7e980a5a588
+commit=172885a54c406856bbbf52240229d1d545c98951


### PR DESCRIPTION
- Better clarify cave crawler location and teleports