### PR TITLE
Update and rename Low Detail Raids v1.0 to Automatic Low Detail v1.1

### DIFF
--- a/plugins/low-detail-raids
+++ b/plugins/low-detail-raids
@@ -1,2 +1,2 @@
 repository=https://github.com/bepzi/runelite-plugins.git
-commit=95bdc7a7df728404ccf64193d252ea5ea7e8644d
+commit=3acaf2068a318cad2c2ca200236a0d3c8c08e9c1


### PR DESCRIPTION
- Bump version number to 1.1
- Rename plugin from "Low Detail Raids" to "Automatic Low Detail"
- Add support for the Inferno and TzHaar-Ket-Rak's Challenges
- Add support for Hallowed Sepulchre
- Prevent conflicts between Runelite's built-in Low Detail plugin and this plugin