### PR TITLE
Move profiles repo from spedwards to jzomdev

### DIFF
--- a/plugins/profiles-panel
+++ b/plugins/profiles-panel
@@ -1,2 +1,2 @@
-repository=https://github.com/Spedwards/runelite-plugins.git
+repository=https://github.com/JZomDev/spedwardplugins.git
 commit=c2dd59dcdf324df01c54aeba4cce4577c645f642

--- a/plugins/profiles-panel
+++ b/plugins/profiles-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/spedwardplugins.git
-commit=c2dd59dcdf324df01c54aeba4cce4577c645f642
+commit=e7c085af5c46aee82cd714731e2c241d6a0ae10f

--- a/plugins/profiles-panel
+++ b/plugins/profiles-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/spedwardplugins.git
-commit=e7c085af5c46aee82cd714731e2c241d6a0ae10f
+commit=14814bbecd5f85c53b6bfd729154db7ce3d2c313


### PR DESCRIPTION
I did try to PR this and contact spedwards but they seem to be inactive. 

![image](https://github.com/runelite/plugin-hub/assets/14265490/c32d0b9c-9374-44b2-8fd1-b6cc53842787)

Add RuneLite's profile switching feature to trigger on selecting this plugin's panel rsns

Not sure how to make it show less of a diff while also being under my repo's branch structure.