### PR TITLE
update fortis-colosseum to v1.4.0

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=532aba3ede16aa4b223aca1d458a172a2a0bb75d
+commit=bb94eca56ed782f75607012c923777de14b89956


### PR DESCRIPTION
adds the ability to hide loot previews and show overall loot totals on the modifier select interface