### PR TITLE
Create regular expression item counter 

### DIFF
--- a/plugins/item-counter
+++ b/plugins/item-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/jammy-dodgers/item-counter.git
-commit=2879eade523ee4abe61c68aa973187f4513c8029
+commit=8fc90c96cc7cacfeb9557e9463d7d1086d4f1af7

--- a/plugins/item-counter
+++ b/plugins/item-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/jammy-dodgers/item-counter.git
-commit=8ee2b4a705bf1582c9b61e79ed9bde89a675d21b
+commit=b514be630d9ec95733c459d8f08951de02665360

--- a/plugins/item-counter
+++ b/plugins/item-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/jammy-dodgers/item-counter.git
-commit=8fc90c96cc7cacfeb9557e9463d7d1086d4f1af7
+commit=8ee2b4a705bf1582c9b61e79ed9bde89a675d21b

--- a/plugins/item-counter
+++ b/plugins/item-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/jammy-dodgers/item-counter.git
-commit=c1d067a26fe0a5cd88b9743bd0f680ddc71eb3e1
+commit=c0b0d3f55349752b50c6ebe073ea659b8bc9e638

--- a/plugins/item-counter
+++ b/plugins/item-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/jammy-dodgers/item-counter.git
+commit=c1d067a26fe0a5cd88b9743bd0f680ddc71eb3e1

--- a/plugins/item-counter
+++ b/plugins/item-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/jammy-dodgers/item-counter.git
-commit=c0b0d3f55349752b50c6ebe073ea659b8bc9e638
+commit=2879eade523ee4abe61c68aa973187f4513c8029

--- a/plugins/item-counter
+++ b/plugins/item-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/jammy-dodgers/item-counter.git
-commit=b514be630d9ec95733c459d8f08951de02665360
+commit=f5af6341cfae541eb9978bc0739e021cb01e32c4


### PR DESCRIPTION
Sorry for duplicating this, Github didn't warn me that renaming the branch on my fork would automatically close the pull request. Couldn't find a way to change the PR to the newly renamed branch.

Counts the number of items in your inventory / equipped that matches regular expressions.
An example of a place where this is useful: 
You need 1250 more mole parts of either kind to finish making all your saradomin brews. 
You can match on "Mole (claw|skin)" and it will display the total number of things in your inventory that match the regex
(Though I didn't get a screenshot of that specific example, I'm sure you get the idea of it)

![alt text](https://github.com/jammy-dodgers/item-counter/blob/master/img.png?raw=true)