### PR TITLE
Update nylo-death-indicators to v1.0.8

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=0c3d0996a3052f8f6a51963b4b46192906f4e3a0
+commit=fa070ce2afe0e9dd690d1b4bbd4797a0e0a3d7b0


### PR DESCRIPTION
This update adds the blade of saeldor, dragon claws, and voidwaker to the list of melee weapons as well as fixes an issue where barrages and chins do not work for users with 200m xp in hitpoints or ranged respectively.