### PR TITLE
Hotfix "Teleport Maps" to fix Xeric's Talisman Map

### DIFF
--- a/plugins/spirit-tree-map
+++ b/plugins/spirit-tree-map
@@ -1,2 +1,2 @@
 repository=https://github.com/MJHylkema/spirit-tree-map.git
-commit=540752f6a5bb85a21a62492b68bc09f75de4b47e
+commit=a0c65e6404630e27a52564f967704f3b04715523


### PR DESCRIPTION
After releasing #5397 it has been reported my plugin has a compatibility issue with "Easy Teleports" plugin.

If "Easy Teleports" is enabled and renaming Xeric's Talisman locations, my teleport map will not find the teleports.  

I was attempting to match the existing widgets based on the default button text, however "Easy Teleports" modifies this text. I have therefore changed the logic to match the widgets based on the list index. 

Issue report: https://github.com/MJHylkema/spirit-tree-map/issues/22