### PR TITLE
Update 117HD to v1.2.6

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=37f6c77d77c77d20360cd95bb287ee8f68718820
+commit=a3c5ffd2329a1199d569afc952d35d35bd4ce4ce
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This update primarily includes a port of the GPU plugin's anti-aliasing patch to fix black border issues with DPI scaling, and various texturing changes.