### PR TITLE
Rainbow Rave 1.2.8 - Compatibility with runelite update.

### DIFF
--- a/plugins/rainbow-rave
+++ b/plugins/rainbow-rave
@@ -1,3 +1,3 @@
 repository=https://github.com/geheur/rainbow-rave.git
-commit=47ae712a8bc5eff315fdc73f71f5eb48d7b29c48
+commit=2b39bbbc9718608621f737231f93ea2ada5db5ae
 warning=This plugin shows bright flashing lights.


### PR DESCRIPTION
ground markers plugin changed in a way that caused a bug in rainbow rave.