### PR TITLE
Update loot-lookup to v1.1.8

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=c2255394d09d81cdf0ece8a487afe635d3afe672
+commit=c50c17a5e1c1d09f67756ef54ce22b296a1c11ad


### PR DESCRIPTION
- Update RuneLite version to latest 1.10.4
- Fix minor issue where text was overlapping for long item names in list view