### PR TITLE
Update visual-sounds (Disable plugin at leviathan, TOA etc.)

### DIFF
--- a/plugins/visual-sounds
+++ b/plugins/visual-sounds
@@ -1,4 +1,3 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds.git
 commit=4ce71795f5a53fb1e086daf23e08001bc04db04d
-disabled=Disabled at Jagex's request
 

--- a/plugins/visual-sounds
+++ b/plugins/visual-sounds
@@ -1,4 +1,4 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds.git
-commit=8b1b587028b62bbef02886b45a5947f12b374208
+commit=4ce71795f5a53fb1e086daf23e08001bc04db04d
 disabled=Disabled at Jagex's request
 

--- a/plugins/visual-sounds
+++ b/plugins/visual-sounds
@@ -1,3 +1,3 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds.git
-commit=4ce71795f5a53fb1e086daf23e08001bc04db04d
+commit=ae8b7e9e76f0b5c6d883184df51401fc15af6d83
 


### PR DESCRIPTION
Prevent abuse against bosses and raids. The plugin was recently disabled at Jagex's request. In an attempt to allow this plugin again, it has been disabled at the following locations:

- DT2 bosses (Vardorvis, Leviathan, Whisperer, Sucellus)
- Vorkath
- Inferno & TzHaar Fight Cave
- Raids (Cox, ToB, ToA)

--- 

Since the plugin was taken down yesterday, I've had multiple D/deaf and colorblind players reach out to me saying how disappointed they are that the plugin is no longer available. If there is anything else that can be done to allow this plugin again, please let me know
