### PR TITLE
Update Dink to v1.10.0

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=c7d296cbd3d037ab0b3c6cf89955fe5b8cda151e
+commit=998c588d3a5d556944cdbac97fc8200c995d8bf9
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.10.0 most notably adds a new notifier for chat messages that match user-specified patterns.
Also, the loot notifier now ignores the rarity of denylisted items for the rarity override setting.
In terms of Varlamore, the loot notifier has updated drop rate data, the pet notifier better supports Smol heredit, and the kill count notifier now tracks Lunar Chest openings.

Full release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.10.0
