### PR TITLE
Update ba-minigame to 1.69

### DIFF
--- a/plugins/ba-minigame
+++ b/plugins/ba-minigame
@@ -1,3 +1,3 @@
 repository=https://github.com/SkylerPIlot/Ba-Minigame.git
-commit=ea4a9a767d5b03dc9387b24602cc4086f1d8e641
+commit=ced5dd804796bbe1a3cb6a9604c39acdd064a9e4
 authors=SkylerPIlot,ransty,equirs


### PR DESCRIPTION
1 liner, fixing penance death infoboxes which broke in the most recent update

edit: ok it's not a 1 line diff because there were some other fixes that didn't go out :pray: 