### PR TITLE
Update max-hit-calculator to latest

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=b51d8dc0dd27217a10b0998f170e8469be28e6c1
+commit=d151667abc840cc25a86014afc00e4ef1e502632

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=d151667abc840cc25a86014afc00e4ef1e502632
+commit=1738d09d4777cdc4f803bdb95ddc57c0f8c6898e


### PR DESCRIPTION
v1.12.0 Update (https://github.com/j-cob44/max-hit-calc/pull/22)
- Added Soulreaper axe stacks calculation
- Added Soulreaper axe special attack calculation

v1.12.1 Update (https://github.com/j-cob44/max-hit-calc/issues/25)
- Fixed HP changes not updating plugin (for Dharok's)
- Fixed plugin startup issue (Logging in without Welcome screen)