### PR TITLE
add fortis-colosseum v1.0.0

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,0 +1,2 @@
+repository=https://github.com/LlemonDuck/fortis-colosseum.git
+commit=e9e698490b5d01da09be228034f11af319208238


### PR DESCRIPTION
For now, only contains left-click bank-all on the loot chest. Once the wave spawns are known and on the wiki, I'll add a wave spawn overlay a la Fight Cave Waves.