### PR TITLE
Adds barrows nothing sound plugin

### DIFF
--- a/plugins/barrows-nothing-sound
+++ b/plugins/barrows-nothing-sound
@@ -1,2 +1,2 @@
-repository=https://https://github.com/JillevdW/barrows-nothing-sound.git
+repository=https://github.com/JillevdW/barrows-nothing-sound.git
 commit=91bdb5da46b6c1d666b7a2496dd2d143bb5c3e63

--- a/plugins/barrows-nothing-sound
+++ b/plugins/barrows-nothing-sound
@@ -1,0 +1,2 @@
+repository=https://https://github.com/JillevdW/barrows-nothing-sound.git
+commit=91bdb5da46b6c1d666b7a2496dd2d143bb5c3e63

--- a/plugins/barrows-nothing-sound
+++ b/plugins/barrows-nothing-sound
@@ -1,2 +1,2 @@
 repository=https://github.com/JillevdW/barrows-nothing-sound.git
-commit=91bdb5da46b6c1d666b7a2496dd2d143bb5c3e63
+commit=fbf23a60c8471052c9ad3fca81090e3ec59c4a18

--- a/plugins/barrows-nothing-sound
+++ b/plugins/barrows-nothing-sound
@@ -1,2 +1,2 @@
 repository=https://github.com/JillevdW/barrows-nothing-sound.git
-commit=d9b7e634bfe0de1eb1333ea04ba1546ccb60605e
+commit=ab83a08bdf817fa892d307d4ab5f140d484a92b6

--- a/plugins/barrows-nothing-sound
+++ b/plugins/barrows-nothing-sound
@@ -1,2 +1,2 @@
 repository=https://github.com/JillevdW/barrows-nothing-sound.git
-commit=fbf23a60c8471052c9ad3fca81090e3ec59c4a18
+commit=d9b7e634bfe0de1eb1333ea04ba1546ccb60605e


### PR DESCRIPTION
Adds a sound that plays when the user does not receive an item from the Barrows loot chest. This is in reference to the Swampletics Youtube series, where this sound is played when Settled opens an empty chest.