### PR TITLE
Update quest-helper to 4.1.1.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=4f34a217c0567feca6ee6a8bb7e26ecf256eed6f
+commit=1377c2273ef6e710e373c0892908d037bb5458cf


### PR DESCRIPTION
1-line change to hopefully avoid the issue with menu options still appearing even when a RLObject is hidden. This should resolve the issue of the fake whisperer model having options when hidden.