### PR TITLE
Add clan-chat-webhook plugin to Repository

### DIFF
--- a/plugins/clan-chat-webhook
+++ b/plugins/clan-chat-webhook
@@ -1,0 +1,2 @@
+repository=https://github.com/pascalla/clan-chat-webhook.git
+commit=df9d6236757589357dd4f43f9dd5d9441db016cd


### PR DESCRIPTION
Plugin allows Clan Chat messages and broadcasts to be sent via a Webhook. It also natively supports Discord webhooks.

![image](https://user-images.githubusercontent.com/22846433/221707542-676a8f33-7bb8-4787-b05c-57a71cdbf16f.png)
