### PR TITLE
Update target-true-tile to 1.1.0

### DIFF
--- a/plugins/target-true-tile
+++ b/plugins/target-true-tile
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/runelite-target-true-tile.git
-commit=c26ef263ed8fa8cee4970225eff5d2780a08c028
+commit=3c9ada86252f046d6b2c698a77062e265a3300aa
 authors=Notloc

--- a/plugins/target-true-tile
+++ b/plugins/target-true-tile
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/runelite-target-true-tile.git
-commit=edaded407f36c85cb41db9d1ddb25f079d858573
+commit=c26ef263ed8fa8cee4970225eff5d2780a08c028
 authors=Notloc


### PR DESCRIPTION
Adds option for improved tile rendering that prevents overdraw on the player and target NPC