### PR TITLE
Update party-panel to v3.2.4

### DIFF
--- a/plugins/party-panel
+++ b/plugins/party-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/party-panel.git
-commit=cfcac7737ce35680dd3912a6be39f30a0503bf93
+commit=3a58a2768eab1b561feb15371364ceb415fbd483


### PR DESCRIPTION
* Fixes the run energy value to be displayed in the 0-100 range instead of the 0-10000 range
* Clears the players inventory & equipment when they turn off the plugin 