### PR TITLE
Update rumour-reminder - Remove Kebbity tuft related highlighting

### DIFF
--- a/plugins/rumour-reminder
+++ b/plugins/rumour-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/DrJam/rumour-reminder.git
-commit=e243a54523e46cab25586ffb0da5de4c6661d5dc
+commit=38a5b7aefc4314dc1f321bea74c994bcea23aa61


### PR DESCRIPTION
Removing equivalent turn-in options per update today
- Kebbity Tufts from Hunter rumours can now only be handed in if they were obtained from the same kebbit that you've been assigned.