### PR TITLE
Create name-changer

### DIFF
--- a/plugins/name-changer
+++ b/plugins/name-changer
@@ -1,0 +1,2 @@
+repository=https://github.com/mlgudi/name-swapper.git
+commit=7fb649f3328c8c4bfca666d65945a214cac02a68


### PR DESCRIPTION
Allows users to change specific player names to names of their choosing using a side panel.

Requested by Soup for use during Gielinor Games recordings.