### PR TITLE
Update Dink to v1.1.3

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=fc33539ff49e6338aecc7a461f202eca5d08b27c
+commit=0035f26b8c714081de537f69a2de07cf771ab7b3
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.1.3 contains a number of quality-of-life improvements and bug fixes. Most notably, kill count notifications can fire on new personal best times, loot from unsired can now trigger a notification (experimental), and webhook requests can be attempted multiple times with greater timeout (to work around transient network issues).

https://github.com/pajlads/DinkPlugin/releases/tag/v1.1.3