### PR TITLE
Updated Emote Clue Items to 4.2.0.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=9a2161f3a1197dcf3df9ae6881ddae694edb0561
+commit=311667c03b75e26f4214865075f20d5a373ad24e


### PR DESCRIPTION
This patch features the following updates.
* Fixed an issue with stash unit headers given an incorrect grey tone after toggling fill statuses (see [emote-clue-items/pull92](https://github.com/larsvansoest/emote-clue-items/pull/92)).
* Enabled fill status synchronisation for the noticeboard in Watson's house (see [emote-clue-items/pull92](https://github.com/larsvansoest/emote-clue-items/pull/92)). 
  > To enable this feature, enable "Sync Watson Board" in the plugin settings.

![watson-sync](https://user-images.githubusercontent.com/5564172/222982321-209eb058-f117-415a-ba11-625010e46886.gif)

* Updated to RuneLite version 1.9.11.2. (see [emote-clue-items/pull92](https://github.com/larsvansoest/emote-clue-items/pull/92))