### PR TITLE
Update old-school-snitch to 1.1.1

### DIFF
--- a/plugins/old-school-snitch
+++ b/plugins/old-school-snitch
@@ -1,3 +1,3 @@
 repository=https://github.com/wkpatrick/old-school-snitch.git
-commit=4557ba2c5f06b77ae573798c508c398725d7df30
+commit=476eba5eb95ed6190eb513a2cccf59fd16f569d8
 warning=This plugin submits your player name, player model, account hash, xp data, drop data, in-game location, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
- Fix issue with detecting runite mining.
- Add Open Website button to the plugin panel.
- Skip name updates if the current name has already been set