### PR TITLE
Update Dink to v1.6.0

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=096b312dad3cad5cad0608c21c0fde920ac90f51
+commit=6405bfc8cfdada31498215e10eb94c3730e9aa6a
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.6.0 adds a new notifier for Grand Exchange transactions, and allows a level notification to be sent upon reaching max skill experience (200M).

Full release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.6.0
