### PR TITLE
Add Hold Left Click

### DIFF
--- a/plugins/hold-left-click
+++ b/plugins/hold-left-click
@@ -1,0 +1,2 @@
+repository=https://github.com/Jbleezy/runelite-plugins.git
+commit=eb922f0625a4848b87bc8da426e180657e0fe0f1


### PR DESCRIPTION
Reclicks once every tick while holding left click

Doesn't move the mouse at all, just simply reclicks without having to lift finger up and down to decrease repetitive strain injury