### PR TITLE
update tombs-of-amascut to v2.4.1

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tombs-of-amascut.git
-commit=9cc2826d6d264b626307b98a518fb3d353598bc4
+commit=470defc8064e347e87e90e41430af015f32bc7c5


### PR DESCRIPTION
always shows left-right columns for health bars, needed for determining groups of players at certain pieces of content