### PR TITLE
Fix Annoyance Mute Teleport (Only others)

### DIFF
--- a/plugins/annoyance-mute
+++ b/plugins/annoyance-mute
@@ -1,3 +1,3 @@
 repository=https://github.com/Broooklyn/runelite-external-plugins.git
-commit=a373a36bdf2455685c75110366d324fa5c32e9a6
+commit=6ace035680d4ce10475a62ffb23dfd9b0fae1808
 authors=jzomdev

--- a/plugins/annoyance-mute
+++ b/plugins/annoyance-mute
@@ -1,3 +1,3 @@
 repository=https://github.com/Broooklyn/runelite-external-plugins.git
-commit=6ace035680d4ce10475a62ffb23dfd9b0fae1808
+commit=26beba28b75c5435dbf8d9cb839985742e72a5ad
 authors=jzomdev


### PR DESCRIPTION
Teleport (Only others) used to check if your animation ID was -1 and that the sound would allowed through if your animation wasn't -1 instead of checking to see if the animation + sound was your animation + sound. 