### PR TITLE
Add left-click-bank-actions plugin

### DIFF
--- a/plugins/left-click-bank-actions
+++ b/plugins/left-click-bank-actions
@@ -1,0 +1,2 @@
+repository=https://github.com/evanblaine/left-click-bank-actions.git
+commit=6772fa726525ea7d3f232f98d0e2aa3a5394040c


### PR DESCRIPTION
Adds configurable item equipping, eating, and drinking directly from the bank interface using only the mouse.