### PR TITLE
Update max-hit-calculator to latest

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=c26aae8bcbb978c7424f916e3f26d38ddcd8a46c
+commit=0527e001ab68dbb8b0acdbd7b05f8140bbbd4ce3


### PR DESCRIPTION
Fix checks for null errors that could cause plugin crashes
Fix for Keris Partisan Weapon Type issue