### PR TITLE
Add infinite money bag tracker v1

### DIFF
--- a/plugins/infinite-money-bag-tracker
+++ b/plugins/infinite-money-bag-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/infinite-money-bag-tracker.git
-commit=eab64cd4dd3f226a5672b100c5502794ef7f9d86
+commit=5575b34dd615664f83a73c832a2bbf010bb7f29f

--- a/plugins/infinite-money-bag-tracker
+++ b/plugins/infinite-money-bag-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/rugg0064/infinite-money-bag-tracker.git
+commit=eab64cd4dd3f226a5672b100c5502794ef7f9d86


### PR DESCRIPTION
Infinite money bag tracker is a plugin that tracks how many coins you have pulled from the Infinite money bag.
![image](https://github.com/runelite/plugin-hub/assets/35048262/58d96e52-9f45-4736-b95a-904d59cec23b)
