### PR TITLE
Update creators-kit to v1.3.1

### DIFF
--- a/plugins/creators-kit
+++ b/plugins/creators-kit
@@ -1,2 +1,2 @@
 repository=https://github.com/ScreteMonge/creators-kit.git
-commit=aeef26f7955e3adb79b34ebdf4b1982b93c8529c
+commit=cb47549d4b5579ff51d30761a55100c3d6cb29d5


### PR DESCRIPTION
- CreatorsOverlay now overlays all objects based on distance to camera instead of player
- Added feature to invert faces in Model Anvil
- Updated ReadMe
- Replaced magic constants in Pathfinder
- Spinners in the Anvil can be reset by right-clicking
- Hotkey for quickly changing Orb Speed through a popup added
- Updated orb speed to remember speed set using hotkeys
- Removed unnecessary functions
- Interface update to accommodate flatlaf colour changes
- Added primitive model import functions
- Attempting to add a program step in an illegal tile will now prevent the addition of a step, rather than breaking the program
- Player Getter now regards Local Player as "Local Player" instead of actual player name
- Removed Text.removeTags from Player Getter in favour of just the player name
- Toolbox now remembers the last window size you set
- Spelling mistakes fixed

- Bugfix: reordering panels in the Anvil wasn't actually reordering the array for saving/loading purposes
- Bugfix: Pathfinder will no longer attempt to explore neighbours outside of the scene size
- Bugfix: Objects were not properly being handled in terms of which arrays they belonged to (Manager or Side panel arrays) causing them to reappear after Switching even if deleted
- Bugfix: Loading models or setups from file now appropriately handles non-existent files and accounts for when json isn't typed in the load dialogue window
- Bugfix: ClearColourButton in ModelAnvil now properly updates text after pasting