### PR TITLE
Fix region locker compute shader instability

### DIFF
--- a/plugins/region-locker
+++ b/plugins/region-locker
@@ -1,3 +1,3 @@
 repository=https://github.com/slaytostay/region-locker.git
-commit=c66b3d3b8358b4a791d3ad12aa599be19adecb9f
+commit=07bdf6e49cfad63a3041c247546ef11a52958cd7
 authors=slaytostay,ahooder


### PR DESCRIPTION
A couple of users reported that the plugin crashes very frequently with compute shaders enabled, and it turns out I missed some changes from RuneLite's GPU plugin in my initial update. This should fix that.