### PR TITLE
Update inferno-stats to v2.1.4

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=04bd867ceda46b37c4c799bc2641deeed5dfa0f8
+commit=e515481cd34db04e62060125623c19a1431aefe5

--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=e515481cd34db04e62060125623c19a1431aefe5
+commit=2882c98a87d283053b003ae57250372624da2585


### PR DESCRIPTION
Fixes a bug where Bow of faerdhinen attacks would count as a 5 tick action (tbow default) instead of 4.