### PR TITLE
Update clan-list-exporter to v1.1

### DIFF
--- a/plugins/clan-list-exporter
+++ b/plugins/clan-list-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/di-brian/clan-list-exporter.git
-commit=1b33ba3abd40f461ad41f37d9f60c6d8d204679d
+commit=b38a9ab5764d961906aa109fbc3ceb6bc9cdbf96


### PR DESCRIPTION
- Extends timestamp on exported file to include specific time of export