### PR TITLE
Introduce hitsplat-tracker

### DIFF
--- a/plugins/hitsplat-tracker
+++ b/plugins/hitsplat-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/leejt/hitsplat-tracker.git
+commit=64cd889a48bb106688ce25d4f9a913735b3f2091

--- a/plugins/hitsplat-tracker
+++ b/plugins/hitsplat-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/hitsplat-tracker.git
-commit=64cd889a48bb106688ce25d4f9a913735b3f2091
+commit=bf7a3276c5091dd452cd223473831b414f8fefef


### PR DESCRIPTION
This makes tracking hitsplats for combat research (https://oldschool.runescape.wiki/w/RuneScape:Sandbox/combat_pseudocode) significantly easier, by logging them to the client log. Example output:

```
2023-04-22 00:45:17 BST [Client] INFO  c.h.HitsplatTrackerPlugin - NPC name=Loar Shade, id=1277, index=5993 type=16 amount=2 ratio=28
2023-04-22 00:45:26 BST [Client] INFO  c.h.HitsplatTrackerPlugin - SELF type=16 amount=3, ratio=5
2023-04-22 00:45:28 BST [Client] INFO  c.h.HitsplatTrackerPlugin - NPC name=Loar Shade, id=1277, index=5993 type=16 amount=7 ratio=23
2023-04-22 00:45:31 BST [Client] INFO  c.h.HitsplatTrackerPlugin - NPC name=Loar Shade, id=1277, index=5993 type=16 amount=8 ratio=17
2023-04-22 00:45:34 BST [Client] INFO  c.h.HitsplatTrackerPlugin - NPC name=Loar Shade, id=1277, index=5993 type=16 amount=15 ratio=6
2023-04-22 00:45:35 BST [Client] INFO  c.h.HitsplatTrackerPlugin - SELF type=16 amount=2, ratio=5
2023-04-22 00:45:37 BST [Client] INFO  c.h.HitsplatTrackerPlugin - NPC name=Loar Shade, id=1277, index=5993 type=16 amount=1 ratio=5
2023-04-22 00:45:38 BST [Client] INFO  c.h.HitsplatTrackerPlugin - SELF type=16 amount=1, ratio=4
2023-04-22 00:45:40 BST [Client] INFO  c.h.HitsplatTrackerPlugin - NPC name=Loar Shade, id=1277, index=5993 type=16 amount=6 ratio=0
```