### PR TITLE
add aerial-fishing-timers plugin

### DIFF
--- a/plugins/aerial-fishing-timers
+++ b/plugins/aerial-fishing-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/call-me-maple/aerial-fishing-timers.git
-commit=f2f521eacb91097c8c40d645dd9c166851cb9851
+commit=c9d89932b4ae3aa72728b6327144e74ffabd655a

--- a/plugins/aerial-fishing-timers
+++ b/plugins/aerial-fishing-timers
@@ -1,0 +1,2 @@
+repository=https://github.com/call-me-maple/aerial-fishing-timers.git
+commit=f2f521eacb91097c8c40d645dd9c166851cb9851


### PR DESCRIPTION
This plugin adds circle indicators to aerial fishing spots to show when they may despawn.