### PR TITLE
Create global-chat

### DIFF
--- a/plugins/global-chat
+++ b/plugins/global-chat
@@ -1,0 +1,2 @@
+repository=https://github.com/RusseII/region-chat.git
+commit=0ca8ee7bcced5608b3764d98396f447afc9b8ac3


### PR DESCRIPTION
This creates a global chat that is shared across all players in a world that have installed the plugin. Useful for making sure you don't accidentally walk too far away and miss each others messages. 