### PR TITLE
Add death charge reminder plugin

### DIFF
--- a/plugins/death-charge-reminder
+++ b/plugins/death-charge-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/InfernoStats/death-charge-reminder.git
+commit=1fce1a1caad7678c8a87ed3c73a834e017b7b15f


### PR DESCRIPTION
This plugin adds an overlay for a configurable amount of ticks to remind a user to death charge after it expires. This has been requested for inferno speedrunning where previously players would summon a thrall and death charge simultaneously, but since the CA update (2 min thralls) they get desynced and forget to death charge again.

![image](https://user-images.githubusercontent.com/77599829/206585449-3cae50f5-2ffe-4078-98f4-9d0e56fd1ca1.png)