### PR TITLE
Add No-Adviser plugin

### DIFF
--- a/plugins/no-adviser
+++ b/plugins/no-adviser
@@ -1,0 +1,2 @@
+repository=https://github.com/Daylend/disable-adviser.git
+commit=c69e6bdd83807ce01d0a082b38f853db030010a6


### PR DESCRIPTION
Disables the Activity Adviser button next to the minimap when in combat, or optionally, all the time.