### PR TITLE
update fortis-colosseum to v1.2.1

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=48241a04f9150bf6afb0e50ca25adeed38fac491
+commit=2b5c1fe7f25f9976ca2f5ea3d7a24dae0032c059


### PR DESCRIPTION
removes an erroneous spacer in the waves overlay on wave 12

support in-wave time tracking for transparent chatbox

show cumulative wave time without between-wave time