### PR TITLE
Create StopMisclickingTiles

### DIFF
--- a/plugins/stopmisclickingtiles
+++ b/plugins/stopmisclickingtiles
@@ -1,0 +1,2 @@
+repository=https://github.com/WhatATopic/StopMisclickingTiles.git
+commit=f06d0617b4f5f4db5c00ff8cb8190cc37aabfb4e


### PR DESCRIPTION
Allows users to shift + right-click a tile and disable the "Walk here" action on that tile.