### PR TITLE
Add remaining-casts

### DIFF
--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=03970ada2695109a42582ba86bb9e00914dcfd49
+commit=f97d7d79947c589e4759a0b45739eb83e8315418

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=33c4ebc6c33c8d698d5a43662d9e34e0f00e038e
+commit=6e63522acbe186328d428a89067c8d01f4f40102

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=6e63522acbe186328d428a89067c8d01f4f40102
+commit=cd5d564a331c10286c5b6e4bf8549a6caf409473

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=f97d7d79947c589e4759a0b45739eb83e8315418
+commit=f83ed90d18ea3a1c456a697a552300dc1f79af12

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=34ae2d17e2cae3f60d38bfeedf916aa34f7f8bd1
+commit=1c9bd4a835f9bec18ec7dd6c14e604de9e836524

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=a4dff59faa80deeb384b6e2ea5f541d30f110e25
+commit=33c4ebc6c33c8d698d5a43662d9e34e0f00e038e

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=f83ed90d18ea3a1c456a697a552300dc1f79af12
+commit=34ae2d17e2cae3f60d38bfeedf916aa34f7f8bd1

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=106c9bb5b11e52d699ba5d1d2972c0c75491f911
+commit=264e9177d2cc9c2d4d79163ee74940b868644f73

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=264e9177d2cc9c2d4d79163ee74940b868644f73
+commit=03970ada2695109a42582ba86bb9e00914dcfd49

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,0 +1,2 @@
+repository=https://github.com/salverrs/Remaining-Casts.git
+commit=7df979af2b4e965ab69b06efb78797a9476e9dec

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=cf13ec4dae7ade69e8e460aa210f3881aaa8d9cf
+commit=c26825216c8ec966224bb63248bb1b1484cbc7b7

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=cd5d564a331c10286c5b6e4bf8549a6caf409473
+commit=106c9bb5b11e52d699ba5d1d2972c0c75491f911

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=7df979af2b4e965ab69b06efb78797a9476e9dec
+commit=a4dff59faa80deeb384b6e2ea5f541d30f110e25

--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=1c9bd4a835f9bec18ec7dd6c14e604de9e836524
+commit=cf13ec4dae7ade69e8e460aa210f3881aaa8d9cf


### PR DESCRIPTION
Add new plugin: Remaining Casts

- Shows the number of remaining casts through tooltips and infoboxes
- Tracks multiple spell costs at once
- Can filter spells affected using whitelist/blacklist