### PR TITLE
Update Plugin Presets to v2.8.1

### DIFF
--- a/plugins/plugin-presets
+++ b/plugins/plugin-presets
@@ -1,2 +1,2 @@
 repository=https://github.com/antero111/plugin-presets.git
-commit=ef45db1208bb8d6df83f8e9be4c5892d8f152409
+commit=203fabef1d19cfe118c9cc5e7c376cd66fc05e8e


### PR DESCRIPTION
- Fixed RuneLite client size setting not working while Plugin Presets plugin was enabled. (Issue from # support)
- Fixed dropdown checkboxes to new ui style