### PR TITLE
Update Dink to v1.2.2

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=1c8d880a3e042c82ff423f603df2646ff1ca03cb
+commit=a8f1e9366242b7615cb1f1d8a2f182d0edfcec04
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Hotfix that fixes Discord notifications not firing for users with spaces in their names when using default settings

Bug report issue: https://github.com/pajlads/DinkPlugin/issues/142

https://github.com/pajlads/DinkPlugin/releases/tag/v1.2.2
