### PR TITLE
Wintertodt idle

### DIFF
--- a/plugins/wintertodt-idle
+++ b/plugins/wintertodt-idle
@@ -1,2 +1,2 @@
 repository=https://github.com/ryansand20/plugins.git
-commit=0ae8511c66694d9d20b697ccff39257e7da0c611
+commit=98b1e47e091515793d84b6d41bfdf01d178e1c59

--- a/plugins/wintertodt-idle
+++ b/plugins/wintertodt-idle
@@ -1,0 +1,2 @@
+repository=https://github.com/ryansand20/plugins.git
+commit=0ae8511c66694d9d20b697ccff39257e7da0c611


### PR DESCRIPTION
A Wintertodt Idle plugin inspired by Wilderness Player Alarm.
Super simple, super visible overlay for playing on a second monitor.

I tried every existing Wintertodt plugin, and none of them are visible enough to avoid losing time.
RuneLite needs this plugin!