### PR TITLE
Add "No Player Use" plugin

### DIFF
--- a/plugins/no-player-use
+++ b/plugins/no-player-use
@@ -1,0 +1,2 @@
+repository=https://github.com/oohwooh/no-use-players.git
+commit=dff362d01fa7c562729f3b859cc25dce984696df

--- a/plugins/no-player-use
+++ b/plugins/no-player-use
@@ -1,2 +1,2 @@
 repository=https://github.com/oohwooh/no-use-players.git
-commit=dff362d01fa7c562729f3b859cc25dce984696df
+commit=002fe50f094c3fd5cc0e75535381ba92cd9cabde


### PR DESCRIPTION
Simple plugin that removes menu options related to using items on other players. This is especially helpful for UIMs looking to unnote/note items in crowded areas.