### PR TITLE
Add Afk Hellrat Behemoth

### DIFF
--- a/plugins/afk-hellrat-behemoth
+++ b/plugins/afk-hellrat-behemoth
@@ -1,0 +1,2 @@
+repository=https://github.com/FirstTwoWeeks/AfkHellratBehemoth.git
+commit=adf8678d41f9caa3c16da478af7181d6e8dcc643

--- a/plugins/afk-hellrat-behemoth
+++ b/plugins/afk-hellrat-behemoth
@@ -1,2 +1,2 @@
 repository=https://github.com/FirstTwoWeeks/AfkHellratBehemoth.git
-commit=5adee881700475223c985057b5fac2c3753d88f1
+commit=8bdfbcabd7262234b3426e3ea52cbb9e4fc4c6b9

--- a/plugins/afk-hellrat-behemoth
+++ b/plugins/afk-hellrat-behemoth
@@ -1,2 +1,2 @@
 repository=https://github.com/FirstTwoWeeks/AfkHellratBehemoth.git
-commit=adf8678d41f9caa3c16da478af7181d6e8dcc643
+commit=5adee881700475223c985057b5fac2c3753d88f1


### PR DESCRIPTION
This plugin makes it extremely afk to safely fight Hell-Rat Behemoths with your cat.  Using 6.9 billion fight simulations that were done in advance and hard coded into the plugin, this plugin knows when your cat is unlikely to win a fight and you need to heal it.  You can set percent success and low HP thresholds that you will be notified at.  