### PR TITLE
Update inferno-stats to v2.1.6

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=21f145d4b635fba1ff86dde8f4e36c87deed6d83
+commit=260aaa3463d962c23bd8fc2bd991911fcdf1850c


### PR DESCRIPTION
Fixes a bug where the Colosseum wave text tricks the plugin into thinking a wave has started without a proper location being assigned and causes a NullPointerException down the line