### PR TITLE
Day & night brightness plugin

### DIFF
--- a/plugins/day-night-brightness
+++ b/plugins/day-night-brightness
@@ -1,2 +1,2 @@
 repository=https://github.com/larswolters98/runelite-day-night-brightness-plugin.git
-commit=98ba0dc06acd375dc3e8e929eba5a56ff78cac65
+commit=bff6c9cc399c8f9d85b9f391980d1570212e5800

--- a/plugins/day-night-brightness
+++ b/plugins/day-night-brightness
@@ -1,0 +1,2 @@
+repository=https://github.com/larswolters98/runelite-day-night-brightness-plugin.git
+commit=29c273992815d16c39d85549ae01b2b26321bd15

--- a/plugins/day-night-brightness
+++ b/plugins/day-night-brightness
@@ -1,2 +1,2 @@
 repository=https://github.com/larswolters98/runelite-day-night-brightness-plugin.git
-commit=29c273992815d16c39d85549ae01b2b26321bd15
+commit=98ba0dc06acd375dc3e8e929eba5a56ff78cac65

--- a/plugins/day-night-brightness
+++ b/plugins/day-night-brightness
@@ -1,2 +1,2 @@
 repository=https://github.com/larswolters98/runelite-day-night-brightness-plugin.git
-commit=bff6c9cc399c8f9d85b9f391980d1570212e5800
+commit=7a4021d348c9ab6b2fdb9a454abb0ce5af3b8448


### PR DESCRIPTION
This is a simple plugin for setting your client's brightness based on the current time to imitate a day and night
effect. When enabled, the plugin will set your brightness level when logging in. All feedback is welcome of course.