### PR TITLE
Update thrall-helper to v1.8

### DIFF
--- a/plugins/thrall-helper
+++ b/plugins/thrall-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/PortAGuy/thrall-helper.git
-commit=c5842a53e66f086526c92b192db27895e0f0ea7f
+commit=bde662523d9458a4f625ced013a973ca9e92abc1


### PR DESCRIPTION
Updates thrall helper to v1.8

- Removes the reminder box when spell is clicked & animation is played
- Fixed reminder box appearing briefly when using "Only on Arceuus Spellbook"