### PR TITLE
add idle-flasher

### DIFF
--- a/plugins/idle-flasher
+++ b/plugins/idle-flasher
@@ -1,0 +1,2 @@
+repository=https://github.com/poi56iop/idle-flasher.git
+commit=bf227fd6df4761450a37d380214809a115499fac


### PR DESCRIPTION
Hello!

This is a rather simple one.
No current plugin that I can find will flash the screen continuously as long as you remain idle.
A common workaround is to have idle notifications and make every notification flash the screen, but that's far from ideal.

This plugin allows you to tint/flash the screen in configurable colors (with configurable flashing durations) when idle.
Users can also configure delays before the flashing starts, and have keypresses/clicks temporarily disable the idle flashing/tint without resetting the main idleness timer.

There is also an option to tint the screen a different color when not idle.

Thank you for your time!