### PR TITLE
Create afkspot-finder

### DIFF
--- a/plugins/afkspot-finder
+++ b/plugins/afkspot-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/branisk/runelite-afkspot-finder.git
-commit=81f9e4c8eb5e1edbc12acf5b71973f5439c01075
+commit=f050fc519f9b6c51947553c5f889d44324882738

--- a/plugins/afkspot-finder
+++ b/plugins/afkspot-finder
@@ -1,0 +1,2 @@
+repository=https://github.com/branisk/runelite-afkspot-finder
+commit=8bfd7293a24a356c885f957b62c136609c9765de

--- a/plugins/afkspot-finder
+++ b/plugins/afkspot-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/branisk/runelite-afkspot-finder.git
-commit=c1871e7ae8801bc5fc8b6fefb774ab839b153a85
+commit=81f9e4c8eb5e1edbc12acf5b71973f5439c01075

--- a/plugins/afkspot-finder
+++ b/plugins/afkspot-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/branisk/runelite-afkspot-finder.git
-commit=a60dcde5cdf6894bbd9843c4900bcecd12d868be
+commit=58a39f50e5b431c3e0b204bdba976e8c97697a61

--- a/plugins/afkspot-finder
+++ b/plugins/afkspot-finder
@@ -1,2 +1,2 @@
-repository=https://github.com/branisk/runelite-afkspot-finder
+repository=https://github.com/branisk/runelite-afkspot-finder.git
 commit=8bfd7293a24a356c885f957b62c136609c9765de

--- a/plugins/afkspot-finder
+++ b/plugins/afkspot-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/branisk/runelite-afkspot-finder.git
-commit=f050fc519f9b6c51947553c5f889d44324882738
+commit=b0e4dcde72f894a59e586f2e0ee44a6b37b20936

--- a/plugins/afkspot-finder
+++ b/plugins/afkspot-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/branisk/runelite-afkspot-finder.git
-commit=b9eeac666d72b9dc0609172366655bc00f7b4211
+commit=c1871e7ae8801bc5fc8b6fefb774ab839b153a85

--- a/plugins/afkspot-finder
+++ b/plugins/afkspot-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/branisk/runelite-afkspot-finder.git
-commit=8bfd7293a24a356c885f957b62c136609c9765de
+commit=b9eeac666d72b9dc0609172366655bc00f7b4211

--- a/plugins/afkspot-finder
+++ b/plugins/afkspot-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/branisk/runelite-afkspot-finder.git
-commit=b0e4dcde72f894a59e586f2e0ee44a6b37b20936
+commit=c8b5730287a729115abdfaefb861f44f0a24824b

--- a/plugins/afkspot-finder
+++ b/plugins/afkspot-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/branisk/runelite-afkspot-finder.git
-commit=c8b5730287a729115abdfaefb861f44f0a24824b
+commit=a60dcde5cdf6894bbd9843c4900bcecd12d868be


### PR DESCRIPTION
This plugin is used for AFKing combat skills, where it finds the tiles with the highest density of NPCs to determine where you should stand in order to spend the most time in combat, and gain the most experience.

For example:
![image](https://user-images.githubusercontent.com/56201891/234699243-9def3305-d99a-4f50-a427-9cf3d4b3dc84.png)
The red squares are the most densely populated squares in this image.

The color of the square denotes how many NPC's have touched the square:
- Red = 3 or more
- Yellow = 2
- Green = 1
