### PR TITLE
Create check-for-spores

### DIFF
--- a/plugins/check-for-spores
+++ b/plugins/check-for-spores
@@ -1,0 +1,2 @@
+repository=https://github.com/123z/check-for-spores
+commit=4578a966c1e44c215f955f02f551a7a65d71f1a0


### PR DESCRIPTION
Notifies the user if seaweed spores spawn, can enable to only show the notification when underwater