### PR TITLE
Dmwatch 1.7 + base repo owner change

### DIFF
--- a/plugins/dmwatch
+++ b/plugins/dmwatch
@@ -1,3 +1,3 @@
 repository=https://github.com/zguilt/DMWatch.git
-commit=a66416935e7fa19e4bc464a03712388c340b9b21
+commit=0ef646fa1cdcc8c22d8fa79a2d86c4c39ba8262a
 warning=This plugin interacts with a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/dmwatch
+++ b/plugins/dmwatch
@@ -1,3 +1,3 @@
-repository=https://github.com/DMWatch/DMWatch.git
-commit=e6694966c2e0071fa08b02f6a6acd0a7765048c9
-authors=zguilt
+repository=https://github.com/zguilt/DMWatch.git
+commit=a66416935e7fa19e4bc464a03712388c340b9b21
+warning=This plugin interacts with a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
The DMWatch org account owner is no longer around, might as well do the development from the dev account anyhow.

The website that the plugin will now interact with is a live end point that gets the name updates of scammers, relying on github  has a 5 minute cache delay.

By offering closer to real time data by default we will help protect people from serial scammers that name change 20 times in a day. 