### PR TITLE
added better-tile-exporter

### DIFF
--- a/plugins/better-tile-exporter
+++ b/plugins/better-tile-exporter
@@ -1,0 +1,2 @@
+repository=https://github.com/BeardSecond/better-tile-exporter.git
+commit=bef21fbb42bdef67f8590e679222cb559d937b86


### PR DESCRIPTION
Adds 2 optional menu items to the world menu drop down:

![image](https://github.com/runelite/plugin-hub/assets/162346614/e085111c-f91a-4168-8655-c23d7254c864)

- `Visible Ground Markers`: only export markers which are within the camera viewpoint. You can move or zoom the camera to include/exclude markers.

- `Close Ground Markers`: only export markers which are within a configurable distance from the player. This distance can be set in the settings of the plugin.

The purpose is to only export relevant ground markers in a more intuitive way e.g. to export only olm tiles not tiles from the whole raid