### PR TITLE
Create Highlight Stackable Items

### DIFF
--- a/plugins/Highlight Stackable Items
+++ b/plugins/Highlight Stackable Items
@@ -1,0 +1,2 @@
+repository=https://github.com/horse4lunch/Highlight-Stackable-Items.git
+commit=fa9e830c1b7c37048e6f01a5bb8306a5aa0ae399


### PR DESCRIPTION
Highlights stackable items if you are carrying them.
Example. If you have fire runes in your inventory fire rune drops will be highlighted on the ground. 