### PR TITLE
Create dodgy-necklace-reminder

### DIFF
--- a/plugins/dodgy-necklace-reminder
+++ b/plugins/dodgy-necklace-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/LiamStachiw/dodgy-necklace-reminder.git
+commit=057b4fb6eb028646a63ca022cac0c37b16d50ec6

--- a/plugins/dodgy-necklace-reminder
+++ b/plugins/dodgy-necklace-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/LiamStachiw/dodgy-necklace-reminder.git
-commit=057b4fb6eb028646a63ca022cac0c37b16d50ec6
+commit=9323b697464302f93fcd15586879c600d8f95169


### PR DESCRIPTION
This plugin will remind the user to equip a dodgy necklace with an overlay whenever the user has a dodgy necklace in their inventory while also not having one already equipped.