### PR TITLE
Bump gloopylite to v1.1

### DIFF
--- a/plugins/gloopylite
+++ b/plugins/gloopylite
@@ -1,2 +1,2 @@
 repository=https://github.com/andmcadams/gloopylite.git
-commit=83fe1a2475dc7b2a30874fb481a2302d99ef1ae8
+commit=79f6dfdda77eaa78d35b7f5bda6c2778a7dec68b


### PR DESCRIPTION
Fixes some incorrect page name restrictions and trys to avoid clickthru when clicking links in a transparent chatbox