### PR TITLE
Update profit-tracker

### DIFF
--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/mrhappyasthma/runelite-profit-tracker.git
-commit=41cc7c622b031bb3e503b89fda973f06f2562a1f
+commit=dcec5c2661428c3af0626b7e0b3fd9faaf0cb6c5


### PR DESCRIPTION
Update to the latest version 1.4.

Changelog:

- No longer treats `BANK_DEPOSIT_CHEST` deposits as "profit".