### PR TITLE
Create snipelist-indicator

### DIFF
--- a/plugins/snipelist-indicator
+++ b/plugins/snipelist-indicator
@@ -1,0 +1,2 @@
+repository=git@github.com:javaj0hn/snipe-list-indicator.git
+commit=890a98083163c0d3fbd35b76f1a714f19f558637

--- a/plugins/snipelist-indicator
+++ b/plugins/snipelist-indicator
@@ -1,2 +1,2 @@
-repository=git@github.com:javaj0hn/snipe-list-indicator.git
+repository=https://github.com/javaj0hn/snipe-list-indicator.git
 commit=890a98083163c0d3fbd35b76f1a714f19f558637


### PR DESCRIPTION
This plugin allows you to add players rsns to a list so you can get the same benefits of player indicators but without them having to be in a CC, Friends etc. The intended purpose of this extension is to mark certain players as "dangerous" or risky while pking so you know you can avoid/run away if they are seen.