### PR TITLE
Add interface-hider plugin

### DIFF
--- a/plugins/interface-hider
+++ b/plugins/interface-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/CreativeTechGuy/interface-hider.git
+commit=59a782ce895f77ce6859468b3579ea76cbc3c6c1

--- a/plugins/interface-hider
+++ b/plugins/interface-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/interface-hider.git
-commit=59a782ce895f77ce6859468b3579ea76cbc3c6c1
+commit=ef325451bb7dd3553fe6b596b88a9f94ceecff29

--- a/plugins/interface-tweaker
+++ b/plugins/interface-tweaker
@@ -1,0 +1,2 @@
+repository=https://github.com/CreativeTechGuy/interface-tweaker.git
+commit=e87e174f8d03071e3c8bcee058e64b927ec574c7

--- a/plugins/interface-tweaker
+++ b/plugins/interface-tweaker
@@ -1,2 +1,0 @@
-repository=https://github.com/CreativeTechGuy/interface-tweaker.git
-commit=e87e174f8d03071e3c8bcee058e64b927ec574c7


### PR DESCRIPTION
A plugin which enables players to make transparent (or completely hide) almost any interface element.

To comply with Jagex's rules on hiding interfaces, this plugin prohibits any modifications of the spellbook.