### PR TITLE
Create no-new-items

### DIFF
--- a/plugins/no-new-items
+++ b/plugins/no-new-items
@@ -1,2 +1,2 @@
 repository=https://github.com/timwestwood/NoNewItems.git
-commit=b547a7482962c6404c0e276341dc7246ca85ede6
+commit=579931e2cfbbd775404fd19ed50464b44a882091

--- a/plugins/no-new-items
+++ b/plugins/no-new-items
@@ -1,2 +1,2 @@
 repository=https://github.com/timwestwood/NoNewItems.git
-commit=d7e27e4530f0077aefc4ed6dd774c2d8945af085
+commit=eed318cc219b8a629266853ab3bd3d65f9f736c8

--- a/plugins/no-new-items
+++ b/plugins/no-new-items
@@ -1,0 +1,2 @@
+repository=https://github.com/timwestwood/NoNewItems.git
+commit=d7e27e4530f0077aefc4ed6dd774c2d8945af085

--- a/plugins/no-new-items
+++ b/plugins/no-new-items
@@ -1,2 +1,2 @@
 repository=https://github.com/timwestwood/NoNewItems.git
-commit=eed318cc219b8a629266853ab3bd3d65f9f736c8
+commit=b547a7482962c6404c0e276341dc7246ca85ede6


### PR DESCRIPTION
No New Items is a plugin for players who want to maximise their nostalgia by avoiding items which have been added to Old School RuneScape (OSRS) since its initial release. It does so by changing the visual appearance of new items to be bright red, acting as a visual warning. There is also an option to change the in-game name of new items.

By default, the plugin will consider items from the original God Wars dungeon and the armour reward from the easy Varrock diary as new because they weren't present in the game at the time of the backup used to create OSRS. But as these were actually added to the main game in 2007 and may be considered "old school" by many players, there is a toggle to allow such items. Similarly, the plugin will default to recolouring the coin pouches from pickpocketing that replaced coins as part of an update to tackle botting/autoclicking, but this can be toggled too.