### PR TITLE
Update Dink to v1.5.3

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=e4709b23b23448f6fe22acf4bd01e7031857b323
+commit=096b312dad3cad5cad0608c21c0fde920ac90f51
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Removal of `Skill.OVERALL` usage, level notifier bugfix, and new override value for `Notify Interval` in level notifier.


Full release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.5.3