### PR TITLE
Update 117HD to v1.2.6.5

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=131736853e19c75ef24f11463209bf79dce065ea
+commit=80c8584741947609db5dd690e8643d5764f181fa
 authors=RS117,sosodev,ahooder

--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=76818fd8fce17c0ba55fc0c00851e662d91b3e3d
+commit=131736853e19c75ef24f11463209bf79dce065ea
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Fixes vanilla UVs with a depth offset, such as on the mirror shield.

https://user-images.githubusercontent.com/831317/224451273-6211530e-a550-46ef-88a1-2cb86ac1ed2f.mp4

