### PR TITLE
Update infernostats to v2.1.3

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=33ffeb1f569a8867b4c2d239095057ccf327d529
+commit=04bd867ceda46b37c4c799bc2641deeed5dfa0f8


### PR DESCRIPTION
Inferno speedrunners have gotten much faster with the release of Masori and Lightbearer!

- Added sub-45 splits to give better predicted times for the fastest of completions.
- Removed `enabledByDefault = false`. Not sure why that has been in there for so long.