### PR TITLE
Update radius-markers to v1.9

### DIFF
--- a/plugins/radius-markers
+++ b/plugins/radius-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=862d5fecd7c34fc1b001a88c94fb6e3ab0425099
+commit=b7980aa7c0fd97b82f6987a65fccd3bb69b2d3ff


### PR DESCRIPTION
To make maintaining this plugin a little easier for future boss releases I have decided to no longer support radius marking NPCs without a name, regardless if they are invisible or not.

**You can still mark these NPCs as normal with e.g. [Better NPC Highlight](https://github.com/MoreBuchus/buchus-plugins/tree/better-npc-highlight#better-npc-highlight).**

Examples of specific NPCs where you will no longer be able use radius markers:
- Awakened Leviathan tornadoes
- Duke Sucellus gas vents
- Hunllef tornadoes
- Sepulchre swords and bolts
- Vardorvis swinging axes
- Verzik tornadoes
