### PR TITLE
Add lizardman-shaman-minion-alert plugin

### DIFF
--- a/plugins/lizardman-shaman-minion-alert
+++ b/plugins/lizardman-shaman-minion-alert
@@ -1,0 +1,2 @@
+repository=https://github.com/baloooouu/lizardman-shaman-minion-alert.git
+commit=72c99d5ccea094e16053d94cb0c270793dde4d10


### PR DESCRIPTION
This plugin plays a sound alert whenever a Lizardman shaman spawns minions.

There is a similar plugin that exists already, however it does not work and the source github seems to be deleted.

Example video:


https://user-images.githubusercontent.com/106890323/232166934-f7120fb5-bf26-40e3-bcf9-3a96a76f5584.mp4

