### PR TITLE
Update theatre-of-blood-stats to v1.3.2

### DIFF
--- a/plugins/theatre-of-blood-stats
+++ b/plugins/theatre-of-blood-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/HSJ-OSRS/theatreofbloodstats.git
-commit=2c1d2806f2808ed592ebb939fc278ae7fcb2b153
+commit=bf3e162503e66df75e259060ede6711c98129117


### PR DESCRIPTION
Changes Sotetseg and Maiden time tracking to not use the boss HP since it doesn't update every tick