### PR TITLE
Nex KC Helper

### DIFF
--- a/plugins/nex-kc-helper
+++ b/plugins/nex-kc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Marco648135/nexkchelper.git
-commit=e7d77a4d2e295a7e225dad2ff16ffa0326b2588a
+commit=7d8339a5f16f95e76918ee355aa044aed71414d2

--- a/plugins/nex-kc-helper
+++ b/plugins/nex-kc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Marco648135/nexkchelper.git
-commit=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
+commit=be8e7fd1b2474ce663580f1b4609cbe49470ed06

--- a/plugins/nex-kc-helper
+++ b/plugins/nex-kc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Marco648135/nexkchelper.git
-commit=be8e7fd1b2474ce663580f1b4609cbe49470ed06
+commit=f780901eeb927c0e135cdf6a5224231144a0f2e1

--- a/plugins/nex-kc-helper
+++ b/plugins/nex-kc-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Marco648135/nexkchelper.git
+commit=6e0637363c8e3c4f909d6fecd1e80ee7dc48483f

--- a/plugins/nex-kc-helper
+++ b/plugins/nex-kc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Marco648135/nexkchelper.git
-commit=6cc08d321f4488adfab983182b9bab9594667552
+commit=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

--- a/plugins/nex-kc-helper
+++ b/plugins/nex-kc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Marco648135/nexkchelper.git
-commit=6e0637363c8e3c4f909d6fecd1e80ee7dc48483f
+commit=e7d77a4d2e295a7e225dad2ff16ffa0326b2588a

--- a/plugins/nex-kc-helper
+++ b/plugins/nex-kc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Marco648135/nexkchelper.git
-commit=7d8339a5f16f95e76918ee355aa044aed71414d2
+commit=6cc08d321f4488adfab983182b9bab9594667552


### PR DESCRIPTION
A plugin intended to provide QOL primarily to nex KC, by making it clear which NPCs have been venomed and which still need to be.