### PR TITLE
Update 117HD to v1.2.6.2

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=92669fae151b92ab3eea3f09611dbf4b50290704
+commit=d9dff1080f2bb2a37be71b11e283e81c5a039972
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Move vanilla UV calculation to compute shaders

Port of https://github.com/runelite/runelite/commit/369fcb7c706616d721b7564a217222eb45445654