### PR TITLE
Slayer tag highlight

### DIFF
--- a/plugins/slayer-tag-highlight
+++ b/plugins/slayer-tag-highlight
@@ -1,0 +1,2 @@
+repository=https://github.com/Mafham/mafham-plugins.git
+commit=fcdde02712e36e29cf599096f43f7403c9457c7a

--- a/plugins/slayer-tag-highlight
+++ b/plugins/slayer-tag-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/Mafham/mafham-plugins.git
-commit=fcdde02712e36e29cf599096f43f7403c9457c7a
+commit=b3c4e23dedd2b45d4cd8a2f886f3c4d8fba0fb1f


### PR DESCRIPTION
Highlights NPCs that are on your slayer task but not interacting with you, and removes them from the highlights once they start interacting. Useful for tagging NPCs in multi-combat slayer to see which ones you haven't clicked on yet

2nd pull request because forgot license file, sorry about that!