### PR TITLE
Add 'Toxic NPCs' plugin

### DIFF
--- a/plugins/toxicnpcs
+++ b/plugins/toxicnpcs
@@ -1,0 +1,2 @@
+repository=https://github.com/stevenhay/ToxicNPCs.git
+commit=a2ea1f2a916532e966acd5f22beb934ccdbf29f5


### PR DESCRIPTION
Toxic NPCs will cause any NPC around you within a certain number of tiles (configurable) to talk shit whenever the player (enabled by default), another player (enabled by default) or another NPC (disabled by default) dies.