### PR TITLE
Create wilderness-player-alarm

### DIFF
--- a/plugins/wilderness-player-alarm
+++ b/plugins/wilderness-player-alarm
@@ -1,2 +1,2 @@
 repository=https://github.com/adhansen/plugin-repo.git
-commit=afdeacba85a3cc7cb807e00ffdec7342775864c8
+commit=64c26e1e81738f6e20958f339384988c8922e8ce

--- a/plugins/wilderness-player-alarm
+++ b/plugins/wilderness-player-alarm
@@ -1,2 +1,2 @@
 repository=https://github.com/adhansen/plugin-repo.git
-commit=287c3f38584a83ba7aac72e6742a628315cbff15
+commit=afdeacba85a3cc7cb807e00ffdec7342775864c8

--- a/plugins/wilderness-player-alarm
+++ b/plugins/wilderness-player-alarm
@@ -1,0 +1,2 @@
+repository=https://github.com/adhansen/plugin-repo.git
+commit=287c3f38584a83ba7aac72e6742a628315cbff15


### PR DESCRIPTION
### Overview
This PR adds a new plugin called `Wilderness Player Alarm` to the plugin hub that alerts the user to the presence of others by flashing the whole screen with a bright color. The intention is mainly for scout accounts that camp outside wildy boss lairs while a ~~prey animal~~ player with risk inside the arena fights the boss.

### Legality
I referenced this rules page while implementing the plugin:
https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1
and don't believe that I'm infringing on any of the rules. There is an option in the plugin to refrain from flashing when the detected player is a friend/clanmate but I don't think that's infringing on the rules any more than the "Player Indicators" plugin which highlights friends/clanmates/others etcetera differently with even more granularity. Logic depending on a players' skull status is new but that's not mentioned in the rules at all.

