### PR TITLE
readme: add CI build failed step

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ commit=9db374fc205c5aae1f99bd5fd127266076f40ec8
 
  7. Write a short description of what your plugin does and then create your pull request.
 
- 8. Be patient and wait for your plugin to be reviewed and merged.
+ 8. Once you have created your pull request, you may see that your plugin has failed the CI check. If this happens click the ❌ next to your commit and check the build details. Once you've read over the build error, make the requested changes to your plugin and update the `commit=` in your PR with the commit hash of your new change.  
+Don't worry about how many times it takes you to resolve build errors; we prefer all changes be kept in a single pull request to avoid spamming notifications with further newly-opened PRs.
+
+ 9. Be patient and wait for your plugin to be reviewed and merged.
 
 ## Updating a plugin
 To update a plugin, simply update the manifest with the most recent commit hash. 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ commit=9db374fc205c5aae1f99bd5fd127266076f40ec8
 
  7. Write a short description of what your plugin does and then create your pull request.
 
- 8. Once you have created your pull request, you may see that your plugin has failed the CI check. If this happens click the ❌ next to your commit and check the build details. Once you've read over the build error, make the requested changes to your plugin and update the `commit=` in your PR with the commit hash of your new change.  
+ 8. Check the result of your PR's CI workflow. With a ✔️ all is good, however if it has a ❌ next to your commit click it to check the build log for details of the failure. Once you've read over the build error, make the required changes, and push another commit to update the PR with the new `commit=` hash.  
 Don't worry about how many times it takes you to resolve build errors; we prefer all changes be kept in a single pull request to avoid spamming notifications with further newly-opened PRs.
 
  9. Be patient and wait for your plugin to be reviewed and merged.


### PR DESCRIPTION
Adds a step to instruct users what to do when their build fails, as well as suggesting they keep all their changes in that PR, and don't open new PRs due to spam