### PR TITLE
Update statussocket

### DIFF
--- a/plugins/statussocket
+++ b/plugins/statussocket
@@ -1,2 +1,2 @@
 repository=https://github.com/The-Jani/StatusSocket.git
-commit=7d9463fca06c6a1af2163370499c0d69f3a1ca57
+commit=5bdb8395230cf156bb8f19a3e3fbc681c4fc7048

--- a/plugins/statussocket
+++ b/plugins/statussocket
@@ -1,2 +1,2 @@
-repository=https://github.com/DStatIO/StatusSocket.git
-commit=2a55f01ee1fbc8f9cee95bc28cf0f49b8747ecd4
+repository=https://github.com/The-Jani/StatusSocket.git
+commit=7d9463fca06c6a1af2163370499c0d69f3a1ca57


### PR DESCRIPTION
Updated plugin to work with the most recent version of RuneLite, removed Skill.OVERALL from the fetch list, as of it's deprecated since v1.10.6.

Plugin seems to be abandoned.