### PR TITLE
Update Region Locker to v2.2

### DIFF
--- a/plugins/region-locker
+++ b/plugins/region-locker
@@ -1,3 +1,3 @@
 repository=https://github.com/slaytostay/region-locker.git
-commit=07bdf6e49cfad63a3041c247546ef11a52958cd7
+commit=36ee825cdaa02bab2903ab1c52e2b2e27ffd64e1
 authors=slaytostay,ahooder


### PR DESCRIPTION
This brings the plugin in line with the most recent RuneLite GPU plugin, thus it depends on https://github.com/runelite/runelite/commit/37580e5c72221b067e3c02d3d0131e0e8d5d4c75.

Other changes include some UI QOL.