### PR TITLE
can-i-eat

### DIFF
--- a/plugins/can-i-eat
+++ b/plugins/can-i-eat
@@ -1,0 +1,2 @@
+repository=https://github.com/Drurison/can-i-eat.git
+commit=711a11b87409a4edfe792d3d7532dc067cdfc653

--- a/plugins/can-i-eat
+++ b/plugins/can-i-eat
@@ -1,2 +1,2 @@
 repository=https://github.com/Drurison/can-i-eat.git
-commit=711a11b87409a4edfe792d3d7532dc067cdfc653
+commit=75461894f7397e563ba1700a141757465c8ad52c


### PR DESCRIPTION
This plugin works somewhat like Idle Notifier, but instead of setting a threshold for prayer or hitpoints, you select the food / prayer restoration items you'd be using. This will allow the plugin to alert you when it's possible to either eat food or drink a prayer restoration item.