### PR TITLE
disable slashswapper plugin

### DIFF
--- a/plugins/slash-swapper
+++ b/plugins/slash-swapper
@@ -1,2 +1,3 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
 commit=c0a4a2bd52c267b7f00cb7b3ed6b5296c8d3d1dc
+disabled=unmaintained


### PR DESCRIPTION
Plugin broke with today's update and was working mediocre before that. I've decided not to pursue it further and happy to give ownership to anyone that wants to try mirroring the spaghetti code in the chat system.