### PR TITLE
Updates random-event-analytics | Potential fix for old profiles

### DIFF
--- a/plugins/random-event-analytics
+++ b/plugins/random-event-analytics
@@ -1,2 +1,2 @@
 repository=https://github.com/zmanowar/random-event-analytics.git
-commit=e639b67c492e72ee80369af6d34e7d2f871d136e
+commit=65b9c0fb1778c344fb2c131c659a3af4ccec2f39


### PR DESCRIPTION
The plugin was throwing an error when we attempt to migrate old profile configuration to `configManager`.

I suspect the profiles were created, never had a random event (and/or potentially crashed without saving the file), and the plugin was updated to the newer version that attempted to migrate the local config.