### PR TITLE
Update autocasting

### DIFF
--- a/plugins/autocast-utilities
+++ b/plugins/autocast-utilities
@@ -1,3 +1,3 @@
 repository=https://github.com/jcarbelbide/autocasting.git
-commit=a0d1f13a9063d71ad2b9ebe74200ee48dfab441d
+commit=5502c016af801d8399c822d2b13b3de4843a9f72
 authors=jcarbelbide,zbruennig


### PR DESCRIPTION
New plugin hub description
Commits were squashed so diff is much smaller than the one the bot links. With [two-dot](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons) diff:
[a0d1f13a9063d71ad2b9ebe74200ee48dfab441d..5502c016af801d8399c822d2b13b3de4843a9f72](https://github.com/jcarbelbide/autocasting/compare/a0d1f13a9063d71ad2b9ebe74200ee48dfab441d..jcarbelbide:5502c016af801d8399c822d2b13b3de4843a9f72)