### PR TITLE
hot-fix: global chat: fix spam duplicate messages

### DIFF
--- a/plugins/global-chat
+++ b/plugins/global-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/RusseII/region-chat.git
-commit=104cd4a555266635ee530d6f971bd6734fcfc759
+commit=431c57d1441127f1c496cf704b3b229f18a76dde
 warning=This plugin submits all sent chat messages and your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Simple changes that fixes bug that causes messages to be spammed in the global chat 

![CleanShot 2024-03-09 at 15 52 04](https://github.com/runelite/plugin-hub/assets/15036618/a83a0bbf-4fc1-49ac-931f-4272fc7fe6ea)
