### PR TITLE
Update Dink to v1.6.5

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=92ae725f9a902e241bd7a38c4c7f35c5a98ea34b
+commit=3c765f3d232ea64842df53a4d894c3a6a727a87c
 authors=Mm2PL,pajlada,Felanbird,iProdigy

--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=3c765f3d232ea64842df53a4d894c3a6a727a87c
+commit=d98697c038629920007c341a5afe7fd9715fa269
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.6.4 fixes some bugs and includes new features.

In particular, dangerous death detection is improved for CG/TOA, and the kill count notifier now reports the correct challenge duration/PB for (Corrupted) Gauntlet.

In terms of notable features, the diary notifier now includes individual task data, the loot notifier item filters now support wildcards, and a new notifier has been added to inform custom webhook handlers upon character login.


Dink v1.6.5 fixes dangerous death detection for Galvek, adds more information to `LOGIN` notifications, migrates widget usage to the new API, and includes first steps for Leagues handling.


Full release notes:
https://github.com/pajlads/DinkPlugin/releases/tag/v1.6.4
https://github.com/pajlads/DinkPlugin/releases/tag/v1.6.5
