### PR TITLE
Convert "Spirit Tree Map" to AIO "Teleport Maps" Plugin

### DIFF
--- a/plugins/spirit-tree-map
+++ b/plugins/spirit-tree-map
@@ -1,2 +1,2 @@
 repository=https://github.com/MJHylkema/spirit-tree-map.git
-commit=6ecace2ef2f354cb76fb0ee20056b060dbe23896
+commit=6f146940e988db339219b05fe089c48284037f03


### PR DESCRIPTION
Updating the existing "Spirit Tree Map" plugin to an AIO "Teleport Maps" plugin. This will be extended in the future to support more teleport maps. 

**Please let me know if I haven't done the plugin rename aspect correctly**

- Renamed plugin name, class names. Added `@PluginDescriptor(configName = "SpiritTreeMapPlugin")` annotation to newly named `TeleportMapsPlugin` as I was told this would allow it to keep existing installs. See https://github.com/MJHylkema/spirit-tree-map/commit/7db5f5ba33321c668c5e9408bd78adaf31e68773 for changes related to the rename.
- Convert existing spirit tree code to a more generic, reusable implementation.
- Add support for Fossil Island Mushtree interface
- Tweak the Spirit Tree Map and hotkey sprites

New Fossil Island Mushtree interface:
![image](https://github.com/runelite/plugin-hub/assets/20365453/6a204bd1-d1ef-45e2-a81c-f3ceda14d113)
