### PR TITLE
Update World Cycle to v1.1

### DIFF
--- a/plugins/world-cycle
+++ b/plugins/world-cycle
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/world-cycle.git
-commit=f1c67d0c1eeaf65e24965ace388531e13c155bb1
+commit=e44d3443751e5b7deaec75cd0d7d17452c34e154


### PR DESCRIPTION
Workaround to prevent keyboard from being locked in an incorrect state which previously locked input/blocked hotkeys from being pressed.