### PR TITLE
Unranked kc tracker

### DIFF
--- a/plugins/unranked-kc-tracker
+++ b/plugins/unranked-kc-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Erishion-Games-LLC/Runelite-Unranked-KC-Tracker-Plugin.git
 commit=2728b18ac7ff078f3b54b305639cf3faccac91ee
-author=Ben-Colwell
+authors=Ben-Colwell

--- a/plugins/unranked-kc-tracker
+++ b/plugins/unranked-kc-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Erishion-Games-LLC/Runelite-Unranked-KC-Tracker-Plugin.git
-commit=
+commit=2728b18ac7ff078f3b54b305639cf3faccac91ee
 author=Erishion Games LLC

--- a/plugins/unranked-kc-tracker
+++ b/plugins/unranked-kc-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Erishion-Games-LLC/Runelite-Unranked-KC-Tracker-Plugin.git
-commit=2728b18ac7ff078f3b54b305639cf3faccac91ee
+commit=7cfbc67f5d9a6573cfcea3da5b5056170f9f6db1
 authors=Ben-Colwell

--- a/plugins/unranked-kc-tracker
+++ b/plugins/unranked-kc-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/Erishion-Games-LLC/Runelite-Unranked-KC-Tracker-Plugin.git
+commit=
+author=Erishion Games LLC

--- a/plugins/unranked-kc-tracker
+++ b/plugins/unranked-kc-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Erishion-Games-LLC/Runelite-Unranked-KC-Tracker-Plugin.git
 commit=2728b18ac7ff078f3b54b305639cf3faccac91ee
-author=Erishion Games LLC
+author=Ben-Colwell


### PR DESCRIPTION
An easy way to see KC and other values not tracked on the High scores.

Values are easy to fake, so prefer to use the high score values when available.

If a boss is highlighted in orange, that boss is being tracked on the high scores and you should use the value on the high scores instead.
![Capture](https://user-images.githubusercontent.com/52632729/219872887-b2628759-95f3-4d61-901b-355d8a034a72.PNG)
