### PR TITLE
Update Dink to v1.3.2

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=4b3748832918706163f84f6ea8adbe407ca9ffd5
+commit=4cee08a0899cfc9604c57e06e387a7c6ddd842fc
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
## What's changed

This release includes a good amount of small changes and fixes.
Death notifications spam less by ignoring some safe areas such as LMS.
Chat message warnings in case the Dink config and the Runescape settings are compatible have been improved.
A little UX fix, notifier configuration sections are now collapsed by default.
Fixed a bug that caused the slayer notifier to stop firing when the user receiver more than 999 points (the comma in 1,000 tricker our regex).
Fixed an edge case where not all data about pet acquisitions would be captured due to GIM chat messages being slow at firing.

Link to release with full changelog: https://github.com/pajlads/DinkPlugin/releases/tag/v1.3.2
