### PR TITLE
Update client-resizer

### DIFF
--- a/plugins/client-resizer
+++ b/plugins/client-resizer
@@ -1,3 +1,3 @@
 repository=https://github.com/YvesW/client-resizer.git
-commit=a83c3252d5e0e5ed17e60b2d0c5da7b188ad68fe
+commit=744a57740137eb72d2a7dedaa72767fe1741d44a
 authors=YvesW

--- a/plugins/client-resizer
+++ b/plugins/client-resizer
@@ -1,3 +1,3 @@
 repository=https://github.com/YvesW/client-resizer.git
-commit=744a57740137eb72d2a7dedaa72767fe1741d44a
+commit=93e69270fa071e9baf4599e10e41041499fe5c2e
 authors=YvesW


### PR DESCRIPTION
Updates client-resizer to be compatible with flatlaf, and introduces a couple of workarounds for people with niche setups, so the people in ``#support`` can stop complaining.
Changelist includes:
- Fix automatic client resizing after flatlaf changes
- Add hotkey-based repositioning
   - Also supports some locations the Windows window manager does not like. For example the 3 people that want to have their menubar/title bar above the top edge of their monitor, can rejoice.
- Adds a hacky way to do snap back/contain in screen.
   - Also allows for setting 'soft' snap back, i.e. only snapping back when the user drags the client a bit over the screen edge. This allows the user to still drag the client to another screen if desired. Example can be seen here: https://github.com/YvesW/client-resizer/tree/master#snapping-back-contain-in-screen

Please note that while the diff does look big, approximately 90% of the diff are small or copy-pasted config changes, readme changes, config related variable declaration/setting these variables, or copy-pasted HotkeyListeners. I hope that makes reviewing a bit easier.