### PR TITLE
Update PartyHealthStatus to v1.3

### DIFF
--- a/plugins/party-health-status
+++ b/plugins/party-health-status
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/party-health-status.git
-commit=ac61cd1236a7d185b4868cf2a374bb3c28aa7fd4
+commit=6c9a397f6898614484413c41df899d18a12f5722


### PR DESCRIPTION
Update plugin to use it's own message rather than partyData, to preserve realtime HP.

Additionally, now that all clients need to have the plugin enabled to send data; an added config to hide all players has been added.