### PR TITLE
Update party-heartbeat

### DIFF
--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=1e1d860b84196bb1e2b90fdc8dfc33cf70c72ecf
+commit=bfe92ab7db608554add4a76afeef96ced1a11c93
 authors=elkcarc,JaccodR

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=da521c0c0d7c3c12b707480d73f7168f3c7b5fd1
-authors=elkcarc,JaccodR
+commit=5925962355f7b454c7ce9721b645eb03ece6e92b
+authors=elkcarc,Scowled

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=546c45aba764496ac8a089de9ca51e64a95bf8da
+commit=4013cac53b60af229d82e1db8d61e284b6a13b38
 authors=elkcarc,Scowled

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=bfe92ab7db608554add4a76afeef96ced1a11c93
+commit=da521c0c0d7c3c12b707480d73f7168f3c7b5fd1
 authors=elkcarc,JaccodR

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=4013cac53b60af229d82e1db8d61e284b6a13b38
+commit=84b6b2b90212f35831d0f1cc4e76d93904502b3d
 authors=elkcarc,Scowled

--- a/plugins/party-heartbeat
+++ b/plugins/party-heartbeat
@@ -1,3 +1,3 @@
 repository=https://github.com/elkcarc/party-heartbeat.git
-commit=5925962355f7b454c7ce9721b645eb03ece6e92b
+commit=546c45aba764496ac8a089de9ca51e64a95bf8da
 authors=elkcarc,Scowled


### PR DESCRIPTION
Bugfix. Added a config option to the disconnection alert timeout as the default party login check takes upwards of 1 minute to expire.