### PR TITLE
Update bone-running

### DIFF
--- a/plugins/bone-running
+++ b/plugins/bone-running
@@ -1,2 +1,2 @@
 repository=https://github.com/Elrol/Run4LessPlugin.git
-commit=8a439757f3679f13cbd88bbb8a365bf5e38e7ecd
+commit=208692a1e00273ad7bbae248cefe465325b96ff6


### PR DESCRIPTION
Updated the plugin to work with the latest version
Fixed bug where channel names with spaces wouldn't work properly with the plugin
Changed the defaults to the Bone Dash group