### PR TITLE
Add potion-dose-overlay plugin definition

### DIFF
--- a/plugins/potion-dose-overlay
+++ b/plugins/potion-dose-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/trs/runelite-potion-dose-overlay.git
+commit=bf05d7405093c2b9dd8a0dbe9d450cadfbd559cd


### PR DESCRIPTION
This plugin adds an overlay to potion-type items showing the number of does left.

![icon](https://github.com/runelite/plugin-hub/assets/15315657/37dcaa45-f318-4d21-8c4d-369466378b34)

I created this as I sometimes have a hardtime determining if a potion is 4 or 3 dose.