### PR TITLE
Update clan-chat-country-flags to v1.2.1

### DIFF
--- a/plugins/clan-chat-country-flags
+++ b/plugins/clan-chat-country-flags
@@ -1,2 +1,2 @@
 repository=https://github.com/melkypie/clanchatcountryflags.git
-commit=40e9a8f628603cc98cb06cb136c526da2f206f92
+commit=e3bee0d8f7ebc1b31aa8cfa26bd7064cff8a351b


### PR DESCRIPTION
Fixes the plugin to work for clan and guest clan chats