### PR TITLE
Update 117HD to v1.2.9.1

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=9cd53a65ea3ecad2eefb1e56f104f12fb05ea003
+commit=020052451191c2dc36a8a7aa1c9470702a137aaf
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Depends on https://github.com/runelite/runelite/commit/5ef33f53e6912cf9b1930cd47f4b079bfabd5d23

This switches our OpenCL code from JOCL to LWJGL's OpenCL bindings.