### PR TITLE
Update easy-blastfurnace to v1.4.2

### DIFF
--- a/plugins/easy-blastfurnace
+++ b/plugins/easy-blastfurnace
@@ -1,2 +1,2 @@
 repository=https://github.com/Toofifty/easy-blastfurnace.git
-commit=025daa48c55403df1df08fca4799092bf907076c
+commit=9d66feffe020f78e68e6fc94432fb91feba50d63

--- a/plugins/easy-blastfurnace
+++ b/plugins/easy-blastfurnace
@@ -1,2 +1,3 @@
 repository=https://github.com/Toofifty/easy-blastfurnace.git
 commit=9d66feffe020f78e68e6fc94432fb91feba50d63
+authors=hugocowan


### PR DESCRIPTION
I am a maintainer of the easy blastfurnace plugin and have made a new version update. @Toofifty gave me access rights to maintain the repo.

[Changelog](https://github.com/Toofifty/easy-blastfurnace/releases/tag/v1.4.2)