### PR TITLE
Update Plugin Presets to v2.8

### DIFF
--- a/plugins/plugin-presets
+++ b/plugins/plugin-presets
@@ -1,2 +1,2 @@
 repository=https://github.com/antero111/plugin-presets.git
-commit=914449fabe9678b7914ad384ef021ab50dfb8d1f
+commit=ef45db1208bb8d6df83f8e9be4c5892d8f152409


### PR DESCRIPTION
Added ability to keybind multiple presets to one keybind to easily toggle/cycle between presets. Removed legacy plugin preset support.
Fixes https://github.com/antero111/plugin-presets/issues/60