### PR TITLE
Update easy-blastfurnace to v1.4.5

### DIFF
--- a/plugins/easy-blastfurnace
+++ b/plugins/easy-blastfurnace
@@ -1,3 +1,3 @@
 repository=https://github.com/Toofifty/easy-blastfurnace.git
-commit=c917b27f3ed23d3103826312ee174a0c4babea6f
+commit=d69af0eba78b171f32e08ff29e3b972bfa33e386
 authors=hugocowan

--- a/plugins/easy-blastfurnace
+++ b/plugins/easy-blastfurnace
@@ -1,3 +1,3 @@
 repository=https://github.com/Toofifty/easy-blastfurnace.git
-commit=d69af0eba78b171f32e08ff29e3b972bfa33e386
+commit=4b21c4e282e5092903e8f661c736636a0b70ccec
 authors=hugocowan


### PR DESCRIPTION
[Changelog](https://github.com/Toofifty/easy-blastfurnace/releases/tag/v1.4.4)

EDIT: Bumped version again to fix deprecation errors.