### PR TITLE
Update not-enough-runes to v1.4

### DIFF
--- a/plugins/not-enough-runes
+++ b/plugins/not-enough-runes
@@ -1,2 +1,2 @@
 repository=https://github.com/Hannah-GBS/notenoughrunes.git
-commit=e7f26639ec68b8f01147f25e962ee03c95edd3d6
+commit=e688e98a161d6618d32fcb6303568fd493e3042b


### PR DESCRIPTION
Adds a configurable right click lookup to items in the inventory and bank, as well as GE and HA prices on item panels.