### PR TITLE
Update dynamic-inventory-tags - fixes some weapons not highlighting correctly

### DIFF
--- a/plugins/dynamic-inventory-tags
+++ b/plugins/dynamic-inventory-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/BraveH/gear-switch-alert.git
-commit=4e0c789501b2499df97b985e0c7ccea7660e5a87
+commit=23f29622f36c40bafefa3cf0385aab2d80826117


### PR DESCRIPTION
Thanks to @daltonpearson for this fix with long range magic casting weapons.