### PR TITLE
Added ring-of-forging-helper plugin

### DIFF
--- a/plugins/ring-of-forging-helper
+++ b/plugins/ring-of-forging-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/asundr/rof-helper.git
+commit=ea6f06714f5b5d7d9e0aa09f2399bea5aa09e779

--- a/plugins/ring-of-forging-helper
+++ b/plugins/ring-of-forging-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/asundr/rof-helper.git
-commit=ea6f06714f5b5d7d9e0aa09f2399bea5aa09e779
+commit=a6390ddc7a86d06272a66fe9994c98ebae4e07c7


### PR DESCRIPTION
This plugin aids the player when smelting iron with the Ring of Forging by:
- Alerting them when a ROF is not equipped through
    - System notifications
    - Warning text box on screen
- Highlighting either ROF or iron ore in the bank depending on whether the player has ROF equipped
- Providing an icon that keeps track of the current remaining ROF charges