### PR TITLE
Transfer Ownership of "Inventory Total" Plugin

### DIFF
--- a/plugins/inventory-total
+++ b/plugins/inventory-total
@@ -1,2 +1,2 @@
-repository=https://github.com/erversteeg/inventorytotal.git
+repository=https://github.com/MosheBenZacharia/inventorytotal.git
 commit=7efeb7133c1bda17c38b0d52f5d02473371f3eab


### PR DESCRIPTION
Hello,

The plugin has not seen updates in three months and is seemingly abandoned. Me and a friend have made multiple attempts to reach out to the owner of the plugin to no avail:

3 weeks ago: https://github.com/erversteeg/inventorytotal/issues/4 
1 week ago: https://github.com/erversteeg/inventorytotal/issues/5

We're also unable to find the author's discord or email.

I've worked on some changes over the past several weeks and I'm hoping to get a head start on ownership transfer now.