### PR TITLE
Update OSRSProfile Plugin

### DIFF
--- a/plugins/osrsprofile
+++ b/plugins/osrsprofile
@@ -1,4 +1,4 @@
 repository=https://github.com/mathiasHillmann/OsrsProfilePlugin.git
-commit=736995de7fd7ab8f8944b0259d008ba92baca68d
+commit=90afea40c38d4b7b19119d89b71960b213dc1e31
 warning=This plugin submits your player stats, achievements and IP address to a server not controlled or verified by the RuneLite developers.
 authors=H1llman

--- a/plugins/osrsprofile
+++ b/plugins/osrsprofile
@@ -1,4 +1,4 @@
 repository=https://github.com/mathiasHillmann/OsrsProfilePlugin.git
-commit=90afea40c38d4b7b19119d89b71960b213dc1e31
+commit=08cb5987ba3a051f42cb60e7ea65f66ad5df6250
 warning=This plugin submits your player stats, achievements and IP address to a server not controlled or verified by the RuneLite developers.
 authors=H1llman


### PR DESCRIPTION
Fixed the following issues:
- The plugin would not fetch the `varbs`/`varps` from the API after installing due to manually updating the account hash, which was updated only on login.
- Deprecation warning on `WidgetInfo`
- Also added a chat command to export the player's model to the API