### PR TITLE
Add Frost HP & Run

### DIFF
--- a/plugins/frost-hp-run
+++ b/plugins/frost-hp-run
@@ -1,2 +1,2 @@
 repository=https://github.com/erversteeg/Frost-Hp-Run.git
-commit=daaf1adccf0d0500cce896f5bf7a2183f8b85447
+commit=5b128dde4451c524a164885f4d47153f0a421957

--- a/plugins/frost-hp-run
+++ b/plugins/frost-hp-run
@@ -1,0 +1,2 @@
+repository=https://github.com/erversteeg/Frost-Hp-Run.git
+commit=daaf1adccf0d0500cce896f5bf7a2183f8b85447


### PR DESCRIPTION
Frost HP & Run has two parts: an hp bar and a run bar. The hp bar is more of a "main" bar and can have up to all 4 of hp, prayer, run, and special attack bars. The run bar is a second bar that involves only running. Each bar is either always visible (at a set opacity) on the UI or can show and hide depending on the situation. The main bars will show in combat or for each bar that's included and the value of the bar changes (and isn't annoying) like for example when eating, drinking a prayer potion, or when a prayer is active and the run bar shows while moving. The health bar changes color to show envenom, poison, and disease. Prayer bar changes color the show that a prayer is active, and run changes color the show stamina buff.