### PR TITLE
Create whos-gonna-poop

### DIFF
--- a/plugins/whos-gonna-poop
+++ b/plugins/whos-gonna-poop
@@ -1,2 +1,2 @@
 repository=https://github.com/ElOsoGroso/WhosGonnaPoop.git
-commit=5e2e48ca5fa07e25c0df96d2fa77c2572267e19d
+commit=2b8964b2a07075212b771a91e6fbe8ab4168359e

--- a/plugins/whos-gonna-poop
+++ b/plugins/whos-gonna-poop
@@ -1,2 +1,2 @@
 repository=https://github.com/ElOsoGroso/WhosGonnaPoop.git
-commit=2b8964b2a07075212b771a91e6fbe8ab4168359e
+commit=31faed3df8e636870ed5383f616eb7e6f83e2b51

--- a/plugins/whos-gonna-poop
+++ b/plugins/whos-gonna-poop
@@ -1,2 +1,2 @@
 repository=https://github.com/ElOsoGroso/WhosGonnaPoop.git
-commit=b2b09ff15d7082fa54d29d479042b89f577d5335
+commit=cf93a26734809fbdd37e513f7563259ba967f7c9

--- a/plugins/whos-gonna-poop
+++ b/plugins/whos-gonna-poop
@@ -1,2 +1,2 @@
 repository=https://github.com/ElOsoGroso/WhosGonnaPoop.git
-commit=37178955c717d5a968feac1519c55f6cb99e1d58
+commit=b2b09ff15d7082fa54d29d479042b89f577d5335

--- a/plugins/whos-gonna-poop
+++ b/plugins/whos-gonna-poop
@@ -1,0 +1,2 @@
+repository=https://github.com/ElOsoGroso/WhosGonnaPoop.git
+commit=4e7580653b2ab07cc006b5f41a9b4340661f3d34

--- a/plugins/whos-gonna-poop
+++ b/plugins/whos-gonna-poop
@@ -1,2 +1,2 @@
 repository=https://github.com/ElOsoGroso/WhosGonnaPoop.git
-commit=4e7580653b2ab07cc006b5f41a9b4340661f3d34
+commit=609a5e71761cf92afe3c92043859e4b1611c78e3

--- a/plugins/whos-gonna-poop
+++ b/plugins/whos-gonna-poop
@@ -1,2 +1,2 @@
 repository=https://github.com/ElOsoGroso/WhosGonnaPoop.git
-commit=31faed3df8e636870ed5383f616eb7e6f83e2b51
+commit=17e3933c12bae79e7e442dcfdd6db62ec98164c4

--- a/plugins/whos-gonna-poop
+++ b/plugins/whos-gonna-poop
@@ -1,2 +1,2 @@
 repository=https://github.com/ElOsoGroso/WhosGonnaPoop.git
-commit=17e3933c12bae79e7e442dcfdd6db62ec98164c4
+commit=37178955c717d5a968feac1519c55f6cb99e1d58

--- a/plugins/whos-gonna-poop
+++ b/plugins/whos-gonna-poop
@@ -1,2 +1,2 @@
 repository=https://github.com/ElOsoGroso/WhosGonnaPoop.git
-commit=609a5e71761cf92afe3c92043859e4b1611c78e3
+commit=5e2e48ca5fa07e25c0df96d2fa77c2572267e19d


### PR DESCRIPTION
Whos Gonna Poop is a plugin that highlights the orbs and player models of whoever is next to poop in Kephri in Tombs of Amascut.