### PR TITLE
Create Boost Performance

### DIFF
--- a/plugins/boost-performance
+++ b/plugins/boost-performance
@@ -1,0 +1,2 @@
+repository=https://github.com/1Defence/boost-performance.git
+commit=a2a9d3bdadf5fb10fbc2b5cef9142290faacd459


### PR DESCRIPTION
Track performance of a boost session, streamer event or clan event without needing kill credit

https://github.com/runelite/plugin-hub/assets/63735241/5837b70d-e940-40eb-9b91-41fa3a3e5627

### Visibility
Handles multiple worlds at once and utilizes party to ensure all kills are seen.
	**_Note for maintainers: there are [checks](https://github.com/1Defence/boost-performance/blob/a2a9d3bdadf5fb10fbc2b5cef9142290faacd459/src/main/java/com/boostperformance/BoostPerformancePlugin.java#L523) in place to ensure only one player per party is sending each unique event._**

### KPH
Estimated hourly rate of the boss dying

- Initial kill is always disregarded to get a more accurate estimate and the start of a session begins when a boss dies
- Snipes do not lower this value, prevents vastly incorrect estimates if you snipe early into a session

### KC
Number of times a boss has died, the number of burner kills will be appended in brackets

- Burner kills will not be taken into account for calculations but are displayed for tracking purposes.

### Snipes
Tracks snipe count and calculates the frequency you're losing kills at

- _Currently only works for party members that receive kill credit_
- First value is raw number of snipes
- Second value is the fraction of snipe frequency
- Third value in brackets is the percentage of kills that have been sniped

![Snipes](https://github.com/runelite/plugin-hub/assets/63735241/536dc2c2-ef33-4378-b25c-5b29c729541f)

### EHB
Calculates efficient hours bossed

- First value is how many hours you've gained in the given time frame
- Second value in brackets is the multiplier of how much over/under the expected EHB rate you are
- Updated on github.io to ensure expected rates are always in line with temple

![EHB](https://github.com/runelite/plugin-hub/assets/63735241/e9cb8c94-a31d-4f56-94e6-cbc0838784cb)

Resetting a current session adds to a secondary panel to keep track of your overall efficiency/killcount throughout the day.

Should you kill multiple different bosses the header will state "Overall Mixed" to prevent confusion on values that won't be possible at a current boss.
