### PR TITLE
Update c-engineer-completed to v1.0.5

### DIFF
--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=1930230fbb1ff86797ac738d1f96505ecb658002
+commit=2c7ac0886434fde0696625b389d6ab294ce905d7


### PR DESCRIPTION
Fixes the collection log setting warning showing after a temporary disconnect