### PR TITLE
[flatlaf] Update elysiumevents-plugin

### DIFF
--- a/plugins/elysiumevents-plugin
+++ b/plugins/elysiumevents-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/cmsu224/clan-events.git
-commit=8955d05b6bfdaf8a080a4e5a8af0ec500a9b743e
+commit=493d686101805ca510d15c027aa5c97d624c3b80


### PR DESCRIPTION
Makes old plugin version work after runelite´s flatlaf migration