### PR TITLE
Disable magic-secateurs plugin

### DIFF
--- a/plugins/magic-secateurs
+++ b/plugins/magic-secateurs
@@ -1,2 +1,3 @@
 repository=https://github.com/PISTOLCUPCAKES/magic-secateurs.git
 commit=0e673a61f9a8e9f000e93a745adf040427ea7293
+disabled=true


### PR DESCRIPTION
Disable magic-secateurs plugin as it is no longer needed after Poll 78 changes.