### PR TITLE
Create forestrycc

### DIFF
--- a/plugins/forestrycc
+++ b/plugins/forestrycc
@@ -1,0 +1,2 @@
+repository=https://github.com/rangdevelopment/root-tracker.git
+commit=9308234430b3afb5224b04627bdf77d867744057

--- a/plugins/forestrycc
+++ b/plugins/forestrycc
@@ -1,2 +1,2 @@
 repository=https://github.com/rangdevelopment/root-tracker.git
-commit=9308234430b3afb5224b04627bdf77d867744057
+commit=eb034f16563a28cc5088cdaa50b9dae605205940

--- a/plugins/forestrycc
+++ b/plugins/forestrycc
@@ -1,2 +1,2 @@
 repository=https://github.com/rangdevelopment/root-tracker.git
-commit=eb034f16563a28cc5088cdaa50b9dae605205940
+commit=32485b3e77dce8768ed22d53d4ec0a23ad2d9378


### PR DESCRIPTION
A plugin for tracking forestry events in a CC such as roots, mulch, and saps. When users type messages in chat, this plugin creates/destroys timers. 