### PR TITLE
Update NPC ID to 1.2

### DIFF
--- a/plugins/npc-id
+++ b/plugins/npc-id
@@ -1,2 +1,2 @@
 repository=https://github.com/XrioBtw/npc-id.git
-commit=23c7e1e2dff7fcd491b4a3390612678db1b91e3a
+commit=47d77cef917ce9d6b96140ff7b116b687f8b6483


### PR DESCRIPTION
I don't think it is ever legitimately useful to display invisible/null npcs, so I removed them.