### PR TITLE
Update boss-health-indicators to version 1.1

### DIFF
--- a/plugins/boss-health-indicators
+++ b/plugins/boss-health-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/boss-health-indicators.git
-commit=248da1e4dcdb0c92e19d4a9e5addde9b87e0616e
+commit=c3ad0ea867fce9f758f7dbaf415ebb56804cd7fd


### PR DESCRIPTION
Update to verson 1.1:
- Fix error if users are using `Opponent Information` plugin
- Add regular expressions to boss indicator matching. The foremost reason reason for this is to add a global indicator at 20% to notify users when to use the "Executioner" relic in the new League.