### PR TITLE
update fortis-colosseum to v1.1.4

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=b4e0d675d1e2529829eccb9244b43f8a6c22b2ee
+commit=e5de4b6dd8ab074272b94eb04945864f4ea72a49


### PR DESCRIPTION
fixes manticore spawn count on wave 6