### PR TITLE
Update clan-kdr to v1.2

### DIFF
--- a/plugins/clan-kdr
+++ b/plugins/clan-kdr
@@ -1,2 +1,2 @@
 repository=https://github.com/di-brian/clan-kdr.git
-commit=d9553efffecf97a19c1141e385fe46d15026797e
+commit=7813d508979dc5bfb8ccd1eb4c9d5d27f4d59123


### PR DESCRIPTION
- Adds ability to exclude deaths where member of own cc died for nothing