### PR TITLE
Update cannon-highlighter

### DIFF
--- a/plugins/cannon-highlighter
+++ b/plugins/cannon-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/ConorLeckey/Cannon-Highlighter.git
-commit=237d8b0072f83951c10950543ceb863cd843e352
+commit=46c2659d82aa5ed80c5f9187ec0a4102982107ba


### PR DESCRIPTION
Fixes issue preventing cannon being detected after applying ornament kit