### PR TITLE
Add "ABC Alchemy" plugin. 

### DIFF
--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=c0e1952800e810bc3144dd2217d51afb1b77517e
+commit=75b7d27b40e20ca34625ece352d62bc4820b9f31
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=6ed96ed0f7986fdb0ab032777def766919b25554
+commit=c0e1952800e810bc3144dd2217d51afb1b77517e
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=40083fa382660f5b3f65d2e835b5d3ff2d6e8dd8
+commit=8842404d77aa7d44a99f82ad36268a981c06ef74
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=1ae41d9eafb415b8edecdbc01b5a5dff24c1c9da
+commit=f3a366c64cf621bbeae795189920445d0f85a118
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,0 +1,3 @@
+repository=https://github.com/vartan/abc-alch.git
+commit=6ed96ed0f7986fdb0ab032777def766919b25554
+authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=10c1d179e1f3cfb0704eed1cd5a804b31c1639d6
+commit=40083fa382660f5b3f65d2e835b5d3ff2d6e8dd8
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=1ee08d1f4c74a9263d304d47826085818e1e6b83
+commit=ea59fb354e314cb192cda2d57251044e83b9b757
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=e862c9ff4e97fde31586285fb78b6e77b80efd51
+commit=427023ac5464a397b8fbdcc87588f390567052e1
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=cf23a3b36c422140cb14eab66a2f059906f64083
+commit=e862c9ff4e97fde31586285fb78b6e77b80efd51
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=8842404d77aa7d44a99f82ad36268a981c06ef74
+commit=1ae41d9eafb415b8edecdbc01b5a5dff24c1c9da
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=427023ac5464a397b8fbdcc87588f390567052e1
+commit=10c1d179e1f3cfb0704eed1cd5a804b31c1639d6
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=8d2711bcdc2428370462b65113639f944ff2f2b1
+commit=cf23a3b36c422140cb14eab66a2f059906f64083
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=2d95b078a5d90ea78387ed0ce5f302e5d67bc81f
+commit=1ee08d1f4c74a9263d304d47826085818e1e6b83
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=75b7d27b40e20ca34625ece352d62bc4820b9f31
+commit=8d2711bcdc2428370462b65113639f944ff2f2b1
 authors=Vartan

--- a/plugins/abc-alch
+++ b/plugins/abc-alch
@@ -1,3 +1,3 @@
 repository=https://github.com/vartan/abc-alch.git
-commit=f3a366c64cf621bbeae795189920445d0f85a118
+commit=2d95b078a5d90ea78387ed0ce5f302e5d67bc81f
 authors=Vartan


### PR DESCRIPTION
This plugin includes 2 major features:

1. An overlay that highlights the intersection between the alchemy spell and the optimal inventory slot.
2. A sidebar panel that shows the most profitable items to alch. All prices use RuneLite APIs.