### PR TITLE
Create Thrall Damage Counter

### DIFF
--- a/plugins/thrall-damage-counter
+++ b/plugins/thrall-damage-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/BraveH/thralldamagecounter.git
+commit=d278f99b20f5da7184b252821958d2ad0695c608

--- a/plugins/thrall-damage-counter
+++ b/plugins/thrall-damage-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/BraveH/thralldamagecounter.git
-commit=d278f99b20f5da7184b252821958d2ad0695c608
+commit=613f15f1e43c77edeb1e5cd4079708ccb05a4062


### PR DESCRIPTION
Adds a counter that tallies the total amount of damage done by your summoned thralls towards enemy units. The tally can be reset by shift clicking the overlay and selecting the RESET menu option.