### PR TITLE
DMWatch 1.6a - Update discord link

### DIFF
--- a/plugins/dmwatch
+++ b/plugins/dmwatch
@@ -1,2 +1,2 @@
 repository=https://github.com/DMWatch/DMWatch.git
-commit=ad5e0c9554fb8f8033f6c7357aaad95e701b800a
+commit=58f3d2da45b16279183e186c1fa0cce13ed4f009

--- a/plugins/dmwatch
+++ b/plugins/dmwatch
@@ -1,2 +1,3 @@
 repository=https://github.com/DMWatch/DMWatch.git
 commit=58f3d2da45b16279183e186c1fa0cce13ed4f009
+authors=zguilt


### PR DESCRIPTION
In a recent event the `dm` discord vanity url was removed from our discord, we have taken `dmwatch` instead. The plugin has various links in it to `dm` and this update patches it to be `dmwatch` instead. 