### PR TITLE
Update Inventory Setups to v1.18 and Bank Tag Layouts

### DIFF
--- a/plugins/bank-tag-layouts
+++ b/plugins/bank-tag-layouts
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/bank-tag-custom-layouts.git
-commit=a0d57b62078eac9478d904cf337f392c4c97a75f
+commit=0d168895788e8ec1d8176810514983ec486e3d7b

--- a/plugins/inventory-setups
+++ b/plugins/inventory-setups
@@ -1,2 +1,2 @@
 repository=https://github.com/dillydill123/inventory-setups.git
-commit=f0684ecaff905940c8c3186f91c466570d030fcb
+commit=05f604baf0278878a84b135106708ffabb76f64f


### PR DESCRIPTION
Inventory setups v1.18

- V3 data (separate key per setup)
- search by item or notes in setup
- blazing blowpipe -> toxic blowpipe
- Fix patch notes panel not displaying correctly

That last point made me want to quit Java Swing

Also update Bank Tag Layouts to use the new V3 data. @geheur please confirm the commit is correct. These need to be merged at the same time to avoid a headache