### PR TITLE
Update Stealing Artefacts to v1.3

### DIFF
--- a/plugins/stealing-artefacts
+++ b/plugins/stealing-artefacts
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/StealingArtefacts.git
-commit=ae51e6bbff14264184ac4bd967f912ff8b60b754
+commit=0cb35b204fb83efa099927603a5911aca4966585
 authors=pajlada


### PR DESCRIPTION
This release adds an icon, and removes some spammy `log.debug` calls.
