### PR TITLE
Add clan kdr plugin

### DIFF
--- a/plugins/clan-kdr
+++ b/plugins/clan-kdr
@@ -1,2 +1,2 @@
 repository=https://github.com/di-brian/clan-kdr.git
-commit=befff0a411ee4d163c9baa7bd1470274d5b10fba
+commit=a08d5a7df2c4d48d9614a471ed85329c9c3bc04e

--- a/plugins/clan-kdr
+++ b/plugins/clan-kdr
@@ -1,0 +1,2 @@
+repository=https://github.com/di-brian/clan-kdr.git
+commit=befff0a411ee4d163c9baa7bd1470274d5b10fba


### PR DESCRIPTION
A plugin that displays an overlay with clans KDR based on kill and death messages from clan chat.