### PR TITLE
Add Scouting plugin

### DIFF
--- a/plugins/event-scouting
+++ b/plugins/event-scouting
@@ -1,3 +1,3 @@
 repository=https://github.com/peanubnutter/scoutingplugin.git
-commit=58f2ce69525a2d0134f0d3fc4057939c8285ef37
+commit=cf200bdf9b0e055cc345e511e849cdf7342919aa
 warning=This plugin submits the location and time of found events along with your IP address and username to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/scouting
+++ b/plugins/scouting
@@ -1,0 +1,2 @@
+repository=https://github.com/peanubnutter/scoutingplugin.git
+commit=c79516212347c9b9b64e80318af3b523de391163

--- a/plugins/scouting
+++ b/plugins/scouting
@@ -1,2 +1,2 @@
 repository=https://github.com/peanubnutter/scoutingplugin.git
-commit=c79516212347c9b9b64e80318af3b523de391163
+commit=58f2ce69525a2d0134f0d3fc4057939c8285ef37

--- a/plugins/scouting
+++ b/plugins/scouting
@@ -1,2 +1,3 @@
 repository=https://github.com/peanubnutter/scoutingplugin.git
 commit=58f2ce69525a2d0134f0d3fc4057939c8285ef37
+warning=This plugin submits the location and time of found events along with your IP address and username to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
The Scouting plugin crowdsources various events as you encounter them, automatically reporting any enabled event types to the server. Currently only some Forestry events are supported. 