### PR TITLE
update fortis-colosseum to v1.1.3

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=488db1cb69c8d26d4568cebd7eb93f8d8d87e652
+commit=b4e0d675d1e2529829eccb9244b43f8a6c22b2ee


### PR DESCRIPTION
don't show waves outside colosseum 