### PR TITLE
Add combat-logger plugin

### DIFF
--- a/plugins/combat-locked
+++ b/plugins/combat-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/christianlegge/combat-locked-plugin.git
-commit=e7df05c4ad0f686cf5377019714c324f711011ac
+commit=c8c23059c674c579fd1cff687e916cffc4953378

--- a/plugins/combat-locked
+++ b/plugins/combat-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/christianlegge/combat-locked-plugin.git
-commit=c8c23059c674c579fd1cff687e916cffc4953378
+commit=e7df05c4ad0f686cf5377019714c324f711011ac

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/SuperNerdEric/combat-logger.git
+commit=2225f24d770026cc02bbad8304ad6655a0e5ea6e

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=2225f24d770026cc02bbad8304ad6655a0e5ea6e
+commit=c8c23059c674c579fd1cff687e916cffc4953378

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=c8c23059c674c579fd1cff687e916cffc4953378
+commit=eb54a9471cada44d902b96b3ed4dadf93f5b057a


### PR DESCRIPTION
Add combat-logger plugin.

Logs combat events to a file. Combat logs can then be analyzed by an external tool to calculate DPS, etc.

![image](https://github.com/runelite/plugin-hub/assets/7608429/40d21342-7e5e-49e8-a83c-aee3ab87f462)
