### PR TITLE
Update konar-milestone-reminder with slayer master hiding

### DIFF
--- a/plugins/konar-milestone-reminder
+++ b/plugins/konar-milestone-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/michael-gutman/konar-milestone-reminder.git
-commit=ccabbe9423c6c46a4269c90ca85c45b64c4aadab
+commit=75e8cddf7ed62ab4d39fc7545268a73de0a00972


### PR DESCRIPTION
Adds the ability to hide non-Konar slayer masters when Konar reminder is active.
Props to @Henness0666 