### PR TITLE
Add Chrono Plugin to the Plugin Hub

### DIFF
--- a/plugins/chrono
+++ b/plugins/chrono
@@ -1,0 +1,2 @@
+repository=https://github.com/IdylRS/chrono-plugin
+commit=f3f1d20e0e68fd21bbb83fba225dedfd966f6192


### PR DESCRIPTION
Game mode that restricts your account through RuneScape's releases