### PR TITLE
Update max-hit-calculator to v1.12.2

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=1738d09d4777cdc4f803bdb95ddc57c0f8c6898e
+commit=8f37cb409706fe0fabb059c68dcebe435329763d


### PR DESCRIPTION
- Fixed Charge buff not activating calculator