### PR TITLE
Create Corrupted Gauntlet Prayer Helper

### DIFF
--- a/plugins/Corrupted Gauntlet Helper
+++ b/plugins/Corrupted Gauntlet Helper
@@ -1,0 +1,2 @@
+repository=https://github.com/PlayerCoder1/Nameless-CG-Plugin.git
+commit=ae1a5ce7ca345ee4aa6b00c14462abf5fc1903f8

--- a/plugins/Corrupted Gauntlet Helper
+++ b/plugins/Corrupted Gauntlet Helper
@@ -1,2 +1,2 @@
 repository=https://github.com/PlayerCoder1/Nameless-CG-Plugin.git
-commit=ae1a5ce7ca345ee4aa6b00c14462abf5fc1903f8
+commit=148831fd97c26c66c6d5ad5ccb9e30742a6054c9


### PR DESCRIPTION
This plugin counts how many attacks the Corrupted Gauntlet did and tells the player what to pray between range and magic