### PR TITLE
Update profit-tracker to v1.2

### DIFF
--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/mrhappyasthma/runelite-profit-tracker.git
-commit=573dc45b5ab256ba6845d87cd9b23a0ffd385fa2
+commit=be90ef9756a0f3cbe8c06506711bf75c1809a609

--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/mrhappyasthma/runelite-profit-tracker.git
-commit=5f3cf1082fab8e9eb0828c2195c3426d3553d650
+commit=55394e7f5441bd10d2bb35ddd9b0778778a75505

--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/mrhappyasthma/runelite-profit-tracker.git
-commit=55394e7f5441bd10d2bb35ddd9b0778778a75505
+commit=573dc45b5ab256ba6845d87cd9b23a0ffd385fa2

--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/mrhappyasthma/runelite-profit-tracker.git
-commit=4612018f678cf9ffc49470e0df876990878712bc
+commit=5f3cf1082fab8e9eb0828c2195c3426d3553d650


### PR DESCRIPTION
Fixes https://github.com/mrhappyasthma/runelite-profit-tracker/issues/4.

This just updates the metadata of the plugin to point to the appropriate github repo after the change of ownership.