### PR TITLE
Create Trouver Parchment Alerts plugin

### DIFF
--- a/plugins/trouver-parchment-alerts
+++ b/plugins/trouver-parchment-alerts
@@ -1,2 +1,2 @@
 repository=https://github.com/zlight97/trouver-parchment-alert.git
-commit=e07ae4d21596fd2df81dd89ed97ba45c57004c38
+commit=a2df8c1cf603acb5adef8ec38f4fc3fcacc27834

--- a/plugins/trouver-parchment-alerts
+++ b/plugins/trouver-parchment-alerts
@@ -1,0 +1,2 @@
+repository=https://github.com/zlight97/trouver-parchment-alert.git
+commit=c7b66fe91d5d1757310c527d228c667e45956623

--- a/plugins/trouver-parchment-alerts
+++ b/plugins/trouver-parchment-alerts
@@ -1,2 +1,2 @@
 repository=https://github.com/zlight97/trouver-parchment-alert.git
-commit=070ee2fcbc61f62d997aae110b561196ad32e9ef
+commit=e07ae4d21596fd2df81dd89ed97ba45c57004c38

--- a/plugins/trouver-parchment-alerts
+++ b/plugins/trouver-parchment-alerts
@@ -1,2 +1,2 @@
 repository=https://github.com/zlight97/trouver-parchment-alert.git
-commit=c7b66fe91d5d1757310c527d228c667e45956623
+commit=070ee2fcbc61f62d997aae110b561196ad32e9ef

--- a/plugins/trouver-parchment-alerts
+++ b/plugins/trouver-parchment-alerts
@@ -1,2 +1,2 @@
 repository=https://github.com/zlight97/trouver-parchment-alert.git
-commit=a2df8c1cf603acb5adef8ec38f4fc3fcacc27834
+commit=4482b979109c95aa41a668fa71663e7360601ae7


### PR DESCRIPTION
This is a plugin that will notify you when you are carrying an unlocked (unparchmented) item. It can be configured to always be on, or only in pvp zones. It can also be configured to flash.