### PR TITLE
Create world-finder

### DIFF
--- a/plugins/world-finder
+++ b/plugins/world-finder
@@ -1,0 +1,2 @@
+repository=https://github.com/Cgende/World-Finder.git
+commit=97e5397dd0f5a1389def57b4f4e2a1377447d3c2

--- a/plugins/world-finder
+++ b/plugins/world-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/Cgende/World-Finder.git
-commit=97e5397dd0f5a1389def57b4f4e2a1377447d3c2
+commit=b6cf9a1235d50786af62c85cb069cfec5e74c997


### PR DESCRIPTION
A modified version of the world hopper plugin which adds a column to sort by when a world was last visited. This is useful to avoid hopping to worlds you've already checked when looking for a free world. Also works with the party plugin to show when anyone in the party was last in the world.