### PR TITLE
Update clan-fight-performance-tracker to v1.1

### DIFF
--- a/plugins/clan-fight-performance-tracker
+++ b/plugins/clan-fight-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/di-brian/clan-fight-performance-tracker.git
-commit=8207ea618b16df1a11658a05afe8961b5b51dae2
+commit=a23a90bdc3798955ae714788bddaae57c010e823


### PR DESCRIPTION
- Adds ability to track amount of max hits
- Adds ability to track amount of snares thrown
- Future proof "in pvp" checks in case spec orb gets enabled in pvp