### PR TITLE
Home Improvement Plugin

### DIFF
--- a/plugins/home-improvement
+++ b/plugins/home-improvement
@@ -1,2 +1,2 @@
-repository=https://github.com/Mike-U5/rl-plugin-home-improvement
+repository=https://github.com/Mike-U5/rl-plugin-home-improvement.git
 commit=f80aa33ed5015a87f9af6fe83e8f0c49c53ebc61

--- a/plugins/home-improvement
+++ b/plugins/home-improvement
@@ -1,0 +1,2 @@
+repository=https://github.com/Mike-U5/rl-plugin-home-improvement
+commit=f80aa33ed5015a87f9af6fe83e8f0c49c53ebc61


### PR DESCRIPTION
Removes irrelevant furniture menu options from the PoH if you are not in building mode. The following options are removed:

- Remove
- Upgrade
- Revert
- Remove-room
- Remove-decorations
- Build-in