### PR TITLE
Add PVP Protection

### DIFF
--- a/plugins/pvpprotection
+++ b/plugins/pvpprotection
@@ -1,0 +1,2 @@
+repository=https://github.com/pvpProtection/pvpProtection.git
+commit=c92ba32ab9eda7bdcd535a578b968979e2e9c76a


### PR DESCRIPTION
PVP Protection is a spin off & rebrand of the now defunct DMWatch project. The goal is the same, to allow people to be tagged as trusted and to allow people to be tagged as scammers/rushers/ahkers and cheaters. 

This project's features will start off as equal as to what DMWatch 2.0 version was going to launch as and will diverge as the project matures.