### PR TITLE
Update pleae to 1.1.0

### DIFF
--- a/plugins/pleae
+++ b/plugins/pleae
@@ -1,2 +1,2 @@
 repository=https://github.com/toasty-toast/runelite-pleae.git
-commit=dd69881975332f24c1fc8effdfa2faadc7bae571
+commit=d415e3e53a187daec47b0f9d35734de4b53d60ce


### PR DESCRIPTION
Updates the Pleae plugin to have a configurable message show when you die, where it was a hard-coded message before.