### PR TITLE
Update ccwatcher to v1.1

### DIFF
--- a/plugins/cc-watcher
+++ b/plugins/cc-watcher
@@ -1,2 +1,2 @@
 repository=https://github.com/ryanjpwatts/chat-channel-watcher.git
-commit=e5c3bcfe8c5136bdccfd570d19fce00be7e59724
+commit=665cd28a4cef0dcda08d8784f2c8258eaeb2b008


### PR DESCRIPTION
- Fixed bug that was ignoring prevName config on join events
- Added support for clan chats, not just friend chats (toggleable)
- Added optional player highlighting in friend chat widget
- Added option to send rsn, whether they have joined or left and timestamp to an API endpoint (with optional bearer auth)