### PR TITLE
Add dialogue-assistant v1.0

### DIFF
--- a/plugins/dialogue-assistant
+++ b/plugins/dialogue-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Dialogue-Assistant.git
-commit=62fb8f07b918e9203f8ed0a80b278edcb72b7380
+commit=cca2782d64863f4646efd45d6503ab69a170fe3a

--- a/plugins/dialogue-assistant
+++ b/plugins/dialogue-assistant
@@ -1,2 +1,2 @@
-repository=https://github.com/salverrs/Dialogue-Assistant
+repository=https://github.com/salverrs/Dialogue-Assistant.git
 commit=62fb8f07b918e9203f8ed0a80b278edcb72b7380

--- a/plugins/dialogue-assistant
+++ b/plugins/dialogue-assistant
@@ -1,0 +1,2 @@
+repository=https://github.com/salverrs/Dialogue-Assistant
+commit=62fb8f07b918e9203f8ed0a80b278edcb72b7380


### PR DESCRIPTION
Adds Dialogue Assistant plugin v1.0

Features:
- Highlight or lock (disable) NPC chat dialogue options
- Configured per NPC by right-clicking chat options
- Choose highlight/lock text colours using plugin config