### PR TITLE
Update 117HD to v1.2.5.2

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=048f0496e3b3517a80a8e310361975da059c3ed3
+commit=37f6c77d77c77d20360cd95bb287ee8f68718820
 authors=RS117,sosodev,ahooder

--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=074be4f883e98f89668db50e10fc0901aeef4f04
+commit=048f0496e3b3517a80a8e310361975da059c3ed3
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This minor patch fixes an issue where clickboxes would become visible if there is heavy fog:
![image](https://user-images.githubusercontent.com/831317/208548592-e178136b-b13d-4698-9329-2bdb569651b6.png)

And it fixes cases where the special color `12345678` would be incorrectly applied to models in some cases:
![image](https://user-images.githubusercontent.com/831317/208548759-08ba5f83-8736-4a7d-a6fd-47d47f21cfb6.png)

Deprecated calls to `Model.calculateExtreme` have been removed, and a couple of texturing PRs are also included.