### PR TITLE
Create afk-marks-canafis

### DIFF
--- a/plugins/afk-marks-canafis
+++ b/plugins/afk-marks-canafis
@@ -1,0 +1,2 @@
+repository=https://github.com/powerus117/RLAfkMarksCanafis.git
+commit=3e905320535126dddfa3944f49b51fe51821e32f


### PR DESCRIPTION
This plugin allows the player to track the mark of grace cooldown on the canafis agility course.