### PR TITLE
Create Loot console logger

### DIFF
--- a/plugins/loot-console-logger
+++ b/plugins/loot-console-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/EmerycP/loot-console-logger.git
+commit=6189a2e717cca1d959a957cf479aa896d00e88f1

--- a/plugins/loot-console-logger
+++ b/plugins/loot-console-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/EmerycP/loot-console-logger.git
-commit=c6bd584335894e9a51ad66a99c32514bb9d6d42b
+commit=78d153ef16f1177a5e6190d8cb9a46c1a30d0bdc

--- a/plugins/loot-console-logger
+++ b/plugins/loot-console-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/EmerycP/loot-console-logger.git
-commit=6189a2e717cca1d959a957cf479aa896d00e88f1
+commit=c6bd584335894e9a51ad66a99c32514bb9d6d42b


### PR DESCRIPTION
A very simple plugin that logs the drops in the OSRS's console. 
Pretty useful when playing with multiple accounts on limited screen space.
I plan to add more type of logs, color & message customization

You can add some drops in an ignore list.
You can also highlight specified drops.
![java_RitZB8IDoP](https://user-images.githubusercontent.com/38258431/222274356-f0d64420-ef55-4c65-982d-dfab44a024a8.png)
