### PR TITLE
Take ownership of the Stealing Artefacts plugin

### DIFF
--- a/plugins/stealing-artefacts
+++ b/plugins/stealing-artefacts
@@ -1,3 +1,3 @@
-repository=https://github.com/Chris-Bitler/Runelite-StealingArtefacts.git
+repository=https://github.com/pajlads/StealingArtefacts.git
 commit=f78e4910abb41624c667acee368736fda5aa6e98
 disabled=hides hint arrow


### PR DESCRIPTION
This PR does not change anything with the plugin itself, hence why it's left disabled.

If preferred I can push the code changes to this PR too once they're done
