### PR TITLE
Update loot-lookup to v1.1.7

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=819ba1c5fb480ff63aa96bcc9ff43dc09b5bad96
+commit=c2255394d09d81cdf0ece8a487afe635d3afe672


### PR DESCRIPTION
* Fix issue where "Lookup Drops" is always the 1st menu option, happened after November 30th game update:
    *  [https://github.com/donth77/loot-lookup-plugin/issues/18](https://github.com/donth77/loot-lookup-plugin/issues/18)
    * [https://github.com/donth77/loot-lookup-plugin/issues/17](https://github.com/donth77/loot-lookup-plugin/issues/17)