### PR TITLE
Add Examine Player plugin to plugin hub

### DIFF
--- a/plugins/examine-player
+++ b/plugins/examine-player
@@ -1,0 +1,2 @@
+repository=https://github.com/pkhermouch/examine-player.git
+commit=6085f4fa891970da21204fa5403e51a565d28f1f


### PR DESCRIPTION
Give players the ability to set customizable examine text on their player, and examine other players.

This plugin adds a menu option on players, "Examine", which will fetch their examine text and display it as a game message. If the player does not have any examine text, a default message will appear.

This plugin relies on the Redis instance in the Runelite API to read and write players' examine texts. Since there is no generic endpoint for new plugins to save data to the Redis instance, this plugin piggy-backs off of the Slayer plugin's endpoints. Redis keys are namespaced by a prefix to ensure that this plugin's data never collides with data written by the Slayer plugin. I realize that this isn't 100% kosher, but it was a way to get my plugin to work using what exists already. If the community decides it's worth having another endpoint in the API to more generically support new plugins integrating with the Redis instance, I'd be happy to contribute to that effort.

Also, because Redis data written by the Runelite API expires after 2 minutes, this plugin periodically refreshes the local player's examine text by sending another write request as long as the player stays logged in, so that his/her examine text is available on-demand for other players to see. Assuming even modest adoption by the player base, this could quickly overwhelm the Runelite API with refresh requests (not entirely sure what the throughput limits of the Runelite API are, but I tried to be conservative.) This is another shortcoming that could easily be addressed by more explicit support in the Runelite API as detailed above.