### PR TITLE
Add click minimap orbs plugin

### DIFF
--- a/plugins/click-minimap-orbs
+++ b/plugins/click-minimap-orbs
@@ -1,0 +1,2 @@
+repository=https://github.com/Macweese/runelite-external-plugins.git
+commit=1c6475b9c5ece741364319adf6d589a3c019b951


### PR DESCRIPTION
Plugin to prevent clicking through the minimap orbs (health and special attack) on resizable mode.