### PR TITLE
Update 117HD to v1.3.1.1

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=9bf3bcfc07e141e1a4b4ce4e5198b143fead9c8f
+commit=52be876b5fdbb217ad105639116c5c351ac44c6c
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Fix NPE near the desert phoenix before completion of Shadow of the Storm (and possibly other null impostors with lights attached).