### PR TITLE
Save Evil Creatures

### DIFF
--- a/Save-Evil-Creatures
+++ b/Save-Evil-Creatures
@@ -1,2 +1,0 @@
-repository=https://github.com/Jinxer42/Save-Evil-Creatures.git
-commit=aad0f80df4d3b628c1785490aa83cfc87bbcefaa


### PR DESCRIPTION
A plugin that replaces many gnome models with evil creature models.  Submitting for review to be added to the plugin hub.