### PR TITLE
Update Dink to v1.8.3

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=63dc5cdbf6d86edcb0a2181c46b0060fe734403f
+commit=fb4ff979db6ec51a15aba7e40bb635862a56c6a3
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Fix an issue with `::dinkimport`-ing safe death exceptions, handle Scurries for pet notifs, and disable the Leagues notifier.

https://github.com/pajlads/DinkPlugin/releases/tag/v1.8.3