### PR TITLE
Update no-bad-alchs to v0.8.1

### DIFF
--- a/plugins/no-bad-alchs
+++ b/plugins/no-bad-alchs
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/no-bad-alchs.git
-commit=b9a39d10254f880ea7a36f32ee955a4de15cabfb
+commit=e48159601b929e06c3e9f140ca10aa4bf03aba3d


### PR DESCRIPTION
Fixed a bug where any spell cast was defaulting to High Alch.