### PR TITLE
Update region-locker to v2.3

### DIFF
--- a/plugins/region-locker
+++ b/plugins/region-locker
@@ -1,3 +1,3 @@
-repository=https://github.com/Adam-/runelite-plugins.git
-commit=87e4b5cdf502e3b6a6e864619a59bc83f24d1abc
+repository=https://github.com/slaytostay/region-locker.git
+commit=727d5f909e9b049976881bbbebb0d3befe266e2a
 authors=slaytostay,ahooder

--- a/plugins/region-locker
+++ b/plugins/region-locker
@@ -1,3 +1,3 @@
 repository=https://github.com/slaytostay/region-locker.git
-commit=727d5f909e9b049976881bbbebb0d3befe266e2a
+commit=96c0234e383a4f7ee2616cb73e941e41a75cf59c
 authors=slaytostay,ahooder


### PR DESCRIPTION
Depends on https://github.com/runelite/runelite/commit/5ef33f53e6912cf9b1930cd47f4b079bfabd5d23

This includes [Adam's fix](https://github.com/slaytostay/region-locker/commit/234598508d7dd76ab2703b2fafd822a299321266) and updates the plugin with the new OpenCL changes, and resets the repository back to what it was prior to https://github.com/runelite/plugin-hub/commit/7eb52225c878eb96e08c1d497c8e2d4556f8b577