### PR TITLE
Add hide-zammy-darkness plugin

### DIFF
--- a/plugins/hide-zammy-darkness
+++ b/plugins/hide-zammy-darkness
@@ -1,0 +1,2 @@
+repository=https://github.com/R-Y-M-R/BrightenZammyPlugin.git
+commit=fb6e7fbb340925efe4b964e2093b3994246873a8


### PR DESCRIPTION
# Overview

This PR adds a new plugin called ``hide-zammy-darkness`` to the plugin hub. It allows the user to hide the Zamorak Godwars Dungeon darkness overlay. This plugin was inspired by a previous OSBuddy plugin I used to use. 

# Legality

I referenced the rules: https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1 and I do not believe my plugin infringes any of the game rules.