### PR TITLE
Update 117 HD to 1.2.7.1

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=dda3ca54d715d776a300e4126e705af8df17af84
+commit=b25f86c3dc89a733338ea5d20069215b80bc8902
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Fixes an AMD shader compile bug with Mesa drivers on Linux.