### PR TITLE
Update line-markers to v1.2

### DIFF
--- a/plugins/line-markers
+++ b/plugins/line-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=92ff848d00755e41d4845abddaa94308e382f571
+commit=4851f4e2e005c1f1dc9b5aefec7e30d425863701


### PR DESCRIPTION
- Replaced `HotkeyListener` with `KeyListener` to allow `shift`+`/` and `shift`+`5` on macOS Ventura while listening for the `shift` key