### PR TITLE
Not Ranked support

### DIFF
--- a/plugins/trackscape-connector
+++ b/plugins/trackscape-connector
@@ -1,3 +1,3 @@
 repository=https://github.com/fatfingers23/trackscape-connector-plugin.git
-commit=752a1fc3b66669cd5d28c551d31af2ae13ebed04
+commit=6b2e61cd29d7fdef3756e11d12bd923fa2a226cf
 warning=This plugin submits clan chat messages and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
There was an error that if a clan used "Not Ranked," it would error out and not send those messages to Discord. This resolves that.