### PR TITLE
Update instant-idle-notify to v1.0.2

### DIFF
--- a/plugins/instant-idle-notify
+++ b/plugins/instant-idle-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
-commit=c9276ca38a74a93378b9de6948684f6f162771b7
+commit=fbe4cc564dd5e81466e532be350081576d8b6b71


### PR DESCRIPTION
4 lines of code changed
Stop herblore from double notifying.