### PR TITLE
Add Tick Fixer for Mac plugin

### DIFF
--- a/plugins/tick-fixer-for-mac
+++ b/plugins/tick-fixer-for-mac
@@ -1,0 +1,2 @@
+repository=https://github.com/jonathangarelick/tick-fixer.git
+commit=60d63ae652b50c0e35d7e290f4e809a7e9303770


### PR DESCRIPTION
This plugin simply pings the local gateway every 200ms in order to prevent a Mac energy saving feature from creating extra packet latency. 

You can see more information here
https://www.reddit.com/r/2007scape/comments/165nhch/huge_increase_in_tick_quality_on_mac_with_this/
and here
https://apple.stackexchange.com/questions/357075/latency-spikes-on-wifi-power-saving-measure

Thanks!