### PR TITLE
Update 117HD to v1.2.10.1

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=11ec507832024c1316987a43e9ab0ed6ec0d1357
+commit=dd33dd177816a4f47c2600c569d3234d8717c2cd
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This should hopefully fix issues on older Intel Macs causing the plugin to lock up entirely. Conflicts with https://github.com/runelite/plugin-hub/pull/4855, but I will update that after.