### PR TITLE
Updated Emote Clue Items to v4.2.1.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=311667c03b75e26f4214865075f20d5a373ad24e
+commit=8557bc829a64bf956c2dd5e7e30acd752a3f9ee7


### PR DESCRIPTION
This patch features the following updates.

* Fixed warrior guild bank elite clue not correctly synchronising with Watson board. (see [emote-clue-items#93](https://github.com/larsvansoest/emote-clue-items/issues/93))
* Fixed a typo in Khazari Jungle hard clue. (see [emote-clue-items/pull94](https://github.com/larsvansoest/emote-clue-items/pull/94))
* Fixed plugin crash after switching to a newly created profile. (see [emote-clue-items#95](https://github.com/larsvansoest/emote-clue-items/issues/95))
* Fixed plugin induced stutter when loading a new area. (see [emote-clue-items#96](https://github.com/larsvansoest/emote-clue-items/issues/95))
* Updated RuneLite version to 1.10.4. (see [emote-clue-items/pull97](https://github.com/larsvansoest/emote-clue-items/pull/97))