### PR TITLE
Update `hunter-rumours` to `1.1.2`

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=51972ecfc9fd05ab894e6fd342a9c47a111fa58e
+commit=8e93ff106cb047f1ff00785849b5a7fcac8c1685

--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=b44c163403b201e5c1f120384dde4b1b79c6fbac
+commit=d8fadf47a31ad194389fee8b824294afc235f107

--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=8e93ff106cb047f1ff00785849b5a7fcac8c1685
+commit=0bce4b72aa8d7228c482d3cb9278412b1535374f

--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=0bce4b72aa8d7228c482d3cb9278412b1535374f
+commit=b44c163403b201e5c1f120384dde4b1b79c6fbac


### PR DESCRIPTION
- **`1.1.0`**
	- Adds tracking of back-to-back state
	- Adds pity rate display to rumour infobox
		- Handles the guild outfit as well
	- Updates infobox to use image of hunter creature instead of the special item
	- Removes "Rumour" text from infobox
	- Fixes `Unknown` rumours showing up as `Unknown (Box Trap)`
	- Fix Tool Leprechauns being erroneously highlighted
		- For real this time
- **`1.1.1`**
	- Tracks number of hunter creatures caught while on-task
		- Displays how many to go until you hit the pity rate
	- Adds new config entries
	- Moves/categorizes a bunch of config entries
	- Improves infobox tooltip
	- Significantly improves default plugin settings
		- Disables list of hunters/rumours by default
		- Disables highlighting of known/unknown hunters by default
		- Makes default highlight colors less garish
- **`1.1.2`**
	- Handles Hunter name in Quetzal Whistle's "Rumour" chat message, per recent game update