### PR TITLE
Update Dink to v1.8.4

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=fb4ff979db6ec51a15aba7e40bb635862a56c6a3
+commit=379ad12598998e0e5bb2549c0ef8487b827f391b
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Handles the Graveyard in MTA as a safe death, allows the user to add death ignores based on regionID & adds a command for getting said regionID's, and changes how the minValue setting works in Loot notifications for PvP Loot Chests

+747/-777 of this PR is moving README stuff around

https://github.com/pajlads/DinkPlugin/releases/tag/v1.8.4
actually reviewable diff: 
https://github.com/pajlads/DinkPlugin/compare/a7eb0074363f93b70d37737dcc66389402a16e5c...pajlads:379ad12598998e0e5bb2549c0ef8487b827f391b +
https://github.com/pajlads/DinkPlugin/commit/a7eb0074363f93b70d37737dcc66389402a16e5c