### PR TITLE
Update examine-tooltip to v1.4.6

### DIFF
--- a/plugins/examine-tooltip
+++ b/plugins/examine-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/examine-tooltip.git
-commit=5521e99d84343d11efc265ca3e4918d4b3c3a154
+commit=a8f933ff418d2e78571dae4fc24f248eb7057bbc


### PR DESCRIPTION
Stretched Mode was causing problems with interface examines because I was using the wrong function to get the canvas bounds.

Fixes https://github.com/Cyborger1/examine-tooltip/issues/11