### PR TITLE
update fortis-colosseum to v1.3.2

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=a52d2f12bfd7f402348835bb8580cf1d99fcba2b
+commit=532aba3ede16aa4b223aca1d458a172a2a0bb75d


### PR DESCRIPTION
splits: track wave 12 time as delta from cumulative