### PR TITLE
Update Inventory Setups to v1.17

### DIFF
--- a/plugins/inventory-setups
+++ b/plugins/inventory-setups
@@ -1,2 +1,2 @@
 repository=https://github.com/dillydill123/inventory-setups.git
-commit=0f25a7b1df95cebf5a8eef17973833e48bd03572
+commit=b4ce59c1e64038bd283dde28240c62b6a3e6715e


### PR DESCRIPTION
Adds feature for UIMs death piling. Highlights and swaps menu entries on piles on the ground depending on if they are in the setup or not. This feature is disabled by default. 