### PR TITLE
Add Wintertodt Idle

### DIFF
--- a/plugins/wintertodt-idle
+++ b/plugins/wintertodt-idle
@@ -1,0 +1,2 @@
+repository=https://github.com/ryansand20/plugins.git
+commit=678192f2419dc34305c906671ee1c6a34e6774a9


### PR DESCRIPTION
A Wintertodt Idle plugin inspired by Wilderness Player Alarm.
Super simple, super visible overlay for playing on a second monitor.

I tried every existing Wintertodt plugin, and none of them are visible enough to avoid losing time.
RuneLite needs this plugin!