### PR TITLE
Update aerial-fishing-timers to 1.1

### DIFF
--- a/plugins/aerial-fishing-timers
+++ b/plugins/aerial-fishing-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/call-me-maple/aerial-fishing-timers.git
-commit=c9d89932b4ae3aa72728b6327144e74ffabd655a
+commit=a740dccf361b18f6af6bc4527c643a212a511835


### PR DESCRIPTION
- Add an option to increment by tick instead of continuously
- Add an option to draw a line where spots can despawn
- Fixes a NPE