### PR TITLE
Update 117HD to v1.2.10.5

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=005188fee936b430f7b1859df5206389ff59140f
+commit=6df5efaa2d20f3bc8a91f6816c62088cfcb9c0a7
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Fixes the following shading bug:
![image](https://github.com/runelite/plugin-hub/assets/831317/b18fad1d-1f77-4cca-9852-e4d8e3f88877)
![image](https://github.com/runelite/plugin-hub/assets/831317/ee5de781-55d9-491a-a63c-7b2aab99876d)
