### PR TITLE
Update quest-helper to 4.3.1.2

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=c7ec04c04956a271ac70813615aef82454e1c067
+commit=39313b2db89b194b6e9e726c91c8e8a9db5443de


### PR DESCRIPTION
Fixes tree IDs for most recent quest release.