### PR TITLE
Create Bank Tag WikiTagger file for submitting a plugin

### DIFF
--- a/Bank Tag WikiTagger
+++ b/Bank Tag WikiTagger
@@ -1,0 +1,2 @@
+repository=https://github.com/Manieri/Bank-Tag-WikiTagger.git
+commit=afb219fa3a4725f768ececb1161f8ab945991603

--- a/Bank Tag WikiTagger
+++ b/Bank Tag WikiTagger
@@ -1,2 +1,0 @@
-repository=https://github.com/Manieri/Bank-Tag-WikiTagger.git
-commit=afb219fa3a4725f768ececb1161f8ab945991603

--- a/plugins/bank-tag-wikitagger
+++ b/plugins/bank-tag-wikitagger
@@ -1,0 +1,2 @@
+repository=https://github.com/Manieri/Bank-Tag-WikiTagger.git
+commit=afb219fa3a4725f768ececb1161f8ab945991603

--- a/plugins/bank-tag-wikitagger
+++ b/plugins/bank-tag-wikitagger
@@ -1,2 +1,2 @@
 repository=https://github.com/Manieri/Bank-Tag-WikiTagger.git
-commit=afb219fa3a4725f768ececb1161f8ab945991603
+commit=6dbdd01a3d2231170b1bdd7bfa4cb3dcdc5fa0ce


### PR DESCRIPTION
Hello,

I'd like to start this off stating this project is based off an abandoned project, Wiki Bank Tag Integration, by a fellow named Mitch. It was left roughly 2 years ago now, but the functionality for the **Categories** continues to work as intended, but the **Monster Drops** functionality has been broke for 2+ years now.

What I am submitting is a rendition of what was -- I have only added Drops functionality to not takeaway from the original project and the Drops functionality has the added feature of not requiring _'s between spaced out monster names like it's predecessor. What it does exactly is create bank tags based on specific monster drops through data from the Old School RuneScape Wiki by calling ::drops [monster name] in game. 