### PR TITLE
Prestige, making 92-99 more fun

### DIFF
--- a/plugins/prestige
+++ b/plugins/prestige
@@ -1,2 +1,2 @@
 repository=https://github.com/ckosidow/prestige-levelling.git
-commit=c1061c5e3f01ed7fcb7f0ccdb69f45f303c9f6b8
+commit=cf7246359c303eff67270148fcf3f60f0394c2c2

--- a/plugins/prestige
+++ b/plugins/prestige
@@ -1,2 +1,2 @@
 repository=https://github.com/ckosidow/prestige-levelling.git
-commit=0c321407e5b5011362825e6c111eff0a8aa48372
+commit=40c0cab3d97c6a8b1b9a48f96527b8c7733b8918

--- a/plugins/prestige
+++ b/plugins/prestige
@@ -1,2 +1,2 @@
 repository=https://github.com/ckosidow/prestige-levelling.git
-commit=40c0cab3d97c6a8b1b9a48f96527b8c7733b8918
+commit=4d63f59dfddff629bc2b94a83473014d66c64fc8

--- a/plugins/prestige
+++ b/plugins/prestige
@@ -1,2 +1,2 @@
 repository=https://github.com/ckosidow/prestige-levelling.git
-commit=cf7246359c303eff67270148fcf3f60f0394c2c2
+commit=0c321407e5b5011362825e6c111eff0a8aa48372

--- a/plugins/prestige
+++ b/plugins/prestige
@@ -1,0 +1,2 @@
+repository=https://github.com/ckosidow/prestige-levelling.git
+commit=c1061c5e3f01ed7fcb7f0ccdb69f45f303c9f6b8


### PR DESCRIPTION
Introducing Prestige, a levelling plugin that resets your level from 92 back to 1 and visually doubles your xp rate on your way back to 99.

Includes level messages, fireworks and xp drops.