### PR TITLE
Update quest-helper to 4.2.5

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=393ec7313b6bdb8ef5dd0521bad641dda21aa361
+commit=f93c4649c05737010f45401718360f85ba145030


### PR DESCRIPTION
Adds Children of the Sun and removes references to Kourend Favour.