### PR TITLE
Create wiki-dialogue

### DIFF
--- a/plugins/wiki-dialogue
+++ b/plugins/wiki-dialogue
@@ -1,0 +1,2 @@
+repository=https://github.com/AshleyThew/wiki-dialogue.git
+commit=c8ad0933643548ec5390c014fb0ee7494762daf8


### PR DESCRIPTION
This plugin allows for easier copying of text from chat for external use, such as the wiki.