### PR TITLE
Update vengeance helper to v1.1

### DIFF
--- a/plugins/vengeance-helper
+++ b/plugins/vengeance-helper
@@ -1,2 +1,2 @@
-repository=https://github.com/Th3mike/Vengeance-Helper.git
-commit=c3c63d5f363092fe2ec90baf067b815aeca6011c
+repository=https://github.com/cwjoshuak/vengeance-helper-plugin.git
+commit=39afebfc71b6e00835978c9ddd69f0b14abac6af


### PR DESCRIPTION
Takeover plugin from https://github.com/Th3mike/Vengeance-Helper.git as there has been no response to their issues in > 1 year and the plugin can cause notification spam.

Fixes:
1. Notification Spam

New:
1. Config option for overlay appearing only when on Lunar Spellbook
2. Modified timer config option from minutes to seconds
3. Updated readme
