### PR TITLE
Create easylootsell

### DIFF
--- a/plugins/easylootsell
+++ b/plugins/easylootsell
@@ -1,0 +1,2 @@
+repository=https://github.com/TarrenG/easylootsell.git
+commit=85f1d55abc374dd69924bc00546d9542b0db7068

--- a/plugins/easylootsell
+++ b/plugins/easylootsell
@@ -1,2 +1,2 @@
 repository=https://github.com/TarrenG/easylootsell.git
-commit=85f1d55abc374dd69924bc00546d9542b0db7068
+commit=d3004325b8add7086813ff873257f3de24e64ba2


### PR DESCRIPTION
Highlights items with more than 0 qty in a specific bank tab for easy identification while selling off a loot tab to prevent time wasted trying to track down the last few items hidden between placeholders.