### PR TITLE
Update c-engineer-completed to v1.0.3

### DIFF
--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=8261b87923b6e5862fa6dd7362b12f405be17ea6
+commit=fe56131e5d3cecbfac7e111834229d37402281da


### PR DESCRIPTION
Adds a game chat warning message if both the following are true:
- collection log notifications are enabled in the plugin settings
- collection log chat notifications are **_disabled_** in the in-game settings

when 

- the user logs in
- when the game setting becomes disabled (only if plugin has collection log enabled)
- when the plugin setting becomes enabled (only if game settings has collection log chat notifications disabled)

but with a cooldown of ~10 seconds.

Once users have the settings correctly set, they won't see any warning - this is simply because a lot of people contact me asking why specifically the collection log voiceline isn't working, and it's because the plugin relies on the chat message from the game's own notification to trigger it.