### PR TITLE
Update 117HD to v1.3.1.3

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=ce36eb27a3337d25b466e4504c0f7c0520e0cdf0
+commit=11c9c206da39646434e6cb9a33eec078c277656b
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Apparently the new Christmas event is unbearably bright without yet another patch:
![image](https://github.com/runelite/plugin-hub/assets/831317/728a7e98-8d69-4e74-9dc9-e400c40cffdf)
