### PR TITLE
update "gp per hour" to 1.2

### DIFF
--- a/plugins/gp-per-hour
+++ b/plugins/gp-per-hour
@@ -1,3 +1,3 @@
 repository=https://github.com/MosheBenZacharia/GP-Per-Hour.git
-commit=57fa4dcdb1a332d5cc1e67c032e8454a2a3a2a7e
+commit=801ab466fcfa2932c3fd7b186e83b910a24b6881
 authors=MosheBenZacharia

--- a/plugins/gp-per-hour
+++ b/plugins/gp-per-hour
@@ -1,3 +1,3 @@
 repository=https://github.com/MosheBenZacharia/GP-Per-Hour.git
-commit=801ab466fcfa2932c3fd7b186e83b910a24b6881
+commit=319af06a795a72372d14656265375a2e0d7ef8c1
 authors=MosheBenZacharia

--- a/plugins/gp-per-hour
+++ b/plugins/gp-per-hour
@@ -1,3 +1,3 @@
 repository=https://github.com/MosheBenZacharia/GP-Per-Hour.git
-commit=319af06a795a72372d14656265375a2e0d7ef8c1
+commit=6f06c5e8534f7f51c3676469847943e7b79cc8b5
 authors=MosheBenZacharia


### PR DESCRIPTION
* Option to only show positive gold drops.
* Option to set the value of Brimstone Keys to zero.
* Option to use low or high alchemy values.
* Seedlings now remap to sapling prices.
* Seed vault now counts as a bank interface.
* Fix NPE in log basket, and support new 'empty' message
* Support gem bag updates from pickpocketing messages
* Fix bug with ash sanctifier decreasing charges whenever prayer drains
* Add support for tracking Venator Bow charges