### PR TITLE
Update maple-xp-bar

### DIFF
--- a/plugins/maple-xp-bar
+++ b/plugins/maple-xp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/SirHitech/MapleXPBar.git
-commit=730f6af950b62c53ff329b6e45dea9b1c6d99f8e
+commit=05d9ca4e128b0042660aae26ccb0d5642970ba0b

--- a/plugins/maple-xp-bar
+++ b/plugins/maple-xp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/SirHitech/MapleXPBar.git
-commit=05d9ca4e128b0042660aae26ccb0d5642970ba0b
+commit=7e407452138507e049587cd41e5c4609a6b5d287


### PR DESCRIPTION
new config option to only show percentage
fix a few bugs:
- Bar was not in correct location in Transparent mode when chat was collapsed
- Some config options did not apply when 3 bar mode was on