### PR TITLE
Update max-hit-calculator to v1.12.3

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=8f37cb409706fe0fabb059c68dcebe435329763d
+commit=c26aae8bcbb978c7424f916e3f26d38ddcd8a46c


### PR DESCRIPTION
v1.12.3 Update:
- Corrected Soulreaper Axe Soulstack calculations (j-cob44/max-hit-calc#27)
- Fixed Warped Sceptre not allowing 'vs type' calculations
- Fixed rounding errors with next max hit predictions 