### PR TITLE
Update `custom-item-hovers` to `1.2.0`

### DIFF
--- a/plugins/custom-item-hovers
+++ b/plugins/custom-item-hovers
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-custom-item-hovers.git
-commit=3dd9fed982f567275663a4d6395295b26e0eda4f
+commit=5178a342e0211e3c106fa26eab8c7a64b393a13d


### PR DESCRIPTION
- Revamps expressions
	- Previously, a simple text-replace engine with a few variables and functions handled dynamic text in item hovers.
		- Terrible
	- Now, full mathematical expressions, with variables, functions, and parentheses, are supported
	- EG, `${floor(1 / (qty * 2)) + high_alch}`
	- **Maintains Backwards Compatibility**
		- `<%` and `%>` are valid expression start and end tokens
			- But `${` and `}` are the ones that you should use moving forward
		- All existing variables and functions have been ported over
			- EG, `<%qtymult(5)%>` will still work just the same as it did before
				- However, now, the expression is going through the full expression engine, where `qtymult` is a function that exists for backwards compatibility
				- The following expressions are equivalent to the above, and are all valid:
					- `${qtymult(5)}`
					- `${qty * 5}`
					- `<%qty * 5%>`
					- `<%qtymult(1) * 5%>`
	- **Note**: None of this involves any unsafe `eval`-like code; it is not an actual scripting engine and cannot be used to execute arbitrary code.
- Adds Item Data Tables  
	- See `docs/ItemTables.md` for explanation