### PR TITLE
Update quest-helper 4.2.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=6226dd328ec9392bd08eebb43a064f2d33c26414
+commit=ba2ea69f057db6209714ba45908d30c8528593b1

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=ba2ea69f057db6209714ba45908d30c8528593b1
+commit=c1127304aa4f9e1c7f6ed43fe65a0587e8cb1406


### PR DESCRIPTION
* Updates API usage to remove deprecated usage of Widget
* Fixes the Cheerer appearing too long
* Fixes to various helpers
* Remove DT2 boss demo due to current concerns