### PR TITLE
Update boss-health-indicators to 1.2

### DIFF
--- a/plugins/boss-health-indicators
+++ b/plugins/boss-health-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/rugg0064/boss-health-indicators.git
-commit=c3ad0ea867fce9f758f7dbaf415ebb56804cd7fd
+commit=943dc583c2abd2c3bec190ecb665eaa37664a38e


### PR DESCRIPTION
Update to 1.2
- Fixed bug: Regular expression matches do not show unless the bosses exact name is also added to the plugin.
- Fixed bug: Some floating point numbers don't display correctly.