### PR TITLE
Add Forestry Plugin

### DIFF
--- a/plugins/forestry
+++ b/plugins/forestry
@@ -1,0 +1,2 @@
+repository=https://github.com/claudiodekker/runelite-forestry.git
+commit=423ce4e696b13984d7b9f0ac34bf73669486867b


### PR DESCRIPTION
This PR adds a RuneLite plugin that makes Forestry easier.

## Features:

- Automatically highlights and helps with Forestry Events.
- Get notified when a Forestry Event occurs while AFK (can be disabled).
- Auto-disable the plugin when you're not carrying an Axe & Forestry Kit (can be customized).
- Displays Forestry Events on your Minimap (can be disabled).
- Ability to customize all highlighting colors (per Forestry Event).
- Ability to customize the Minimap event indicator color, as well as to use the "real" per-event highlighting colors instead of a singular color.
- Ability to customize whether to highlight a tile, the outline of an object, the width of the outline and so forth.

---

**Flowering Tree**:
- Marks all Flower Bushes part of the event.
- Tracks which Flower Bushes you've already checked.
- Tracks which Flower Bush you've obtained the Strange Pollen from.
- Indicates which Flower Bush you're supposed to bring the Strange Pollen to.

**Leprechaun**
- Marks the Leprechaun, so you can easily see where it is.

**Rising Roots**
- Marks all Roots part of the events.
- Indicates the location of a Large Root, making it easier to spot.
- Get notified when a new Large Root spawns while AFK

**Struggling Sapling**
- Marks all Mulch piles that are part of the event.
- Marks the Sapling itself, making it easier to spot.
- Marks all Unidentified Mulch.
- Marks Mulch the Struggling Sapling likes, as well as the slot for which it likes it.
- Once all three Mulches are identified, it marks all other Mulches as Inactive.