### PR TITLE
Update c-engineer-completed to v1.0.3 (fixed)

### DIFF
--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=8261b87923b6e5862fa6dd7362b12f405be17ea6
+commit=f801f76922457cdb0ed3d544aee62a2af01f55ec


### PR DESCRIPTION
Adds warning for collection log notification setting being disabled when plugin setting for collection log notifications is enabled.

This previously would always warn when hopping due to the game setting being temporarily seen as 0, so I have disabled the warning for ANY game state that isn't fully logged in.