### PR TITLE
Add Tooltips Extended

### DIFF
--- a/plugins/tooltips-extended
+++ b/plugins/tooltips-extended
@@ -1,0 +1,2 @@
+repository=https://github.com/iipom/tooltips-extended.git
+commit=6a44062203343c52d7e29bfae312bee3ba66f7cd

--- a/plugins/tooltips-extended
+++ b/plugins/tooltips-extended
@@ -1,2 +1,2 @@
 repository=https://github.com/iipom/tooltips-extended.git
-commit=6a44062203343c52d7e29bfae312bee3ba66f7cd
+commit=3ab3e43af4fe4de10512c1af96593ced3c7e3669


### PR DESCRIPTION
This plugin just takes the base plugin Mouse Tooltips and adds the ability to show the extra right click options as a tooltip, similar to how the mouse tooltips are in the C++ client.