### PR TITLE
Add Touchscreen Plugin

### DIFF
--- a/plugins/touchscreen
+++ b/plugins/touchscreen
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/Runelite-touchscreen.git
-commit=99bf9962235ae782690448f343d655e54fd2cb78
+commit=8c2ce0a7092d7a3c02979222f75ff851b424763d
 authors=Notloc

--- a/plugins/touchscreen
+++ b/plugins/touchscreen
@@ -1,0 +1,3 @@
+repository=https://github.com/Notloc/Runelite-touchscreen.git
+commit=e79926b16ca6837130c7a1f429bf44181831219a
+authors=Notloc

--- a/plugins/touchscreen
+++ b/plugins/touchscreen
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/Runelite-touchscreen.git
-commit=4abac810addb277716d22824080679d5d51bdb4c
+commit=99bf9962235ae782690448f343d655e54fd2cb78
 authors=Notloc

--- a/plugins/touchscreen
+++ b/plugins/touchscreen
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/Runelite-touchscreen.git
-commit=8c2ce0a7092d7a3c02979222f75ff851b424763d
+commit=b9058d3e1ecc6d2c4844aa61b72ce20eac4373a7
 authors=Notloc

--- a/plugins/touchscreen
+++ b/plugins/touchscreen
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/Runelite-touchscreen.git
-commit=e79926b16ca6837130c7a1f429bf44181831219a
+commit=4abac810addb277716d22824080679d5d51bdb4c
 authors=Notloc


### PR DESCRIPTION
*Fixes*
- Fixed the dead input bug.
    - (Without this plugin touch inputs will be missed/inaccurate as the mouse position from last frame is used for interacting, but touch inputs teleport the mouse, so that can be a massive difference)

*Features*
* Ability to rotate the camera by dragging on the game view
* Ability to zoom the camera by dragging vertically on the minimap
* Ability to zoom the minimap by dragging horizonally on the minimap
* Ability to scroll various menus by dragging on the menu
* Faster right clicking option
    * Click and hold to open the right click menu as normal on touchscreen, without releasing the click move your finger onto the desired option then release

*Video Examples*
- Before
    - https://www.youtube.com/watch?v=HEus8rMrut0
- After
    - https://www.youtube.com/watch?v=UGWogZZtLlk