### PR TITLE
Create hold-your-ground

### DIFF
--- a/plugins/hold-your-ground
+++ b/plugins/hold-your-ground
@@ -1,0 +1,2 @@
+repository=https://github.com/skeldoor/hold-your-ground.git
+commit=b1dbe50e8f808b0d438bcb0a9d1089d1546a7014


### PR DESCRIPTION
This plugin is designed to help Tilemen and Chunkmen stay within their unlocked boundaries.

The plugin will restrict actions that could cause you to leave your allowed region. It does this by enforcing customisable levels of restriction on your player character which control how your character interacts with NPCs.