### PR TITLE
Update shortest-path to v1.12.1

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=d1f2cd65bf26a6b16481a17ebdcc7605b8d6d764
+commit=9c097206f68319cb003ab7aa9633ba3bf72dcfca


### PR DESCRIPTION
- Updated the collision map to the 2024-01-10 Children of the Sun update
- Moved transport data from text files to tabulated files
- Added fairy ring code AKR for Hosidius Vinery
- Added Tempoross ferry and Ruins of Unkah shantay pass
- Added Tree Gnome Stronghold north-east corner rocks
- Added Stranglewood rowboat from Mount Quidamortem
- Added some of the key-locked doors in Melzar's Maze
- Added Viyeldi caves jagged wall
- Added Crafting Guild door
- Added Ice Troll Caves entrance