### PR TITLE
Resolves duplicate WS messages

### DIFF
--- a/plugins/trackscape-connector
+++ b/plugins/trackscape-connector
@@ -1,3 +1,3 @@
 repository=https://github.com/fatfingers23/trackscape-connector-plugin.git
-commit=bd6c4c965dacdd73f68d9a0a7c1f5a9179e9e0bc
+commit=752a1fc3b66669cd5d28c551d31af2ae13ebed04
 warning=This plugin submits clan chat messages and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/trackscape-connector
+++ b/plugins/trackscape-connector
@@ -1,3 +1,3 @@
 repository=https://github.com/fatfingers23/trackscape-connector-plugin.git
-commit=180c79c9e17bb685e08b8d6cdf6a747a9f57779f
+commit=bd6c4c965dacdd73f68d9a0a7c1f5a9179e9e0bc
 warning=This plugin submits clan chat messages and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
There was a bug if a player hopped worlds the websocket would just create more connections instead of shutting down and re starting. 