### PR TITLE
Update consumable-cooldowns to 1.1.2

### DIFF
--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,2 +1,2 @@
 repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
-commit=94be2311ccca83c906800fde88a8e8b55e36465f
+commit=c4dbf59a698b4816c847c383d9997245a222d580


### PR DESCRIPTION
- Ignore menu option clicked events which can't be an inventory slot (anything with `param0` above 27). This prevents the log from being spammed with warnings when interacting with objects that have `drink` or `eat as the left click option. I.e. PoH rejuvenation pool.