### PR TITLE
Update fashionscape to 1.2.1

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=d3aac74fb66e8617b87dea0d65c34addbd3502d0
+commit=7b4d72c60f97aad1b525e2f973a73f022bab8494


### PR DESCRIPTION
Data update for new bounty hunter stuff. Allowed unfortified elidinis ward and virtus robes in the plugin since their models are no longer beta placeholders.