### PR TITLE
Update bot-detector to v1.3.9.2

### DIFF
--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,4 +1,4 @@
 repository=https://github.com/Bot-detector/bot-detector.git
-commit=5ffabc78ba6329cbf612cb7778257a7c57f33a08
+commit=db306de03f9f505d83bfceeadeb0db130286f859
 warning=This plugin submits the names, locations, and gear of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic,Cyborger1

--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,4 +1,4 @@
 repository=https://github.com/Bot-detector/bot-detector.git
-commit=db306de03f9f505d83bfceeadeb0db130286f859
+commit=0e2a828bbd9b36de05fc526641ecd28bf1ae6da5
 warning=This plugin submits the names, locations, and gear of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic,Cyborger1


### PR DESCRIPTION
Changed a deprecated variable from Runelite's API.

Changed the plugin's API URL to point to our new subdomain (`api.prd.osrsbotdetector.com`).