### PR TITLE
Update nylo-death-indicators to v1.0.7

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=253d5bec65adf1f8f674406f37eedc48a0a50baf
+commit=0c3d0996a3052f8f6a51963b4b46192906f4e3a0


### PR DESCRIPTION
This update adds support for barrage and chin attacks by checking the surrounding nylocas and applying damage if the attack will kill everything it can hit.