### PR TITLE
Update tick-dance-aim-trainer to v1.1.1

### DIFF
--- a/plugins/tick-dance-aim-trainer
+++ b/plugins/tick-dance-aim-trainer
@@ -1,2 +1,2 @@
 repository=https://github.com/929482/tick-dance-aim-trainer.git
-commit=4ee7027bd691cd764fa901f6c24dfd4d12e89488
+commit=24c79d645f7c7ac4b734a022fa2a5168f78d86ca


### PR DESCRIPTION
Moves the plugin's menu entries to a submenu.