### PR TITLE
Add dialogue-assistant

### DIFF
--- a/plugins/dialogue-assistant
+++ b/plugins/dialogue-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Dialogue-Assistant.git
-commit=d8c1a93d0a9351881552a4aa32dc21b47018387f
+commit=0cff6c5942be99273e20f8f77961f21185daa716

--- a/plugins/dialogue-assistant
+++ b/plugins/dialogue-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Dialogue-Assistant.git
-commit=ad6fcab2abaeb7afdcc4a3a7662c1fdf218a3415
+commit=78d77ea1725fb359ca3d9a4aaa222de6d57553fb

--- a/plugins/dialogue-assistant
+++ b/plugins/dialogue-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Dialogue-Assistant.git
-commit=78d77ea1725fb359ca3d9a4aaa222de6d57553fb
+commit=d8c1a93d0a9351881552a4aa32dc21b47018387f

--- a/plugins/dialogue-assistant
+++ b/plugins/dialogue-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Dialogue-Assistant.git
-commit=1b1dd748bc05294c99b1165241731e27de2a2a96
+commit=ad6fcab2abaeb7afdcc4a3a7662c1fdf218a3415

--- a/plugins/dialogue-assistant
+++ b/plugins/dialogue-assistant
@@ -1,0 +1,2 @@
+repository=https://github.com/salverrs/Dialogue-Assistant.git
+commit=1b1dd748bc05294c99b1165241731e27de2a2a96


### PR DESCRIPTION
Adds Dialogue Assistant plugin

Features:
- Highlight or lock (disable) NPC chat dialogue options
- Configured per NPC by right-clicking chat options
- Choose highlight/lock text colours using plugin config