### PR TITLE
Update f2p-star-assist.

### DIFF
--- a/plugins/f2p-star-assist
+++ b/plugins/f2p-star-assist
@@ -1,2 +1,2 @@
 repository=https://github.com/Jannyboy11/F2P-Star-Assist-PluginHub.git
-commit=268a06b480a2ea1e1ae589b05ba09e06d3c89686
+commit=66c2078e5557932a4d87e3887aa8f0b0d8ec0f5d


### PR DESCRIPTION
This update changes the double scouting location for Varrock south east to tiles tiles that are safe for lvl-3 players (outside the agression zone of the rats).
Also, some new abbreviations that are being used by the F2P StarHunt community have been added to the chat recogniser.