### PR TITLE
Add Osrs Profile plugin

### DIFF
--- a/plugins/osrsprofile
+++ b/plugins/osrsprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/mathiasHillmann/OsrsProfilePlugin.git
-commit=de00f7059b60e61796c19189aa0c0ac785d31493
+commit=8f32f5bd732b4fe5df237fbb9c1db5a039fcd38c

--- a/plugins/osrsprofile
+++ b/plugins/osrsprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/mathiasHillmann/OsrsProfilePlugin.git
-commit=5f8848fc113b23fe7eef8d685232a3809221cab7
+commit=de00f7059b60e61796c19189aa0c0ac785d31493

--- a/plugins/osrsprofile
+++ b/plugins/osrsprofile
@@ -1,2 +1,2 @@
 repository=https://github.com/mathiasHillmann/OsrsProfilePlugin.git
-commit=d650233c61c0ffe4bdd04a6b616b275a816c35dc
+commit=5f8848fc113b23fe7eef8d685232a3809221cab7

--- a/plugins/osrsprofile
+++ b/plugins/osrsprofile
@@ -1,0 +1,2 @@
+repository=https://github.com/mathiasHillmann/OsrsProfilePlugin.git
+commit=d650233c61c0ffe4bdd04a6b616b275a816c35dc

--- a/plugins/osrsprofile
+++ b/plugins/osrsprofile
@@ -1,2 +1,3 @@
 repository=https://github.com/mathiasHillmann/OsrsProfilePlugin.git
-commit=8f32f5bd732b4fe5df237fbb9c1db5a039fcd38c
+commit=587e6ba6dfbf06827abf2a46d12ff284c328edd1
+warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.

--- a/plugins/osrsprofile
+++ b/plugins/osrsprofile
@@ -1,3 +1,3 @@
 repository=https://github.com/mathiasHillmann/OsrsProfilePlugin.git
-commit=587e6ba6dfbf06827abf2a46d12ff284c328edd1
+commit=fd45a445e057ace112534f5f4acf5dbc7d297487
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.

--- a/plugins/osrsprofile
+++ b/plugins/osrsprofile
@@ -1,3 +1,3 @@
 repository=https://github.com/mathiasHillmann/OsrsProfilePlugin.git
 commit=fd45a445e057ace112534f5f4acf5dbc7d297487
-warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.
+warning=This plugin submits your player stats and achievements, and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This plugin scrapes the data of the player and sends it to an external server to show your data similar to how RuneScape 3's adventurer's log work.

Data that will be scraped (Not all are tracked at this moment, but will be added as I develop the API and website): Skills, Quests, Slayer monsters log, Collection log, Achievement diaries, Minigames count, Combat tasks, Boss kills.

The website is available at osrsprofile.com

A warning similar to WikiSync would be needed when trying to install the plugin:
![image](https://github.com/runelite/plugin-hub/assets/9846320/8bd01f11-7a2d-4ee0-8c49-541feac2c00f)


Profile with the data scraped:
https://osrsprofile.com/player/H1llman
![image](https://github.com/runelite/plugin-hub/assets/9846320/57ceb130-a41e-45ba-b405-a87e802e5120)

If needed I am on the official RuneLite discord by the name of H1llmann.
