### PR TITLE
Add/slayer helper

### DIFF
--- a/plugins/slayer-helper
+++ b/plugins/slayer-helper
@@ -1,2 +1,2 @@
-repository=https://github.com/adrocic/slayer-helper
+repository=https://github.com/adrocic/slayer-helper.git
 commit=4444755a67bc97f14493291cf788f082eabc084f

--- a/plugins/slayer-helper
+++ b/plugins/slayer-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/adrocic/slayer-helper
-commit=4444755
+commit=4444755a67bc97f14493291cf788f082eabc084f

--- a/plugins/slayer-helper
+++ b/plugins/slayer-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/adrocic/slayer-helper
+commit=4444755


### PR DESCRIPTION
This plugin gives detailed information on any slayer task. It shows items needed, monster styles, attributes, slayer masters etc. It provides link to wiki for everything currently, but in the near future will provide information catered to the User and provide overlays such as World Map location of task monsters that are available to the user.