### PR TITLE
Add Tree Count plugin

### DIFF
--- a/plugins/treecount
+++ b/plugins/treecount
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/tree-count-plugin.git
-commit=06c9d452e22a66c448a1c6fe6577c70ee174012d
+commit=27b9a0bf96785604772cd2e942bcf6cf3efa6c62

--- a/plugins/treecount
+++ b/plugins/treecount
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/tree-count-plugin.git
-commit=9c82ef442e3f674064508c64acafc84721ef1058
+commit=06c9d452e22a66c448a1c6fe6577c70ee174012d

--- a/plugins/treecount
+++ b/plugins/treecount
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/tree-count-plugin.git
-commit=c6ba4330e94c7ab12cfc002c06d218e6fdac1b56
+commit=b978974bdcd8364457f13749d19bc16b2fefd83a

--- a/plugins/treecount
+++ b/plugins/treecount
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/tree-count-plugin.git
-commit=b978974bdcd8364457f13749d19bc16b2fefd83a
+commit=9c82ef442e3f674064508c64acafc84721ef1058

--- a/plugins/treecount
+++ b/plugins/treecount
@@ -1,0 +1,2 @@
+repository=https://github.com/Infinitay/tree-count-plugin.git
+commit=c6ba4330e94c7ab12cfc002c06d218e6fdac1b56

--- a/plugins/treecount
+++ b/plugins/treecount
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/tree-count-plugin.git
-commit=27b9a0bf96785604772cd2e942bcf6cf3efa6c62
+commit=312b95b5ba842b2d463c7558b45d5c830ece9f29


### PR DESCRIPTION
With OSRS's first part of the forestry update, they added invisible boosts to woodcutting depending on the number of players chopping a given tree. This plugin helps users distinguish how many players are chopping a tree by displaying a counter on the tree indicating how many players are currently chopping it.

 
![image](https://github.com/runelite/plugin-hub/assets/6964154/fb26aeee-aaf8-4daa-a820-0a9f692a68de)
