### PR TITLE
Update custom-settings-easter-eggs to v1.0.1

### DIFF
--- a/plugins/custom-settings-easter-eggs
+++ b/plugins/custom-settings-easter-eggs
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/custom-settings-easter-eggs.git
-commit=42ce58060152f97484f7ab812f8791fde29b3a7f
+commit=827e28ce244bbfdf2ad5c3c71bb0c5d9dac767ee


### PR DESCRIPTION
I don't know how long this has been broken for, but at some point it seems like the child ID for the setting widget's results page changed from 17 to 18.