### PR TITLE
Bank Multisearch 1.0.1 - prevent breaking bank tags plugin entirely.

### DIFF
--- a/plugins/bank-multisearch
+++ b/plugins/bank-multisearch
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/bank-multisearch.git
-commit=59679440bcac9a4d887065d3919c2dbaa82e4132
+commit=551d3b150a55e3e4aa8069bab7e4e5d3e0b03813


### PR DESCRIPTION
Oops.