### PR TITLE
Create anchovy-pizza-helper

### DIFF
--- a/plugins/anchovy-pizza-helper
+++ b/plugins/anchovy-pizza-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/vpavanv/AnchovyPizzaHelper.git
+commit=a66dbb90024ee1fe7f372d6d1525cc6779415278


### PR DESCRIPTION
This is a plugin that helps players combo-eat in F2P with anchovy pizzas. It only highlights full anchovy pizzas as only eating the first halves is what allows quick healing vs eating the second halves. 