### PR TITLE
Update hd-minimap

### DIFF
--- a/plugins/hd-minimap
+++ b/plugins/hd-minimap
@@ -1,2 +1,2 @@
 repository=https://github.com/Mark7625/runelite-external-plugins.git
-commit=495f1b4341c998bf44021913f85e05b05837b885
+commit=57206d714a2b54441946435576b08418388c97e5

--- a/plugins/hd-minimap
+++ b/plugins/hd-minimap
@@ -1,2 +1,2 @@
 repository=https://github.com/Mark7625/runelite-external-plugins.git
-commit=57206d714a2b54441946435576b08418388c97e5
+commit=60073c81b85ef7706e0ec812c474f5359f0f7983

--- a/plugins/hd-minimap
+++ b/plugins/hd-minimap
@@ -1,2 +1,2 @@
 repository=https://github.com/Mark7625/runelite-external-plugins.git
-commit=53f92aa41d8012601170d6d48e6888bda0473269
+commit=495f1b4341c998bf44021913f85e05b05837b885


### PR DESCRIPTION
Made it so the minimap renderer does not use this one when '117 HD' is enabled this ensures '117 HD' always takes priority 