### PR TITLE
Add Random Screenshot plugin

### DIFF
--- a/plugins/random-screenshot
+++ b/plugins/random-screenshot
@@ -1,2 +1,2 @@
 repository=https://github.com/neeerp/runelite-random-screenshot.git
-commit=ce4dfe04e54b86eaad49982765ca6fb7d082ba01
+commit=22d26013714aaf5d0c22fe905d3b99d76ba957ee

--- a/plugins/random-screenshot
+++ b/plugins/random-screenshot
@@ -1,0 +1,2 @@
+repository=https://github.com/neeerp/runelite-random-screenshot.git
+commit=ce4dfe04e54b86eaad49982765ca6fb7d082ba01


### PR DESCRIPTION
This plugin takes a screenshot with a 1 in `n` chance every game tick, where `n` is configurable.

The base of this plugin was lifted directly from the core Screenshot plugin and simplified significantly.

(This plugin was suggested in https://github.com/runelite/runelite/discussions/16608. Here, it's suggested that this should _not_ be part of the core Screenshot plugin, hence why I've made this plugin hub plugin)