### PR TITLE
Update the-gauntlet

### DIFF
--- a/plugins/the-gauntlet
+++ b/plugins/the-gauntlet
@@ -1,2 +1,2 @@
 repository=https://github.com/rdutta/runelite-gauntlet.git
-commit=b78770d5b4e2d8f10c8ecc389d9644f41b61a80c
+commit=8a22c9b495a0fe565c11f93f5ea1c7b645449755


### PR DESCRIPTION
* Add incremental counting to resource infobox counters

This replicates the behavior of https://runelite.net/plugin-hub/show/gauntlet plugin, which is currently broken and seems to no longer be maintained.