### PR TITLE
Update Collection log plugin to v2.3.0

### DIFF
--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,2 +1,2 @@
 repository=https://github.com/evansloan/collection-log.git
-commit=514ded46bcb730b8b984253ead8d80034ce18e5c
+commit=18d6e02cbe4c15ec58ce4665dc628acfe9d65156


### PR DESCRIPTION
- Mark items as obtained on new collection log item chat message
- Fix total item count being uploaded to site as unique item count