### PR TITLE
Update no-new-items

### DIFF
--- a/plugins/no-new-items
+++ b/plugins/no-new-items
@@ -1,2 +1,2 @@
 repository=https://github.com/timwestwood/NoNewItems.git
-commit=bfab6769374ff9b7ed0b859ba0cc026e1ac49e63
+commit=79f68521d25ff01ed17d106ab442ddfd98e85746


### PR DESCRIPTION
Added a toggle for the versions of the crystal shield and bow whose bonuses don't decrease as the items degrade.

Included Spiritual rangers, warriors and mages in the God Wars toggle (these 'items' are just the icons in the slayer guide).

Added the missing chat warnings for the toggles in the previous update.