### PR TITLE
Create ModifiedLeftClickDropper

### DIFF
--- a/plugins/modified-left-click-dropper
+++ b/plugins/modified-left-click-dropper
@@ -1,0 +1,2 @@
+repository=https://github.com/Mili-NT/ModifiedLeftClickDropper.git
+commit=c4ba7b701d85a7cf469733527f9cad24ad843e3a


### PR DESCRIPTION
ModifiedLeftClickDropper is a modified version of JZomDev's Left Click Dropper with wildcard support for item names added in (as this feature was rejected from the original and marked as not planned)

How it works:
- Type in a comma separated list of items to enable left click drop on
- Any wildcards (*) are converted to their proper regex forms (.*)
- Each targeted item name is matched against the item list using .matches()