### PR TITLE
remove GoTR AFK plugin

### DIFF
--- a/plugins/zom-afk-gotr
+++ b/plugins/zom-afk-gotr
@@ -1,2 +1,0 @@
-repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=ba5c479d39b8f99c50d73ce95a6066f72905d4d3


### PR DESCRIPTION
**Reason for requested removal**
This plugin serves as a net detriment to legitimate players engaging with the GoTR minigame.

**Background**
It encourages (and facilitates) players entering the minigame and going AFK after absolute minimal interaction to abuse the point system.

This is problematic because:
1. Too many people doing this (note: currently has _over 10k active installs_) leads to games being repeatedly lost as proper engagement is required throughout, not just at the very beginning.
2. Games are capped to 200 players per world - in peak times you must compete with other players to get into the minigame across basically all GoTR worlds. More leechers mean a harder time for those who wish to actually play the minigame as intended to get in.

I am unsure the proper protocol for requesting a plugin to be removed - please do let me know if there is a different procedure to follow.

![image](https://github.com/runelite/plugin-hub/assets/78256408/da8bd86a-cb9a-4ab5-8406-e97deca406c7)
