### PR TITLE
Update loot-lookup to v1.1.10

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=9ecd0e8516b766a656826700a96d2660c4251a03
+commit=f15b789db22deaf7b4bafddfbb9e91a7e9f6852c


### PR DESCRIPTION
* Update the plugin to be compatible with latest RuneLite version
* Update dependencies
* Inject OkHttpClient instead of creating new instance