### PR TITLE
Update tray-indicators

### DIFF
--- a/plugins/tray-indicators
+++ b/plugins/tray-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/DMAD777/tray-indicators.git
-commit=4b013362c005bc1d082a10ec0c40f3c2f0362c9a
+commit=7843a2ee10be5ca66d8b2813b2813c46ca1409a8


### PR DESCRIPTION
Rewrote the Tray Indicator plugin to make it more readable and to fix a recurring bug.