### PR TITLE
Update commit hash of rc-pouch

### DIFF
--- a/plugins/rc-pouch-usage
+++ b/plugins/rc-pouch-usage
@@ -1,2 +1,2 @@
 repository=https://github.com/DavidVentura/rc-pouch-alert.git
-commit=a4dc45e86320cfc0611f0720412df657c80d0159
+commit=ce6e46d87d7ec4ad488cbd8569b5d68142e2ffe4


### PR DESCRIPTION
- Updated the commit hash to the latest master of the rc-pouch-usage plugin.

Updates since last hash inclue:

- Fixed counter not working when Bank window is not open;
- Improved onItemContainerChanged to prevent filling multiple pouches simultaneously from being treated as only filling the last-clicked pouch with the total stored essence;
- Removed ZMI-related stuff since plugin should not be dependent on being near ZMI now