### PR TITLE
Update aqp-finder

### DIFF
--- a/plugins/aqp-finder
+++ b/plugins/aqp-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/JamesShelton140/aqp-finder.git
-commit=d77a0d0da373a0d650948221f69ffac03696dcc3
+commit=215c64e4e00bd46bd63b81813e942c5581c535ce


### PR DESCRIPTION
- Overlay helper now ignores chatbox channel commands so alignment is correct in clan chat etc.
- Fixed issue when aligning with unranked friends chat members (no rank icon)
- Added plugin hub icon