### PR TITLE
Update `hunter-rumours` to `1.0.1`

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=64bbbcacb1e13b8266c32f44e09dd94d43c1efaf
+commit=51972ecfc9fd05ab894e6fd342a9c47a111fa58e


### PR DESCRIPTION
- Fixes tool leprechauns being highlighted when there is no active rumour