### PR TITLE
Update bot-detector to v1.3.9.1

### DIFF
--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,4 +1,4 @@
 repository=https://github.com/Bot-detector/bot-detector.git
-commit=5ffabc78ba6329cbf612cb7778257a7c57f33a08
+commit=9eb6ff4266c10731d315222d3765eb152bd4e247
 warning=This plugin submits the names, locations, and gear of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic,Cyborger1


### PR DESCRIPTION
- Fix for broken Manual Detect functionality: API call was missing a parameter indicating the upload was manual, so the API treated it as an automatic upload.