### PR TITLE
Update metronome-infobox README gif links

### DIFF
--- a/plugins/metronome-infobox
+++ b/plugins/metronome-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/kentor/metronome-infobox.git
-commit=2c9f6906c6b3cca4486108d29e1c1634eca0a35d
+commit=7ba35e87af2516200fbe5ec60959cb2155f8333a


### PR DESCRIPTION
I think I finally figured out how to get the gifs to show up on https://runelite.net/plugin-hub/show/metronome-infobox

So the way most other plugins do it is by hosting the image on something like imgur, adding that to the README, and then letting github mirror/host the image which removes the .gif extension. This is how plugins like https://runelite.net/plugin-hub/show/visual-metronome show gifs. The reason that the .gif extension breaks showing gifs is due to this code: https://github.com/runelite/runelite.net/blob/master/src/modules/plugin-hub.js#L114-L118

I couldn't get imgur to host gifs (they'd get converted to mp4, don't know a way around it), so instead I'm hosting the gif in my repo instead, except this time I won't add the .gif extension. This should make the plugin-hub page show the gif now. 