### PR TITLE
Annoyance mute update

### DIFF
--- a/plugins/annoyance-mute
+++ b/plugins/annoyance-mute
@@ -1,3 +1,3 @@
 repository=https://github.com/Broooklyn/runelite-external-plugins.git
-commit=da51e5808576e9a4cfd934feac0a855c12fcd2c1
+commit=45ffd36e7b261d5f4490d42800e6a388bf537f83
 authors=jzomdev


### PR DESCRIPTION
Move to a system that allows the same ID to be muted based on the Sound Effect type.

Types being:
Area sound effect and Sound Effect.

As of right now, only Mining gem rocks is something that is impacted by this change as Gem rocks share the same sound id as the Smashing!