### PR TITLE
Add Low Detail Raids plugin

### DIFF
--- a/plugins/low-detail-raids
+++ b/plugins/low-detail-raids
@@ -1,0 +1,2 @@
+repository=https://github.com/bepzi/runelite-plugins.git
+commit=95bdc7a7df728404ccf64193d252ea5ea7e8644d


### PR DESCRIPTION
This plugin is a fork of [Low Detail Chambers](https://runelite.net/plugin-hub/show/low-detail-chambers) which adds support for the other two raid encounters (Theatre of Blood and Tombs of Amascut). It automatically toggles Low Detail mode whenever the player is inside a raid. This behavior can be toggled per-raid type.