### PR TITLE
Update Smart Chat Input Color to 1.5.0

### DIFF
--- a/plugins/input-recolor
+++ b/plugins/input-recolor
@@ -1,3 +1,3 @@
 repository=https://github.com/MarbleTurtle/Color-Coordinator.git
-commit=7ff37101f92eea0a590d23a2b535fb067a35d92e
+commit=1de5ab055335c634d24637c22d9f76e55eb40345
 authors=Ririshi,MarbleTurtle

--- a/plugins/input-recolor
+++ b/plugins/input-recolor
@@ -1,3 +1,3 @@
 repository=https://github.com/MarbleTurtle/Color-Coordinator.git
-commit=80067fea18237040c0e7e8b7fdb69ed9ccf011b0
+commit=7ff37101f92eea0a590d23a2b535fb067a35d92e
 authors=Ririshi,MarbleTurtle


### PR DESCRIPTION
Most important changes:

* Bugfixes for messages having an `@`-less channel prefix without a space after it (https://github.com/MarbleTurtle/Color-Coordinator/pull/13)
* Added cross-plugin support for Slash Swapper
* Reformatted with spaces instead of tabs (creates large, ugly diff)

Also did a bunch of code clean-up and added some documentation.

To see more graceful diffs, please see the individual commits.