### PR TITLE
Update nylo-death-indicators to v1.0.9

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=fa070ce2afe0e9dd690d1b4bbd4797a0e0a3d7b0
+commit=a969e23676b13f1f2e080b0baa824c6eb870a866


### PR DESCRIPTION
One line change to use the correct damage calculation when a player is casting a barrage spell using a powered staff.