### PR TITLE
Update fashionscape to 1.2.4

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=580072a0be87ba0f8c32487e8be23574c931ea35
+commit=bd2adf78d572e12a5bf5a3a451ce0e602aa64f0e


### PR DESCRIPTION
Removes unneeded calls to now-removed APIs, fixing the build.