### PR TITLE
Update FlippingUtilities

### DIFF
--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,3 +1,3 @@
 repository=https://github.com/Flipping-Utilities/rl-plugin.git
-commit=ea80c6c73e899664adce93887b4598c9f1c1978f
+commit=983ac4ff3fd90f77b0bcc1a999d312d4120151d9
 authors=zumaad


### PR DESCRIPTION
enabling recipes with coins and accounting for people using staffs instead of buying elemental runes