### PR TITLE
Update named-pets commit hash to 1.0.2

### DIFF
--- a/plugins/named-pets
+++ b/plugins/named-pets
@@ -1,3 +1,3 @@
 repository=https://github.com/pappymint/named-pets-runelite.git
-commit=3e2934466469aed50062b0009cb1cbab8d2152e3
+commit=29e55d679d64304f13cac3d5258adc94c960d6b4
 authors=pappymint


### PR DESCRIPTION
Updating plugin `named-pets`

- Adds ability to view previously named pets above POH pets
- New config option that replaces the default pet name with the custom name in menu entries