### PR TITLE
Feature/home improvement plugin

### DIFF
--- a/plugins/home-improvement
+++ b/plugins/home-improvement
@@ -1,2 +1,2 @@
-repository=https://github.com/Mike-U5/rl-plugin-home-improvement
+repository=https://github.com/Mike-U5/rl-plugin-home-improvement.git
 commit=f80aa33ed5015a87f9af6fe83e8f0c49c53ebc61

--- a/plugins/home-improvement
+++ b/plugins/home-improvement
@@ -1,0 +1,2 @@
+repository=https://github.com/Mike-U5/rl-plugin-home-improvement
+commit=f80aa33ed5015a87f9af6fe83e8f0c49c53ebc61

--- a/plugins/home-improvement
+++ b/plugins/home-improvement
@@ -1,2 +1,2 @@
 repository=https://github.com/Mike-U5/rl-plugin-home-improvement.git
-commit=f80aa33ed5015a87f9af6fe83e8f0c49c53ebc61
+commit=e1f7c5f96658cac4bb49a48ade6030f4b37c4053


### PR DESCRIPTION
An update for the Home Improvement Plugin.
While doing Mahogany Homes, the "remove" option is removed from items that you have already built. (It's not actually possible to remove these regardless)  
  
The PoH check has been changed to check for either a House Portal or a Wintumber Tree because _some houses_ do not actually have a house portal.