### PR TITLE
Uri Quotes Plugin

### DIFF
--- a/plugins/uri-quotes
+++ b/plugins/uri-quotes
@@ -1,0 +1,3 @@
+repository=https://github.com/rozzan/uri-quotes.git
+commit=cc57fa7b2e27f7ef1178a15552c6ccc9253e3fab
+authors=rozza


### PR DESCRIPTION
This plugin allows users to change what Uri says when you complete an Emote clue step. The data is provided through raw text, or via a URL, both provided via the plugin config.