### PR TITLE
Add fire-timer plugin

### DIFF
--- a/plugins/fire-timer
+++ b/plugins/fire-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/autumn-smellegy/fire-timer.git
+commit=ebf4599a82b28e3fe19e576f4ee9c62dfe9474c8

--- a/plugins/fire-timer
+++ b/plugins/fire-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/autumn-smellegy/fire-timer.git
-commit=ebf4599a82b28e3fe19e576f4ee9c62dfe9474c8
+commit=d7371c6bc0803e20fcf160b53f9890a9aa2b3a97


### PR DESCRIPTION
This plugin creates a timer over player-created fires in game. It counts in ticks starting at 200. It changes color after 100 ticks have elapsed to indicate that the fire can now disappear at anytime. The timer colors are configurable.