### PR TITLE
Update consumable-cooldowns to 1.1.1

### DIFF
--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,2 +1,2 @@
 repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
-commit=b544aae3d743d68934401de5d02ed2eab972e9fe
+commit=94be2311ccca83c906800fde88a8e8b55e36465f


### PR DESCRIPTION
Changelog
- Fixed radius calculation against moving target for pie cooldown indicator that caused some visual artifacts
- Fixed bottom-to-top and pie cooldown indicators not calculating the right progress percentage for items with non regular cooldowns such as summer pies.
- Added support for new consumable items added with desert treasure 2