### PR TITLE
Updated DropTracker to v2.3

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=cfbc3f5c83b874eab25cdbcb297b43e7c3a735af
-warning=This plugin submits your player name, clan member names, drop data, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.
+commit=4a543ffa301aa69689ce1770bc85c6c6f6be585a

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=4a543ffa301aa69689ce1770bc85c6c6f6be585a
+commit=303b19e51f113b725472d5a4698c0a10e2391fc2

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=fa855fd98109a22b4bcbe01173bd086d80743b3b
+commit=8611dc99a765979eeea6ebf9c7591b0b5a0d9079

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=303b19e51f113b725472d5a4698c0a10e2391fc2
+commit=97201494755c978fb59eb09752fbc4a3e77d4f0a

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=97201494755c978fb59eb09752fbc4a3e77d4f0a
+commit=fa855fd98109a22b4bcbe01173bd086d80743b3b


### PR DESCRIPTION
Removed warning on install (All external connections are still locked behind warning messages in the plugin config) In addition, players are now able to use Google Sheets without registering in the DropTracker database, to keep clan logs or personal logs of their drops.
**Non-registered** players (anyone using the plugin) can use a Google Spreadsheet to store their drops without any back-end connections required, besides standard Discord webhooks (granted the spreadsheet is valid and the DropTracker account can access it)

This functionality was implemented as a request from a clan wanting to run PvP events through Google Sheets, and it felt suitable for a more broad audience