### PR TITLE
Create player-highlighter plugin

### DIFF
--- a/plugins/player-highlighter
+++ b/plugins/player-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/mezettle/runelite-plugins.git
+commit=431ae825d8acfef42de692378ec7ae78da1cfa07


### PR DESCRIPTION
This plugin highlights players that are within a configurable radius from the user.
https://github.com/mezettle/runelite-plugins/tree/player-highlighter
![image](https://user-images.githubusercontent.com/98920532/218179894-bc16e9f2-c2c1-44ef-a7b4-85084ebd217a.png)
