### PR TITLE
Update 117HD to v1.2.8.7

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=78c28c374ed0f4b40408ac69012d935a1e26ee28
+commit=7d9a4cda146692370310f476d368b8efcb034b0f
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Quick fix for an issue with light alignment for odd-sized TileObjects.