### PR TITLE
Update quest-helper to 4.1.2

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=9782cd1aa21dc2dedaa5d805aa93cc2f829634c3
+commit=8e2e5b0d0cba9a56244b4a5bc7c2fe28dcdad8a9


### PR DESCRIPTION
Various improvements to older helpers + resolves the issue with trying to set the RSProfile Config whilst logged out.