### PR TITLE
Updating to 1.5 and re-enabling tempoross plugin

### DIFF
--- a/plugins/tempoross
+++ b/plugins/tempoross
@@ -1,3 +1,2 @@
 repository=https://github.com/nmlynch94/runelite-external-plugins.git
-commit=c5093e93a675e481f456c81aabb286db162c173f
-disabled=totemMap leaks scenes
+commit=1477477d59c70bde6fc07a6cb80f88e36a2f2d32


### PR DESCRIPTION
Address https://github.com/nmlynch94/runelite-external-plugins/issues/4 and https://github.com/nmlynch94/runelite-external-plugins/issues/2. Fixes the memory leak that caused the plugin to be disabled.