### PR TITLE
Update Chat Panel to v1.5

### DIFF
--- a/plugins/chatpanel
+++ b/plugins/chatpanel
@@ -1,3 +1,3 @@
 repository=https://github.com/Yenof/Chat-Panel.git
-commit=7393b106caa567e995048dbc789bc7376b57d128
+commit=c383bd812a504030c40c2386604ec3e519a85c60
 authors=Yenof

--- a/plugins/chatpanel
+++ b/plugins/chatpanel
@@ -1,3 +1,3 @@
 repository=https://github.com/Yenof/Chat-Panel.git
-commit=c383bd812a504030c40c2386604ec3e519a85c60
+commit=0614bcdb2136d91d138a3612abb67207b3ec9e19
 authors=Yenof

--- a/plugins/chatpanel
+++ b/plugins/chatpanel
@@ -1,3 +1,3 @@
 repository=https://github.com/Yenof/Chat-Panel.git
-commit=11f92c3f7ffadfbdabaa3c6e2ba85d1ab0d6fd20
+commit=108c86a7da899128cf5f6ef15c81b454b8e868f4
 authors=Yenof

--- a/plugins/chatpanel
+++ b/plugins/chatpanel
@@ -1,3 +1,3 @@
 repository=https://github.com/Yenof/Chat-Panel.git
-commit=0614bcdb2136d91d138a3612abb67207b3ec9e19
+commit=11f92c3f7ffadfbdabaa3c6e2ba85d1ab0d6fd20
 authors=Yenof


### PR DESCRIPTION
Multiple bug/error fixes 
(was spamming the log with warn and errors every chat message if tool tip instructions were ignored)

Pop out window now disposes itself when plugin shutdown 
Tabs are now recreated when added or removed

Add opacity
Add sidebar icon position option
Add hide pop out button option
Add auto-pop out window option, and a delay to prevent issues
Add clear tab history

Cleaned up code a little
Add new images and descriptions to readme, including a contact @


Rapid breakthroughs on things I thought to be very far off have enabled me to upgrade to v1.5 during the same PR, sorry about that. 


Additional new features (1.5):

Add Pop out tabs (pop out for pop out)
Add right click menu on tabs
Add Export option (and lastdirectorypath option, but only remembers within client sessions)
Add PopOutTab to shutdown cleanup and reload
Upgrade timestamp format options more similar to core
Changed hidepopoutbutton to DisablePopOut to be more clear
Add hide sidebar icon option
Add warning about closing pop out window without a sidebar icon

Other clarifications to config entries