### PR TITLE
Nylo stats plugin

### DIFF
--- a/plugins/nylo-stats
+++ b/plugins/nylo-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/JaccodR/nylo-stats.git
-commit=506fb266ccf4abdae3f1eabd2cff71a95082d27a
+commit=fdbbbc1422a18b7553a83c7a5a3c9899880a8862

--- a/plugins/nylo-stats
+++ b/plugins/nylo-stats
@@ -1,0 +1,2 @@
+repository=https://github.com/JaccodR/nylo-stats.git
+commit=e15de8637b4a2729fe6bed96c3d43b03a6cd6753

--- a/plugins/nylo-stats
+++ b/plugins/nylo-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/JaccodR/nylo-stats.git
-commit=e15de8637b4a2729fe6bed96c3d43b03a6cd6753
+commit=506fb266ccf4abdae3f1eabd2cff71a95082d27a


### PR DESCRIPTION
Plugin that displays stats about the nylocas room AFTER the players have completed the room (to comply with 3rd party plugin guidelines). It displays the amount of times the players have stalled the nylocas waves. It also shows the distribution of small nylocas splits.