### PR TITLE
Update Unpotted reminder to 1.0.4

### DIFF
--- a/plugins/unpotted-reminder
+++ b/plugins/unpotted-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/unpotted-reminder.git
-commit=33917a7e6946345c7d833119e8a1af64cbbaa1c4
+commit=526db7a2b5e76299162a3d1f0a7087080c86b418


### PR DESCRIPTION
- Added optional cooldown for notifier.
- Only alert for imbued heart when it is actually available. Credit to JuliusAF on GitHub for most of this logic.