### PR TITLE
Update friend-finder to v1.3.0 [sololegends]

### DIFF
--- a/plugins/friend-finder
+++ b/plugins/friend-finder
@@ -1,3 +1,3 @@
 repository=https://github.com/sololegends/runelite-friend-finder.git
-commit=b19233a4b9ba20c7e9d01b5f926f2b6afe3e668f
+commit=c6cdc89e71e9528bdbd00db47861c448c9a954f7
 warning=This plugin submits your rsn, player location, health, prayer level, and your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
# Release v1.3.0
Large update to area knowledge and private mode handled

- Now when private chat is set to "off" the plugin won't send or receive position updates
- Added support for tagging regions by id instead of just coord bounds
- Added a TON of regions for bosses, underground, and instanced areas
- Added support for private instance recognition
- Fixed some position accuracy issues when using the show text mode for points
- Integrated the getLocation directly into the friend point
- Updated README
- Added icon