### PR TITLE
Add gotr-leech

### DIFF
--- a/plugins/gotr-leech
+++ b/plugins/gotr-leech
@@ -1,0 +1,2 @@
+repository=https://github.com/QuestingPet/gotr-leech.git
+commit=8aa324d848e3054b7ad2bb861b11ba2ab89d7ccf


### PR DESCRIPTION
Add Guardians of the Rift Leech

Plugin for helping to leech/afk in GotR by obtaining the minimum required points for rewards (150) and then mining the rest of the round. Useful while working.

I'm sorry.