### PR TITLE
Create touchscreen

### DIFF
--- a/plugins/touchscreen
+++ b/plugins/touchscreen
@@ -1,2 +1,2 @@
 repository=https://github.com/ggaviglio/touchscreen.git
-commit=3419d3179401d0141f0625f36a712b5d92a935da
+commit=65f2b860d8261c98c0d7be934b9c64e258debbd6

--- a/plugins/touchscreen
+++ b/plugins/touchscreen
@@ -1,0 +1,2 @@
+repository=https://github.com/ggaviglio/touchscreen.git
+commit=3419d3179401d0141f0625f36a712b5d92a935da


### PR DESCRIPTION
Add/fix controls for touchscreens.
Left click activates after release. This fixes issue with clicks occurring before mouse position has updated. 
Click hold is rebound to right mouse.
Click drag is rebound to middle mouse, except when an item container is being clicked.