### PR TITLE
update fortis-colosseum to v1.4.4

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=29167ee970d901086ba20423ff9fc8e25d91b077
+commit=67a129f93b02e2cdb0e3c68b310d217e1460b8a1


### PR DESCRIPTION
* fixes a new bug that showed non-existent wave 13+ spawns after defeating sol heredit
* pauses livesplit game time between waves