### PR TITLE
Create emblem-trader-skull-timer

### DIFF
--- a/plugins/emblem-trader-skull-timer
+++ b/plugins/emblem-trader-skull-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/Teekiz/skull-timer.git
+commit=ea661abd89743f2d5a626992211f09409f570d5e


### PR DESCRIPTION
Creates an infobox timer lasting 20 minutes when receiving a skull icon from the Emblem Trader. This will disappear when the player loses the skull (such as on death) or when the timer runs out. It does not create a timer for other skulled status sources (e.g. PKing).