### PR TITLE
tob-qol: release v1.2.0

### DIFF
--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=60dadc51adbf6c1edaeae874bc41beb251d528e5
+commit=5342777881403c54c6f8e425cf5958066e3b683b

--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=f5c8e4c0aa7b9eec07593b80f60d0f11ca063958
+commit=60dadc51adbf6c1edaeae874bc41beb251d528e5


### PR DESCRIPTION
- fixes: entry mode not resetting room upon death
- fixes: instance timer building on launch (not using config font size and offset)
- adds: salve and spellbook reminder
- adds: verzik green ball wee-woo alert
- updates: discord name reference