### PR TITLE
Update Dink to v1.8.2

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=a4fb5570b6c8680dee3e7ccbe9c8d3e844d46ec1
+commit=63dc5cdbf6d86edcb0a2181c46b0060fe734403f
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
reverts the Christmas logo back to normal and changes coin handling to use `ItemVariationMapping`

https://github.com/pajlads/DinkPlugin/releases/tag/v1.8.2