### PR TITLE
Update 117HD to v1.2.8.1

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=8510e28ab4dfa3dbd51a207b13fbbc77fdfce0d3
+commit=40be936265d3e875019522338be689eb0c747065
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This fixes an issue which caused the plugin to be unusable on macOS.