### PR TITLE
Update nylo-death-indicators to v1.0.10

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=a969e23676b13f1f2e080b0baa824c6eb870a866
+commit=33bfeb695c2998bda6aaa2680f15062d98760f20


### PR DESCRIPTION
Adds support for the Tumeken's Shadow and Corrupted weapons