### PR TITLE
Add consumable-cooldowns plugin

### DIFF
--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,0 +1,2 @@
+repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
+commit=dc3ba90ca581e3b63718f13e09c36128e01b33f1

--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,2 +1,2 @@
 repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
-commit=dc3ba90ca581e3b63718f13e09c36128e01b33f1
+commit=e774893de68b309861173cd5d42284601881cbbc

--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,2 +1,2 @@
 repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
-commit=e774893de68b309861173cd5d42284601881cbbc
+commit=55dcfccc8c2a735deac9402426eeab04179c9dbd


### PR DESCRIPTION
Displays cooldown indicators for the various consumable item categories. To help players better understand when and when they can't consume items. See the README for more details.

For rendering the cooldown fill overlay I used the same draw/cache logic as the inventory tags plugin.

![cooldown-indicators-example-1](https://github.com/runelite/plugin-hub/assets/66518222/d1f8a8cb-53ad-4fe4-b18c-b811acb04900)
