### PR TITLE
Create ctc3

### DIFF
--- a/plugins/ctc3
+++ b/plugins/ctc3
@@ -1,0 +1,2 @@
+repository=https://github.com/Clank1337/ctc3-emote.git
+commit=5a7cc0b38c1ee62a28853f54e6be350643be9e19


### PR DESCRIPTION
This plugin highlights the emotes required in order to get into the vault of the Varrock basement. 17 emotes are required to enter in a precise order. The plugin only highlights the emotes when standing on the 4 tiles next to the gates to enter.