### PR TITLE
Update 117HD to v1.2.6.4

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=9e198616b247e050c32213a9a0ff8343c6a814c3
+commit=76818fd8fce17c0ba55fc0c00851e662d91b3e3d
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Here we go again... Hopefully the last patch for this UV stuff :sweat_smile:

Fix the following UV issue when having model textures disabled:
![image](https://user-images.githubusercontent.com/831317/224285481-fbc591a9-dae6-4fac-89eb-9b6278019d9c.png)
