### PR TITLE
Add party-games plugin

### DIFF
--- a/plugins/party-games
+++ b/plugins/party-games
@@ -1,0 +1,2 @@
+repository=https://github.com/Maurits825/party-games.git
+commit=996a9a8de407c8cf10bc3a4698b9c050e12e30da


### PR DESCRIPTION
Add party games plugin. This plugin uses the Party plugin to allow party members to play games. Current games include rock paper scissors and coin flip.