### PR TITLE
[Hotfix] Updates Emote Clue Items to v4.3.1.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=c141afb64cb4071d437a6c8886933b007735a342
+commit=31e4e52d44fdddbade81792f029ea2b342f9458e


### PR DESCRIPTION
This update of Emote Clue Items features the following updates.

Patches a RuneLite STASHUnit reference which caused the plugin to be incompatible with RuneLite's latest version. (see [emote-clue-items#105](https://github.com/larsvansoest/emote-clue-items/issues/105))