### PR TITLE
Update herblorerecipes to v1.7.1

### DIFF
--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,2 +1,2 @@
 repository=https://github.com/climbridecode/herblore-recipes.git
-commit=3138534bf7d1b9418965f406cc4841907a76a140
+commit=f40d245f6de6d62779977f953107f6ee3d0c8586


### PR DESCRIPTION
Adds support for toggling tooltip on Imp Repellent & its ingredients bc the tooltip is so long.