### PR TITLE
update fortis-colosseum to v1.1.2

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=cda0c8bd1e519fa95109347a33f03c0e04201f5f
+commit=488db1cb69c8d26d4568cebd7eb93f8d8d87e652


### PR DESCRIPTION
fixes a bug that shows 0x ranger spawns when it should be 2x