### PR TITLE
runewatch: update to v2.4.0

### DIFF
--- a/plugins/runewatch
+++ b/plugins/runewatch
@@ -1,2 +1,2 @@
 repository=https://github.com/while-loop/runelite-plugins.git
-commit=15a183dfee5479111d56d7046be07a285d0dc284
+commit=20e2287268ef5e58cad16f664a2c1ea24cb13bd3


### PR DESCRIPTION
This new version of the RuneWatch plugin separates the watchlist json file and the plugin into their seperate branches. 

The old process contained commits both from the watchlist and plugin making it difficult to collab on just plugin changes.

The watchlist & updater moved to the `runewatch-updater` branch and the code is now pointing at the new URL for the json list.