### PR TITLE
add lifesizedshents plugin

### DIFF
--- a/plugins/lifesizedshents
+++ b/plugins/lifesizedshents
@@ -1,0 +1,2 @@
+repository=https://github.com/Himonn/life-size-shents.git
+commit=af0143703e724b7980488cde0f0335ca5cf02135


### PR DESCRIPTION
this plugin sets the playercomposition of any player who spawns with the name 'shents' to a gnome child npc. It also features a config option to add menu entries on shift right click to turn any other player into a gnome child npc, or change the 'shents' rsn behaviour to any other rsn