### PR TITLE
Update consumable-cooldowns to 1.0.2

### DIFF
--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,2 +1,2 @@
 repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
-commit=3d2b7222bdbd4f618e170ce601d81b71ec6ff2b8
+commit=11a97647456cf9265e32bfc257bd2e3928e0108b


### PR DESCRIPTION
- Adds some missing consumables
- Removed cooldown indicator for absorption potions as these don't have any
- Fixes cooldown indicator for consumables that have a quantity in one item slot (purple sweets)
- Fixes a bug where actions on a consumable with the same item id could not be registered as consumed when that item was already in the action queue
- Items that are consumed 1 or more ticks after the menu option was clicked can now be registered as consumed (i.e. high latency worlds or slow server response).