### PR TITLE
Update max-hit-calculator to v1.1.8

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=1ff1546e865d9b6e9ea8668f0a6dd540f8308ebd
+commit=030dbed2a3bef6b74e4da816c62ebfddb4c23ff1


### PR DESCRIPTION
- Bugfixes on Plugin Install and plugin enabling while already logged in (j-cob44/max-hit-calc#15)