### PR TITLE
Update shortest-path to v1.12

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=01c53bb54c68a92e2d70fefb8ac77b75f694e4aa
+commit=d1f2cd65bf26a6b16481a17ebdcc7605b8d6d764


### PR DESCRIPTION
- Updated the collision map to 2023-08-03 to include the Desert Treasure 2 areas
- Added the new BLS fairy ring south of Mount Quidamortem
- Added a missing BKS fairy ring for Zanaris
- Fixed a few smaller stability issues, thanks to @jocopa3
- Pathfinding is now restarted when the user changes an option related to transports
- Added an optional debug panel with information about path length, total nodes, number of transports and calculation time, thanks to @jocopa3
![illustration-debug-panel](https://github.com/runelite/plugin-hub/assets/53493631/301386a6-4fc4-437d-9276-173e8b697221)
