### PR TITLE
Create No Steven plugin

### DIFF
--- a/plugins/no-steven
+++ b/plugins/no-steven
@@ -1,0 +1,2 @@
+repository=https://github.com/two-zee/no-steven.git
+commit=b60a773ef6957270e9f9c0b5918a898117166522

--- a/plugins/no-steven
+++ b/plugins/no-steven
@@ -1,2 +1,2 @@
 repository=https://github.com/two-zee/runelite-plugins.git
-commit=7405e88233a3f51e5080606f987f074d3f7c4695
+commit=86156371f6fab0aa924e645d336e1c116b144809

--- a/plugins/no-steven
+++ b/plugins/no-steven
@@ -1,2 +1,2 @@
 repository=https://github.com/two-zee/runelite-plugins.git
-commit=86156371f6fab0aa924e645d336e1c116b144809
+commit=16878be92f9ea49c3eafc2740f8fef8018758684

--- a/plugins/no-steven
+++ b/plugins/no-steven
@@ -1,2 +1,2 @@
 repository=https://github.com/two-zee/runelite-plugins.git
-commit=e6e81a83578518cb049813ccf540c8ad6b472e4a
+commit=a3c86c87bda4453f7d474a709295c50355df8a29

--- a/plugins/no-steven
+++ b/plugins/no-steven
@@ -1,2 +1,2 @@
-repository=https://github.com/two-zee/no-steven.git
-commit=a9c2bbc3d1e19b0a8f2eac73610f05cf11788363
+repository=https://github.com/two-zee/runelite-plugins.git
+commit=e6e81a83578518cb049813ccf540c8ad6b472e4a

--- a/plugins/no-steven
+++ b/plugins/no-steven
@@ -1,2 +1,2 @@
 repository=https://github.com/two-zee/no-steven.git
-commit=b60a773ef6957270e9f9c0b5918a898117166522
+commit=a9c2bbc3d1e19b0a8f2eac73610f05cf11788363

--- a/plugins/no-steven
+++ b/plugins/no-steven
@@ -1,2 +1,2 @@
 repository=https://github.com/two-zee/runelite-plugins.git
-commit=a3c86c87bda4453f7d474a709295c50355df8a29
+commit=7405e88233a3f51e5080606f987f074d3f7c4695

--- a/plugins/no-steven
+++ b/plugins/no-steven
@@ -1,2 +1,2 @@
 repository=https://github.com/two-zee/runelite-plugins.git
-commit=16878be92f9ea49c3eafc2740f8fef8018758684
+commit=9348b583d580d402c784509af64d13bb6be9d4e3


### PR DESCRIPTION
A RuneLite plugin that hides everything related to the "SteVen" bots that plague F2P.

It can hide their:
- Entities (e.g. models)
- 2D entities (e.g. hitsplats)
- Overhead chats
- Chat interface chats
- The models of who they are interacting with