### PR TITLE
Update theatre-of-blood-stats to v1.3.3

### DIFF
--- a/plugins/theatre-of-blood-stats
+++ b/plugins/theatre-of-blood-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/HSJ-OSRS/theatreofbloodstats.git
-commit=bf3e162503e66df75e259060ede6711c98129117
+commit=51b7fd099f09c38d0e1a930bc243cacebb97e310


### PR DESCRIPTION
Fixes maiden split tracking when more than 1 Nylocas spawns