### PR TITLE
Update quest-helper to 4.0.4

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=96949d31436c64a0bc13457f4f2843daddd7dfef
+commit=2243b96b375a106c9ac3b13b24cdd57fea075c8a


### PR DESCRIPTION
Adds a herb run helper. Currently duplicates inaccessible timer classes and relies on the timer Plugin.