### PR TITLE
Update tree-despawn-timer to 1.3.1

### DIFF
--- a/plugins/tree-despawn-timer
+++ b/plugins/tree-despawn-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/tree-despawn-timer.git
-commit=c010b188439074791ddc087cf9af9c17cdf5bb71
+commit=34bf3a7a65d0a82c2f4e154a5e011a646b540c33


### PR DESCRIPTION
This fixes the issue where animations will initially face the wrong direction by rechecking the animation state a few ticks after it changes.