### PR TITLE
Update remaining-casts

### DIFF
--- a/plugins/remaining-casts
+++ b/plugins/remaining-casts
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/Remaining-Casts.git
-commit=c6f77e277a46979ba3374523791f29a9d7ccbcc6
+commit=1fd38f70979f761d53043cf866d2eedb10bb245d


### PR DESCRIPTION
- Fixed spell name lookup not passing the correct names
- Deprioritized sprite ID lookup (rescaled spell ids not yet mapped)
- Fixed Tome of Fire and added support for Kodai wand
- Added ability to pin/unpin spell casts via menu option
- Added compatibility for Normal Ancient Teleports
- Updated README