### PR TITLE
Update to v1.5.3 - Fix unable to build + remove debug log

### DIFF
--- a/plugins/treecount
+++ b/plugins/treecount
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/tree-count-plugin.git
-commit=fcfe2cbdb1500256e6e12f091ffd76be78898dce
+commit=231c78559f4885f38d8b5122543ca60e6b7e9bcb


### PR DESCRIPTION
- Resolves failed to build as of RL v1.10.25 due to `ObjectID` changes
- Removed debug logs because they probably wrote too much due to excessive logging for detailed testing