### PR TITLE
Added new plugin - Chat Logging v1.0.0 - Sololegends

### DIFF
--- a/plugins/chat-logging
+++ b/plugins/chat-logging
@@ -1,0 +1,2 @@
+repository=https://github.com/sololegends/runelite-chat-logging.git
+commit=5fedbe11310cc30b046cc9de41292d8e27248f71


### PR DESCRIPTION
- Handles logging clan, group, private, game, public, and private chat
- Configuration for what channel(s) to log
- Configuration for log retention rules
- Configuration for Username sub directories

Note:  
Yes, this is similar to the existing `chat-logger` plugin, however that plugin is no longer maintained.  

This is effectively an updated version of that plugin after I got word the old one will not be updated when making a pull request to `chat-logger`