### PR TITLE
Add npc-roasts plugin

### DIFF
--- a/plugins/npc-roasts
+++ b/plugins/npc-roasts
@@ -1,0 +1,2 @@
+repository=https://github.com/dseeler/npc-roasts.git
+commit=63ff9ce74233765a629666f4fc8384aa76c8eada


### PR DESCRIPTION
A just-for-fun plugin that enables NPCs to "roast" you on death.