### PR TITLE
update fortis-colosseum to v1.4.1

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=bb94eca56ed782f75607012c923777de14b89956
+commit=e22d1374725f7689bfce0299078b0ec0f56f12f0


### PR DESCRIPTION
* splits: show in-wave timer for wave 12
* splits: don't show duplicate wave 12 entry after beating sol heredit
* splits: option to show fewer lines