### PR TITLE
Update Escape Crystal (v1.2)

### DIFF
--- a/plugins/escape-crystal
+++ b/plugins/escape-crystal
@@ -1,2 +1,2 @@
 repository=https://github.com/johnvictorfs/escape-crystal-runelite-plugin.git
-commit=d71bde9601fbdd3ce32243bba3c794b37920c700
+commit=7eccd9e0804aff8d4d899bfbc583368a5698e228


### PR DESCRIPTION
- **Features**
  - Add setting to show the crystal infobox even if auto-tele is inactive
  - Add setting to only send auto-tele notifications when in combat
- **Bug Fixes**
  - Only send notifications if escape crystal is in inventory/equipped/active when in gauntlet
  - Make the plugin work if the escape crystal is equipped instead of just when in inventory
  - Make the plugin work inside the gauntlet (if entered with an active crystal)
    - Also added a setting (turned on by default) to send a warning notification if the player has entered the Gauntlet lobby without an active escape crystal
 