### PR TITLE
New TrackScape Connector plugin

### DIFF
--- a/plugins/name-change-detector
+++ b/plugins/name-change-detector
@@ -1,3 +1,3 @@
 repository=https://github.com/fatfingers23/osrs-name-change-detector.git
-commit=b1520008dea89b169a3e6a769f0aa740d9b66686
+commit=6594ed40172a34c83a3bcd0d51f5434e44baf722
 warning=This plugin makes web requests to the Wise Old Man and Crystal Math Labs websites to retrieve players previous names.

--- a/plugins/trackscape-connector
+++ b/plugins/trackscape-connector
@@ -1,0 +1,3 @@
+repository=https://github.com/fatfingers23/trackscape-connector-plugin.git
+commit=c63394427842917b3a0a7d28d3f44fbff55c12a1
+warning=This plugin may submit all your clan chat messages and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers. As well as may receive incoming messages from said website.


### PR DESCRIPTION
This is a new plugin that connects RuneLite to a discord bot called [TrackScape](https://github.com/fatfingers23/trackscape-discord-bot). This bot is used to bridge discords and clan chats. Some features include. 
* Messages in game send to the discord
* Ability to receive in game messages from discord
* Styled broadcasts of various clan broadcasts