### PR TITLE
Fight Caves Spawn Predictor - v1.1.0

### DIFF
--- a/plugins/spawnpredictor
+++ b/plugins/spawnpredictor
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/spawn-predictor.git
-commit=87a1f7dcbb3f590f8e1c823273146b35e669091e
+commit=89a81cec5ac6834e555d90340517b2cda80ad2ce


### PR DESCRIPTION
- adds jagex server UTC time reference instead of local
- adds AccountMemory for rotation and waves based on RSN
- removes the ability to see rotation predictions when you don't wait for the plugin to determine the proper wave rotation to be set on the plugin (~60 seconds for a new minute to calculate and the plugin to be 100% sure it's ready to go)