### PR TITLE
Update max-hit-calculator to v1.1.5

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=4988431151a7be6751480c19efdfcecba8135663
+commit=de12a266ff4d01bba6c24f8090aa4d8658e1f02b


### PR DESCRIPTION
Fix for Ranged Throwing Weapon calculations including ammo slot