### PR TITLE
Update Nylo Stats

### DIFF
--- a/plugins/nylo-stats
+++ b/plugins/nylo-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/JaccodR/nylo-stats.git
-commit=e9939c155b2ce06773607c778b628916ef1cdf57
+commit=8ffba1e26c4e2cf96756c246655f5e03b2f062ef

--- a/plugins/nylo-stats
+++ b/plugins/nylo-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/JaccodR/nylo-stats.git
-commit=c340b587900b98fefcb08751221db71d6802a971
+commit=e9939c155b2ce06773607c778b628916ef1cdf57

--- a/plugins/nylo-stats
+++ b/plugins/nylo-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/JaccodR/nylo-stats.git
-commit=fdbbbc1422a18b7553a83c7a5a3c9899880a8862
+commit=c340b587900b98fefcb08751221db71d6802a971


### PR DESCRIPTION
Due to popular request some additional options have been added:
- Added option to display the amount of nylos alive at the time of stalling
- Added option to see precap and postcap splits
- Fixed stalls being wrong when spectating mid-nylo
- Fixed colors of chatmessages for players not on fixed layout
- Added icon
- Updated HMT stalls to account for cap being different