### PR TITLE
Update tempoross to 1.4

### DIFF
--- a/plugins/tempoross
+++ b/plugins/tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/nmlynch94/runelite-external-plugins.git
-commit=09ae20bcd71ee3544b64e94d7bee9f3d3acf5a3e
+commit=c5093e93a675e481f456c81aabb286db162c173f


### PR DESCRIPTION
Allow changing the pie wheel timer to ticks or seconds instead.