### PR TITLE
Update Dink to v1.5.2

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=c3a19db4c378f511c3caf5a0ce0097e7c662715f
+commit=e4709b23b23448f6fe22acf4bd01e7031857b323
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.5.2 augments rich embeds with relevant wiki links and fixes some bugs. In particular, death notifications feature improved kept/lost classification of stackable items, and level notifications are more reliable for combat levels.

Full release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.5.2
