### PR TITLE
Create placeholders-warning

### DIFF
--- a/plugins/placeholders-warning
+++ b/plugins/placeholders-warning
@@ -1,0 +1,2 @@
+repository=https://github.com/CheesyCracks/placeholders-warning.git
+commit=9b6f3cb421b6754b6cf013510ad8864a5051c541


### PR DESCRIPTION
Simple plugin that alerts you when the "Always Set Placeholders" button in your bank is disabled.

- makes the icon flash
- sends a game message
- sends a notification

config lets you disable these notification options.

I've used tags for organization and sorting because the Always Set Placeholders button is a core feature that makes banks sortable, so having it on all the time is very important for organization.