### PR TITLE
Create daily-impling-jars

### DIFF
--- a/plugins/daily-impling-jars
+++ b/plugins/daily-impling-jars
@@ -1,0 +1,2 @@
+repository=https://github.com/Samuel-Fox/Daily-Impling-Jars.git
+commit=a726a10b5225d8ae9d72abb0b37fc1f2e2389b22


### PR DESCRIPTION
Plugin that send a chat message when the player can buy impling jars from Elnock Inquisitor in Puro-Puro. Works like the daily task indicator plugin.