### PR TITLE
Add shift click option to equipment-inspector config

### DIFF
--- a/plugins/equipment-inspector
+++ b/plugins/equipment-inspector
@@ -1,3 +1,3 @@
 repository=https://github.com/botanicvelious/Equipment-Inspector.git
-commit=22743e05a1b94e5c6f9df0d989d88ef75360b169
+commit=3bb6bbf9686211169f3c8a5732cee864940bf7f6
 authors=waistcoat,botanicvelious

--- a/plugins/equipment-inspector
+++ b/plugins/equipment-inspector
@@ -1,3 +1,3 @@
 repository=https://github.com/botanicvelious/Equipment-Inspector.git
-commit=4e94eb0021394697a9b5ff78c8348b0179b73b89
+commit=22743e05a1b94e5c6f9df0d989d88ef75360b169
 authors=waistcoat,botanicvelious

--- a/plugins/equipment-inspector
+++ b/plugins/equipment-inspector
@@ -1,3 +1,3 @@
 repository=https://github.com/botanicvelious/Equipment-Inspector.git
-commit=fe4796f3e351c6064ac37233a03440fe64b02189
+commit=4e94eb0021394697a9b5ff78c8348b0179b73b89
 authors=waistcoat,botanicvelious


### PR DESCRIPTION
Adding some color and formatting to prices, a shift click option, and making the panel not show up in nav until used.

https://github.com/botanicvelious/Equipment-Inspector/pull/29

https://github.com/botanicvelious/Equipment-Inspector/pull/31

https://github.com/botanicvelious/Equipment-Inspector/pull/32

![priceColors](https://github.com/runelite/plugin-hub/assets/6578377/22502792-5103-4632-a4b6-78cffc9297ba)

![shift](https://github.com/runelite/plugin-hub/assets/6578377/4b408c02-0def-4142-9bf6-e684a2c3aaf9)

