### PR TITLE
update to pull in new hosidius vinery fairy ring

### DIFF
--- a/plugins/fairy-ring-butterflies
+++ b/plugins/fairy-ring-butterflies
@@ -1,2 +1,2 @@
 repository=https://github.com/Jmmuir/Fairy-Ring-Butterflies.git
-commit=c9095472885b2811ff42e64a4b86f52c0b701b3a
+commit=3e60d1ea2f12edac3c6d53fe680e41644c115def


### PR DESCRIPTION
adds biome-denoting coordinates for the vinery fairy ring added today, and also the fairy queen hideout ring, which was previously left on the default biome, intended only for the house ring or new rings with biome mode enabled.