### PR TITLE
added PC Rewards

### DIFF
--- a/plugins/pcrewards
+++ b/plugins/pcrewards
@@ -1,0 +1,2 @@
+repository=https://github.com/marvinb16/PC-Rewards.git
+commit=78df5fbf18796aba7a2695049db71b1eab1e34c2


### PR DESCRIPTION
PC Rewards is a plugin that allows the user to customize the Pest Control rewards shop by giving them the ability to pick and choose what shop options they would like to have displayed to prevent any misclicks if turning in large sums of points.