### PR TITLE
Add Day/Night Cycle

### DIFF
--- a/plugins/daynight-cycle
+++ b/plugins/daynight-cycle
@@ -1,0 +1,2 @@
+repository=https://github.com/Natchuuuu/day-night.git
+commit=311786b9da950eb7914602fc95b78de7e491848d


### PR DESCRIPTION
Adds a configurable day/night cycle based on your system time.

Automatically changes sky-box color, fog and lighting settings to match with your time of day, or select what part of day/night you want to experience. Please view the README for upcoming feature plans and contact information.

![](https://cdn.discordapp.com/attachments/1191205417527803907/1191552785196527726/image.png)
![](https://cdn.discordapp.com/attachments/1191205417527803907/1191337578285256704/image.png)
![](https://cdn.discordapp.com/attachments/1191205417527803907/1191607422310166578/RuneLite_2RrivLCb8y.jpg)
