### PR TITLE
Update loot-broadcast-party -- Fixing issue on startup.

### DIFF
--- a/plugins/loot-broadcast-party
+++ b/plugins/loot-broadcast-party
@@ -1,2 +1,2 @@
 repository=https://github.com/07Zuko/loot-broadcast-party.git
-commit=bc06ac21eed75db919c0a988a1a0d785aee19eb9
+commit=252ad738550fc7e2ceb35cc0603ed49dd593d6b8


### PR DESCRIPTION
Fixed an issue where the plugin was trying to pull in a panel.