### PR TITLE
Update Smart Chat Input Color to 1.3.0

### DIFF
--- a/plugins/input-recolor
+++ b/plugins/input-recolor
@@ -1,3 +1,3 @@
 repository=https://github.com/MarbleTurtle/Color-Coordinator.git
-commit=19c800dd5d8446f33b93ddf61427c06ae1073c3d
-authors=MarbleTurtle,Ririshi
+commit=edf64b8267d341aadf4d394e6307371f3b58dc86
+authors=Ririshi,MarbleTurtle


### PR DESCRIPTION
All changes in this update are from PR https://github.com/MarbleTurtle/Color-Coordinator/pull/9.

I've changed the author order since MarbleTurtle is no longer supporting his plugins and I am "officially" taking over main support for it as of this version.