### PR TITLE
Update world-location to v1.3

### DIFF
--- a/plugins/world-location
+++ b/plugins/world-location
@@ -1,2 +1,2 @@
 repository=https://github.com/XrioBtw/world-location.git
-commit=ba7f7af98bc7c3bd608a4c4d5999a30354541c00
+commit=e7cc968a570c83326255391fa41c6a0d1b87d44e

--- a/plugins/world-location
+++ b/plugins/world-location
@@ -1,2 +1,2 @@
 repository=https://github.com/XrioBtw/world-location.git
-commit=8bd3d5d9d3c1d12311231a33e1aeb2c7a69c7a33
+commit=ba7f7af98bc7c3bd608a4c4d5999a30354541c00


### PR DESCRIPTION
- Only show the hovering coordinate tooltip over the scene, and not over e.g. the inventory.