### PR TITLE
[Equipment-inspector] Adding members icons when inspecting in f2p

### DIFF
--- a/plugins/equipment-inspector
+++ b/plugins/equipment-inspector
@@ -1,3 +1,3 @@
 repository=https://github.com/botanicvelious/Equipment-Inspector.git
-commit=d5496bce9fcfaafe3e581e9a8fb5184822313f3c
+commit=7538009b6617068368a09854dbc62f3baf6d1bf9
 authors=waistcoat,botanicvelious

--- a/plugins/equipment-inspector
+++ b/plugins/equipment-inspector
@@ -1,3 +1,3 @@
 repository=https://github.com/botanicvelious/Equipment-Inspector.git
-commit=3bb6bbf9686211169f3c8a5732cee864940bf7f6
+commit=d5496bce9fcfaafe3e581e9a8fb5184822313f3c
 authors=waistcoat,botanicvelious


### PR DESCRIPTION
![members](https://github.com/runelite/plugin-hub/assets/6578377/94c84b8b-a61d-4de7-8ef9-1ab14fe477d7)

Based on a suggestion. I think the icon looks better than (Members) at the end
https://github.com/botanicvelious/Equipment-Inspector/issues/18

Second commit addresses: https://github.com/botanicvelious/Equipment-Inspector/issues/36