### PR TITLE
Plugin that replaces Uri dialogue with Dril tweets

### DIFF
--- a/plugins/replace-uri-dialogue-with-dril-tweets
+++ b/plugins/replace-uri-dialogue-with-dril-tweets
@@ -1,2 +1,2 @@
 repository=https://github.com/Mike-U5/dril-quotes-for-uri.git
-commit=637dc0d6e47314cd6862192ae2d0a660ab1d5b4f
+commit=116d18a0cc533482024f8320254165d4708032a3

--- a/plugins/replace-uri-dialogue-with-dril-tweets
+++ b/plugins/replace-uri-dialogue-with-dril-tweets
@@ -1,0 +1,2 @@
+repository=https://github.com/Mike-U5/dril-quotes-for-uri.git
+commit=45ec9ae5ca6411d5b1866684155a1050c97a63a8

--- a/plugins/replace-uri-dialogue-with-dril-tweets
+++ b/plugins/replace-uri-dialogue-with-dril-tweets
@@ -1,2 +1,2 @@
 repository=https://github.com/Mike-U5/dril-quotes-for-uri.git
-commit=45ec9ae5ca6411d5b1866684155a1050c97a63a8
+commit=637dc0d6e47314cd6862192ae2d0a660ab1d5b4f


### PR DESCRIPTION
This plugin does not connect to any kind of API, the tweets are randomly picked from a hardcoded list in DrilQuotes.java.

(NpcDialogueReplacementPlugin was the original name for this plugin before it was repurposed)