### PR TITLE
Re-enable qolting after memory-usage reduction

### DIFF
--- a/plugins/qolting
+++ b/plugins/qolting
@@ -1,3 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/Qolting.git
-commit=deb12130b7acdda86a1628583bafcd176d5f90de
-disabled=excessive memory usage
+commit=a2eafe0e67f44646ed43b8f117b1fae64f0076e2


### PR DESCRIPTION
`GroundItem`s store their coordinates directly, rather than keeping references to `Tile`s.
https://github.com/ArtsicleOfficial/Qolting/compare/deb1213..a2eafe0?diff=split#diff-59d829955bae602f2c94d300e2aa0673a818e2e44080ad0877049caa3db7c9b0R9

`ArrayList<GroundItem> nearbyItems` now removes items after they have existed for 5 minutes
https://github.com/ArtsicleOfficial/Qolting/blob/a2eafe0e67f44646ed43b8f117b1fae64f0076e2/src/main/java/com/qolting/QoltingPlugin.java#L715

Unrelatedly, one may now use this plugin outside of Darkmeyer by clicking a checkbox in the config
https://github.com/ArtsicleOfficial/Qolting/compare/deb1213..a2eafe0?diff=split#diff-90883516368ae9fc25564391d80d8ab3c7e5b2dc943477688da20f14a893188eR70