### PR TITLE
Add GloopyLite plugin

### DIFF
--- a/plugins/gloopylite
+++ b/plugins/gloopylite
@@ -1,2 +1,2 @@
-repository=https://github.com/andmcadams/gloopylite
+repository=https://github.com/andmcadams/gloopylite.git
 commit=443244502698a2d2dbaddce2dc1dd95798494963

--- a/plugins/gloopylite
+++ b/plugins/gloopylite
@@ -1,0 +1,2 @@
+repository=https://github.com/andmcadams/gloopylite
+commit=443244502698a2d2dbaddce2dc1dd95798494963

--- a/plugins/gloopylite
+++ b/plugins/gloopylite
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/gloopylite.git
-commit=443244502698a2d2dbaddce2dc1dd95798494963
+commit=83fe1a2475dc7b2a30874fb481a2302d99ef1ae8


### PR DESCRIPTION
Outputs a new message in the chatbox that acts as a wiki link for each `[[square bracketed]]` phrase in a message. Disallows phrases that contain certain characters that cannot be in wiki page names (`# < > [ ] _ { | }`). Link takes you to a page if there's a match for a page or redirect, otherwise you will go to the search results page for the query.

![image](https://user-images.githubusercontent.com/5871961/222309313-0884c4ee-c332-4b7c-9dff-d13732c099e6.png)
