### PR TITLE
Submission of plugin: email-notifications

### DIFF
--- a/plugins/email-notifications
+++ b/plugins/email-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/boiwantlearncode/email-notifications.git
+commit=60693a2fa39c8e1d348ccbbf1bf630081d28f508


### PR DESCRIPTION
Sends an email on notification event. Sender email has to be hosted on gmail.