### PR TITLE
Create nearby-players plugin

### DIFF
--- a/plugins/nearby-players
+++ b/plugins/nearby-players
@@ -1,0 +1,2 @@
+repository=https://github.com/CreativeTechGuy/nearby-players.git
+commit=0ad0a388b7659247153feaff319512a8e5e794ad


### PR DESCRIPTION
This plugin tracks nearby and recent players and lists them in a panel. This has many uses from being able to lookup/report bots which teleport the instant you see them, see how many players are on your screen, find players in a crowd, etc.