### PR TITLE
Update star-calling-assist

### DIFF
--- a/plugins/star-calling-assist
+++ b/plugins/star-calling-assist
@@ -1,3 +1,3 @@
 repository=https://github.com/zodaz/star-calling-assist.git
-commit=e4ce3883f3f1fff3c55e8b64539f9c946f01cfd2
-warning=This plugin submits your current world number along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers. If enabled in the config, your in-game name will also be sent (default off).
+commit=03d0f433c431311d3a4f8c1e97bb1cfa7895c4da
+warning=This plugin submits your current world number along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/star-calling-assist
+++ b/plugins/star-calling-assist
@@ -1,3 +1,3 @@
 repository=https://github.com/zodaz/star-calling-assist.git
-commit=03d0f433c431311d3a4f8c1e97bb1cfa7895c4da
+commit=41cb3d6b53bad244e21dc8ad4e59634cae863d19
 warning=This plugin submits your current world number along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
- Changed plugin display name and description.
- Added default endpoint which is maintained by the starminers discord.
- Fixed issue where the miner count of a previous star would be sent when not close enough to the current star to render players.