### PR TITLE
Create easy-arceuus-runecrafting

### DIFF
--- a/plugins/easy-arceuus-runecrafting
+++ b/plugins/easy-arceuus-runecrafting
@@ -1,0 +1,2 @@
+repository=https://github.com/poi56iop/easy-arceuus-runecrafting.git
+commit=e31f272e2af12a2ba32b2bbbf2e6787008e533a2

--- a/plugins/easy-arceuus-runecrafting
+++ b/plugins/easy-arceuus-runecrafting
@@ -1,2 +1,2 @@
 repository=https://github.com/poi56iop/easy-arceuus-runecrafting.git
-commit=e31f272e2af12a2ba32b2bbbf2e6787008e533a2
+commit=7428f84125b2f137d842dc7ad6f45255a4a501c2

--- a/plugins/easy-arceuus-runecrafting
+++ b/plugins/easy-arceuus-runecrafting
@@ -1,2 +1,2 @@
 repository=https://github.com/poi56iop/easy-arceuus-runecrafting.git
-commit=7428f84125b2f137d842dc7ad6f45255a4a501c2
+commit=5107bb355d7d267bd8ef39e74af16a1340bb315e


### PR DESCRIPTION
Contextual highlights and screen flashing for Arceuus Runecrafting.

Highlights the clickbox of the next thing to click when doing arceuus runecrafting. (essence, altars, chisel, shortcuts, etc.)

Configurable colors, flashing, flashing speed, etc.

Optionally tint the screen in different colors when idle and/or active.

Running out of steam to make handling of soul runes and lower agility levels bulletproof for v1; hopefully that's fine. I've called out the limitations in the README.