### PR TITLE
tobqol - v.1.10.15 api patch

### DIFF
--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=c732be275611bc40bdde1bbd69525e2fd8b04b1b
+commit=f5c8e4c0aa7b9eec07593b80f60d0f11ca063958


### PR DESCRIPTION
Resolves build errors related to `onExternalPluginsChanged`.