### PR TITLE
Update 117HD to v1.3.2

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=11c9c206da39646434e6cb9a33eec078c277656b
+commit=eed65694393ee10831d53fe6be2dc07b835eafd8
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This is a bit of a big diff, so if it's strongly preferred, I can make a minimal patch for Varlamore. Just let me know :+1:

Fixes:
- Varlamore texture issues.
- Fix seafloor disappearing when right-clicking (again).
- Fix broken water in underground areas
- Display proper error messages for the new Mesa-based Windows OpenGL compatibility addon
- Prevent config processing while loading a scene
- Add option to prefer vanilla shadows over 117 HD shadows in encounters like Olm in Chambers of Xeric
- Heaps of texture changes

The triple dot diff on Github shows some unnecessary changes by the looks of it. This is more concise: https://github.com/117HD/RLHD/compare/11c9c206da39646434e6cb9a33eec078c277656b..eed65694393ee10831d53fe6be2dc07b835eafd8?w=0