### PR TITLE
Add Lamp Lockout Plugin

### DIFF
--- a/plugins/lamp-lockout
+++ b/plugins/lamp-lockout
@@ -1,0 +1,2 @@
+repository=https://github.com/seditionist/lamp-lockout.git
+commit=ceffff40f8f732d84cad918ee609d00393f75497


### PR DESCRIPTION
Remove skill options in lamp interface to prevent accidental XP

### Features

- Default remove all skill options
- Configure which skills to show