### PR TITLE
Herblorerecipes: fix Shift/Ctrl keybinds

### DIFF
--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,2 +1,2 @@
 repository=https://github.com/climbridecode/herblore-recipes.git
-commit=9447280a06dab4418f4341bead9b866871ffedd4
+commit=3138534bf7d1b9418965f406cc4841907a76a140


### PR DESCRIPTION
Shift/Ctrl keybinds weren't working correctly. This addresses that issue.