### PR TITLE
Update time-tracking-reminder

### DIFF
--- a/plugins/time-tracking-reminder
+++ b/plugins/time-tracking-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/queicherius/runelite-time-tracking-reminder.git
-commit=85c49dcc8cfaf43b11639b54a3feb97602c28fc6
+commit=a4f480e05a0202ed598c5eca9ec0f9098a7d1ef7


### PR DESCRIPTION
- Now ignores crystal tree patches if they are empty