### PR TITLE
Update 117HD to v1.2.8.9

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=ad721beb2dbbc69aaa7d68b7ba352e9fe94e3cc2
+commit=34f1fce4026612e17ca770c53c5ba30055a08976
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This *should* be the final nail in the coffin for these light positioning issues. Now it just gets local positions directly from `TileObject`s, instead of going local -> potentially instanced world -> real chunk -> instanced local, which resulted in overlapping lights when the same object was present on multiple copies of a room in a POH. And just in case this change somehow broke something unexpectedly again, I've spent a while going through many different lights in different locations, instanced & not, and so far everything appears to be working properly.