### PR TITLE
Add RBW Bitwarden Authenticator Plugin

### DIFF
--- a/plugins/rbw-bitwarden
+++ b/plugins/rbw-bitwarden
@@ -1,0 +1,3 @@
+repository=https://github.com/nea89o/rbw-bitwarden-runelite.git
+commit=c888c5569f8573a93d9e57555d94ddadd909c008
+


### PR DESCRIPTION
This plugin adds the ability to pull passwords from bitwarden using the [`rbw`](https://github.com/doy/rbw) CLI tool. That tool has the advantage of having a daemon over the regular bitwarden tool. This means the login into your password manager does not happen via a session id (which would need to be stored in your
    settings or in your .profile).