### PR TITLE
Update Dink to v1.7.2

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=5e1fb19db2222565af9d116e6d632f9e51b19faf
+commit=bf0b900dfc5c37c076595e7346b2a92e696c4f83
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Removes custom handling for unsired, as the native loot tracker will handle this in the next Runelite version.

Relies on https://github.com/runelite/runelite/commit/875b7fe7924eeb92ada77b688d7f43a495e7e345