### PR TITLE
Add default-minimap-zoom

### DIFF
--- a/plugins/default-minimap-zoom
+++ b/plugins/default-minimap-zoom
@@ -1,3 +1,3 @@
 repository=https://github.com/YvesW/default-minimap-zoom.git
-commit=1728ea90f32f392ecda6a9c7995ac3c009a1e928
+commit=b738fe894f14c61e2069e40b5260fa281918885b
 authors=YvesW

--- a/plugins/default-minimap-zoom
+++ b/plugins/default-minimap-zoom
@@ -1,3 +1,3 @@
 repository=https://github.com/YvesW/default-minimap-zoom.git
-commit=640efceee33af6b198840ad0c094ddb3ba8ee22e
+commit=05d2d493306d75a246559c3b0b5c7a00a420f7c9
 authors=YvesW

--- a/plugins/default-minimap-zoom
+++ b/plugins/default-minimap-zoom
@@ -1,3 +1,3 @@
 repository=https://github.com/YvesW/default-minimap-zoom.git
-commit=7d1d7e6b63fd997cb135b1e51682c62a664d0bd9
+commit=1728ea90f32f392ecda6a9c7995ac3c009a1e928
 authors=YvesW

--- a/plugins/default-minimap-zoom
+++ b/plugins/default-minimap-zoom
@@ -1,3 +1,3 @@
 repository=https://github.com/YvesW/default-minimap-zoom.git
-commit=05d2d493306d75a246559c3b0b5c7a00a420f7c9
+commit=138a0ff3fdd8523c862ae87ab513a1360aa80b84
 authors=YvesW

--- a/plugins/default-minimap-zoom
+++ b/plugins/default-minimap-zoom
@@ -1,3 +1,3 @@
 repository=https://github.com/YvesW/default-minimap-zoom.git
-commit=b738fe894f14c61e2069e40b5260fa281918885b
+commit=640efceee33af6b198840ad0c094ddb3ba8ee22e
 authors=YvesW

--- a/plugins/default-minimap-zoom
+++ b/plugins/default-minimap-zoom
@@ -1,3 +1,3 @@
-repository=https://github.com/YvesW/random-event-hider.git
+repository=https://github.com/YvesW/default-minimap-zoom.git
 commit=7d1d7e6b63fd997cb135b1e51682c62a664d0bd9
 authors=YvesW

--- a/plugins/default-minimap-zoom
+++ b/plugins/default-minimap-zoom
@@ -1,0 +1,3 @@
+repository=https://github.com/YvesW/random-event-hider.git
+commit=7d1d7e6b63fd997cb135b1e51682c62a664d0bd9
+authors=YvesW


### PR DESCRIPTION
Very simple plugin to set the default minimap zoom in specific configurable scenarios (when starting client, on every login, on every world hop).

If there are any problems or issues, please let me know! Also feel free to DM me on Discord or in `#Development` in the RL discord (`@Yves W`).

Thanks in advance for taking the time to review this!

Edit: added right-click support for the minimap. If this is racey with the internal right-click on minimap code, or if this might trigger Jagex's anti-cheat, please let me know. However, a simple consume should not trigger anti-cheat.