### PR TITLE
Global chat: Bug fix when turning on plugin + lower cost

### DIFF
--- a/plugins/global-chat
+++ b/plugins/global-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/RusseII/region-chat.git
-commit=33e6a72089e91d8e06f93cd9fb2a8e325509b3c8
+commit=403f4d0d17dd537838f3929a37bb095e1e5e3372
 warning=This plugin submits all sent chat messages and your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
* Changes how some of the events are sent to lower my Ably costs.
* Now connects to the global chat when turning on the plugin vs requiring a re-log