### PR TITLE
Add boss hp reorder plugin

### DIFF
--- a/plugins/boss-hp-reorder
+++ b/plugins/boss-hp-reorder
@@ -1,0 +1,2 @@
+repository=https://github.com/TheStonedTurtle/boss-hp-reorder.git
+commit=d0ad9b15e6a629b5f595678a4963e3e53eabd914


### PR DESCRIPTION
This plugin repositions the Boss HP Bar to be at the top of the screen when XP drops are set to the center

Base RL
![](https://raw.githubusercontent.com/TheStonedTurtle/boss-hp-reorder/master/docs/before.gif)
With this plugin
![](https://raw.githubusercontent.com/TheStonedTurtle/boss-hp-reorder/master/docs/after.gif)