### PR TITLE
Update customizable-xp-drops to v1.7.3.2

### DIFF
--- a/plugins/customizable-xp-drops
+++ b/plugins/customizable-xp-drops
@@ -1,2 +1,2 @@
 repository=https://github.com/l2-/template-plugin.git
-commit=50c4c18b1304bfbec66276f009e78545243dfdff
+commit=76ad3d0749b3c24020635880cfe866a9daff8eea


### PR DESCRIPTION
Fix the xp tracker not rendering and throwing errors in client log because of the removal of Skill.Overall