### PR TITLE
Add duke-barrel-swap plugin

### DIFF
--- a/plugins/duke-barrel-swap
+++ b/plugins/duke-barrel-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/Ryanbarker0/duke-barrel-swap.git
-commit=0303d739da3cb9c1215e41bc6f02ab3555db307c
+commit=c8a888edc9885f8d07e78777b6632ab1d8384932

--- a/plugins/duke-barrel-swap
+++ b/plugins/duke-barrel-swap
@@ -1,0 +1,2 @@
+repository=https://github.com/Ryanbarker0/duke-barrel-swap.git
+commit=0303d739da3cb9c1215e41bc6f02ab3555db307c


### PR DESCRIPTION
Adds `duke-barrel-swap`

The plugin adds a small quality of life improvement to the Duke Sucellus room. When Musca/Arder mushrooms are in the players inventory, the default option on Fermentation Vats will be swapped to `Check`. When there are no Musca/Arder mushrooms (either it's empty or the player has ground them into Musca/Arder powder) the option will be set to `Fill`. This stops accidentally filling the barrels when the player still has Musca/Arder mushrooms.