### PR TITLE
Update max-hit-calculator to latest

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=0527e001ab68dbb8b0acdbd7b05f8140bbbd4ce3
+commit=df83349f87176d91c18840ec74e258e087519462

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=a6d6db52111a655a926fc9568bce58676b86565f
+commit=0527e001ab68dbb8b0acdbd7b05f8140bbbd4ce3

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=df83349f87176d91c18840ec74e258e087519462
+commit=d258aa81d8a0a2f8c2e8cdc14b013c9295b84aa3


### PR DESCRIPTION
Bugfixes (March 26):
- Fix checks for null errors that could cause plugin crashes
- Fix for Keris Partisan Weapon Type issue
<br>
Bugfixes (April 2):

- Fix for Powered Staves Defensive Casting mode
<br>
v1.12.5 Update (April 5):

- Added Differences for Charged and Uncharged Tonalztics of Ralos
- Added Dual Macuahuitl Special Attack Bonus
- Fix for Blue Moon Spear type mismatches
