### PR TITLE
Create cbow-animation-stall

### DIFF
--- a/plugins/cbow-animation-stall
+++ b/plugins/cbow-animation-stall
@@ -1,2 +1,2 @@
 repository=https://github.com/ggaviglio/cbow-animation-stall.git
-commit=ac611f5912853e5035d435c097d7a946ba76d9cd
+commit=a41df4d98e7008dfb9a416b4ffd4b3b958032537

--- a/plugins/cbow-animation-stall
+++ b/plugins/cbow-animation-stall
@@ -1,2 +1,2 @@
 repository=https://github.com/ggaviglio/cbow-animation-stall.git
-commit=82a1c65f64274f5b9b05bf92e5efdb1bcf5026d5
+commit=ac611f5912853e5035d435c097d7a946ba76d9cd

--- a/plugins/cbow-animation-stall
+++ b/plugins/cbow-animation-stall
@@ -1,0 +1,2 @@
+repository=https://github.com/ggaviglio/cbow-animation-stall.git
+commit=82a1c65f64274f5b9b05bf92e5efdb1bcf5026d5


### PR DESCRIPTION
Reverts the crossbow animation ID during PVM. Uses the original/PVP animation ID with an animation stall.