### PR TITLE
Dialogue Extractor

### DIFF
--- a/plugins/dialogue-extractor
+++ b/plugins/dialogue-extractor
@@ -1,2 +1,2 @@
 repository=https://github.com/AshleyThew/wiki-dialogue.git
-commit=d74dfd942eb75a635cedb85be23ecd9f33aa47af
+commit=e8ddfd757aba0df892f82855f04ce685085661aa

--- a/plugins/dialogue-extractor
+++ b/plugins/dialogue-extractor
@@ -1,2 +1,2 @@
 repository=https://github.com/AshleyThew/wiki-dialogue.git
-commit=d4a15d39671f6d34a137f6f03ea6b1e1003a8483
+commit=d74dfd942eb75a635cedb85be23ecd9f33aa47af

--- a/plugins/dialogue-extractor
+++ b/plugins/dialogue-extractor
@@ -1,2 +1,2 @@
 repository=https://github.com/AshleyThew/wiki-dialogue.git
-commit=8300940a111f7828aeca9aa5c730d3fa3c8ced79
+commit=d4a15d39671f6d34a137f6f03ea6b1e1003a8483

--- a/plugins/dialogue-extractor
+++ b/plugins/dialogue-extractor
@@ -1,2 +1,2 @@
 repository=https://github.com/AshleyThew/wiki-dialogue.git
-commit=f820631df064fa6183948d824e50c831eca159e6
+commit=f66c09d8134444f9872464cc915955128d828659

--- a/plugins/dialogue-extractor
+++ b/plugins/dialogue-extractor
@@ -1,0 +1,2 @@
+repository=https://github.com/AshleyThew/wiki-dialogue.git
+commit=f820631df064fa6183948d824e50c831eca159e6

--- a/plugins/dialogue-extractor
+++ b/plugins/dialogue-extractor
@@ -1,2 +1,2 @@
 repository=https://github.com/AshleyThew/wiki-dialogue.git
-commit=6552692d403cf2044d1a557e27e0bec3f1006ceb
+commit=8300940a111f7828aeca9aa5c730d3fa3c8ced79

--- a/plugins/dialogue-extractor
+++ b/plugins/dialogue-extractor
@@ -1,2 +1,2 @@
 repository=https://github.com/AshleyThew/wiki-dialogue.git
-commit=f66c09d8134444f9872464cc915955128d828659
+commit=537b83332cc9271309001534cacb81350e5bb9ec

--- a/plugins/dialogue-extractor
+++ b/plugins/dialogue-extractor
@@ -1,2 +1,2 @@
 repository=https://github.com/AshleyThew/wiki-dialogue.git
-commit=537b83332cc9271309001534cacb81350e5bb9ec
+commit=6552692d403cf2044d1a557e27e0bec3f1006ceb

--- a/plugins/dialogue-extractor
+++ b/plugins/dialogue-extractor
@@ -1,2 +1,2 @@
 repository=https://github.com/AshleyThew/wiki-dialogue.git
-commit=e8ddfd757aba0df892f82855f04ce685085661aa
+commit=b7fa2f1dcf94f14c9a226582f4ef05d40c3b3c90


### PR DESCRIPTION
This plugin allows for easier copying of text from chat for external use, such as the osrs wiki.