### PR TITLE
Update toa-mistake-tracker to v1.4

### DIFF
--- a/plugins/toa-mistake-tracker
+++ b/plugins/toa-mistake-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/QuestingPet/ToaMistakeTracker.git
-commit=a349ff22908856ccfc022fb9a8f48bf4be01f635
+commit=8a1b1d809f204ea9630f3664b43581c4ff75a518


### PR DESCRIPTION
Fix various Akkha Quadrant Special mistake detection bugs. More details on [the issue](https://github.com/QuestingPet/ToaMistakeTracker/issues/6).