### PR TITLE
Update `custom-item-hovers` to `1.1.3`

### DIFF
--- a/plugins/custom-item-hovers
+++ b/plugins/custom-item-hovers
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-custom-item-hovers.git
-commit=a9ccfaf1259187a4910e286094e7e2832811363b
+commit=fd78f564bd380b35625cdcdd59e84f212d49113f

--- a/plugins/custom-item-hovers
+++ b/plugins/custom-item-hovers
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-custom-item-hovers.git
-commit=fd78f564bd380b35625cdcdd59e84f212d49113f
+commit=3dd9fed982f567275663a4d6395295b26e0eda4f


### PR DESCRIPTION
- Adds `qtydivide` and `qtydividefloor` functions
- Injects `Gson` instance instead of instantiating a new one
- Removes use of deprecated `WidgetInfo` and `WidgetID` APIs