### PR TITLE
Improve looting bag plugin reliability

### DIFF
--- a/plugins/looting-bag-value
+++ b/plugins/looting-bag-value
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
-commit=ee0066b1a9f6ce2da702493dede1e96e0d67573d
+commit=868905b15000fe49a79a19dccff9dc06c6f41ae3


### PR DESCRIPTION
- Add support for using items on looting bag
- Supports the menu to choose amount (including add X)
- Supports the setting that adds all of that item
- Add support for setting to disallow supply items to be picked up directly into looting bag
- Improve support for untradeable that can't be put in looting bag
- Large refactors & optimizations
- update author

I am not the original author but patrick has given be admin rights to the repo for this plugin.