### PR TITLE
Update Dink to v1.3.1

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=932b711a901bb28e05ab43280a774c2ddeac2aa0
+commit=4b3748832918706163f84f6ea8adbe407ca9ffd5
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.3.1 fixes a few edge cases (for level and kill count notifiers), augments pet metadata with the acquisition milestone, and allows skipping death notifications if the total value of the lost items is below a configurable threshold.

https://github.com/pajlads/DinkPlugin/releases/tag/v1.3.1