### PR TITLE
Watchdog: v2.14.1 - Remove SoundFiredAlerts, alert filter, mp3 support, and eleven labs tts

### DIFF
--- a/plugins/watchdog
+++ b/plugins/watchdog
@@ -1,3 +1,2 @@
 repository=https://github.com/adamk33n3r/runelite-watchdog.git
-commit=07ec39cd52727b39a4d1868e27d4156d3ce6cb1d
-disabled=Disabled at Jagex's request
+commit=1eb7abf1397dcf5d2502a08cb2cba12c53581d69


### PR DESCRIPTION
Jagex no likey the sound fired alerts, so this removes them.

This also adds the jaco mp3 player, did I do it correctly? 