### PR TITLE
Create Construction QOL

### DIFF
--- a/plugins/zom-con-qol
+++ b/plugins/zom-con-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=6877a43b575959d5e0ae8b5afe2c48a9baec8fa7
+commit=988003e07016f00cb2372c0eae9e123d32f9fbad

--- a/plugins/zom-con-qol
+++ b/plugins/zom-con-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=b660fb4a55d086717c801150f9eef11da48ed4dd
+commit=6877a43b575959d5e0ae8b5afe2c48a9baec8fa7

--- a/plugins/zom-con-qol
+++ b/plugins/zom-con-qol
@@ -1,0 +1,2 @@
+repository=https://github.com/JZomDev/zom-external-plugins.git
+commit=b660fb4a55d086717c801150f9eef11da48ed4dd


### PR DESCRIPTION
Switch keys at the construction menu

![image](https://github.com/runelite/plugin-hub/assets/14265490/9e29e38c-0237-45b9-941e-183158e73763)

This is done during onWidgetLoaded event and modifying the widget's onKeyListener

I couldn't seem to get a key remapper to work and I don't know why, it was like the keyPressed event was firing on the widget before I could intercept it and replace it with the new key code to make 1 -> 3 and 3 -> 1

I'm all ears for the correct way to do this, I just wanted *something* to exist for now