### PR TITLE
Party World Map Pin

### DIFF
--- a/plugins/party-map-pin
+++ b/plugins/party-map-pin
@@ -1,2 +1,2 @@
 repository=https://github.com/DoinkOink/party-map-pin.git
-commit=3222ba71d9bc5cf3350436a1bbf4f9b383dfeadd
+commit=1e2fe8b03dd6f5c4a1c4b40aaa692238eff6eae3

--- a/plugins/party-map-pin
+++ b/plugins/party-map-pin
@@ -1,0 +1,2 @@
+repository=https://github.com/DoinkOink/party-map-pin.git
+commit=3222ba71d9bc5cf3350436a1bbf4f9b383dfeadd

--- a/plugins/party-map-pin
+++ b/plugins/party-map-pin
@@ -1,2 +1,2 @@
 repository=https://github.com/DoinkOink/party-map-pin.git
-commit=1e2fe8b03dd6f5c4a1c4b40aaa692238eff6eae3
+commit=7a203312679b02825e27936eb25383486e754866


### PR DESCRIPTION
This plugin allows you to drop and send pins on the World Map for all your party members with the plugin to see. This will allow you to direct your friends to a specific part of the map for easier understanding.