### PR TITLE
Update better-npc-highlight

### DIFF
--- a/plugins/better-npc-highlight
+++ b/plugins/better-npc-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/MoreBuchus/buchus-plugins.git
-commit=c37c48bf71757c5b90630d086176778620417dfa
+commit=609c887477749b5329a6a3bcb6f3265e3a2eca5f


### PR DESCRIPTION
**Update to v1.0.7**

- Small Fix - Check if the NPC is not dead or dying before drawing above overlay