### PR TITLE
Update nylo-death-indicators to v1.0.11

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=33bfeb695c2998bda6aaa2680f15062d98760f20
+commit=408a6e2f3827fc1dc3b8210913b5e9aea54217e7


### PR DESCRIPTION
Add support for Dragonfire Shield and Dragonfire Ward which are used to damage blue nylocas. The recent update granting them defensive experience instead of magic broke how they interacted with sanguinesti staves and now requires an additional animation check to calculate the damage as one quarter of the defense experience gained.