### PR TITLE
update dps-calculator to v2.3.2

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=49a768dbda81b2d15b07cab2be22ac0b611e3255
+commit=1b4e92c57e4fec84bbfb9701ece81c11e408c9cc


### PR DESCRIPTION
fixes an issue that prevents client from starting when github is slow to respond