### PR TITLE
Update poisoned-npcs to v0.2.0: detect enchanted emerald bolts

### DIFF
--- a/plugins/poisoned-npcs
+++ b/plugins/poisoned-npcs
@@ -1,2 +1,2 @@
 repository=https://github.com/tautges/runelite-poisoned-npcs-plugin.git
-commit=0ef5a66db857788b1d2343d1ba3926e33705cd80
+commit=b8e2c928ff3bbef07daacb563ca6418748a9c5ae


### PR DESCRIPTION
Detect enchanted emerald bolts as a poisoned weapon, and fix an issue with ammo not being detected.