### PR TITLE
Update 117HD to v1.2.8.2

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=40be936265d3e875019522338be689eb0c747065
+commit=785810829d75d22462bd6939cd4827697f5b0e22
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This fixes a silly mistake which causes the floor at Zebak to appear almost entirely black, among other much less noticeable errors.