### PR TITLE
Update c-engineer-completed to v1.0.4

### DIFF
--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=f801f76922457cdb0ed3d544aee62a2af01f55ec
+commit=1930230fbb1ff86797ac738d1f96505ecb658002


### PR DESCRIPTION
Replaces a number of existing sounds and adds some additional ones with a new trigger method - all sounds were sourced by C Engineer

Also adds a config option to download streamer troll sounds that can be disabled if the user doesn't want us to waste their disk space with sounds they will never use

Also includes a fix from llemonduck to close the clip on plugin shutdown if needed