### PR TITLE
Update 117HD to v1.2.10.10

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=57f47ede9b71c48c4fc33a6e5125c70a5ed84dad
+commit=de9bbf47565dcd555b48afa80d239a4532ff748b
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Minor changes to fix minor issues with 1.2.10.9:
- Fix some floors in POH that had disappeared.
- Reduce thrall light brightness.
- Undo shader change that introduced an unintentionally grainy look to everything.
- Slightly change the environment for The Stranglewood.