### PR TITLE
Vital issue with low-value drops for clan events

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=42a046ad0de7afdf3e3b1f54887c61300b7cc5c5
+commit=a39aec910c861796e5c7c0407de74c6133665074
 warning=This plugin submits your player name, clan member names, drop data, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Previously, we selected to remove the npc or event name from low value drops to reduce the size of each embed sent to discord.

This presents an issue for clan events such as the one we are about to run in a few days, where players can obtain the items required for their task by opening implings, etc.

As a result, this update is quite small as it simply adds an extra field to the embed for each message sent; and a speedy approval would be greatly appreciated!