### PR TITLE
Update remaining-casts

### DIFF
--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=c26825216c8ec966224bb63248bb1b1484cbc7b7
+commit=71e75f86493bb407dcd55c13c02da394365d0b4f


### PR DESCRIPTION
1 line change - fixes the rune count not being initially updated when enabling the plugin in-game.