### PR TITLE
Pre-GE - A lite ironman plugin

### DIFF
--- a/plugins/pre-ge
+++ b/plugins/pre-ge
@@ -1,0 +1,2 @@
+repository=https://github.com/plankst/prege-plugin.git
+commit=34b437f6c7c4672e1e9d7b2d3c5a53b041a00fce

--- a/plugins/pre-ge
+++ b/plugins/pre-ge
@@ -1,2 +1,2 @@
 repository=https://github.com/plankst/prege-plugin.git
-commit=34b437f6c7c4672e1e9d7b2d3c5a53b041a00fce
+commit=b437397ecbc0e0f5451bdd8e42172fca9f9cc9a4


### PR DESCRIPTION
A simple plugin that simulates pre Grand Exchange era by disabling any Grand Exchange related menu options.

**Note:**
reopening a pull request due to a messed up properties file