### PR TITLE
add plugin last-recall-lock

### DIFF
--- a/plugins/last-recall-lock
+++ b/plugins/last-recall-lock
@@ -1,2 +1,2 @@
 repository=https://github.com/pelletier2017/runelite-last-recall-lock.git
-commit=747594d55f41d5ae6703be245a52ca996ed7c265
+commit=6f8c9d1ead294b639031bed9cee4dd016ed3005c

--- a/plugins/last-recall-lock
+++ b/plugins/last-recall-lock
@@ -1,0 +1,2 @@
+repository=https://github.com/pelletier2017/runelite-last-recall-lock.git
+commit=747594d55f41d5ae6703be245a52ca996ed7c265

--- a/plugins/last-recall-lock
+++ b/plugins/last-recall-lock
@@ -1,2 +1,2 @@
 repository=https://github.com/pelletier2017/runelite-last-recall-lock.git
-commit=284d50e1569e41670ee10000d891963eea9ec8a7
+commit=a15ffa04e55c915efb9ec2c85afaf36fd336684e

--- a/plugins/last-recall-lock
+++ b/plugins/last-recall-lock
@@ -1,2 +1,2 @@
 repository=https://github.com/pelletier2017/runelite-last-recall-lock.git
-commit=6a216ef3e55707a0543b51758b95c777a83eccc5
+commit=284d50e1569e41670ee10000d891963eea9ec8a7

--- a/plugins/last-recall-lock
+++ b/plugins/last-recall-lock
@@ -1,2 +1,2 @@
 repository=https://github.com/pelletier2017/runelite-last-recall-lock.git
-commit=6f8c9d1ead294b639031bed9cee4dd016ed3005c
+commit=6a216ef3e55707a0543b51758b95c777a83eccc5


### PR DESCRIPTION
Add last-recall-lock plugin to hide teleports when the teleport would override your last recall.