### PR TITLE
Adds OSRS Archipelago plugin

### DIFF
--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=5ae037b7bc26be12526616bfe696e8c4079f1440
+commit=c8ba7199313f3adbdb1fae28ae327d25000a4c68

--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=3adc267497ed4570b4cf379f2a21fd5478091725
+commit=f2f861f1bdba3a6e50d0a0c73271470a2ae69913

--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=f2f861f1bdba3a6e50d0a0c73271470a2ae69913
+commit=d99f8d7e8b76de9ac5e277b700bf99533b863042

--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=d99f8d7e8b76de9ac5e277b700bf99533b863042
+commit=d5b963c9f420bc123a943f3ec342aa8b09e66b09

--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=c8ba7199313f3adbdb1fae28ae327d25000a4c68
+commit=6f80aac7a5d218807f5efccbe0610067dda124a5

--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,0 +1,2 @@
+repository=https://github.com/digiholic/osrs-archipelago.git
+commit=3adc267497ed4570b4cf379f2a21fd5478091725

--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=d5b963c9f420bc123a943f3ec342aa8b09e66b09
+commit=5ae037b7bc26be12526616bfe696e8c4079f1440


### PR DESCRIPTION
Adds a plugin for connecting to a Multiworld Randomizer generated by [Archipelago.gg](https://archipelago.gg/)

The Archipelago program will generate a series of randomized tasks that can be completed to unlock items for the player, or any other player in a different game connected to the same server, allowing a co-operative game mode that can connect OSRS to other players or even entirely different video games.