### PR TITLE
Update quest-helper to 4.0.7

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=a5c8882c2d363493f1c265633e17272ca840d5ac
+commit=ee3580e992d2595269ee92c7a0be3aaca6d7a876

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=8b7c82877b011abf07370b118fc82562d6e191ca
+commit=a5c8882c2d363493f1c265633e17272ca840d5ac

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=ee3580e992d2595269ee92c7a0be3aaca6d7a876
+commit=8f415632ee80e7946b989dadaebdebbaf5f53ab1


### PR DESCRIPTION
A couple small fixes to existing helpers, and updates the tree IDs to match new Forestry IDs.

This should build once the newest version of Runelite is live.

Edit: Now has a helper for the barrows miniquest.