### PR TITLE
Create Normal Ancient Teleports plugin

### DIFF
--- a/plugins/normal-ancient-teleports
+++ b/plugins/normal-ancient-teleports
@@ -1,2 +1,2 @@
 repository=https://github.com/IdylRS/runelite-plugins.git
-commit=9cf809eee49c69d01c3e5a29912c225a09f3a094
+commit=b874aef14928ef78a1b3afe15c21710c05eae37c

--- a/plugins/normal-ancient-teleports
+++ b/plugins/normal-ancient-teleports
@@ -1,2 +1,2 @@
 repository=https://github.com/IdylRS/runelite-plugins.git
-commit=798b98213a683c691f3f08ac153681a4705a47d3
+commit=4f7f734eabff98a1ac5eeee7a8fdb784336c8a80

--- a/plugins/normal-ancient-teleports
+++ b/plugins/normal-ancient-teleports
@@ -1,0 +1,2 @@
+repository=https://github.com/IdylRS/runelite-plugins.git
+commit=798b98213a683c691f3f08ac153681a4705a47d3

--- a/plugins/normal-ancient-teleports
+++ b/plugins/normal-ancient-teleports
@@ -1,2 +1,2 @@
 repository=https://github.com/IdylRS/runelite-plugins.git
-commit=4f7f734eabff98a1ac5eeee7a8fdb784336c8a80
+commit=9cf809eee49c69d01c3e5a29912c225a09f3a094


### PR DESCRIPTION
Renames teleports in the ancient spell book to where they actually go