### PR TITLE
Update BoostPerformance to v1.1

### DIFF
--- a/plugins/boost-performance
+++ b/plugins/boost-performance
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/boost-performance.git
-commit=a2a9d3bdadf5fb10fbc2b5cef9142290faacd459
+commit=bca4c1ea06c77779e8c4e99bdbccb1e101106a9b


### PR DESCRIPTION
Fixes a few issues.

- Only tracks party-members that have the plugin enabled.
This prevents invalid participants from being the "sender" of updates.

- Giant mole can die post-dig, resulting in a death without despawn viewed.
Added additional death event on valid KC messages, for giant mole the plugin needs main/booste in party to be fully accurate, impossible to fix otherwise.

- Abyssal sire has a common world-hop method where the main/boostee never sees the boss spawn due to having a "vent-killer" in the other world, 
Plugin is working as intended but causes confusion with this method. Added a user-error message to indicate that the vent killer or any viewer must be present, in party and have the plugin enabled for kills to properly track.

