### PR TITLE
Party heartbeat

### DIFF
--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=6151c5d91bd7753857e1bea733d51cbfcf9322c8
+commit=7a9a6dfed8f9866e0859e1de024cfb6d31b92d7d
 authors=elkcarc,JaccodR

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=1e1d860b84196bb1e2b90fdc8dfc33cf70c72ecf
+commit=bfe92ab7db608554add4a76afeef96ced1a11c93
 authors=elkcarc,JaccodR

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=47d70e4b31744449b4557924ebe94f976cb91ac2
+commit=1e1d860b84196bb1e2b90fdc8dfc33cf70c72ecf
 authors=elkcarc,JaccodR

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=380ed2e6d191858934e8bbe56887c26213a541fc
+commit=47d70e4b31744449b4557924ebe94f976cb91ac2
 authors=elkcarc,JaccodR

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=1109afe69df946e007511720c7c66c7e1525c681
+commit=8a1c60292a0b737b7d8934fee581d0ec7deea7ec
 authors=elkcarc,JaccodR

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=8a1c60292a0b737b7d8934fee581d0ec7deea7ec
+commit=380ed2e6d191858934e8bbe56887c26213a541fc
 authors=elkcarc,JaccodR

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=7a9a6dfed8f9866e0859e1de024cfb6d31b92d7d
+commit=1109afe69df946e007511720c7c66c7e1525c681
 authors=elkcarc,JaccodR

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,0 +1,3 @@
+repository=https://github.com/elkcarc/party-heartbeat.git
+commit=6151c5d91bd7753857e1bea733d51cbfcf9322c8
+authors=elkcarc,JaccodR


### PR DESCRIPTION
Bugfix. Added a timeout to the disconnection alert to address the party plugin's default timeout of several minutes being too long for the notification to reasonably go on for.