### PR TITLE
Fix Keris Cam

### DIFF
--- a/plugins/zom-keris-cam
+++ b/plugins/zom-keris-cam
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=067bce811accc2c1346cd732cc13711c578a104c
+commit=651033dbe8480938c292f9416bda05e1ebd1eacd

--- a/plugins/zom-keris-cam
+++ b/plugins/zom-keris-cam
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=651033dbe8480938c292f9416bda05e1ebd1eacd
+commit=606238de9d02cb48e9aff49615fc1dc69200e96e


### PR DESCRIPTION
v1.0.1
Fix Keris Cam

The plugin broke back when the ImageCapture/Screenshot plugin got reworked on 10/14/2023 which this plugin relied on.