### PR TITLE
update not-enough-runes

### DIFF
--- a/plugins/not-enough-runes
+++ b/plugins/not-enough-runes
@@ -1,2 +1,2 @@
 repository=https://github.com/Hannah-GBS/notenoughrunes.git
-commit=69bc3bfff25bbea13057469ff9ca2efd7a7839df
+commit=e7f26639ec68b8f01147f25e962ee03c95edd3d6


### PR DESCRIPTION
loads the sqlite driver by name to resolve issues with hub classloading