### PR TITLE
remove magic-secateurs. No longer needed

### DIFF
--- a/plugins/magic-secateurs
+++ b/plugins/magic-secateurs
@@ -1,2 +1,0 @@
-repository=https://github.com/PISTOLCUPCAKES/magic-secateurs.git
-commit=0e673a61f9a8e9f000e93a745adf040427ea7293


### PR DESCRIPTION
Remove magic-secateurs plugin as it is [no longer needed after Poll 78 changes](https://oldschool.runescape.wiki/w/Magic_secateurs#cite_note-1).