### PR TITLE
Update client-resizer

### DIFF
--- a/plugins/client-resizer
+++ b/plugins/client-resizer
@@ -1,3 +1,3 @@
 repository=https://github.com/YvesW/client-resizer.git
-commit=ab5d0289d74af45f22da69281c12f7f9c10490ba
+commit=7df739d9b3838f17990ab01ea930f709527043a1
 authors=YvesW


### PR DESCRIPTION
This update adds a workaround that allows for resizing of the client after the user has manually adjusted the client size by dragging the edges of the client (closes https://github.com/YvesW/client-resizer/issues/7). 