### PR TITLE
Create dynamic-inventory-tags

### DIFF
--- a/plugins/dynamic-inventory-tags
+++ b/plugins/dynamic-inventory-tags
@@ -1,0 +1,2 @@
+repository=https://github.com/BraveH/gear-switch-alert.git
+commit=678a3b4ffe407a7f47d57bd219144a2921024b98

--- a/plugins/dynamic-inventory-tags
+++ b/plugins/dynamic-inventory-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/BraveH/gear-switch-alert.git
-commit=d13074da05857b3783e85921f2ba00be1e75d682
+commit=9f53a1a6a35a072b420fc090f063e7d351226e01

--- a/plugins/dynamic-inventory-tags
+++ b/plugins/dynamic-inventory-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/BraveH/gear-switch-alert.git
-commit=678a3b4ffe407a7f47d57bd219144a2921024b98
+commit=d13074da05857b3783e85921f2ba00be1e75d682


### PR DESCRIPTION
A plugin to tag gear items that are missing from your current switch. Depending on the weapon type equipped, melee/range/magic gear gets highlighted accordingly if they aren't equipped. To set if an item is meant to be defined as Melee gear, Range gear, or Magic gear... shift + right click the item and set it manually.

Useful to identify when a part of a gear switch has not been equipped.