### PR TITLE
Create key-remapping-plus

### DIFF
--- a/plugins/key-remapping-plus
+++ b/plugins/key-remapping-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/macica2/key-remapping-plus.git
-commit=644d070a7e1df4820cc09620a13e2ce02d483384
+commit=d168335f210278bfe5d8ddbd97c28d24e5c88683

--- a/plugins/key-remapping-plus
+++ b/plugins/key-remapping-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/macica2/key-remapping-plus.git
-commit=d168335f210278bfe5d8ddbd97c28d24e5c88683
+commit=f505159cccfec4d8c6602873946c0a8da1a96127

--- a/plugins/key-remapping-plus
+++ b/plugins/key-remapping-plus
@@ -1,0 +1,2 @@
+repository=https://github.com/macica2/key-remapping-plus.git
+commit=644d070a7e1df4820cc09620a13e2ce02d483384


### PR DESCRIPTION
This is a clone of the official Key Remapping plugin, with modifications to let users change the "Press Enter to Chat..." text and color. 

It was originally submitted as a change to the official plugin, but was never approved since users would likely get confused if they accidentally changed the text without realizing. I got the OK on the Discord server by Adam to create this as a 3rd-party plugin instead ([source](https://discord.com/channels/301497432909414422/301497432909414422/1208871143793106994)) so that users have to knowingly opt in.