### PR TITLE
Update 117HD to v1.3.0.2

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=85cbc9477794aa49c9ca5f04130e5c3a15303d65
+commit=5baebf885f5f3484a1a5fd5d0d4fd1c46e73c219
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Don't attempt to add a purple light to purple chests in Tombs of Amascut. Apparently we're now adding purple lights to white chests.