### PR TITLE
Update Ferox Restore Alert

### DIFF
--- a/plugins/ferox-restore-alert
+++ b/plugins/ferox-restore-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/eddiewastaken/FeroxRestoreAlert.git
-commit=15e697253706710b2b56fede68b100a41677ab02
+commit=c6013d5d38b6268dd2c7a68fc25daf3867d52407

--- a/plugins/ferox-restore-alert
+++ b/plugins/ferox-restore-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/eddiewastaken/FeroxRestoreAlert.git
-commit=c6013d5d38b6268dd2c7a68fc25daf3867d52407
+commit=487323d0e07d30433341cea3695084e3ab4cce73


### PR DESCRIPTION
Add custom 'restored' run energy value to config, default to 90 to avoid overlay instantly re-appearing after moving away from source of restoration; Fix persistent overlay bug with explicit check for leaving Ferox