### PR TITLE
Add Shade Chest Highlighter

### DIFF
--- a/plugins/shade-chests
+++ b/plugins/shade-chests
@@ -1,0 +1,2 @@
+repository=https://github.com/eemkukko/shade-chests.git
+commit=88bf9ae77d1431a5c9c83448095c026e8e0eb540

--- a/plugins/shade-chests
+++ b/plugins/shade-chests
@@ -1,2 +1,2 @@
 repository=https://github.com/eemkukko/shade-chests.git
-commit=88bf9ae77d1431a5c9c83448095c026e8e0eb540
+commit=35d6bb511ae18a767c263726bc80cef94f3254fe


### PR DESCRIPTION
Highlights chests in the Mort'ton shade catacombs based on which keys a player has in their inventory.