### PR TITLE
Update statussocket

### DIFF
--- a/plugins/statussocket
+++ b/plugins/statussocket
@@ -1,2 +1,2 @@
 repository=https://github.com/The-Jani/StatusSocket.git
-commit=02fb0c7df979315a1f2f5ce157b657744d889d0e
+commit=3265a8bae632a3cc31ca18f53cb4b117fd8fe45b

--- a/plugins/statussocket
+++ b/plugins/statussocket
@@ -1,2 +1,2 @@
-repository=https://github.com/DStatIO/StatusSocket.git
-commit=2a55f01ee1fbc8f9cee95bc28cf0f49b8747ecd4
+repository=https://github.com/The-Jani/StatusSocket.git
+commit=02fb0c7df979315a1f2f5ce157b657744d889d0e


### PR DESCRIPTION
Removed Skill.OVERALL from the fetch list, as of it's deprecated since RuneLite 1.10.6.

Plugin seems to be abandoned.