### PR TITLE
Update plugin-presets to v2.4

### DIFF
--- a/plugins/plugin-presets
+++ b/plugins/plugin-presets
@@ -1,2 +1,2 @@
 repository=https://github.com/antero111/plugin-presets.git
-commit=d26faeb8c986413d114a16efa736faaf96a22dcc
+commit=c0693c9b4c425d43cc17155d8a518758eded0701


### PR DESCRIPTION
From changelog: 

Fixed custom settings causing infinite plugin toggle loop when loading presets. Thanks to [equirs](https://github.com/equirs)

Added partial config indicator.

Replaced custom setting checkbox with "remove" button.