### PR TITLE
Add Boss Health Indicators plugin

### DIFF
--- a/plugins/boss-health-indicators
+++ b/plugins/boss-health-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/rugg0064/boss-health-indicators.git
+commit=2ae2df2c32aaa198a2e50aa7a3f032ae80e61a99


### PR DESCRIPTION
Boss Health Indicators is a basic plugin that adds markers on boss health bars.

![ingame](https://user-images.githubusercontent.com/35048262/233190712-c464fe8b-a6a6-41a3-8899-fc4ee5536ee9.png)
![panel](https://user-images.githubusercontent.com/35048262/233190718-35a7f315-dc31-4798-be53-4bfebeebf29a.png)
