### PR TITLE
Wilderness Warnings

### DIFF
--- a/plugins/wilderness-warnings
+++ b/plugins/wilderness-warnings
@@ -1,2 +1,2 @@
 repository=https://github.com/CalumMagee/wildernesswarnings.git
-commit=7d1f61fd865d28cb84d3eb0d7cd1f326f6c4922a
+commit=d3157ce34becc33e6d92d5223a6abd07d5a626d9

--- a/plugins/wilderness-warnings
+++ b/plugins/wilderness-warnings
@@ -1,0 +1,2 @@
+repository=https://github.com/CalumMagee/wildernesswarnings.git
+commit=7d1f61fd865d28cb84d3eb0d7cd1f326f6c4922a


### PR DESCRIPTION
Disables options to enter the wilderness on High Risk and Target worlds. Spells cast from your spellbook such as Annakarl Teleport are not included in accordance with Jagex guidelines. Other Exceptions: Max Cape black chins teleport, Trollheim agility shortcut, chaos runecrafting altar portal, Portal Nexus Teleports into the wilderness.