### PR TITLE
Update quest-helper to 3.2.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=35a1cea34a53aa66dd27171036af81b6c9eb6922
+commit=5bf1e5690c54095d54962d32bce90e581177eb05


### PR DESCRIPTION
Small fixes, notably one which should avoid conditions in ItemReqSetup being reached too early in certain scenarios.