### PR TITLE
Add the 1Password plugin support!

### DIFF
--- a/plugins/onepassword-plugin
+++ b/plugins/onepassword-plugin
@@ -1,0 +1,3 @@
+repository=https://github.com/tymscar/runelite-1password-plugin.git
+commit=7bbe4d768aea89b467db93ae34fdd1cbd3e2d47d
+warning=You are required to install the 1Password CLI application to use this plugin.<br>Go to the support link for more info and examples!


### PR DESCRIPTION
I was playing around with Runelite and the community plugins and noticed there were Bitwarden and Keepass plugins but not 1Password plugins, so I had to make my own.

This plugin autocompletes your username and password fields from your 1Password vault. It works with both only one account or if you have multiple accounts in your vault!

More info here: https://github.com/tymscar/runelite-1password-plugin