### PR TITLE
Create aerial-tick-colors

### DIFF
--- a/plugins/aerial-tick-colors
+++ b/plugins/aerial-tick-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/JadeGerbitz/Aeirial-Tick-Colors.git
-commit=00774b950795acf3fbe6566b8c3f26f13089c40d
+commit=06dd86c1a101ad04dc4bbad695d646e9c3ad0a76

--- a/plugins/aerial-tick-colors
+++ b/plugins/aerial-tick-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/JadeGerbitz/Aeirial-Tick-Colors.git
-commit=70b959a1fabdbb6b9685f3a223dc29ba4dec7da0
+commit=54dfbe479804d5fe78e0246692ff36e987c85ba1

--- a/plugins/aerial-tick-colors
+++ b/plugins/aerial-tick-colors
@@ -1,2 +1,2 @@
 repository=https://github.com/JadeGerbitz/Aeirial-Tick-Colors.git
-commit=54dfbe479804d5fe78e0246692ff36e987c85ba1
+commit=00774b950795acf3fbe6566b8c3f26f13089c40d

--- a/plugins/aerial-tick-colors
+++ b/plugins/aerial-tick-colors
@@ -1,2 +1,2 @@
-repository=https://github.com/JadeGerbitz/Aeirial-Tick-Colors.git
+repository=https://github.com/JadeGerbitz/Aerial-Tick-Colors.git
 commit=06dd86c1a101ad04dc4bbad695d646e9c3ad0a76

--- a/plugins/aerial-tick-colors
+++ b/plugins/aerial-tick-colors
@@ -1,0 +1,2 @@
+repository=https://github.com/JadeGerbitz/Aeirial-Tick-Colors.git
+commit=70b959a1fabdbb6b9685f3a223dc29ba4dec7da0


### PR DESCRIPTION
My plugin allows the user to select different colors to highlight the fishing spots at aerial fishing based on the number of ticks it will take to catch the fish. The fishing plugin does this already, but it only has colors for 2-tick spots and not 2-tick spots. I think this should help visualize the distance to aerial fishing spots better.