### PR TITLE
Update Dink to v1.6.2

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=6405bfc8cfdada31498215e10eb94c3730e9aa6a
+commit=682539615d23cb8a5c04182c975731179dea700b
 authors=Mm2PL,pajlada,Felanbird,iProdigy

--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=682539615d23cb8a5c04182c975731179dea700b
+commit=170e5af06e29c9b0f4e0bf88853be0834ac6a0fb
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.6.2 most notably fixes loot notifications for the Whisperer kills and avoids duplicate grand exchange notifications for partial trades.

Full release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.6.1 & https://github.com/pajlads/DinkPlugin/releases/tag/v1.6.2
