### PR TITLE
Added new plugin: streamer redeems

### DIFF
--- a/plugins/streamer-redeems
+++ b/plugins/streamer-redeems
@@ -1,0 +1,2 @@
+repository=https://github.com/molteber/streamer-redeems.git
+commit=a490304c745b844692939adf10df90f94673b5e6

--- a/plugins/streamer-redeems
+++ b/plugins/streamer-redeems
@@ -1,2 +1,2 @@
 repository=https://github.com/molteber/streamer-redeems.git
-commit=a490304c745b844692939adf10df90f94673b5e6
+commit=abc4050b16fb0bdf68f67e88d499ab2406404e47


### PR DESCRIPTION
This plugin allows you to connect to a Server-sent event endpoint hosted by yourself or someone else which is connected to a streamer service (ie. twitch) 

Taking twitch into account, streamer can redeem rewards. A streamer can install this plugin and allow him/her/it to be pranked when chatters redeem specific rewards.

This plugin does for now only support triggering a fake collection log popup (which includes a chat message stating that the person was pranked).