### PR TITLE
DropTracker bugfixes (v1.0.1)

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=8b695a6f646fd72cbb45303d57d52c44e3da621c
+commit=46eaf0cc33330a3fed3aa8e87b5f5c24d3d83615
 warning=This plugin submits your player name, clan member names, drop data, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=46eaf0cc33330a3fed3aa8e87b5f5c24d3d83615
+commit=0ebcad220bb8820012b163701a6bf7c2d0d9e80f
 warning=This plugin submits your player name, clan member names, drop data, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
An bug was causing new users to be unable to turn the plugin on; it has been resolved