### PR TITLE
Update Substance version of Chat Panel

### DIFF
--- a/plugins/chatpanel
+++ b/plugins/chatpanel
@@ -1,2 +1,3 @@
 repository=https://github.com/Yenof/Chat-Panel.git
-commit=84c4630d3e4edd7ad5b2a46330f6312890cebd9d
+commit=8950f301bb2b5e52e526a76a7d76aa0008cba11f
+authors=Yenof


### PR DESCRIPTION
**Please don't merge if flatlaf is live.** 

Currently 1.10.19 uses an older version of Chat Panel, this PR brings as many features as I can from the update that is on 1.10.20 (flatlaf).

Removed background color options until I can figure out how to get it working on Substance.  Pop out button a little more janky now.


Substance only, **please don't merge if flatlaf is staying live.** 