### PR TITLE
Add RuneSync

### DIFF
--- a/plugins/runesync
+++ b/plugins/runesync
@@ -1,0 +1,2 @@
+repository=https://github.com/skillingdev/runesync-plugin.git
+commit=a7fca820d4e91afab97fea850502f2d621e7afa2

--- a/plugins/runesync
+++ b/plugins/runesync
@@ -1,2 +1,2 @@
 repository=https://github.com/skillingdev/runesync-plugin.git
-commit=a7fca820d4e91afab97fea850502f2d621e7afa2
+commit=c12fff4e9c6af1f512117b1538e4c909c335152d

--- a/plugins/runesync
+++ b/plugins/runesync
@@ -1,2 +1,3 @@
 repository=https://github.com/skillingdev/runesync-plugin.git
-commit=c12fff4e9c6af1f512117b1538e4c909c335152d
+commit=a126ed1df40448f0d87e003efc5f473904eb8d02
+warning=This plugin shares your IP and username with a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Adds the plugin companion for [RuneSync](https://www.runesync.com)

Last leagues I was frustrated by the hiscores only being a current snapshot of an account (rather than a time series), and hiscores not tracking collection log items.

For now, this plugin sends loot to the RuneSync API, which allows RuneSync to display users' unique drops. In the future I'd like to display which tasks they have completed, what zones they unlocked, etc. See https://www.runesync.com/users/mid%20packs for an example (except imagine that stats are changing over time, and the loot shown are only collection log items)