### PR TITLE
Update undying-retribution-timer

### DIFF
--- a/plugins/undying-retribution-timer
+++ b/plugins/undying-retribution-timer
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/undying-retribution-timer.git
-commit=d8e02b0f8c4e870bdc37a8e7303080985277e4fc
+commit=b7aff70ee8fd0569d867c0f5f386a19e0c025c21
 authors=DominickCobb

--- a/plugins/undying-retribution-timer
+++ b/plugins/undying-retribution-timer
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/undying-retribution-timer.git
-commit=b7aff70ee8fd0569d867c0f5f386a19e0c025c21
+commit=7dbc9dd12a418e332548926959baaee3c49aa9f1
 authors=DominickCobb


### PR DESCRIPTION
Add save/pause on hop/logout
- Should remember ticks remaining on cooldown when hopping or logging out 

Add ? when ticks are < 0 and no ready message
- Still unsure when it resets with no message, such as a ToB completion