### PR TITLE
Create Guardians Of The Rift Extended plugin

### DIFF
--- a/plugins/guardians-of-the-rift-extended
+++ b/plugins/guardians-of-the-rift-extended
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanCollaert/Guardians-Of-The-Rift-Extended.git
-commit=1e5ec9abb05e55dff77097b59b959538aa8b5ffd
+commit=a5238572e1d0752aabf2c6ec8cc35a9a78025524

--- a/plugins/guardians-of-the-rift-extended
+++ b/plugins/guardians-of-the-rift-extended
@@ -1,0 +1,2 @@
+repository=https://github.com/NathanCollaert/Guardians-Of-The-Rift-Extended.git
+commit=1e5ec9abb05e55dff77097b59b959538aa8b5ffd


### PR DESCRIPTION
The plugin adds the following to the Guardians of the Rift minigame:

### Outlines
* Outline the Deposit Pool when you have runes in your inventory.
* Outline the Great Guardian when you have Guardian Stones in your inventory.
* Outline the Active Guardian Portals / Guardian Portals of which you have the Talisman for.
* Outline the Uncharged Cells Table when you have less than or equal the Uncharged Cells limit in your inventory.
* Outline only the Active Guardian Portals for which you have the sufficient for.
* Outline only the Active Guardian <Elemental/Catalytic/Highest Level/Highest Tier/Highest Profit/Custom> Portal.
### Overlays
* Show Huge Guardian Remains Portal Hint Arrow when one spawns.
* Show Huge Guardian Remains Portal Timer when one spawns.
* Show Active Guardian Portal Timer above portal when activated.
* Show Active Guardian Portal Rune above portal when activated.
* Show Guardian Portal Talisman above portal of which you have the Talisman for.
### Panel
* Show GOTR game start timer.
* Show last Portal spawn timer.
* Show currently saved up elemental/catalytic points.