### PR TITLE
Add Damage Taken Logger

### DIFF
--- a/plugins/damage-taken-logger
+++ b/plugins/damage-taken-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/LittleBitwise/Runelite-DamageTakenLogger.git
-commit=c73f7a5ee4f2d3966ffe767465cc4673ea0eb4d5
+commit=ee925eb12643b1aa88e773c242ee603f248096ac

--- a/plugins/damage-taken-logger
+++ b/plugins/damage-taken-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/LittleBitwise/Runelite-DamageTakenLogger.git
-commit=feaad9c3517ecfd380dc94a13c2dcfd7080d3579
+commit=c73f7a5ee4f2d3966ffe767465cc4673ea0eb4d5

--- a/plugins/damage-taken-logger
+++ b/plugins/damage-taken-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/LittleBitwise/Runelite-DamageTakenLogger.git
-commit=9a32efc4d5bbaa4a3b71417f7ebf99a32d2edc32
+commit=feaad9c3517ecfd380dc94a13c2dcfd7080d3579

--- a/plugins/damage-taken-logger
+++ b/plugins/damage-taken-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/LittleBitwise/Runelite-DamageTakenLogger.git
+commit=9a32efc4d5bbaa4a3b71417f7ebf99a32d2edc32


### PR DESCRIPTION
This plugin displays damage taken in chat, as well as XP gained per kill.

Both are optional, and colors can be configured.

![Total XP per kill](https://imgur.com/FvPoRqC.png)

XP can be displayed as a "per second" rate as well.

![XP per second per kill](https://imgur.com/MdPmp9f.png)

If anyone has a suggestion for a better name _(since this started as just the damage log part)_, I'm open to changing that before this is merged.