### PR TITLE
Update boss-health-indicator

### DIFF
--- a/plugins/boss-health-indicators
+++ b/plugins/boss-health-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/boss-health-indicators.git
-commit=d5801197091043396c600c2aa47b23c963b9fd34
+commit=56ebeb3aa2ae1ee281531446cfc93ff962f91bc7

--- a/plugins/boss-health-indicators
+++ b/plugins/boss-health-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/boss-health-indicators.git
-commit=56ebeb3aa2ae1ee281531446cfc93ff962f91bc7
+commit=a34b4573b7aede5492f83bbdb7f5a68f0d634656

--- a/plugins/boss-health-indicators
+++ b/plugins/boss-health-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/boss-health-indicators.git
-commit=66473e35c0f2d2f1e09d0678e10566c0e70f695a
+commit=d5801197091043396c600c2aa47b23c963b9fd34


### PR DESCRIPTION
Change display name from "Boss Health Indicator" to "Boss Health Indicators"
Add boss reordering, as well as collapsing tabs, as shown below:
![image](https://user-images.githubusercontent.com/35048262/236374879-292595c1-45b6-40f6-9142-96ade4455583.png)
