### PR TITLE
Create tzhaar-death-indicator

### DIFF
--- a/plugins/tzhaar-death-indicator
+++ b/plugins/tzhaar-death-indicator
@@ -1,0 +1,2 @@
+repository=https://github.com/JaccodR/tzhaar-death-indicator.git
+commit=c27957eece36beec95549c399459b96f3557fcc7


### PR DESCRIPTION
This plugin makes NPCs within the Inferno & Fight caves dissapear on xp drop, which is a lot faster than with entity hider. This plugin works the same as the Nylo death indicator.