### PR TITLE
Update quest-helper 4.0.6

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=a3511e4639c2cf7ff6e6bb3f72548d335c9224c1
+commit=7a26bcd665e589802b92ac21c6042e94b03aa297


### PR DESCRIPTION
Small fixes, including for most recent update changes to Archaeology Expert's name.