### PR TITLE
Add clear-unsent-messages

### DIFF
--- a/plugins/clear-unsent-messages
+++ b/plugins/clear-unsent-messages
@@ -1,2 +1,2 @@
 repository=https://github.com/lightningboltemoji/clear-unsent-messages.git
-commit=91d99b66af2d3a3493e245abf976d9fda1f40bfe
+commit=af76998970123c6f247721fc0182251c4a1f7df8

--- a/plugins/clear-unsent-messages
+++ b/plugins/clear-unsent-messages
@@ -1,0 +1,2 @@
+repository=https://github.com/lightningboltemoji/clear-unsent-messages.git
+commit=91d99b66af2d3a3493e245abf976d9fda1f40bfe


### PR DESCRIPTION
Small plugin that clears unsent messages in the chatbox after a configurable delay.

Tries to solve the issue of ending up with garbage in the chatbox (e.g. spaces or numbers) while interacting with NPCs, skilling, etc.

