### PR TITLE
Update customizable-xp-drops to v1.7.2.2

### DIFF
--- a/plugins/customizable-xp-drops
+++ b/plugins/customizable-xp-drops
@@ -1,2 +1,2 @@
 repository=https://github.com/l2-/template-plugin.git
-commit=61c86072d0f83f9bbae34ce6dbeb59bf944a88d0
+commit=3764705429e47d5837cca75e2313a16b5964190a


### PR DESCRIPTION
Looks like I didn't test this enough and it broke the ordering of the multiple overlays used in the plugin. Sorry