### PR TITLE
Add alert notification to Escape Crystal (v1.1)

### DIFF
--- a/plugins/escape-crystal
+++ b/plugins/escape-crystal
@@ -1,2 +1,2 @@
 repository=https://github.com/johnvictorfs/escape-crystal-runelite-plugin.git
-commit=7e19b803f0b8766ca57019f7ef9bf82a8f4367f1
+commit=d71bde9601fbdd3ce32243bba3c794b37920c700


### PR DESCRIPTION
- Add optional notification (disabled by default) for when the alert time in the settings for triggering the escape crystal auto-teleport is reached

![image](https://github.com/runelite/plugin-hub/assets/37747572/0a6deb86-647c-4684-a652-d6be45bdb620)
