### PR TITLE
Update Random Event Analytics | Old / null profile record NPE fix

### DIFF
--- a/plugins/random-event-analytics
+++ b/plugins/random-event-analytics
@@ -1,2 +1,2 @@
 repository=https://github.com/zmanowar/random-event-analytics.git
-commit=65b9c0fb1778c344fb2c131c659a3af4ccec2f39
+commit=12aa3ebe09393a0f56b4c75dd31b722eb2968c3e


### PR DESCRIPTION
Checks for null record before `spawnedTime`.

Having issues replicating the bug, but this should get us a little further.