### PR TITLE
Update 117HD to v1.2.8.5

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=21215f65770453f3b27dfa0c932f2f27d5c221d8
+commit=47c5392ba72a5865312754888323e37b9dfa0083
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Temporary workaround until the next RuneLite version for an issue causing the wrong environment to be applied in some instances during scene loads.