### PR TITLE
Add plugin vardorvis-projectiles

### DIFF
--- a/plugins/vardorvis-projectiles
+++ b/plugins/vardorvis-projectiles
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/vardorvis-projectiles.git
-commit=b21afe0bf0974a62048cf30a21335ffd88bcf9bd
+commit=c5571a568c5bce98e9243761ab5df9d89b1473db

--- a/plugins/vardorvis-projectiles
+++ b/plugins/vardorvis-projectiles
@@ -1,0 +1,2 @@
+repository=https://github.com/InfernoStats/vardorvis-projectiles.git
+commit=b21afe0bf0974a62048cf30a21335ffd88bcf9bd


### PR DESCRIPTION
This plugin allows the user to change the projectiles of Vardorvis' Head (the prayer disabling attack) to the ones from Inferno, CoX, ToB, or ToA. The current ones are both blue and exceedingly hard to distinguish from each other.