### PR TITLE
Update combat-roll to v1.1

### DIFF
--- a/plugins/combat-roll
+++ b/plugins/combat-roll
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=0cd6d8e18efcb9074471bfc410fb129ad93b8f73
+commit=b6898b5a08e05570bec00901b99a5b8788c209f2

--- a/plugins/combat-roll
+++ b/plugins/combat-roll
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=2b7dc23ff4492cdc3b9934a1539d20f9818c01f1
+commit=51cc3d02bfb8d7cba129110b23a3fb2b7a845989

--- a/plugins/combat-roll
+++ b/plugins/combat-roll
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=51cc3d02bfb8d7cba129110b23a3fb2b7a845989
+commit=bb52dc9964191dc610f11c58fc6a10af3a42ee59

--- a/plugins/combat-roll
+++ b/plugins/combat-roll
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=bb52dc9964191dc610f11c58fc6a10af3a42ee59
+commit=0cd6d8e18efcb9074471bfc410fb129ad93b8f73

--- a/plugins/combat-roll
+++ b/plugins/combat-roll
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=b6898b5a08e05570bec00901b99a5b8788c209f2
+commit=77ef354deaa355ad1cd545fa1d736e74bd68f184


### PR DESCRIPTION
- Combat rolls were not showing up on the equipment screen of the bank
- Thick Skin, Rock Skin, Steel Skin, Rigour, Augury, Piety and Chivalry should now correctly boost defence rolls for melee, magic and ranged
- The +8 adjustment constant was removed from player magic defence roll