### PR TITLE
Update 117HD to v1.2.9.4

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=efe6c7004c1b6e6009b49e97db88b15b7a72e8ea
+commit=829180ca58edb57fd2996dac69b44822014f22a2
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Ensure all buffers are initialized, even when no models are submitted to compute shaders. On Apple M2 Max this should avoid a crash when zero tiles are drawn, which could happen either with draw distance set to zero, or by using the blindfold plugin.