### PR TITLE
Add ecumenical-key-tracker

### DIFF
--- a/plugins/ecumenical-key-tracker
+++ b/plugins/ecumenical-key-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/NODDZY/ecumenical-key-tracker.git
+commit=a211a2a3359c1331cefe2a6bf34ac5f7051bc66f


### PR DESCRIPTION
Tracks ecumenical keys (and shards) in inventory/bank. The amount of keys is displayed on the item tooltip and as an infobox (only while within the Wilderness God Wars Dungeon).