### PR TITLE
Add dt2-mistake-tracker

### DIFF
--- a/plugins/dt2-mistake-tracker
+++ b/plugins/dt2-mistake-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/DominickCobb-rs/DT2-Boss-Failure.git
+commit=e32949238450ed395ed75f9da638dd35383a7393
+authors=DominickCobb

--- a/plugins/dt2-mistake-tracker
+++ b/plugins/dt2-mistake-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/DT2-Boss-Failure.git
-commit=e32949238450ed395ed75f9da638dd35383a7393
+commit=a6ff5e4f9349c286e544131564d80c470808471a
 authors=DominickCobb


### PR DESCRIPTION
I've decided this is better than repeat CA failure notifications.