### PR TITLE
Update c-engineer-completed to v1.0.8

### DIFF
--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=13a97af98777aca2112e4401ed955bf5ba0f5b91
+commit=80080208b9505783b13a2f1b5c54e4116922af32


### PR DESCRIPTION
Removes old use-bond troll sound trigger
Removes most of the stat spy sounds leaving only one
Replaces snowball troll sounds with a new set
Adds new troll triggers (emote based)
Adds a QOL non-parchmented infernal cape warning once per plugin session
Adds a custom death sound if it was C that killed you (or at least contributed)
Organises settings into sections