### PR TITLE
Create discord-group-bank-notifications

### DIFF
--- a/plugins/discord-group-bank-notifications
+++ b/plugins/discord-group-bank-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/barthogenes/RuneLite-Discord-GroupBank-Notifications
+commit=00d8b73d9feadfb33d3b7d3b857c2b407525ece2

--- a/plugins/discord-group-bank-notifications
+++ b/plugins/discord-group-bank-notifications
@@ -1,2 +1,2 @@
-repository=https://github.com/barthogenes/RuneLite-Discord-GroupBank-Notifications
+repository=https://github.com/barthogenes/RuneLite-Discord-GroupBank-Notifications.git
 commit=00d8b73d9feadfb33d3b7d3b857c2b407525ece2

--- a/plugins/discord-group-bank-notifications
+++ b/plugins/discord-group-bank-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/barthogenes/RuneLite-Discord-GroupBank-Notifications.git
-commit=d465525e76e89a5297b3a6b4ece0c66780960e4f
+commit=320c0d360902cbbc38621976527fbf6ac45aa054

--- a/plugins/discord-group-bank-notifications
+++ b/plugins/discord-group-bank-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/barthogenes/RuneLite-Discord-GroupBank-Notifications.git
-commit=320c0d360902cbbc38621976527fbf6ac45aa054
+commit=4c4839b8b387072463cc037d8c79732e2c95d08a

--- a/plugins/discord-group-bank-notifications
+++ b/plugins/discord-group-bank-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/barthogenes/RuneLite-Discord-GroupBank-Notifications.git
-commit=00d8b73d9feadfb33d3b7d3b857c2b407525ece2
+commit=d465525e76e89a5297b3a6b4ece0c66780960e4f


### PR DESCRIPTION
This RuneLite plugin sends messages to your Discord channel when you deposit or withdraw items from the Group Bank.