### PR TITLE
Re-enable dmwatch

### DIFF
--- a/plugins/dmwatch
+++ b/plugins/dmwatch
@@ -1,4 +1,3 @@
 repository=https://github.com/DMWatch/DMWatch.git
 commit=e6694966c2e0071fa08b02f6a6acd0a7765048c9
 authors=zguilt
-disabled=No longer operating


### PR DESCRIPTION
Due to popular demand, our community has encouraged us to re-release the plugin. 

Since the deactivation of the plugin we have seen many people scamming again due to no ‘Runewatch’ equal for Deathmatching.
 
For the public good of the Deathmatching scene, we would like to see DMWatch back on the hub to be available to help keep scammers accountable like we originally set out to.