### PR TITLE
Update 117HD to v1.2.10.6

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=6df5efaa2d20f3bc8a91f6816c62088cfcb9c0a7
+commit=5b0e0e6c26e0c2f77b0e248db54a2925a848c19e
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Restrict the code that attempts to patch holes in the ground to the overworld/mainland, since it causes issues in areas like the chaos altar.