### PR TITLE
Nex Split Tracker

### DIFF
--- a/plugins/nex-split-tracker
+++ b/plugins/nex-split-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/KeyboardIsMagic/NexSplitTracker.git
-commit=de109c80b8d53983259c037fdfa31246969b1ec2
+commit=0c2ba6069f73dc208132d0d83edd02391e0365e9


### PR DESCRIPTION
A plugin to track Nex uniques and GP split among teams. Gives nice tables to track different uniques at a glance, and show in-depth stats.