### PR TITLE
Add Tag-ur-it plugin

### DIFF
--- a/plugins/tag-ur-it
+++ b/plugins/tag-ur-it
@@ -1,0 +1,2 @@
+repository=https://github.com/ferror1st/tag-ur-it.git
+commit=d93ab438c9c4d58fcde6449851d7c3956e16fd8e


### PR DESCRIPTION
This plugin allows participants who are all in a party (party plugin required) to play a game of tag, you tag the other players by sending them a trade request.