### PR TITLE
Add GOTR Essence Counter Plugin

### DIFF
--- a/plugins/gotr-essence-counter
+++ b/plugins/gotr-essence-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/kentor/gotr-essence-counter.git
+commit=e1d2e393086f0e91f394ee67974859391020a715


### PR DESCRIPTION
Plugin for counting guardian essences crafted or mined during a game of Guardians of the Rift.