### PR TITLE
Scenery Hider plugin

### DIFF
--- a/plugins/scenery-hider
+++ b/plugins/scenery-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/THEufn/RunelitePlugins.git
+commit=0fc123eea9149bad8f798a9a81ed56a72c4569e4


### PR DESCRIPTION
Allows the player to hide any scenery object by ID. Bloat pillar is disabled.