### PR TITLE
added TombsOfAmascutStats plugin

### DIFF
--- a/plugins/tombs-of-amascut-stats
+++ b/plugins/tombs-of-amascut-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/sreilly64/TombsOfAmascutStats.git
-commit=becccf32a24102da5e4f3ca205499951554d125f
+commit=a0fc5bd373ba0206e7b4c9e005a552b5c56b5a36

--- a/plugins/tombs-of-amascut-stats
+++ b/plugins/tombs-of-amascut-stats
@@ -1,0 +1,2 @@
+repository=https://github.com/sreilly64/TombsOfAmascutStats.git
+commit=becccf32a24102da5e4f3ca205499951554d125f


### PR DESCRIPTION
This plugin, [TombsOfAmascutStats](https://github.com/sreilly64/TombsOfAmascutStats), has essentially the same purpose/functionality as the [Theatre of Blood Stats Plugin](https://github.com/HSJ-OSRS/theatreofbloodstats) but is designed to support the Tombs of Amascut raid. It provides a detailed breakdown of phase times, damage tracking (per enemy, per encounter total, and percentage of team total), and some encounter specific stats such as boss healing. All of which can be configured to be displayed as icons on the buff bar and/or as messages in the chat box.