### PR TITLE
Add no-bad-alchs plugin

### DIFF
--- a/plugins/no-bad-alchs
+++ b/plugins/no-bad-alchs
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/no-bad-alchs.git
-commit=941f172d3c001630abfc10d69b0197bab2147885
+commit=b9a39d10254f880ea7a36f32ee955a4de15cabfb

--- a/plugins/no-bad-alchs
+++ b/plugins/no-bad-alchs
@@ -1,0 +1,2 @@
+repository=https://github.com/CreativeTechGuy/no-bad-alchs.git
+commit=941f172d3c001630abfc10d69b0197bab2147885


### PR DESCRIPTION
Nice little demo and write up about the plugin in the README if you want more details: https://github.com/CreativeTechGuy/no-bad-alchs

Hide items when casting alchemy spells that you likely don't want to accidentally alchemize (such as untradeables or items which alch for less than their GE value).