### PR TITLE
Update Dink to v1.4.1

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=7d18a3aaf9191f6049c695f688ad085495d9f403
+commit=cb819f4909bd955114243c0d12048ab335af301f
 authors=Mm2PL,pajlada,Felanbird,iProdigy

--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=dd437d64cf9f7f3116f1d3a5b00ec584846354a4
+commit=7d18a3aaf9191f6049c695f688ad085495d9f403
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.4.0 most notably includes a new notifier to capture player kills while hitsplats are still visible. This version also fixes a bug with death notifications when multiple NPCs without wiki HP data are simultaneously attacking the player.

v1.4.1 also fixes an issue where death notifs would fire in safe instanced regions (e.g., PoH) 

You can find the full release notes at https://github.com/pajlads/DinkPlugin/releases/tag/v1.4.0 & https://github.com/pajlads/DinkPlugin/releases/tag/v1.4.1

