### PR TITLE
Update 117HD to v1.3.0.1

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=a3ee2629c8d21e6858b2b88e8adddd2078252c73
+commit=85cbc9477794aa49c9ca5f04130e5c3a15303d65
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This is mostly intended as a quick patch for issues introduced in the previous version.
Summary:
- Fix minor artifact with tree textures on AMD GPUs.
- Revert accidental change to light attenuation.
- Fix water in motherlode mine and a few other areas.
- Prevent some weird sun movement at the Arceuus blood altar with the autumn theme active.
- Remove CPU-based shading reversal code in favor of doing it in compute, since the launch went smoothly.
- Remove unnecessary color conversions.