### PR TITLE
DropTracker re-write

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=1dafa1742831aa44fbd46d020337674c6da1c8d8
+commit=e8c14fc151ef844e8377cdecf01bd20df83947fc

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=e8c14fc151ef844e8377cdecf01bd20df83947fc
+commit=86157d364618463ec65dadd04015cb37ad20c90b

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=7d1f67fc6c94e3ed83704140f8c1e62e47ef2a74
+commit=8aed64b51aa42933ae5bfb3ca9b10b832c90d471

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=0f05faead8821b3cf57fa5e6cbff3e8a30391f66
+commit=aafdaf9854f3113bdd3607e3ea202ec05085768d

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=7de61b713043e9819db91e4b752912a60edd718f
+commit=6187c7293bf1e729f5de5b2e704be3c9291c4484

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=aafdaf9854f3113bdd3607e3ea202ec05085768d
+commit=7de61b713043e9819db91e4b752912a60edd718f

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=fbd66ca0c47061c5514cda5672b0439867b8ca40
+commit=7d1f67fc6c94e3ed83704140f8c1e62e47ef2a74

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=8aed64b51aa42933ae5bfb3ca9b10b832c90d471
+commit=1dafa1742831aa44fbd46d020337674c6da1c8d8

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=68a57d5575555c07f3568626186db91308ac1d20
+commit=dffaecd07eef3b2101188b715c3d80b7dc208698

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=86157d364618463ec65dadd04015cb37ad20c90b
+commit=68a57d5575555c07f3568626186db91308ac1d20

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,2 +1,2 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=6187c7293bf1e729f5de5b2e704be3c9291c4484
+commit=fbd66ca0c47061c5514cda5672b0439867b8ca40


### PR DESCRIPTION
Re-wrote the entire plugin to remove lots of excess code and messy logic.
Used a lot of code to rewrite from [Adam's Discord Loot Logger](https://runelite.net/plugin-hub/show/discord-loot-logger).

All players' drops are now tracked via our Discord webhook system, and players can enable their own "discord loot logger"-style webhook notifications for drops if they don't have a clan or don't want to use the Discord bot.

Players can sign up for events in our Discord server, which are centered around drops/pvm content.

Implemented a new side panel with enhanced functionality and much better management of thread usage to prevent latency issues that many users were reporting with the API enabled
