### PR TITLE
Update Plugin Presets to v2.6

### DIFF
--- a/plugins/plugin-presets
+++ b/plugins/plugin-presets
@@ -1,2 +1,2 @@
 repository=https://github.com/antero111/plugin-presets.git
-commit=b9c2c4b2fd83f896736723797a3ff8745d7493e0
+commit=61e146494ada1fb11b7df6141bcb37bf724320f2


### PR DESCRIPTION
From changelog:

Readded refresh presets button to plugin panel. Add load preset option to toggle switch context menu. Fixed auto updater not handling custom settings. Added error warning when preset (re)naming fails. Added way for selecting which preset is auto updated out of all matching presets. Added custom no presets panel with a wiki link.

Diff includes code to preset disabling but its not used as of yet.