### PR TITLE
Update osrs-wiki-crowdsourcing

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=26e30f8ff3312430fac1d1d8b1103adec50feac2
+commit=1757460e7094b8fa921544fd9266ec7172bea81f
 authors=leejt,andmcadams

--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
 commit=1757460e7094b8fa921544fd9266ec7172bea81f
-authors=leejt,andmcadams
+authors=leejt,andmcadams,cdfisher


### PR DESCRIPTION
Includes changes from #5295 by @leejt which was closed for being stale.

Replaces deprecated uses of WidgetID and WidgetInfo.

