### PR TITLE
Update 117HD to v1.2.10.9

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=50a6e5e8f70f1f24ee7497bbe5cc58307e739126
+commit=b839316345fe78f1ba49f49d942cb3610b58ccbc
 authors=RS117,sosodev,ahooder

--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=b839316345fe78f1ba49f49d942cb3610b58ccbc
+commit=57f47ede9b71c48c4fc33a6e5125c70a5ed84dad
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
I accidentally applied the Low Detail plugin's Hide lower planes option even when the plugin was disabled. This adds a fix on top of the commit in https://github.com/runelite/plugin-hub/pull/4928.