### PR TITLE
Fix tasks-tracker

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,4 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=f05532c3816a83acc2cefd4e1fb67f7f73a9b0b9
+commit=5bb21212c189b33db5272ac5d83f783d929d9a98
 authors=tylerthardy
-disabled=freezes client when hopping


### PR DESCRIPTION
Changes:
- The team identified the most likely issue with client freezing (described as "changed 10,000 frame redraws on client thread to 15" on world hop)
- The team added Leagues 4 metadata to support fetching new task json from our json store