### PR TITLE
Update Instant Inventory to v1.2.1

### DIFF
--- a/plugins/instant-inventory
+++ b/plugins/instant-inventory
@@ -1,2 +1,2 @@
 repository=https://github.com/elgbar/instant-inventory.git
-commit=353957f700fa589ac9b797b04383b5ed50d3bd3d
+commit=d49950d25b914814619f341bc6bb3f00a6a063d2

--- a/plugins/instant-inventory
+++ b/plugins/instant-inventory
@@ -1,2 +1,2 @@
 repository=https://github.com/elgbar/instant-inventory.git
-commit=d49950d25b914814619f341bc6bb3f00a6a063d2
+commit=386e878c36dc6cc46bbeb532e4319b9842280bdd

--- a/plugins/instant-inventory
+++ b/plugins/instant-inventory
@@ -1,2 +1,2 @@
 repository=https://github.com/elgbar/instant-inventory.git
-commit=386e878c36dc6cc46bbeb532e4319b9842280bdd
+commit=40a88108f89e9f659fbfe168d8b3b9f42492c709


### PR DESCRIPTION
## 1.2.1 - 2024-03-01

### Fixed

* Fix issue [#13](https://github.com/elgbar/instant-inventory/issues/13), incompatibility with customized shift-clicking
  from the Menu Swapper plugin
* Fix issue [#16](https://github.com/elgbar/instant-inventory/issues/16), depositing into the group ironman storage does
  not work correctly
* Fix wrong quantity when depositing `All` when the item is not stackable