### PR TITLE
Create undying-retribution-cooldown

### DIFF
--- a/plugins/undying-retribution-cooldown
+++ b/plugins/undying-retribution-cooldown
@@ -1,0 +1,2 @@
+repository=https://github.com/Fiffers/undying-retribution-cooldown.git
+commit=642411fae46ebbc46f55a57ff742f82cd61f9a0d


### PR DESCRIPTION
This plugin adds a cooldown timer for the Undying Retribution relic in leagues 4
