### PR TITLE
Create ignore-list-ban-tracker

### DIFF
--- a/plugins/ignore-list-ban-tracker
+++ b/plugins/ignore-list-ban-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/rugg0064/ignore-list-ban-tracker.git
+commit=a3f9e472a62acac8e0e39c8f91095e3f2d5f1155

--- a/plugins/ignore-list-ban-tracker
+++ b/plugins/ignore-list-ban-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/ignore-list-ban-tracker.git
-commit=a3f9e472a62acac8e0e39c8f91095e3f2d5f1155
+commit=87193add59a01ceb57d753271bb98511ced8ae69


### PR DESCRIPTION
Ignore List Ban Tracker is a plugin that utilizes the settings in OSRS that remove banned/muted members from your ignore list to provide feedback to the player on recent bans.