### PR TITLE
Add combat level muting plugin

### DIFF
--- a/plugins/zom-combat-level-muting
+++ b/plugins/zom-combat-level-muting
@@ -1,0 +1,2 @@
+repository=https://github.com/JZomDev/zom-external-plugins.git
+commit=f4943eb4eedbfc7ba15478bc2964b634314bc42a

--- a/plugins/zom-combat-level-muting
+++ b/plugins/zom-combat-level-muting
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=f4943eb4eedbfc7ba15478bc2964b634314bc42a
+commit=18108a337c5588365436586f7fe6a128b28fdaaa


### PR DESCRIPTION
Ability to mute people in the area based on their combat levels, basically a chat filter plugin but with levels.

Combat level selector 3 to 126
Hide type Overhead, Chat box or both

![image](https://github.com/runelite/plugin-hub/assets/14265490/9139f9c6-2d4a-4ba7-8d13-f574dd739b65)
