### PR TITLE
Update nylo-death-indicators to v1.0.6

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=9e855cd80a7929208cb195a4dae604ca0b75bc43
+commit=253d5bec65adf1f8f674406f37eedc48a0a50baf


### PR DESCRIPTION
Some users complained about damage being applied too late for nylos they get the killing XP drop on. This is most likely due to poor internet connections paired with party latency as this issue was noted to be "resolved" when not in a party. This change applies damage locally first, then sends the message to the party instead of waiting for only the party message.