### PR TITLE
Create Max Hit Calculator Plugin

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=061338a5e137b0f7269cb20ee6752d5f7d20eb38
+commit=72c626268c02979ff32c7219f458e7659c8d60a1

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=93a48b3c5a631fdecc3cb74f6d4f7c5a57dfe7fa
+commit=061338a5e137b0f7269cb20ee6752d5f7d20eb38

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,0 +1,2 @@
+repository=https://github.com/j-cob44/max-hit-calc.git
+commit=b197a14fbba32bbbbac3fc893803a3d8762bdc43

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=ef400d1c835bbcce737f04f7523f923f3306a57b
+commit=d704b476b088aeeb0da34f4499d1301621c91e4f

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=8955922ef8a08ee14c6e3f81a7d8f55cd40c5fc3
+commit=a4f69f39c79329a159e4b5c9b22ec6e41ad4c72e

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=a4f69f39c79329a159e4b5c9b22ec6e41ad4c72e
+commit=4345d4e4ba149a13b8e2c8890dc2f15910a2a473

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=72c626268c02979ff32c7219f458e7659c8d60a1
+commit=ac9b6bfd302e78528c7764b475066b705cc01f2e

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=d8fadf75dc2693d04b6a06386291f0c56b178e43
+commit=93a48b3c5a631fdecc3cb74f6d4f7c5a57dfe7fa

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=bed123c05fdfdc590facc49e6518d10158d5c48e
+commit=f00dd75c4326c44d08839a28697900f86c936f7b

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=2857e6c52fde20d88018ebc3c34a502506eb0709
+commit=bed123c05fdfdc590facc49e6518d10158d5c48e

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=d704b476b088aeeb0da34f4499d1301621c91e4f
+commit=2857e6c52fde20d88018ebc3c34a502506eb0709

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=ac9b6bfd302e78528c7764b475066b705cc01f2e
+commit=ef400d1c835bbcce737f04f7523f923f3306a57b

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=b197a14fbba32bbbbac3fc893803a3d8762bdc43
+commit=8955922ef8a08ee14c6e3f81a7d8f55cd40c5fc3

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=4345d4e4ba149a13b8e2c8890dc2f15910a2a473
+commit=d8fadf75dc2693d04b6a06386291f0c56b178e43


### PR DESCRIPTION
Max Hit Calculator Plugin.
based on the original Max Hit plugin which has not been updated in 2+ years but rewritten mostly from scratch.

Automatically calculates Max Hit, Max Spec Hit, Max Hit Vs Type, and Max Spec Vs Type and displays them to the player. A tooltip will be displayed when hovering over the panel to show what stats will help the player achieve their next max hit. Includes configuration toggles to allow the player to customize what they see in the panel.