### PR TITLE
Updated Osrs Profile to latest commit

### DIFF
--- a/plugins/osrsprofile
+++ b/plugins/osrsprofile
@@ -1,3 +1,4 @@
 repository=https://github.com/mathiasHillmann/OsrsProfilePlugin.git
-commit=fd45a445e057ace112534f5f4acf5dbc7d297487
+commit=a952620c52b51cc8ba105eb0f252809e570e0778
 warning=This plugin submits your player stats and achievements, and IP address to a server not controlled or verified by the RuneLite developers.
+authors=H1llman


### PR DESCRIPTION
Fixed these issues with the plugin:
[client.getAccountType() has been deprecated](https://github.com/mathiasHillmann/OsrsProfilePlugin/issues/1)
[Other account profiles that are not the regular game are being tracked](https://github.com/mathiasHillmann/OsrsProfilePlugin/issues/2)

Here are all the changes I have made in a more easily readable format:
https://github.com/mathiasHillmann/OsrsProfilePlugin/pull/3/files

Also changed the author of the plugin to my in game name rather than my real name.