### PR TITLE
Created toxic-npcs plugin details

### DIFF
--- a/plugins/toxic-npcs
+++ b/plugins/toxic-npcs
@@ -1,0 +1,2 @@
+repository=https://github.com/TheJamesLJ/runelite-plugins.git
+commit=d3deba766237f6668f874c299d3c2584a70bb21d


### PR DESCRIPTION
### Plugin Name
Toxic NPCs on Player Death

### Overview
Heavily inspired by IdylRS and his 'bad plugins' idea for toxic npcs that will be toxic to the player if they die.

When a nearby player dies, all nearby npcs will display overhead text that makes fun of them for dying.

Depending on the npc that displays overhead text, there is unique dialogue that will display for them, i.e. God Wars Dungeon bosses and Jad.