### PR TITLE
add attack-types plugin v1

### DIFF
--- a/plugins/attack-types
+++ b/plugins/attack-types
@@ -1,0 +1,2 @@
+repository=https://github.com/cwjoshuak/rl-attack-types.git
+commit=8b85225615d6649ebf1b59ac3478f86d62d723a7


### PR DESCRIPTION
This plugin acts similar to the core plugin Attack Styles, but instead tells you the currently selected attack type (Slash/Crush/Stab/Ranged/Magic)

In the demo video below, the overlay box on the right is from this plugin.

<details>
<summary>Demo Video</summary>

https://github.com/cwjoshuak/rl-attack-types/assets/15935660/3e10065e-7ca8-416e-a477-ccd0a80469a7

</details>