### PR TITLE
Update max-hit-calculator to v1.10.2

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=b2f25d0b25069f6b07e68171282a754c33335a07
+commit=1fcbafdc6b524583587b569fcbdbd01505299d45


### PR DESCRIPTION
Fix for Leagues Ruinous Powers not updating calc on prayer activation