### PR TITLE
Create droptracker

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
 commit=1bc1c000d4cfdf178a83511650b184ef92aea9e1
-author=Joel Halen

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,0 +1,3 @@
+repository=https://github.com/joelhalen/droptracker-plugin.git
+commit=1bc1c000d4cfdf178a83511650b184ef92aea9e1
+author=Joel Halen


### PR DESCRIPTION
The DropTracker is an integration with discord webhooks to send loot automatically to loot leaderboards. Clans can set their own leaderboards up by contacting me.
You can come check ours out if you'd like, just hmu! Here's my reddit thread for more reference:
https://www.reddit.com/r/2007scape/comments/13n0q9w/droptracker_a_discord_addon_bot_for_osrs_clans/
Simply put, the plugin just listens for onLootReceived and onNpcLootReceived events and submits webhooks if the serverId config is in our list of servers.