### PR TITLE
Create item-xp plugin v0.1

### DIFF
--- a/plugins/item-xp
+++ b/plugins/item-xp
@@ -1,0 +1,2 @@
+repository=https://github.com/Laur92/item-xp-plugin.git
+commit=0e9a44b1b168ef6e811f40dcf42fc51b2c723661


### PR DESCRIPTION
A plugin that adds tooltips to items to show how much XP can be gained by using the item.

This plugin is in BETA stage and does not yet have full functionality. Only farming has been added so far.