### PR TITLE
Create npc-accessibility-tagger

### DIFF
--- a/plugins/npc-accessibility-tagger
+++ b/plugins/npc-accessibility-tagger
@@ -1,0 +1,2 @@
+repository=https://github.com/R-Y-M-R/NpcAccessibilityTaggerPlugin.git
+commit=2198454cb966660e1ef320e1355437e8a973ca99


### PR DESCRIPTION
# Overview

This PR adds a new plugin called ``npc-accessibility-tagger`` to the plugin hub. It allows you to tag a specific npc with specific text, and optionally a color. The reason I wrote this plugin was to improve accessibility in the game, as I raid with a teammate who is color blind in ToA and has extreme difficulty determining which monkey is the ranger/mager/meleer.

The idea behind allowing different colors is partially color-blind people may be able to notice the differences between some colors but not all, so this gives them the option to use that if it'll help them.

I will be working with him to improve the plugin further, as well.

# Legality

I referenced the rules: https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1 and I do not believe my plugin infringes any of the game rules.