### PR TITLE
Global chat: Add read-only setting

### DIFF
--- a/plugins/global-chat
+++ b/plugins/global-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/RusseII/region-chat.git
-commit=1ee3780f7153de1e87f2574c32ebb4fc6dfb2543
+commit=33e6a72089e91d8e06f93cd9fb2a8e325509b3c8
 warning=This plugin submits all sent chat messages and your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Adds a setting that gives users an easier way to toggle on/off sending global chat msgs. 