### PR TITLE
Update Dink to v1.6.3

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=170e5af06e29c9b0f4e0bf88853be0834ac6a0fb
+commit=92ae725f9a902e241bd7a38c4c7f35c5a98ea34b
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.6.3 augments notification information and plugin configurability, while expanding webhook support to Discord forum channels. Most notably, loot notifications now include the associated NPC kill count, and filters by item name can be applied to determine whether a loot notification should be triggered. In addition, pet notifications now indicate whether the pet was a duplicate, and level notification messages can include the updated total level of the player.

Full release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.6.3
