### PR TITLE
Add missing animation ID to handegg webhook plugin

### DIFF
--- a/plugins/handegg-discord-webhook
+++ b/plugins/handegg-discord-webhook
@@ -1,2 +1,2 @@
 repository=https://github.com/jurrejelle/handegg-discord-webhook.git
-commit=00c64076bea5689f92e209122febb28fbed35a8a
+commit=84d10ede93225633b73ad812c445a200456d865f

--- a/plugins/handegg-discord-webhook
+++ b/plugins/handegg-discord-webhook
@@ -1,2 +1,2 @@
 repository=https://github.com/jurrejelle/handegg-discord-webhook.git
-commit=4fb3ac6bd6915ec0fd1bc2b69dc5905bed20de09
+commit=00c64076bea5689f92e209122febb28fbed35a8a


### PR DESCRIPTION
Added a missing animation ID to the plugin. apparently both 7995 and 7996 are used for throwing handeggs. I think (pray) that I tested thoroughly enough that this should be all of them now. 