### PR TITLE
add vorkath rotation plugin

### DIFF
--- a/plugins/vorkath-rotation
+++ b/plugins/vorkath-rotation
@@ -1,0 +1,2 @@
+repository=https://github.com/adamgibbons32/vorkath-rotation-plugin.git
+commit=f0b376aea922a82c6dc9339d13b79ce24efa68e2


### PR DESCRIPTION
Simple plugin which shows an icon for the next special attack from Vorkath.

User selects a special attack button in the panel once Vorkath has used a special attack and it shows what the next special attack is.

There is a fixed timer which changes the special attack icon in the panel. User can reset the panel at the end of the fight.

Please reach out if there are any problems.

Thanks for taking the time to review this!