### PR TITLE
Add Jingle Jingle plugin

### DIFF
--- a/plugins/jingle-jingle
+++ b/plugins/jingle-jingle
@@ -1,2 +1,2 @@
 repository=https://github.com/Tayaramisu/JingleJingle.git
-commit=69c7951aaf4dce3616add5a82a4f81238dafb877
+commit=34da913c5cc278fa34599104fa9f008fe9fddb28

--- a/plugins/jingle-jingle
+++ b/plugins/jingle-jingle
@@ -1,2 +1,2 @@
 repository=https://github.com/Tayaramisu/JingleJingle.git
-commit=11728ee66a7e29b39a01178d73552a31ede95a32
+commit=69c7951aaf4dce3616add5a82a4f81238dafb877

--- a/plugins/jingle-jingle
+++ b/plugins/jingle-jingle
@@ -1,0 +1,2 @@
+repository=https://github.com/Tayaramisu/JingleJingle.git
+commit=11728ee66a7e29b39a01178d73552a31ede95a32


### PR DESCRIPTION
Adds customizable jingles for a variety of events that currently don't have jingles (achievement diaries tasks & full completions, mahogany homes, farming contracts).

Jingles are all existing OSRS jingles that are lesser used. The jingles are stored on the "sounds" branch of the repository and are downloaded upon installation of the plugin, in the same manner of the [C Engineer Completed](https://github.com/m0bilebtw/c-engineer-completed) plugin.