### PR TITLE
Add tob notification plugin

### DIFF
--- a/plugins/tob-notification
+++ b/plugins/tob-notification
@@ -1,0 +1,2 @@
+repository=https://github.com/jlee513/tob-notification.git
+commit=be4fad4d50cecda61d5a188398760d09088519f8


### PR DESCRIPTION
This plugin will make an overlay, similar to the thrall reminder plugin, that will use the text from your chatbox to create a unique message in the overlay. This is for the sotetseg death ball, xarpus screech, and verzik green ball. This will only use messages in your chatbox and will not work if another person gets the sotetseg death ball or verzik green ball. 

This plugin was made to help close chat gamers.