### PR TITLE
Adding the fake protection plugin for DMM

### DIFF
--- a/plugins/dmm-fake-protection
+++ b/plugins/dmm-fake-protection
@@ -1,0 +1,2 @@
+repository=https://github.com/zlight97/runelite-plugins.git
+commit=417750d39c47c02650df423d89c8722f34849d3b

--- a/plugins/dmm-fake-protection
+++ b/plugins/dmm-fake-protection
@@ -1,2 +1,2 @@
 repository=https://github.com/zlight97/runelite-plugins.git
-commit=417750d39c47c02650df423d89c8722f34849d3b
+commit=fa694c09d72b13d345abe5a64128318f6f6185a8


### PR DESCRIPTION
This plugin replaces the deadman widget with the protection widget. This is intended to help streamers avoid snipers who are quickly hopping between streams.