### PR TITLE
Update consumable-cooldowns to 1.1.0

### DIFF
--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,2 +1,2 @@
 repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
-commit=11a97647456cf9265e32bfc257bd2e3928e0108b
+commit=b544aae3d743d68934401de5d02ed2eab972e9fe


### PR DESCRIPTION
- Adds seconds and milliseconds cooldown text overlay mode
- Add pie and bottom-to-top cooldown indicator modes
- Adds support for a few consumable items that I missed before