### PR TITLE
Always start submitters on join cc and shutoff on logoff

### DIFF
--- a/plugins/trackscape-connector
+++ b/plugins/trackscape-connector
@@ -1,3 +1,3 @@
 repository=https://github.com/fatfingers23/trackscape-connector-plugin.git
-commit=6594ed40172a34c83a3bcd0d51f5434e44baf722
+commit=feca3c8b2e0504d5fbcc1ad839a15b8e1d63ceba
 warning=This plugin submits clan chat messages and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/trackscape-connector
+++ b/plugins/trackscape-connector
@@ -1,3 +1,3 @@
 repository=https://github.com/fatfingers23/trackscape-connector-plugin.git
-commit=ea9e9e957afdd13bd40bdc0cfb217c040fdb3d47
+commit=180c79c9e17bb685e08b8d6cdf6a747a9f57779f
 warning=This plugin submits clan chat messages and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/trackscape-connector
+++ b/plugins/trackscape-connector
@@ -1,3 +1,3 @@
 repository=https://github.com/fatfingers23/trackscape-connector-plugin.git
-commit=feca3c8b2e0504d5fbcc1ad839a15b8e1d63ceba
+commit=ea9e9e957afdd13bd40bdc0cfb217c040fdb3d47
 warning=This plugin submits clan chat messages and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
I was running into issues with the websocket not re-connecting if the user logged out or stepped away without leaving the client up