### PR TITLE
Add citizens plugin

### DIFF
--- a/plugins/citizens
+++ b/plugins/citizens
@@ -1,3 +1,3 @@
 repository=https://github.com/gc/citizens.git
-commit=8bbf3857bc3df18e3495ceebffbf2bd58013e30e
+commit=971baa0ce9252fdeff11e2be9d750661831cdadb
 authors=Magnaboy,Diabolickal

--- a/plugins/citizens
+++ b/plugins/citizens
@@ -1,3 +1,3 @@
-repository=https://github.com/gc/citizens
+repository=https://github.com/gc/citizens.git
 commit=8bbf3857bc3df18e3495ceebffbf2bd58013e30e
 authors=Magnaboy,Diabolickal

--- a/plugins/citizens
+++ b/plugins/citizens
@@ -1,3 +1,3 @@
 repository=https://github.com/gc/citizens.git
-commit=d3bf1bc7f0ce2036448225b0c1db278bed0787e7
+commit=2e0e7f26652e007c7a33780c9b096c219cde518a
 authors=Magnaboy,Diabolickal

--- a/plugins/citizens
+++ b/plugins/citizens
@@ -1,3 +1,3 @@
 repository=https://github.com/gc/citizens.git
-commit=187271ee3523039f33bb0b83a6c150fb4107c757
+commit=d3bf1bc7f0ce2036448225b0c1db278bed0787e7
 authors=Magnaboy,Diabolickal

--- a/plugins/citizens
+++ b/plugins/citizens
@@ -1,0 +1,3 @@
+repository=https://github.com/gc/citizens
+commit=8bbf3857bc3df18e3495ceebffbf2bd58013e30e
+authors=Magnaboy,Diabolickal

--- a/plugins/citizens
+++ b/plugins/citizens
@@ -1,3 +1,3 @@
 repository=https://github.com/gc/citizens.git
-commit=971baa0ce9252fdeff11e2be9d750661831cdadb
+commit=187271ee3523039f33bb0b83a6c150fb4107c757
 authors=Magnaboy,Diabolickal


### PR DESCRIPTION
Repo: https://github.com/gc/citizens
Description: Adds 'fake NPCs' (Citizens for clarity) around the world, which walk/talk/animate. 

If you are loading the plugin into your client to run it locally, you will find the most citizens in varrock.
They despawn when they are too far away from the player (25~ tiles distance from the player).