### PR TITLE
Update Dynamic Entity Hider to v1.1.1

### DIFF
--- a/plugins/dynamic-entity-hider
+++ b/plugins/dynamic-entity-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/Jbleezy/runelite-plugins.git
-commit=ad32ae098a8dade4e7f570176657c252283845b9
+commit=82b192ba90f949fae6992ebeedf4805c37b8ef4c


### PR DESCRIPTION
Fixes `shouldDraw` being run on threads other than the client thread.