### PR TITLE
Submit PR for Embargo Clan Plugin

### DIFF
--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=6176568fdb1c1de8802d82a939e4ca33e2752474
+commit=b9e12e7c04d2ae1913bec4d44c3cf46bb9a753cd

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=b9e12e7c04d2ae1913bec4d44c3cf46bb9a753cd
+commit=91d6407fda036c810a7be535424f02b3b9a6d97d
 warning=This plugin sends player data to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=91d6407fda036c810a7be535424f02b3b9a6d97d
+commit=9e55cd7edb8dbce085bc5082eafbfb34099476f2
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,2 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
 commit=b9e12e7c04d2ae1913bec4d44c3cf46bb9a753cd
+warning=This plugin sends player data to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data, check out project's README on Github.

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=2f34c970a0db453853b47e966b9ccc2279a6dd2a
+commit=79ba543d6dca12f01377fc1cce291202df444ef9

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=79ba543d6dca12f01377fc1cce291202df444ef9
+commit=6176568fdb1c1de8802d82a939e4ca33e2752474

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=32126fd607417fc70a4a6f844431159de0448861
+commit=7249985e0760484e262fa75e615415319d8de1fb

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=7249985e0760484e262fa75e615415319d8de1fb
+commit=2f34c970a0db453853b47e966b9ccc2279a6dd2a

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=cf9c7b4f9ba5ab65d32c8dd01785dac5a9924311
+commit=32126fd607417fc70a4a6f844431159de0448861

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,0 +1,2 @@
+repository=git@github.com:Sharpienero/Embargo-Plugin.git
+commit=cf9c7b4f9ba5ab65d32c8dd01785dac5a9924311

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
 commit=b9e12e7c04d2ae1913bec4d44c3cf46bb9a753cd
-warning=This plugin sends player data to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data, check out project's README on Github.
+warning=This plugin sends player data to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,2 +1,2 @@
-repository=git@github.com:Sharpienero/Embargo-Plugin.git
+repository=https://github.com/Sharpienero/Embargo-Plugin.git
 commit=cf9c7b4f9ba5ab65d32c8dd01785dac5a9924311

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
 commit=91d6407fda036c810a7be535424f02b3b9a6d97d
-warning=This plugin sends player data to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github
+warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github


### PR DESCRIPTION
**Plugin Name:**
Embargo Clan Plugin

**Purpose:** 
This plugin tracks members stats, scans their bank for a few items that we cannot get from the collection log, displays clan specific information, and links out externally to our discord, website, and GitHub. We do this because of our unique ranking system that tallies up various points of information about a user's account. Instead of manually requesting this information, we decided to write a plugin to collect this.

**External API calls:**
Manifest (`/api/runelite/manifest`) : Inspired by WikiSync, we have an endpoint that allows us to dynamically pass in varbits and varps so that we can update what we want to track on the fly. We currently *only* plan to track achievement diary status, quest point amount, combat achievements,  account type, and TOA/TOB raid related information such as player raid damage, total raid damage, and whether or not someone is in the raid.

Untrackables (`/api/untrackables)`: Submits a subset of items found in the users bank to our database. These items are: 
* Book of the dead
* Music cape + (t) variant
* Barrows gloves
* All imbued god cape variants.

Check Registration (`api/checkregistration`): Returns if the user is registered with our clan.

Get Profile (`api/getgear`) - Returns all of our custom data tracking such as internal clan ranking, internal account points, internal community points, currentCATier, and requirements for our next rank.

Submit Loot (`api/loot`): - Submits the items received for completing one of the several raids (CoX, CM Cox, HMT, TOB, TOA, EM_TOA, Expert Mode TOA). These boss names are received by the route below.

Get Raid Monsters To Track Loot (`/api/lootBosses`): Returns an array of monsters we want to track loot for. This is useful for displaying how much gold has been made inside of our clan raids. It is also used to keep track of which members are raiding together, so that we can foster a inclusive community.

Prepare Raid:  (`api/raid`): Detects when a raid is completed by chat message and submits the players in the raid, the submitter, what type of raid, and the speed in which a user completes the raid to a route so that we can accurately capture which members raided together, regardless of the raid.










