### PR TITLE
Update Smart Chat Input Color to 1.4.0

### DIFF
--- a/plugins/input-recolor
+++ b/plugins/input-recolor
@@ -1,3 +1,3 @@
 repository=https://github.com/MarbleTurtle/Color-Coordinator.git
-commit=edf64b8267d341aadf4d394e6307371f3b58dc86
+commit=80067fea18237040c0e7e8b7fdb69ed9ccf011b0
 authors=Ririshi,MarbleTurtle


### PR DESCRIPTION
Fixes plugin to build correctly with new Varp API. Thanks to @YvesW for the PR :)