### PR TITLE
Update combat-logger to v0.0.6

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=a83d03a696af8719eae3f3c49189478c945ef237
+commit=1bf4f68fcf09215414ccf9979ef42f11fee7d25b

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=26b308374319e11853ca24bfa2bfdf68462217b0
+commit=26e59f904b684ffacb85b677e78350f596d0f620

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=26e59f904b684ffacb85b677e78350f596d0f620
+commit=ca3cc5d55603ea994418ef1b86f51c175d6965e3

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=1bf4f68fcf09215414ccf9979ef42f11fee7d25b
+commit=26b308374319e11853ca24bfa2bfdf68462217b0

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=3beea65025245ed18b0ce96046e5aa53a74499d4
+commit=a83d03a696af8719eae3f3c49189478c945ef237


### PR DESCRIPTION
- We were logging equipment every time your ammo stack size changed. Now we only log equipment changes if an item id changes or when using the `::newlog` command.
- Log player attack animations