### PR TITLE
Afk threshold plugin

### DIFF
--- a/plugins/AFK_Threshold
+++ b/plugins/AFK_Threshold
@@ -1,2 +1,0 @@
-repository=https://github.com/Velite12/AFK_threshold.git
-commit=679cd40e66ad1b308385c95d596818f8ecba0c9e

--- a/plugins/AFK_Threshold
+++ b/plugins/AFK_Threshold
@@ -1,0 +1,2 @@
+repository=https://github.com/Velite12/AFK_threshold.git
+commit=679cd40e66ad1b308385c95d596818f8ecba0c9e

--- a/plugins/afk-threshold
+++ b/plugins/afk-threshold
@@ -1,0 +1,2 @@
+repository=https://github.com/Velite12/AFK_threshold.git
+commit=679cd40e66ad1b308385c95d596818f8ecba0c9e

--- a/plugins/afk-threshold
+++ b/plugins/afk-threshold
@@ -1,2 +1,2 @@
 repository=https://github.com/Velite12/AFK_threshold.git
-commit=679cd40e66ad1b308385c95d596818f8ecba0c9e
+commit=5a31785e890a9414eb8ae7656d4ce2764ce6142f


### PR DESCRIPTION
This plugin allows you to AFK while skilling by setting a minimum time you want to be AFK for and sends you a notification if you are idle at that time, or if you are not idle, it will wait until you become idle and then send you a notification. This plugin basically combines the AFK timer plugin and the Idle Notifier plugin into one for specifically skilling activities, but also allows for more time to AFK after the threshold.