### PR TITLE
Update 117HD to v1.2.9.2

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=fcbcbd368e0a9c7a2513540b14431ccab4ba223f
+commit=c741e4ee39cda76d1bdafb3039b30f263f50eede
 authors=RS117,sosodev,ahooder

--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=020052451191c2dc36a8a7aa1c9470702a137aaf
+commit=fcbcbd368e0a9c7a2513540b14431ccab4ba223f
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This should fix an issue with OpenCL choosing a CPU device instead of the GPU device on some Apple M1 Macs. Does not fix the remaining OpenCL issues.