### PR TITLE
update cox-scouting-qol

### DIFF
--- a/plugins/cox-scouting-qol
+++ b/plugins/cox-scouting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/Filofteia/FilosPlugins.git
-commit=fbeda1b107a88f2f856f2e9a8e2eaa4355d07a32
+commit=1018fd88ca8f425e74bbdcb9bbe0501bb81f6112


### PR DESCRIPTION
Allow the use of spaces after commas in the config.