### PR TITLE
Update 117HD to v1.2.6.1

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=a3c5ffd2329a1199d569afc952d35d35bd4ce4ce
+commit=92669fae151b92ab3eea3f09611dbf4b50290704
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This should help reduce support traffic a bit by providing common suggestions when the plugin fails to enable due to not finding a supported graphics card or running out of memory. The Discord links should hopefully also direct them to us instead of RuneLite's Discord first.

Here's an example response when a GPU lacking OpenGL 4.3 support is detected, and the user is running 32-bit RuneLite which may cause integrated graphics to be used instead of dedicated:
![image](https://user-images.githubusercontent.com/831317/216947654-3657a1e6-97f8-488a-b051-1920cf297f59.png)

Please let me know if we shouldn't be linking to RuneLite's website from a popup like this.

Here's the response to running out of memory when allocating the model cache:
![image](https://user-images.githubusercontent.com/831317/216948187-4a871612-b788-4c70-8d26-871bf71c64a2.png)

In case it helps the review, the hard-coded Discord URL matches the one found in our [project readme](https://raw.githubusercontent.com/117HD/RLHD/a3c5ffd2329a1199d569afc952d35d35bd4ce4ce/README.md) from the prior version.