### PR TITLE
Update Collection log plugin to v3.1.3

### DIFF
--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,2 +1,2 @@
 repository=https://github.com/evansloan/collection-log.git
-commit=02d2a212a2e177741e9a15207290693d51c47f42
+commit=c000e66294866fe56fc0e579faedd5d5f6356f19


### PR DESCRIPTION
* Add Scurrius !log command aliases
* Fix `ArrayIndexOutOfBoundsException` when attempting to update collection log title