### PR TITLE
Update elysiumevents-plugin

### DIFF
--- a/plugins/elysiumevents-plugin
+++ b/plugins/elysiumevents-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/cmsu224/clan-events.git
-commit=493d686101805ca510d15c027aa5c97d624c3b80
+commit=b2973dbe9679f6918cd4e056716855b3749998ae


### PR DESCRIPTION
fix: buttons correctly open urls in Linux