### PR TITLE
Update spirit-tree-map to v1.0.2

### DIFF
--- a/plugins/spirit-tree-map
+++ b/plugins/spirit-tree-map
@@ -1,2 +1,2 @@
 repository=https://github.com/MJHylkema/spirit-tree-map.git
-commit=f7455133e010eeb63d9225384f5b776d19ec767d
+commit=f0a9c8ed8bb994d0c86e6959f5485c9ce7e74133

--- a/plugins/spirit-tree-map
+++ b/plugins/spirit-tree-map
@@ -1,2 +1,2 @@
 repository=https://github.com/MJHylkema/spirit-tree-map.git
-commit=f0a9c8ed8bb994d0c86e6959f5485c9ce7e74133
+commit=6ecace2ef2f354cb76fb0ee20056b060dbe23896


### PR DESCRIPTION
- Address issue causing hotkeys to not work while plugin is active
- Update plugin description
- Included a fix to stop the original spirit tree interface flashing open briefly before the new map appears