### PR TITLE
Update Automatic Low Detail to v1.1.1

### DIFF
--- a/plugins/low-detail-raids
+++ b/plugins/low-detail-raids
@@ -1,2 +1,2 @@
 repository=https://github.com/bepzi/runelite-plugins.git
-commit=3acaf2068a318cad2c2ca200236a0d3c8c08e9c1
+commit=e41c8e281f5e354d25c39b3e0d7968b3ce324b46


### PR DESCRIPTION
- Fixed CoX scouting breaking when reloading the raid from the inside stairs (See https://github.com/bepzi/runelite-plugins/issues/2)
- Changed internal logic for changing low detail mode to only be applied if absolutely necessary
- Minor code optimizations and improvements
- Flag incompatibility with Low Detail Chambers