### PR TITLE
Update ping-grapher to 1.5.2

### DIFF
--- a/plugins/ping-grapher
+++ b/plugins/ping-grapher
@@ -1,2 +1,2 @@
 repository=https://github.com/yuh25/Ping-Grapher.git
-commit=1e32cca29af8e0c814dd08dd98c5cf8957c4b6ad
+commit=c642eda69e4f9d0729253a0cd3628dcfb685d645

--- a/plugins/ping-grapher
+++ b/plugins/ping-grapher
@@ -1,2 +1,2 @@
 repository=https://github.com/yuh25/Ping-Grapher.git
-commit=c642eda69e4f9d0729253a0cd3628dcfb685d645
+commit=fe351113b0be6b8a2d6e5555f131976673bd257b


### PR DESCRIPTION
Make plugin thread-safe (Fix by @iProdigy)
Add warning settings
-Change the colors of the overlay background, graph background, and text when ping or tick reaches a threshold.