### PR TITLE
Update consumable-cooldowns to 1.0.1

### DIFF
--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,2 +1,2 @@
 repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
-commit=55dcfccc8c2a735deac9402426eeab04179c9dbd
+commit=3d2b7222bdbd4f618e170ce601d81b71ec6ff2b8


### PR DESCRIPTION
Changelog:
- Fixes delay on consuming drinks after eating combo food not being shown
- Fixes reverse order of processing consumed items from queue