### PR TITLE
Create bingo-team-indicators

### DIFF
--- a/plugins/bingo-team-indicators
+++ b/plugins/bingo-team-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/BingoTeamIndicators.git
-commit=a4fe3b80a62fae87be2fa1ecfefd1dc1e591ab46
+commit=163d2ea6bfeda2f0a24cbd8f5920816f2d46f37d

--- a/plugins/bingo-team-indicators
+++ b/plugins/bingo-team-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/BingoTeamIndicators.git
-commit=e68b93c4da7a45d592687b50b13442e89467205c
+commit=a4fe3b80a62fae87be2fa1ecfefd1dc1e591ab46

--- a/plugins/bingo-team-indicators
+++ b/plugins/bingo-team-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/BingoTeamIndicators.git
-commit=6f5e83998d8d25d02ee4edf9ef59cd4226e69422
+commit=91b1cfaa8be2dc5d6275f17c4c8ae99be2f70138

--- a/plugins/bingo-team-indicators
+++ b/plugins/bingo-team-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/BingoTeamIndicators.git
-commit=91b1cfaa8be2dc5d6275f17c4c8ae99be2f70138
+commit=e68b93c4da7a45d592687b50b13442e89467205c

--- a/plugins/bingo-team-indicators
+++ b/plugins/bingo-team-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/BingoTeamIndicators.git
-commit=878d2945fad85c70b33d162e3e5f0326ff134fcb
+commit=6f5e83998d8d25d02ee4edf9ef59cd4226e69422

--- a/plugins/bingo-team-indicators
+++ b/plugins/bingo-team-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/EwwItsMike/BingoTeamIndicators.git
+commit=878d2945fad85c70b33d162e3e5f0326ff134fcb


### PR DESCRIPTION
Adds a plugin in which you can add up to 15 teams in a sidepanel.
Plugin reads the names filled in the textareas and adds a chatbox icon corresponding with the teamnumber to easily identify your teammembers, or opposing teammembers in Clan Chat, Guest Clan Chat and Friends Chat.