### PR TITLE
PC Rewards

### DIFF
--- a/plugins/pcrewards
+++ b/plugins/pcrewards
@@ -1,2 +1,2 @@
 repository=https://github.com/marvinb16/PC-Rewards.git
-commit=67e8456ea8141b283323970d275b599e3d288561
+commit=43ab8bd6e6a62734d62f31fd7d0e19989eae5f5e

--- a/plugins/pcrewards
+++ b/plugins/pcrewards
@@ -1,2 +1,2 @@
 repository=https://github.com/marvinb16/PC-Rewards.git
-commit=78df5fbf18796aba7a2695049db71b1eab1e34c2
+commit=66b3044a6e11e9da6ed62482f76ecc4f01616168

--- a/plugins/pcrewards
+++ b/plugins/pcrewards
@@ -1,0 +1,2 @@
+repository=https://github.com/marvinb16/PC-Rewards.git
+commit=78df5fbf18796aba7a2695049db71b1eab1e34c2

--- a/plugins/pcrewards
+++ b/plugins/pcrewards
@@ -1,2 +1,2 @@
 repository=https://github.com/marvinb16/PC-Rewards.git
-commit=66b3044a6e11e9da6ed62482f76ecc4f01616168
+commit=67e8456ea8141b283323970d275b599e3d288561


### PR DESCRIPTION
PC Rewards is a plugin that allows the user to customize the Pest Control rewards shop by giving them the ability to pick and choose what shop options they would like to have displayed to prevent any misclicks if turning in large sums of points.

Resubmitting due to file error.