### PR TITLE
DMWatch 2.0 update

### DIFF
--- a/plugins/dmwatch
+++ b/plugins/dmwatch
@@ -1,3 +1,3 @@
 repository=https://github.com/DMWatch/DMWatch.git
-commit=c8733d893dc57425dc547c1a3e23960cf2f7fa45
+commit=998fcb9fcf47d05e7783c02cb088110366ce68a4
 authors=zguilt

--- a/plugins/dmwatch
+++ b/plugins/dmwatch
@@ -1,3 +1,3 @@
 repository=https://github.com/DMWatch/DMWatch.git
-commit=c5488f9b5bce7413666a67d52765782a26d4f344
+commit=c8733d893dc57425dc547c1a3e23960cf2f7fa45
 authors=zguilt

--- a/plugins/dmwatch
+++ b/plugins/dmwatch
@@ -1,3 +1,3 @@
 repository=https://github.com/DMWatch/DMWatch.git
-commit=7785a420dc46b0ac72721cdb433339233cc1edec
+commit=c5488f9b5bce7413666a67d52765782a26d4f344
 authors=zguilt

--- a/plugins/dmwatch
+++ b/plugins/dmwatch
@@ -1,3 +1,3 @@
 repository=https://github.com/DMWatch/DMWatch.git
-commit=e6694966c2e0071fa08b02f6a6acd0a7765048c9
+commit=7785a420dc46b0ac72721cdb433339233cc1edec
 authors=zguilt


### PR DESCRIPTION
- Simplify the scam/rank lists to prevent rank spoofs.
- Draw scam icons on people whos rsn does not match transmitted name
- Move the github sync list to github pages (different repo) for quicker syncing, option to use live list though
- Alert when private dm is with a scammer (where hwid/hash matches but not rsn)
- Finally add HP to the side panel
- option to always trust players
- remove onCommandExecuted as it was not used probably
- remove party data submitting the scammer/rank status, it's client side data now
- draw friends chat ranks regardless of being in a friends chat - due to friends chat nukes
- remove search bar, it was useless