### PR TITLE
[Hotfix] Updated Emote Clue Items to v4.1.1.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=2e95745a6c5d79b7cd38c5edf9d5a9649238a163
+commit=9a2161f3a1197dcf3df9ae6881ddae694edb0561


### PR DESCRIPTION
This patch features the following updates.
- Fixed missing item highlighting after the [v4.1.0 update](https://github.com/larsvansoest/emote-clue-items/releases/tag/v4.1.0) (see [emote-clue-items#89](https://github.com/larsvansoest/emote-clue-items/issues/89)).
- Fixed typo in STASH Unit name (see [emote-clue-items#86](https://github.com/larsvansoest/emote-clue-items/issues/86)).