### PR TITLE
Update action-progress

### DIFF
--- a/plugins/action-progress
+++ b/plugins/action-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/guillaume009/runelite-plugin-action-progress.git
-commit=f5657c4ea14b8cd8a4cd3293ac62e58c09f256e9
+commit=5907eebf542234b01411972be65d81bddc7832bd

--- a/plugins/action-progress
+++ b/plugins/action-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/guillaume009/runelite-plugin-action-progress.git
-commit=5907eebf542234b01411972be65d81bddc7832bd
+commit=2148792bb1e45aa99ab35a404ace9393b804d078

--- a/plugins/action-progress
+++ b/plugins/action-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/guillaume009/runelite-plugin-action-progress.git
-commit=2148792bb1e45aa99ab35a404ace9393b804d078
+commit=49557efde13ea3b5241fa231ace90382263163b6


### PR DESCRIPTION
 - Add monitoring for logs added to campfire
 - Fix extended antifire not looking for the proper recipe
 - Prevent double clicks from trigger the action progress
 - Add support for chiseling dark essence fragments