### PR TITLE
Update examine-tooltip to v1.4.5

### DIFF
--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=f9a11bd2bbd51556a7d57a6d9aecc3717f81a4bb
+commit=61ecdaa730d420df17bb98fc64e4f21834881a04

--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=61ecdaa730d420df17bb98fc64e4f21834881a04
+commit=6a310ec9d2098a217c5c5c34d4828562dce1b5f3


### PR DESCRIPTION
Added a small amount of control for the overlay's layer to answer a user's request.

Previously, it was simply set to Always On Top. This is still the default, but now a user may set to Above Widgets in the config. This is to allow the overlay to render behind the game's right-click menu.