### PR TITLE
Sololegends: Update friend-finder  v1.2.1

### DIFF
--- a/plugins/friend-finder
+++ b/plugins/friend-finder
@@ -1,3 +1,3 @@
 repository=https://github.com/sololegends/runelite-friend-finder.git
-commit=c9a2b6d8d3f52f23493b70e26728ee0693c340c4
+commit=d8e497d866eabdf2e1dc3ae835f8aac62a758bd2
 warning=This plugin submits your rsn, player location, health, prayer level, and your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/friend-finder
+++ b/plugins/friend-finder
@@ -1,3 +1,3 @@
 repository=https://github.com/sololegends/runelite-friend-finder.git
-commit=8a5751c5c26213b56f5a8d8f784b4f30974e13a0
+commit=c9a2b6d8d3f52f23493b70e26728ee0693c340c4
 warning=This plugin submits your rsn, player location, health, prayer level, and your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
# Release v1.2.1

Various bug fixes and minor updates 

- Added prune to the Friends panel when friend goes offline 
- Added expiration time to friend panel for offline friends 
- Fixed info_updated never getting reset to false after update sent 
- Fixed the plugin display name in the plugin install list
- Fixed prayer max value being sent also as prayer current/boosted value 
- Added player ID to the posted API payload for API hardening
- Fixed map points not clearing when no friends online