### PR TITLE
Update Inventory Setups to v1.14.4

### DIFF
--- a/plugins/inventory-setups
+++ b/plugins/inventory-setups
@@ -1,2 +1,2 @@
 repository=https://github.com/dillydill123/inventory-setups.git
-commit=07350705da22b7a9ec4d01389fde50420b0dcce2
+commit=84559b70b189396d177114aab07607f50f3b00c2


### PR DESCRIPTION
Add toggle to persist hot keys outside bank
Show worn items menu now matches the order of the setups panel
Add and import buttons now open a menu to select between setup and section