### PR TITLE
Update quest-helper to 3.2.4

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=fe97a579e7b1679fd29d3521c018adf4f6c7dea4
+commit=cf6865a4bee28a21a70abd505ae63580c326b965


### PR DESCRIPTION
Fixes Quest Helper for the rock name changes, as well as adds better handling for hull highlighting where no hull exists.

I believe this should only be added once the newest runelite version is live (1.9.14).