### PR TITLE
Create clan-chat-webhook

### DIFF
--- a/plugins/clan-chat-webhook
+++ b/plugins/clan-chat-webhook
@@ -1,2 +1,2 @@
 repository=https://github.com/pascalla/clan-chat-webhook.git
-commit=f40ce9d71da627358b358a0835eb80bd3762cafc
+commit=8c5ff6b231c659e1040a3de5f5ece0231695fbc0

--- a/plugins/clan-chat-webhook
+++ b/plugins/clan-chat-webhook
@@ -1,2 +1,2 @@
 repository=https://github.com/pascalla/clan-chat-webhook.git
-commit=87e0de48e72b8abbbe919497d5bde7658bd2fbc3
+commit=f40ce9d71da627358b358a0835eb80bd3762cafc

--- a/plugins/clan-chat-webhook
+++ b/plugins/clan-chat-webhook
@@ -1,0 +1,2 @@
+repository=https://github.com/pascalla/clan-chat-webhook.git
+commit=87e0de48e72b8abbbe919497d5bde7658bd2fbc3


### PR DESCRIPTION
Plugin allows Clan Chat messages and broadcasts to be sent via a Webhook. It also natively supports Discord webhooks.
![image](https://user-images.githubusercontent.com/22846433/221709315-7aa97990-dc19-4c0b-87c3-e9cd31817e08.png)
