### PR TITLE
Add Chat-channel Watcher

### DIFF
--- a/plugins/cc-watcher
+++ b/plugins/cc-watcher
@@ -1,2 +1,2 @@
 repository=https://github.com/ryanjpwatts/chat-channel-watcher.git
-commit=de1060404adc8108667b040b7472676d26a7737a
+commit=e5c3bcfe8c5136bdccfd570d19fce00be7e59724

--- a/plugins/cc-watcher
+++ b/plugins/cc-watcher
@@ -1,0 +1,2 @@
+repository=https://github.com/ryanjpwatts/chat-channel-watcher.git
+commit=de1060404adc8108667b040b7472676d26a7737a


### PR DESCRIPTION
A plugin that enables the user to receive chat and/or desktop notifications when any user in a list joins or leaves the chat-channel they're currently in.