### PR TITLE
Random Event Analytics: Remove Deprecated `Skill.OVERALL` & Timer Enhancements

### DIFF
--- a/plugins/random-event-analytics
+++ b/plugins/random-event-analytics
@@ -1,2 +1,2 @@
 repository=https://github.com/zmanowar/random-event-analytics.git
-commit=e88e1cc24e765ea25b12601383d7e825c39bdf8f
+commit=637b9d3d453f19197ef981322a4d301b9bac76e4


### PR DESCRIPTION
Removes the `Skill.OVERALL` reference -- fixes https://github.com/zmanowar/random-event-analytics/issues/16: events not being logged correctly & timers not resetting.

- Includes configuration for timer enhancements (tooltips and display)
- Includes icon for plugin hub.