### PR TITLE
Add `hunter-rumours` v1.0.0

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=90f136c88b1f2dd550567a1bf76fc838e3e21744
+commit=15b4c86056194ed26b86454f4685b52521fdaf3c

--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=15b4c86056194ed26b86454f4685b52521fdaf3c
+commit=64bbbcacb1e13b8266c32f44e09dd94d43c1efaf

--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,0 +1,2 @@
+repository=https://github.com/geel9/runelite-hunter-rumours.git
+commit=90f136c88b1f2dd550567a1bf76fc838e3e21744


### PR DESCRIPTION
- Adds Hunter Rumours plug-in, which tracks current and latent hunter rumours

![image](https://github.com/runelite/plugin-hub/assets/1294419/f39ae8f0-6c8d-484b-8ac3-7d5e529662fc)

![image](https://github.com/runelite/plugin-hub/assets/1294419/973f3646-f57f-4048-8627-617c736b6e7d)

![image](https://github.com/runelite/plugin-hub/assets/1294419/e8951bfc-ea57-4b09-95d6-b6a795ae9eff)

![image](https://github.com/runelite/plugin-hub/assets/1294419/bddf8be6-b333-4597-9eb1-6eafd4b6e593)

![image](https://github.com/runelite/plugin-hub/assets/1294419/7cdb05e3-14f9-4ba1-b439-80bd52d73e4d)

![image](https://github.com/runelite/plugin-hub/assets/1294419/f2128a0b-c5a5-45a6-bda3-b91b43f724ce)
