### PR TITLE
Add "GP Per Hour" Plugin

### DIFF
--- a/plugins/gp-per-hour
+++ b/plugins/gp-per-hour
@@ -1,3 +1,3 @@
 repository=https://github.com/MosheBenZacharia/GP-Per-Hour.git
-commit=d150debc638983ec04f106a32f1e688890214c54
+commit=ed854db2994b751bcf8cde33c93a1a2525175212
 authors=MosheBenZacharia

--- a/plugins/gp-per-hour
+++ b/plugins/gp-per-hour
@@ -1,3 +1,3 @@
 repository=https://github.com/MosheBenZacharia/GP-Per-Hour.git
-commit=ad94b78bb41cabd612486809cbf7d29823140023
+commit=d150debc638983ec04f106a32f1e688890214c54
 authors=MosheBenZacharia

--- a/plugins/gp-per-hour
+++ b/plugins/gp-per-hour
@@ -1,0 +1,3 @@
+repository=https://github.com/MosheBenZacharia/GP-Per-Hour.git
+commit=ad94b78bb41cabd612486809cbf7d29823140023
+authors=MosheBenZacharia


### PR DESCRIPTION
# GP Per Hour

_Track your gp/hr across various trips and save your sessions for later viewing._

GP Per Hour is a comprehensive money making tracker, that will accurately calculate your gp/hr by combining your profits and losses over time for any activity.

What makes this more accurate than any other profit tracker? 
- Tracks loss of charge components from weapons, armor, and utility items (Trident, blowpipe, crystal armor, blood essence etc.)
- Keeps track of items in containers (Looting bag, herb sack, etc.)
- Ability to assign value to untradeable items (Tokkul, crystal shards, etc.)

Full readme: https://github.com/MosheBenZacharia/GP-Per-Hour/blob/master/README.md