### PR TITLE
Update tog-crowdsourcing - Nav icon too large

### DIFF
--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=fff30f469b7a6cd2f2fbebd8d77f040ecbf31106
+commit=9fbecd05efff386d5374ebb85517210ab80575ec
 warning=This plugin submits your current world number along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=d6d226e07a6d4e6173ecca4590ff0c91c20d22f7
+commit=567ca2ce08d93c909a4ad6936c164859ea883c7a
 warning=This plugin submits your current world number along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=9fbecd05efff386d5374ebb85517210ab80575ec
+commit=38b4c53b24e8678f3b14f8920da6e3535ba44be7
 warning=This plugin submits your current world number along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/tog-crowdsourcing
+++ b/plugins/tog-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/jcarbelbide/tog-crowdsourcing.git
-commit=567ca2ce08d93c909a4ad6936c164859ea883c7a
+commit=fff30f469b7a6cd2f2fbebd8d77f040ecbf31106
 warning=This plugin submits your current world number along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Fix nav icon too large

Was taking 5MB in memory. Resized to 30x30 px