### PR TITLE
Motherlode profit tracker

### DIFF
--- a/plugins/Motherlode Profit Tracker
+++ b/plugins/Motherlode Profit Tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Smeety/Motherlode-Profit-Tracker.git
+commit=2b64de05d8702c8796627d84541f0b12d2aa9314

--- a/plugins/Motherlode Profit Tracker
+++ b/plugins/Motherlode Profit Tracker
@@ -1,2 +1,0 @@
-repository=https://github.com/Smeety/Motherlode-Profit-Tracker.git
-commit=2b64de05d8702c8796627d84541f0b12d2aa9314

--- a/plugins/motherlode-profit-tracker
+++ b/plugins/motherlode-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Smeety/Motherlode-Profit-Tracker.git
-commit=f94e2ec2c8972392d3c13935194a1fd674b02eb2
+commit=8f04aa6403b46c7dc321340848de0b9691ceaab7

--- a/plugins/motherlode-profit-tracker
+++ b/plugins/motherlode-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Smeety/Motherlode-Profit-Tracker.git
-commit=2b64de05d8702c8796627d84541f0b12d2aa9314
+commit=f9dc3f42e88ac35f786731359ee136772478927f

--- a/plugins/motherlode-profit-tracker
+++ b/plugins/motherlode-profit-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Smeety/Motherlode-Profit-Tracker.git
+commit=2b64de05d8702c8796627d84541f0b12d2aa9314

--- a/plugins/motherlode-profit-tracker
+++ b/plugins/motherlode-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Smeety/Motherlode-Profit-Tracker.git
-commit=f9dc3f42e88ac35f786731359ee136772478927f
+commit=f94e2ec2c8972392d3c13935194a1fd674b02eb2

--- a/plugins/motherlode-profit-tracker
+++ b/plugins/motherlode-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Smeety/Motherlode-Profit-Tracker.git
-commit=8f04aa6403b46c7dc321340848de0b9691ceaab7
+commit=ce80363a3ee79095d92eef04dd840798a3a8ed11

--- a/plugins/motherlode-profit-tracker
+++ b/plugins/motherlode-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Smeety/Motherlode-Profit-Tracker.git
-commit=ce80363a3ee79095d92eef04dd840798a3a8ed11
+commit=d9bd31c33d55ddfbd8329ba0c729dc7e62d0dc6c


### PR DESCRIPTION
The Motherlode Profit Tracker is an overlay plugin that tracks the profits made at the Motherlode Mine. It provides real-time updates on the accumulated profits, allowing players to easily monitor their earnings. The plugin offers a clear and intuitive interface, displaying essential information such as total profit, profit per hour, and customizable options for a personalized experience. With the Motherlode Profit Tracker, players can efficiently track their mining profits and optimize their gameplay at the Motherlode Mine.