### PR TITLE
Create amazeing-chest

### DIFF
--- a/plugins/amazeing-chest
+++ b/plugins/amazeing-chest
@@ -1,0 +1,2 @@
+repository=https://github.com/skeldoor/amazeing-chest.git
+commit=99b379fbdf35a9504b5beab37bb9cec5d0c4a654


### PR DESCRIPTION
A plugin to track how long a maze random chest will be open for before resetting and optionally send a notification.