### PR TITLE
Update Stealing Artefacts to v1.2

### DIFF
--- a/plugins/stealing-artefacts
+++ b/plugins/stealing-artefacts
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/StealingArtefacts.git
-commit=f78e4910abb41624c667acee368736fda5aa6e98
-disabled=hides hint arrow
+commit=ae51e6bbff14264184ac4bd967f912ff8b60b754
+authors=pajlada


### PR DESCRIPTION
This fixes two issues:

1. The hint arrow no longer gets cleared when on a task
   https://github.com/pajlads/StealingArtefacts/commit/42d6b1a53950eff1f400b693bc9ffa9b94d4ec2d

2. The highlights no longer stack up the longer you steal artefacts
   https://github.com/pajlads/StealingArtefacts/commit/d584b22ef824d57ca7db5ed4fc9c64b8e30566c7
