### PR TITLE
Create Discord Multi Notifications

### DIFF
--- a/plugins/Discord Multi Notifications
+++ b/plugins/Discord Multi Notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/NafizHaque/RuneLite-Plugins/tree/DiscordMultiNotifications/DiscordMultiNotifications
-commit= 7ca3cacf743ce24f530a87cd56b74e2058954081
+commit= b123ac43f5d69ad92320e8baf7653a8d8951f031

--- a/plugins/Discord Multi Notifications
+++ b/plugins/Discord Multi Notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/NafizHaque/RuneLite-Plugins/tree/DiscordMultiNotifications/DiscordMultiNotifications
+commit= 7ca3cacf743ce24f530a87cd56b74e2058954081

--- a/plugins/Discord Multi Notifications
+++ b/plugins/Discord Multi Notifications
@@ -1,2 +1,0 @@
-repository=https://github.com/NafizHaque/RuneLite-Plugins/tree/DiscordMultiNotifications/DiscordMultiNotifications
-commit= b123ac43f5d69ad92320e8baf7653a8d8951f031

--- a/plugins/discord-multi-notifications
+++ b/plugins/discord-multi-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/NafizHaque/RuneLite-Plugins.git
+commit=7853779f33c1461039b022a5919c5dc85834f361


### PR DESCRIPTION
This Plugin Provides the ability to parse multiple Discord server webhooks to simultaneously send multiple notifications at a time. 

Features include: multiple webhooks for death screenshots and multiple webhooks for Collection log slots and Loot!

This is intended to provide an All-in-One experience for the user that would want their notifications posted across multiple servers they are apart of.

This eliminates the need for any redundancy as many users use multiple plugins with the same features to have the ability to post to multiple servers.