### PR TITLE
Create rogues-chest plugin v1.0.0

### DIFF
--- a/plugins/rogues-chest
+++ b/plugins/rogues-chest
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
-commit=78e3d62b0f9a234d1b08af5cd32e8c879d410bfd
+commit=6eb2e7c989387d36681d363b9c6ed84e7a264cae

--- a/plugins/rogues-chest
+++ b/plugins/rogues-chest
@@ -1,0 +1,2 @@
+repository=https://github.com/pwatts6060/runelite-plugins.git
+commit=78e3d62b0f9a234d1b08af5cd32e8c879d410bfd


### PR DESCRIPTION
-Tile marker with red/green color on rogues chests indicating if they can be opened or not
-Countdown text on chests that have been looted to indicate how many ticks until they can be opened again
-Notifications for when chests are lootable
-Sound notifications for 1 tick before and when a chest is lootable
-Toggle option to disable for the east chest which isn't efficient to use