### PR TITLE
Update resting to v1.1.4

### DIFF
--- a/plugins/resting
+++ b/plugins/resting
@@ -1,2 +1,2 @@
 repository=https://github.com/ScreteMonge/TestPlugin.git
-commit=bacc2c3ce0e328da8b7f4cd6a41bdb3ebd744c0e
+commit=a20daf32a6db0802cf6cced989fcb87bc1657263


### PR DESCRIPTION
- removed Rest right-click option on fires
- Bugfix: fixed pose animation sticking around after resting while unarmed
- added toggle for Spin emote triggering a Rest