### PR TITLE
update fortis-colosseum to v1.4.2

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,3 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=e22d1374725f7689bfce0299078b0ec0f56f12f0
-disabled=causing crashes after update today
+commit=9e7f8e54d9db30187a760bc7bec8391fbca08080


### PR DESCRIPTION
Fixes a thrown error in the overlay renderer due to the removal of the Doom Scorpion varbit.