### PR TITLE
Update Undying retribution timer

### DIFF
--- a/plugins/undying-retribution-timer
+++ b/plugins/undying-retribution-timer
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/undying-retribution-timer.git
-commit=7dbc9dd12a418e332548926959baaee3c49aa9f1
+commit=89c2b8d652a7f4f63caf08eb1c18b53f92d7b7e3
 authors=DominickCobb

--- a/plugins/undying-retribution-timer
+++ b/plugins/undying-retribution-timer
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/undying-retribution-timer.git
-commit=d8e02b0f8c4e870bdc37a8e7303080985277e4fc
+commit=b7aff70ee8fd0569d867c0f5f386a19e0c025c21
 authors=DominickCobb

--- a/plugins/undying-retribution-timer
+++ b/plugins/undying-retribution-timer
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/undying-retribution-timer.git
-commit=89c2b8d652a7f4f63caf08eb1c18b53f92d7b7e3
+commit=133294260d34027eed89b728f9d4931063f56290
 authors=DominickCobb

--- a/plugins/undying-retribution-timer
+++ b/plugins/undying-retribution-timer
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/undying-retribution-timer.git
-commit=b7aff70ee8fd0569d867c0f5f386a19e0c025c21
+commit=7dbc9dd12a418e332548926959baaee3c49aa9f1
 authors=DominickCobb


### PR DESCRIPTION
Add config setting to show infobox only on cooldown

Prevent timer from continuing on non-league worlds