### PR TITLE
Add Chat Name Colors to external plugin hub

### DIFF
--- a/plugins/chat-name-colors
+++ b/plugins/chat-name-colors
@@ -1,0 +1,2 @@
+repository=https://github.com/BagleBreath/beaglebreath-chat-name-colors.git
+commit=7c6146b8aa757c1bcdf4fa2aed00211bfeba6d85

--- a/plugins/chat-name-colors
+++ b/plugins/chat-name-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/BagleBreath/beaglebreath-chat-name-colors.git
-commit=e7e34a3865edcf2fac13e1d9baef7d9f11535ff5
+commit=efbaa86712e6a50ea174b3a540a9d3f9a92e1026

--- a/plugins/chat-name-colors
+++ b/plugins/chat-name-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/BagleBreath/beaglebreath-chat-name-colors.git
-commit=7c6146b8aa757c1bcdf4fa2aed00211bfeba6d85
+commit=e7e34a3865edcf2fac13e1d9baef7d9f11535ff5


### PR DESCRIPTION
This plugin gives the user the ability to specify colors to rename users in their chat to. 
This helps with readability in large groups with similar names

https://github.com/BagleBreath/beaglebreath-chat-name-colors