### PR TITLE
update tombs-of-amascut to v2.4.6

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tombs-of-amascut.git
-commit=8ac909e3f469f0cae347125860a0c25646d4ff68
+commit=580d0bacf35be058d2dbceab5aff68e4aa8ec2ef


### PR DESCRIPTION
downgrades some log.warn to log.debug to prevent log spam