### PR TITLE
Update fairy-ring-butterflies

### DIFF
--- a/plugins/fairy-ring-butterflies
+++ b/plugins/fairy-ring-butterflies
@@ -1,2 +1,2 @@
 repository=https://github.com/Jmmuir/Fairy-Ring-Butterflies.git
-commit=6f0ff4fce3b5cf20950da997a2432bb5b5cd1d7f
+commit=6b218ea19779363fd1fc664dba7586227dfee8a3

--- a/plugins/fairy-ring-butterflies
+++ b/plugins/fairy-ring-butterflies
@@ -1,2 +1,2 @@
 repository=https://github.com/Jmmuir/Fairy-Ring-Butterflies.git
-commit=239d08847b034d5b83b18d15544a40e8ea8db7ee
+commit=1af83102d4d59be86b1a56b70917b0c94cebc086

--- a/plugins/fairy-ring-butterflies
+++ b/plugins/fairy-ring-butterflies
@@ -1,2 +1,2 @@
 repository=https://github.com/Jmmuir/Fairy-Ring-Butterflies.git
-commit=1af83102d4d59be86b1a56b70917b0c94cebc086
+commit=6f0ff4fce3b5cf20950da997a2432bb5b5cd1d7f


### PR DESCRIPTION
updating fairy ring butterflies plugin version

~ fix arceuus ring being excluded
~ add biome options to pick colours/visiblity depending on location in-world
~ fix compatibility issues with 117HD and the remove option
~ fairy rings no longer revert right after dialling a new code
~ butterflies are now recoloured/removed even for rings which are visible on login