### PR TITLE
Create advanced-raid-tracker

### DIFF
--- a/plugins/advanced-raid-tracker
+++ b/plugins/advanced-raid-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/capslock13/AdvancedRaidTracker.git
+commit=9b1fe45f5ee4777fae489b28393189e8a8ce5869

--- a/plugins/advanced-raid-tracker
+++ b/plugins/advanced-raid-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/capslock13/AdvancedRaidTracker.git
-commit=bb02ec4b703ae60f71d0b59b2dbbfb13936896c7
+commit=61fe6e966defca1beb744210ffefe9fa19e973ca

--- a/plugins/advanced-raid-tracker
+++ b/plugins/advanced-raid-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/capslock13/AdvancedRaidTracker.git
-commit=9b1fe45f5ee4777fae489b28393189e8a8ce5869
+commit=bb02ec4b703ae60f71d0b59b2dbbfb13936896c7


### PR DESCRIPTION
Adds a plugin to track/record advanced statistics about your theatre of blood runs. Primarily used for looking at the data after the run but has some features for chat messages about times/mistakes as well as a way to view a live chart of player attacks during the room. More detailed examples and photos of the interface are available in the readme.