### PR TITLE
Create gauntlet-resource-map

### DIFF
--- a/plugins/gauntlet-resource-map
+++ b/plugins/gauntlet-resource-map
@@ -1,0 +1,2 @@
+repository=https://github.com/hawk-rl/gauntlet-resource-map.git
+commit=8cf29a0801393bccfa70d3b6cbef95d5c92f6c4a


### PR DESCRIPTION
This plugin displays resource nodes on the Gauntlet map.