### PR TITLE
Use client.getItemCount and ItemComposition instead of the ItemId class (reverting changes to build.gradle as well)

### DIFF
--- a/plugins/npc-collection-log
+++ b/plugins/npc-collection-log
@@ -1,3 +1,3 @@
 repository=https://github.com/ElOsoGroso/NPCCollectionLog.git
-commit=988dce503948f84f6d9f8826309ead808c3a3294
+commit=6f14588d36de64354026265ee6a86253052be213
 warning=This plugin submits your account hash and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/npc-collection-log
+++ b/plugins/npc-collection-log
@@ -1,3 +1,3 @@
 repository=https://github.com/ElOsoGroso/NPCCollectionLog.git
-commit=6f14588d36de64354026265ee6a86253052be213
+commit=2af9340500b4399c15ce684e7646d40b3ff2a778
 warning=This plugin submits your account hash and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/npc-collection-log
+++ b/plugins/npc-collection-log
@@ -1,3 +1,3 @@
 repository=https://github.com/ElOsoGroso/NPCCollectionLog.git
-commit=5bc55547317b18ffcb54e66f6cbd56a37d8fdefc
+commit=9f3ffb9bd28bc1afab6a65cf38a5e42e9be8b13d
 warning=This plugin submits your account hash and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/npc-collection-log
+++ b/plugins/npc-collection-log
@@ -1,3 +1,3 @@
 repository=https://github.com/ElOsoGroso/NPCCollectionLog.git
-commit=2af9340500b4399c15ce684e7646d40b3ff2a778
+commit=5bc55547317b18ffcb54e66f6cbd56a37d8fdefc
 warning=This plugin submits your account hash and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
The ItemId class was not available at runtime due to the 'compileOnly' setting, causing crashes on login and gameStateChanged