### PR TITLE
Toa Time Plugin

### DIFF
--- a/plugins/toatime
+++ b/plugins/toatime
@@ -1,0 +1,2 @@
+repository=https://github.com/jamberri-pie/toatime.git
+commit=6fef726fb49442aa926a0d20c299f85300a6de4e


### PR DESCRIPTION
This plugin adds audio and somewhat humorous callouts for the monkey puzzle room in the Path of Apmeken during TOA raids. Only the player with the sight will hear the audio callouts. The player will still need to relay the callouts to their party (if they have one). When the player does not have the sight, there are no audio callouts until they receive the sight again.

Included resources are:
pillars.wav
dd.wav
vents.wav
sightchange.wav