### PR TITLE
Update boss health indicators

### DIFF
--- a/plugins/boss-health-indicators
+++ b/plugins/boss-health-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/boss-health-indicators.git
-commit=33b116479bba5fefa98ce91785409aabe9f4decc
+commit=248da1e4dcdb0c92e19d4a9e5addde9b87e0616e

--- a/plugins/boss-health-indicators
+++ b/plugins/boss-health-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/boss-health-indicators.git
-commit=a34b4573b7aede5492f83bbdb7f5a68f0d634656
+commit=33b116479bba5fefa98ce91785409aabe9f4decc


### PR DESCRIPTION
Update boss health indicators to add two new features:
Config option to hide the side bar panel
![image](https://github.com/runelite/plugin-hub/assets/35048262/bad05b38-e965-4c2c-b101-01d8dd96faf1)

Trigger runelite notifications whenever an hp % threshold is reached on enabled indicators
![image](https://github.com/runelite/plugin-hub/assets/35048262/a90952eb-35ee-4349-b95a-d52ca306ac6d)
![notifications](https://github.com/runelite/plugin-hub/assets/35048262/bc17399b-e21f-4c74-97cc-8cadf5e1d517)
