### PR TITLE
Create discord-screenshot

### DIFF
--- a/plugins/discord-screenshot
+++ b/plugins/discord-screenshot
@@ -1,0 +1,2 @@
+repository=https://github.com/dave-kramer/discord-screenshot.git
+commit=562fc7537ef0291e9c15a2f7e829b6c78706c941


### PR DESCRIPTION
Allows RL users to take a screenshot and instantly send it to their Discord by one click (top bar button) - currently there is no quick option for users to send a screenshot to their Discord, this plugin fixes that.
See README for more details - quick summary, stand anywhere in OSRS, click the Discord Screenshot button and it pops up in your Discord.