### PR TITLE
Update not-enough-runes to v1.5

### DIFF
--- a/plugins/not-enough-runes
+++ b/plugins/not-enough-runes
@@ -1,2 +1,2 @@
 repository=https://github.com/Hannah-GBS/notenoughrunes.git
-commit=35a1a1677080c511a70319a6e1721ac5bd40fdf1
+commit=0a36de24e81336e4aa0a1e3b30eb90e9026db750


### PR DESCRIPTION
Fixes an issue preventing right-click lookup from working on noted items and placeholders.
Also removes deprecated WidgetID usage.