### PR TITLE
Add platz plugin

### DIFF
--- a/plugins/platz
+++ b/plugins/platz
@@ -1,0 +1,3 @@
+repository=https://github.com/i/rl-plugins.git
+commit=2998170f76d61faa1eb02a5e3e70daddbbacbd11
+authors=i


### PR DESCRIPTION
Add platz, a plugin that replaces "lots" when doing a high-value trade with the actual number.