### PR TITLE
Update raid-player-names

### DIFF
--- a/plugins/raid-player-names
+++ b/plugins/raid-player-names
@@ -1,2 +1,2 @@
 repository=https://github.com/solowanna/runelite_plugins.git
-commit=83362c9e94aa3a7b47a545cdf1130ead81fbe2f4
+commit=f44c427a538c8ff517b014fa8ae1942bc6294b35

--- a/plugins/raid-player-names
+++ b/plugins/raid-player-names
@@ -1,2 +1,2 @@
 repository=https://github.com/solowanna/runelite_plugins.git
-commit=f44c427a538c8ff517b014fa8ae1942bc6294b35
+commit=d7af19db5d6c52007bbf29d956a8cf637ebb9348


### PR DESCRIPTION
Update Raid Player names to new version
- Update the build.gradle to support the latest.release runelite version
- It shows the player count in the title.
- Updated 'client.getVar' to 'client.getVarbitValue'