### PR TITLE
Adds lf-skill plugin file

### DIFF
--- a/plugins/lf-skill
+++ b/plugins/lf-skill
@@ -1,0 +1,2 @@
+repository=https://github.com/FaceTanked/runelite-lf-skill.git
+commit=e95d50705fc4b218c14313a9d3e774c534e99225


### PR DESCRIPTION
The "LF Skill" plugin simply replaces the overhead text displayed during the special attack of the dragon axe, harpoon, and pickaxe to "Let's fucking chop!", "Let's fucking fish!", and "Let's fucking mine!", respectively.

Additionally, there is a "no profanity" toggle for those that want to get festive without that specific language.