### PR TITLE
Pre-GE rebrand (now Rune Man Mode)

### DIFF
--- a/plugins/pre-ge
+++ b/plugins/pre-ge
@@ -1,2 +1,2 @@
 repository=https://github.com/plankst/prege-plugin.git
-commit=9c092c5dd412a86981eb18df894eb593d73c3057
+commit=683e5ceb55a3e2049bd220e05c784cbb099af2f7

--- a/plugins/pre-ge
+++ b/plugins/pre-ge
@@ -1,2 +1,2 @@
 repository=https://github.com/plankst/prege-plugin.git
-commit=4044736896a4c3ed925b6083f299363a2c4aba8f
+commit=9c092c5dd412a86981eb18df894eb593d73c3057


### PR DESCRIPTION
Rebranded "Pre-GE" to "Rune Man Mode" to fit it's intended Iron Man-Style purpose.

Note: Rebased fork to resolve merge issues