### PR TITLE
runewatch: update to v2.3.2

### DIFF
--- a/plugins/runewatch
+++ b/plugins/runewatch
@@ -1,2 +1,2 @@
 repository=https://github.com/while-loop/runelite-plugins.git
-commit=940c25796089b4740ed1738a2c1b1ec87422e2dd
+commit=15a183dfee5479111d56d7046be07a285d0dc284

--- a/plugins/runewatch
+++ b/plugins/runewatch
@@ -1,2 +1,2 @@
 repository=https://github.com/while-loop/runelite-plugins.git
-commit=2573e1d9fd6d47c69cf5bf3ef1457d0c9969cbfc
+commit=a02a53a9431ffbcf7778d2f5931e04906e2e0101

--- a/plugins/runewatch
+++ b/plugins/runewatch
@@ -1,2 +1,2 @@
 repository=https://github.com/while-loop/runelite-plugins.git
-commit=a02a53a9431ffbcf7778d2f5931e04906e2e0101
+commit=940c25796089b4740ed1738a2c1b1ec87422e2dd


### PR DESCRIPTION
Add a new config to specific a cooldown before re-alerting players on a watchlist.


This will make it stop alerting each time a player on the watchlist triggers the onPlayerSpawned event within quick successions (teleing, agility rooftops, etc).

Fixes https://github.com/while-loop/runelite-plugins/issues/54, fixes https://github.com/while-loop/runelite-plugins/issues/33