### PR TITLE
New plugin Untrimmed Warning

### DIFF
--- a/plugins/untrimmed-warning
+++ b/plugins/untrimmed-warning
@@ -1,2 +1,2 @@
 repository=https://github.com/pelletier2017/runelite-untrimmed-warning.git
-commit=d40438d1e3f922aa897a63803a9bf977e8b75a44
+commit=0656a5b12367b9bcef9b53c6d5bb48e4b7fa0b1a

--- a/plugins/untrimmed-warning
+++ b/plugins/untrimmed-warning
@@ -1,0 +1,2 @@
+repository=https://github.com/pelletier2017/runelite-untrimmed-warning.git
+commit=d40438d1e3f922aa897a63803a9bf977e8b75a44

--- a/plugins/untrimmed-warning
+++ b/plugins/untrimmed-warning
@@ -1,2 +1,2 @@
 repository=https://github.com/pelletier2017/runelite-untrimmed-warning.git
-commit=0656a5b12367b9bcef9b53c6d5bb48e4b7fa0b1a
+commit=3acdb043d843f171f185b0b8d8fe1b09e47c671f


### PR DESCRIPTION
Helps player protect their untrimmed cape

- Overlay popup when getting close to a new 99 to remind player to hide their untrimmed cape.

- Overlay also describes where the cape is located and whether that spot is safe or not according to the wiki.

- Hide left click pickup for untrimmed cape to avoid auto-trim on pickup.