### PR TITLE
package: update actions to node20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,14 +22,14 @@ jobs:
     if: github.event_name != 'push' || github.repository_owner == 'runelite'
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: adopt
         java-version: 11
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches/
@@ -68,12 +68,12 @@ jobs:
           export PACKAGE_COMMIT_RANGE="${COMMIT_RANGE:-${COMMIT_BEFORE:+$COMMIT_BEFORE...$COMMIT_AFTER}}"
         fi
         exec java -XX:+UseParallelGC -cp package/package/build/libs/package.jar net.runelite.pluginhub.packager.Packager
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: manifest_diff
         path: /tmp/manifest_diff
         retention-days: 1
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: jars
@@ -85,20 +85,20 @@ jobs:
     concurrency: upload
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: adopt
         java-version: 11
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches/
           ~/.gradle/wrapper/
         key: upload-${{ env.CACHE_VERSION }}
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: manifest_diff
         path: /tmp


### PR DESCRIPTION
Actions using node16 are [DEPRECATED!!!](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) so I went ahead and bumped them all to their node20 versions

We've been using these in Dink since whenever dependabot thought we should have them, and so far they have not killed us

also should `CACHE_VERSION` be changed to `2.3.2` or `2.4.0`, I didn't change it yet