### PR TITLE
global chat: fixes bug that causes chat messages to be hidden 

### DIFF
--- a/plugins/global-chat
+++ b/plugins/global-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/RusseII/region-chat.git
-commit=431c57d1441127f1c496cf704b3b229f18a76dde
+commit=1ee3780f7153de1e87f2574c32ebb4fc6dfb2543
 warning=This plugin submits all sent chat messages and your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This small PR fixes a bug that is causing global chat messages to be hidden sometimes when they shouldn't be. 

It is caused by using message IDs for the filtering (which are not unique when logging out and in), instead of player names. 

This fix moves to using player names instead of message IDs. 