### PR TITLE
Update 117HD to v1.2.8.8

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=7d9a4cda146692370310f476d368b8efcb034b0f
+commit=ad721beb2dbbc69aaa7d68b7ba352e9fe94e3cc2
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Prevents crashing in cases where a `LocalPoint` outside an instanced scene leads to out of bounds indexing in RuneLite's `WorldPoint.fromLocalInstance` function.