### PR TITLE
Update instant-inventory to 1.1.1

### DIFF
--- a/plugins/instant-inventory
+++ b/plugins/instant-inventory
@@ -1,2 +1,2 @@
 repository=https://github.com/elgbar/instant-inventory.git
-commit=2d1d45092d5bb343cd29b18600a0f365aee98ccf
+commit=2db3790fdde25becaf25b7f2924b94dfebe7e256


### PR DESCRIPTION
## 1.1.1 - 2023-04-21

### Fixed

* Fix erroneously hiding stacked/noted items when depositing less than all items
