### PR TITLE
readme: add a link to the Rejected/Rolledback Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,9 @@ Don't worry about how many times it takes you to resolve build errors; we prefer
 To update a plugin, simply update the manifest with the most recent commit hash. 
 
 ## Reviewing
-We will review your plugin to ensure it isn't malicious or [breaking
-jagex's rules](https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1).
-__If it is difficult for us to ensure the plugin isn't against the rules we
-will not merge it__. 
+We will review your plugin to ensure it isn't malicious, doesn't [break Jagex's rules](https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1), 
+or isn't one of our previously [Rejected/Rolledback features](https://github.com/runelite/runelite/wiki/Rejected-or-Rolled-Back-Features).  
+__If it is difficult for us to ensure the plugin isn't against the rules we will not merge it__. 
 
 ## Plugin resources
 Resources may be included with plugins, which are non-code and are bundled and distributed with the plugin, such as images and sounds. You may do this by placing them in `src/main/resources`. Plugins on the pluginhub are distributed in .jar form and the jars placed into the classpath. The plugin is not unpacked on disk, and you can not assume that it is. This means that using https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getResource-java.lang.String- will return a jar-URL when the plugin is deployed to the pluginhub, but in your IDE will be a file-URL. This almost certainly makes it behave differently from how you expect it to, and isn't what you want.


### PR DESCRIPTION
Currently if you develop a plugin using _only_ the README found on this repo, you would not have had any connection to this page, and could possible create a plugin that, while not breaking any rules mentioned on Jagex's page, is listed as a Rejected Feature on ours.