### PR TITLE
alch-blocker: v1.3 update

### DIFF
--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/robrichardson13/alch-blocker.git
-commit=3b1ed987a3938c1ee37dee5fa076f621b4b815fe
+commit=30fb54ea09903f926516d2dab57c7eff3e2c2d61


### PR DESCRIPTION
This PR blocks alching items on the block list while using an explorers ring.

![image](https://github.com/robrichardson13/alch-blocker/assets/7288322/0b6facd2-3fae-4879-9d19-58247906f2e0)

Adds a menu option to quickly add items to the blacklist/whitelist:
![image](https://github.com/robrichardson13/alch-blocker/assets/7288322/5b98c4cf-2d23-451b-b37d-82e7a96c653f)
![image](https://github.com/robrichardson13/alch-blocker/assets/7288322/f4118bf2-69df-47d9-b944-1b50a8c6e4e1)


Also changes to use opacity instead of fully hiding the items.
(hiding wasn't always working in the explorer ring interface, was going to make it optional to hide or make transparent)

![image](https://github.com/robrichardson13/alch-blocker/assets/7288322/7d84ffd2-64dc-4a85-81fd-d63679c30e08)

GIF:
![AlchProtect](https://github.com/robrichardson13/alch-blocker/assets/7288322/eea46bae-1110-47da-a1b4-6fc30c322c0a)

closes #3

@RedSparr0w
https://github.com/robrichardson13/alch-blocker/pull/11