### PR TITLE
Update metronome-infobox, fix embedded gifs on plugin-hub

### DIFF
--- a/plugins/metronome-infobox
+++ b/plugins/metronome-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/kentor/metronome-infobox.git
-commit=dec78034985773c10d6036c0d76882dc22949418
+commit=2c9f6906c6b3cca4486108d29e1c1634eca0a35d


### PR DESCRIPTION
I _think_ this may fix the broken embeds on https://runelite.net/plugin-hub/show/metronome-infobox