### PR TITLE
Create collectionlogtoggler

### DIFF
--- a/plugins/collectionlogtoggler
+++ b/plugins/collectionlogtoggler
@@ -1,0 +1,2 @@
+repository=https://github.com/triblion20000/CollectionLogToggler.git
+commit=682485e2bcd5e2b1e2fabf7bc52e8481fe2413d0

--- a/plugins/collectionlogtoggler
+++ b/plugins/collectionlogtoggler
@@ -1,2 +1,2 @@
 repository=https://github.com/triblion20000/CollectionLogToggler.git
-commit=423c77c6ca82c6a02fefd4d5c08aa71fc05e88f0
+commit=8908578b4a27dca4fc1ffcb937be63e80c765626

--- a/plugins/collectionlogtoggler
+++ b/plugins/collectionlogtoggler
@@ -1,2 +1,2 @@
 repository=https://github.com/triblion20000/CollectionLogToggler.git
-commit=6b4b4d95f5c72477b57c027a599b2933ce3f1697
+commit=423c77c6ca82c6a02fefd4d5c08aa71fc05e88f0

--- a/plugins/collectionlogtoggler
+++ b/plugins/collectionlogtoggler
@@ -1,2 +1,2 @@
 repository=https://github.com/triblion20000/CollectionLogToggler.git
-commit=682485e2bcd5e2b1e2fabf7bc52e8481fe2413d0
+commit=6b4b4d95f5c72477b57c027a599b2933ce3f1697


### PR DESCRIPTION
This plugin will be used for snowflake accounts to toggle on and off the 'unlocked' state of a collection log slot item, more support will be added for the entire collection log in the next few days along with the ability to choose whether you want them on or off