### PR TITLE
Create check-for-spores

### DIFF
--- a/plugins/check-for-spores
+++ b/plugins/check-for-spores
@@ -1,0 +1,2 @@
+repository=https://github.com/123z/check-for-spores.git
+commit=66024b8e859e5018ce38163357de3903c5d47b6a


### PR DESCRIPTION
Notifies the user when a seaweed spore has spawned. Can be set to only check when underwater