### PR TITLE
Remove reflection and add missing account build

### DIFF
--- a/plugins/wom-utils
+++ b/plugins/wom-utils
@@ -1,4 +1,4 @@
 repository=https://github.com/wise-old-man/wiseoldman-runelite-plugin.git
-commit=1eb022f125b3239bb68eb3d9de73fface647e344
+commit=72a456d386bd80afd69863fcaf6d4b3308c02517
 warning=This plugin submits the names of you, your friends and members of your clan chat to wiseoldman.net.
 authors=dekvall,rorro,psikoi


### PR DESCRIPTION
- Removes the use of reflection mention here, https://github.com/wise-old-man/wiseoldman-runelite-plugin/issues/8
- Adds missing F2P and Level 3 account build
- Submit name changes when the clan settings interface is opened