### PR TITLE
fix group-ironmen-tracker Overall skill removal

### DIFF
--- a/plugins/group-ironmen-tracker
+++ b/plugins/group-ironmen-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/christoabrown/group-ironmen-tracker.git
-commit=cf7e11e58b4860a158549295f5fab2fd1bc0107e
+commit=eb07a8b303756040ba7027be35c0a1c9b5a72ebe


### PR DESCRIPTION
Removing the "Overall" skill from being tracked as it was removed from the runelite api.