### PR TITLE
Disable tasks-tracker

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,4 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
 commit=f05532c3816a83acc2cefd4e1fb67f7f73a9b0b9
 authors=tylerthardy
+disabled=freezes client when hopping


### PR DESCRIPTION
Per Adam's comment: "if it causes freezes from world hops we should probably disable it"
https://discord.com/channels/301497432909414422/442492468307427330/1165777712317739071

Multiple people have confirmed the plugin causes this problem.
Examples:
https://discord.com/channels/301497432909414422/442492468307427330/1165785112701566997
https://discord.com/channels/301497432909414422/442492468307427330/1165774381683839066
https://discord.com/channels/301497432909414422/442492468307427330/1161052965029818489
https://discord.com/channels/301497432909414422/442492468307427330/1154440093105389720
https://discord.com/channels/301497432909414422/442492468307427330/1150493899270397992