### PR TITLE
Bank tag layouts 1.4.24 - fix auto-layout button not showing up.

### DIFF
--- a/plugins/bank-tag-layouts
+++ b/plugins/bank-tag-layouts
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/bank-tag-custom-layouts.git
-commit=ec0c41c76e9f10be07398351baac38fe5d40a673
+commit=9d4d34b1efea8fce6876a7c9f82e68ce80600585


### PR DESCRIPTION
Somehow must have missed this thing not showing up, sorry.