### PR TITLE
alch-blocker: v1.5 update

### DIFF
--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,2 +1,3 @@
 repository=https://github.com/robrichardson13/alch-blocker.git
 commit=1e3c46807bad3553e12bebe0b229a26d6e746e42
+authors=robrichardson13,zdunbrack

--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/robrichardson13/alch-blocker.git
-commit=0e426d4743f6d9268c1d07f4a990a956a0249ef6
+commit=1e3c46807bad3553e12bebe0b229a26d6e746e42


### PR DESCRIPTION
https://github.com/robrichardson13/alch-blocker/pull/20
#5262 accidentally broke blocking alchs in the transparent mode because I tested with explorer's ring and assumed that was sufficient
this fixes that, updates plugin

cc: @robrichardson13 for visibility