### PR TITLE
AFK GOTR - Alerts you when to start/stop leeching

### DIFF
--- a/plugins/zom-afk-gotr
+++ b/plugins/zom-afk-gotr
@@ -1,0 +1,2 @@
+repository=https://github.com/JZomDev/zom-external-plugins.git
+commit=9126744d1b0d37734e375d9eb24e8f52b4cd7660


### PR DESCRIPTION
## How to use

- Use a GOTR world.
- Take a stack of uncharged cells.
- Mine essence until notified to stop.
- Craft runes that are red tier. Bloods, Deaths & Fire runes. Only have to do it once. (Red just gives most points)
- Place overpowered barrier after you've crafted. (Or what ever barrier) 
- Go back to mining essence. (If you are above 150 points)

You only go AFK after 150 points, this plugin just helps you remember when to do what and then you can chill. 
