### PR TITLE
Update nexus-map

### DIFF
--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,2 +1,2 @@
 repository=https://github.com/Antipixel/nexus-map.git
-commit=2c6f316d72cf6076c028e4025958a05c573b89e0
+commit=24bb4e0412542d21ed9e56e1f04094e98870713c


### PR DESCRIPTION
Updated spelling of 'Carrallanger' to reflect change in latest game update, which was causing the teleport spell to become inactive even when unlocked.