### PR TITLE
Update 117HD to 1.2.8

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=fd4b70ac3e3d9434f1713e3ecc97225b04c1c4e3
+commit=8510e28ab4dfa3dbd51a207b13fbbc77fdfce0d3
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This brings 117HD in line with the recent RuneLite API changes, and depends on https://github.com/runelite/runelite/commit/37580e5c72221b067e3c02d3d0131e0e8d5d4c7