### PR TITLE
Fix brewing v3.0 update - invalid resource path

### DIFF
--- a/plugins/brewing
+++ b/plugins/brewing
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Brewing.git
-commit=3b29b24ee142a13c7bf2296f9318da4011211888
+commit=821bd6e6a036f1a26b2c302a1fc1d1522d4ea972


### PR DESCRIPTION
This fixes an issue with the previous v3.0 update. Resource paths were not specified properly.