### PR TITLE
update clan fight performance tracker to v1.2.1

### DIFF
--- a/plugins/clan-fight-performance-tracker
+++ b/plugins/clan-fight-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/di-brian/clan-fight-performance-tracker.git
-commit=23d280b630c1155537d85637b34fbb0295a58df3
+commit=9822a13d31a0d629ae6fa018b0b8d4947fcf9b01


### PR DESCRIPTION
- fixes bug around setting starting kill count