### PR TITLE
Add fuzzy-bank-search plugin

### DIFF
--- a/plugins/fuzzy-bank-search
+++ b/plugins/fuzzy-bank-search
@@ -1,2 +1,2 @@
 repository=https://github.com/i/rl-plugins.git
-commit=505e7138880a40befa100afb8a5fe7bd0f604f26
+commit=d33bbe1a58d93879a26e0f907d2decfc316fe6b6


### PR DESCRIPTION
Uses fuzzy search when searching your bank to allow for spelling errors and shorthand queries.

For example searching for `msb` or `bofa` does what you'd expect it to do.