### PR TITLE
Update 117HD to v1.2.7.2

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=b25f86c3dc89a733338ea5d20069215b80bc8902
+commit=fd4b70ac3e3d9434f1713e3ecc97225b04c1c4e3
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This is an attempt at fixing some performance degradation that's been reported since the release of 1.2.7. I've not been able to confirm that this is the sole cause, but this at least takes care of one bug leading to issues with caching UVs.