### PR TITLE
Update Nexus Menu Map

### DIFF
--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,2 +1,2 @@
 repository=https://github.com/Antipixel/nexus-map.git
-commit=2c6f316d72cf6076c028e4025958a05c573b89e0
+commit=24bb4e0412542d21ed9e56e1f04094e98870713c

--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,2 +1,2 @@
 repository=https://github.com/Antipixel/nexus-map.git
-commit=24bb4e0412542d21ed9e56e1f04094e98870713c
+commit=9639cdc3c0f455f7bddae374fb260426afd8851d


### PR DESCRIPTION
Updated spelling of 'Carrallanger' to reflect change in latest game update, which was causing the teleport spell to become inactive even when unlocked.