### PR TITLE
Add OldSchoolSnitch plugin

### DIFF
--- a/plugins/old-school-snitch
+++ b/plugins/old-school-snitch
@@ -1,3 +1,3 @@
 repository=https://github.com/wkpatrick/old-school-snitch.git
-commit=c4293974147349a0063496789dacf396b63cfc85
+commit=0cd0650cc5f07f589293c0bd4a10e1307452acf3
 warning=This plugin submits your player name, account hash, xp data, drop data, in-game location, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/old-school-snitch
+++ b/plugins/old-school-snitch
@@ -1,3 +1,3 @@
 repository=https://github.com/wkpatrick/old-school-snitch.git
-commit=7346870323e51244675e36cfb3b9af6b3a405afa
+commit=900e0259804658bf11cb4ba31de808cb4e5ac56f
 warning=This plugin submits your player name, account hash, xp data, drop data, in-game location, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/old-school-snitch
+++ b/plugins/old-school-snitch
@@ -1,3 +1,3 @@
 repository=https://github.com/wkpatrick/old-school-snitch.git
-commit=fdff38f23c8d5a5865873cb57e32276a0062633d
+commit=7346870323e51244675e36cfb3b9af6b3a405afa
 warning=This plugin submits your player name, account hash, xp data, drop data, in-game location, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/old-school-snitch
+++ b/plugins/old-school-snitch
@@ -1,3 +1,3 @@
 repository=https://github.com/wkpatrick/old-school-snitch.git
-commit=900e0259804658bf11cb4ba31de808cb4e5ac56f
+commit=c4293974147349a0063496789dacf396b63cfc85
 warning=This plugin submits your player name, account hash, xp data, drop data, in-game location, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/old-school-snitch
+++ b/plugins/old-school-snitch
@@ -1,0 +1,3 @@
+repository=https://github.com/wkpatrick/old-school-snitch.git
+commit=fdff38f23c8d5a5865873cb57e32276a0062633d
+warning=This plugin submits your player name, account hash, xp data, drop data, in-game location, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Old School Snitch is another XP, Loot, and real time in-game location tracker that has a web interface located at https://oldschoolsnit.ch/ . The plugin contains config options (default off) to enable the loot and location tracking. The server also sets character pages to private be default, meaning the collected information can only be viewed by the owner of that character.

An example of the collected data can be seen here: https://oldschoolsnit.ch/character/2vnluqXHkexeaWgQgkuv2s