### PR TITLE
Add tree-despawn-timer plugin

### DIFF
--- a/plugins/tree-despawn-timer
+++ b/plugins/tree-despawn-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/CreativeTechGuy/tree-despawn-timer.git
+commit=63906ca1ad28f17341389ea9d10b5c2af17b24d8

--- a/plugins/tree-despawn-timer
+++ b/plugins/tree-despawn-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/tree-despawn-timer.git
-commit=a7d91ffb051e9616fd1e4a6fb8f93d0cef5ccaae
+commit=3fdd89b39b6dd7a09452ba9b77a6af70588b7cb2

--- a/plugins/tree-despawn-timer
+++ b/plugins/tree-despawn-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/tree-despawn-timer.git
-commit=63906ca1ad28f17341389ea9d10b5c2af17b24d8
+commit=a7d91ffb051e9616fd1e4a6fb8f93d0cef5ccaae


### PR DESCRIPTION
Shows a timer on trees being chopped down, estimating the amount of time remaining; taking into account the new forestry mechanics.