### PR TITLE
Update shortest-path to v1.9.3

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=9a10730575397e53a2e67296c365f16c6ed58135
+commit=2cd555cbb2e0a73d2556c6e026c17cb06272f46f

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=4e75fb99542619106cc01da14bdaa5ad1c64e7fa
+commit=9a10730575397e53a2e67296c365f16c6ed58135

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=2cd555cbb2e0a73d2556c6e026c17cb06272f46f
+commit=b57d79bfc2ded948195b68d645bd26024fe5d817


### PR DESCRIPTION
- The time it takes to use a transport is now included in the pathfinding calculation (e.g. cutscene duration, stall delay).
- The collision map has been updated to cache revision 210 from 2022-12-07.
- Added an option to clear the current path by right-clicking the world map globe button.
![illustration-clear-path](https://user-images.githubusercontent.com/53493631/209399105-356778cc-1a01-412a-8cfc-d56a05b07de2.png)
- Added a tooltip on the world map that displays the path tile number from start to finish for the hovered tile.
![illustration-progress-tooltip](https://user-images.githubusercontent.com/53493631/209399214-ba05dbce-644c-429e-809a-a3b0cf90538d.png)
- Some missing transports have been added.