### PR TITLE
Add combat-roll plugin

### DIFF
--- a/plugins/combat-roll
+++ b/plugins/combat-roll
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=c564848606f7c8886ec37539c2bb6f703b303c39
+commit=fcd2eefda677ef5e894500d1028e9eb5c6936b3b

--- a/plugins/combat-roll
+++ b/plugins/combat-roll
@@ -1,0 +1,2 @@
+repository=https://github.com/Skretzo/runelite-plugins.git
+commit=c564848606f7c8886ec37539c2bb6f703b303c39


### PR DESCRIPTION
# Combat Roll

Displays attack rolls and defence rolls for all combat styles on the equipment stats interface.

![illustration](https://user-images.githubusercontent.com/53493631/216479471-f30b2fcb-1e19-4b7c-ae1e-15a6e5b88a94.png)
