### PR TITLE
add hunter pouch overlay plugin

### DIFF
--- a/plugins/hunter-pouch-overlay
+++ b/plugins/hunter-pouch-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/trs/runelite-hunter-pouch-overlay.git
-commit=e127bb56c32f4a879b3c7f35fe65bec472404d1e
+commit=dcc682ba14bb869cdbc2ac7f80aacfb466aa0da3

--- a/plugins/hunter-pouch-overlay
+++ b/plugins/hunter-pouch-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/trs/runelite-hunter-pouch-overlay.git
+commit=e127bb56c32f4a879b3c7f35fe65bec472404d1e


### PR DESCRIPTION
This plugin adds an overlay to the hunter pouches showing the number of meat/furs inside.

![icon](https://github.com/runelite/plugin-hub/assets/15315657/472e2b71-a31f-44d5-843e-9153f82fbb87)
