### PR TITLE
Update tree-despawn-timer to 1.3.2

### DIFF
--- a/plugins/tree-despawn-timer
+++ b/plugins/tree-despawn-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/tree-despawn-timer.git
-commit=34bf3a7a65d0a82c2f4e154a5e011a646b540c33
+commit=5c1b0226443cd95a400559add88f2675b4fac0c1


### PR DESCRIPTION
Changes:

* Improve text overlay contrast
* Fix off-by-one for +10 woodcutting bonus (doesn't include yourself apparently)
* Work around animations "dragging" between trees without restarting