### PR TITLE
Create Poisoned NPCs plugin

### DIFF
--- a/plugins/poisoned-npcs
+++ b/plugins/poisoned-npcs
@@ -1,0 +1,2 @@
+repository=https://github.com/tautges/runelite-poisoned-npcs-plugin.git
+commit=0ef5a66db857788b1d2343d1ba3926e33705cd80


### PR DESCRIPTION
Creates a plugin which displays information about whether an NPC is poisoned, has suffered a hit from a poison weapon which could potentially inflict poison, and/or how much poison damage is remaining from the poison with which the NPC is currently afflicted.

When using poisoned weapons, the plugin will always display a timer in an info box counting down to when the first poison splat will hit, if poison has not yet been applied. If poison has been applied and observed, the timer will count down to when the next poison splat will occur. Information on the damage count is also available through a tooltip.

There is also an option to enable an overlay which will display the same information directly over the head of the NPC in question. This overlay is disabled by default.

Full details including screenshots of functionality in the main plugin repo: https://github.com/tautges/runelite-poisoned-npcs-plugin

Previous discussions on this or similar topics: https://github.com/runelite/runelite/issues/7990?fbclid=IwAR3QqfoDAJcXpD3TrCVNAcCWUDd3Q7hslsQBC8UsSdtFeYFxPrMmBNxeWs4

Note that this plugin does not support PvP poison tracking. It is only functional for tracking poison inflicted on NPCs.