### PR TITLE
[Hotfix] Updates Emote Clue Items to v4.2.2.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=8557bc829a64bf956c2dd5e7e30acd752a3f9ee7
+commit=c0f995cf718041ceefb3e1346c6133424acd431c


### PR DESCRIPTION
This patch features the following updates.

* Fixes incompatibility issues with RuneLite version 1.10.20.3. (see [emote-clue-items/pull101](https://github.com/larsvansoest/emote-clue-items/pull/101))
