### PR TITLE
Uri random dialogue replacer plugin

### DIFF
--- a/plugins/npc-dialogue-replacer
+++ b/plugins/npc-dialogue-replacer
@@ -1,2 +1,2 @@
 repository=https://github.com/Mike-U5/npc-dialogue-replacer.git
-commit=31f4ca7a6fbe8265e81a94eb4d229d34c2c73f91
+commit=18aa1751888fa0068cc2f1664dd39890b446e88b

--- a/plugins/npc-dialogue-replacer
+++ b/plugins/npc-dialogue-replacer
@@ -1,0 +1,2 @@
+repository=https://github.com/Mike-U5/npc-dialogue-replacer.git
+commit=4228eaafefe10c04586e627347218bee97ce34ef

--- a/plugins/npc-dialogue-replacer
+++ b/plugins/npc-dialogue-replacer
@@ -1,2 +1,2 @@
 repository=https://github.com/Mike-U5/npc-dialogue-replacer.git
-commit=4228eaafefe10c04586e627347218bee97ce34ef
+commit=31f4ca7a6fbe8265e81a94eb4d229d34c2c73f91


### PR DESCRIPTION
Offers the ability to replace NPC dialogue with text from an external file. Currently only supports Uri's random quotes.

I initially closed this PR when someone pointed out that #5307 has a similar feature but that plugin does not read from files which I personally find more convenient. I also want to update this to include other random NPC dialogue in the future whereas the other plugin's author might not want to do such a thing.