### PR TITLE
Added controller plugin

### DIFF
--- a/plugins/controller
+++ b/plugins/controller
@@ -1,0 +1,2 @@
+repository=https://github.com/willthehuman/controller-plugin.git
+commit=ec85b23ea71416ecc8da2aade8320f43e886a0f4


### PR DESCRIPTION
Added the controller plugin file.

This plugin allows the use of a controller to play osrs.

You can bind different buttons to different tabs that already have a shortcut (see https://oldschool.runescape.wiki/w/Shortcut_keys).

See demo [here](https://github.com/willthehuman/controller-plugin)