### PR TITLE
Updating dropTracker to v1.1

### DIFF
--- a/package/verification-template/build.gradle
+++ b/package/verification-template/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 		because "discord-rare-drop-notifier"
 	}
 	thirdParty("org.json:json:20200518") {
-		because "discord-rare-drop-notifier"
+		because "discord-rare-drop-notifier, droptracker"
 	}
 	thirdParty("org.jsoup:jsoup:1.13.1") {
 		because "discord-rare-drop-notifier, drop-simulator, fire-beats, loot-table, loot-lookup"

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=032bec6952c9065f5479d2c941ec172e66caf9d3
+commit=9fdf0a08fddccd65fb793b0f3bce30b7fa977960

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=9e58c84efd55d18c3a2535a129f33cf662409173
+commit=62ae7f04c75ead4005f3867e6d24e963165f199d

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=46eaf0cc33330a3fed3aa8e87b5f5c24d3d83615
+commit=4b7506ea36e006bfb66b0b4b1879f521e67e3771
 warning=This plugin submits your player name, clan member names, drop data, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=251a3e82d009cfc414e5cd38b397d56fb9d427ac
+commit=9e58c84efd55d18c3a2535a129f33cf662409173

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=ce8bc205371685f79dd9cfd9afd6365c94ba41b9
+commit=21354a0f51183432f1e4af3bcd66a6e78d16056b

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
 commit=1bc1c000d4cfdf178a83511650b184ef92aea9e1
-author=Joel Halen

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=e51174db2cad9ba403917d73bb0fa071ba9b6cfc
+commit=17d79732ba49f5f80ade38490d49c7dfd0558324

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=91f499c12239636cca74a3ab46af1bdaa845ca8f
+commit=251a3e82d009cfc414e5cd38b397d56fb9d427ac

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,0 +1,3 @@
+repository=https://github.com/joelhalen/droptracker-plugin.git
+commit=1bc1c000d4cfdf178a83511650b184ef92aea9e1
+author=Joel Halen

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
 commit=17d79732ba49f5f80ade38490d49c7dfd0558324
+warning=This plugin communicates with a server that is not controlled by RuneLite (to submit drops), and as a result your IP address is inadvertently shared with the authors.

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=d9ef2abe3ca0e3dd2b2ce80ba791669a85764ff7
+commit=91f499c12239636cca74a3ab46af1bdaa845ca8f

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=6e707089f6d4a43782cd5b6992989ef5460300bd
+commit=325d2aa333ec69cec1061a6383b3ff76dbfe23e9

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=1bc1c000d4cfdf178a83511650b184ef92aea9e1
+commit=4d018501de8037cfe9dd687d531ff34645220ca7

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=21354a0f51183432f1e4af3bcd66a6e78d16056b
+commit=032bec6952c9065f5479d2c941ec172e66caf9d3

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=8b695a6f646fd72cbb45303d57d52c44e3da621c
+commit=46eaf0cc33330a3fed3aa8e87b5f5c24d3d83615
 warning=This plugin submits your player name, clan member names, drop data, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=4d018501de8037cfe9dd687d531ff34645220ca7
+commit=ce8bc205371685f79dd9cfd9afd6365c94ba41b9

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=9fdf0a08fddccd65fb793b0f3bce30b7fa977960
+commit=6e707089f6d4a43782cd5b6992989ef5460300bd

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=62ae7f04c75ead4005f3867e6d24e963165f199d
+commit=b85c3e2feec4cbb420cbdd9d17aa29a7d316db84

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=325d2aa333ec69cec1061a6383b3ff76dbfe23e9
+commit=d9ef2abe3ca0e3dd2b2ce80ba791669a85764ff7

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=17d79732ba49f5f80ade38490d49c7dfd0558324
+commit=8b695a6f646fd72cbb45303d57d52c44e3da621c
 warning=This plugin communicates with a server that is not controlled by RuneLite (to submit drops), and as a result your IP address is inadvertently shared with the authors.

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=b85c3e2feec4cbb420cbdd9d17aa29a7d316db84
+commit=e51174db2cad9ba403917d73bb0fa071ba9b6cfc

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
 commit=8b695a6f646fd72cbb45303d57d52c44e3da621c
-warning=This plugin communicates with a server that is not controlled by RuneLite (to submit drops), and as a result your IP address is inadvertently shared with the authors.
+warning=This plugin submits your player name, clan member names, drop data, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Implemented a few new features, such as a member list populated from the WiseOldMan group members and some bugfixes for screenshots.
Also fixed an incompatibility issue with the Discord Rare Drop Notificater plugin.