### PR TITLE
Create player-numeric-stats

### DIFF
--- a/plugins/player-numeric-stats
+++ b/plugins/player-numeric-stats
@@ -1,0 +1,2 @@
+repository=https://github.com/Cryslacks/player-numeric-stats.git
+commit=9925bcd408d744fef9ae1ca2c25195ede9468f17

--- a/plugins/player-numeric-stats
+++ b/plugins/player-numeric-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/Cryslacks/player-numeric-stats.git
-commit=9925bcd408d744fef9ae1ca2c25195ede9468f17
+commit=89dc7c8c2363a9b8aa61a746e382bff6bc9b409b


### PR DESCRIPTION
This plugin adds the ability to have numeric statuses (such as health, prayer, run energy and spec) drawn on the local player.

This is basically a variant of what `Party` plugin does but locally and with more configuration and some added benefits (overload, prayer enhance and stamina tracking)