### PR TITLE
update tombs-of-amascut to v2.4.4

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tombs-of-amascut.git
-commit=f5f52755781afeb427fe09bcddca9b72bd97215d
+commit=8ac909e3f469f0cae347125860a0c25646d4ff68


### PR DESCRIPTION
prevents health bars disappearing in 2-4 scales