### PR TITLE
Update barrows-potential

### DIFF
--- a/plugins/barrows-potential
+++ b/plugins/barrows-potential
@@ -1,2 +1,2 @@
 repository=https://github.com/Godofdrakes/barrows-potential.git
-commit=09b37745efd6a594512d54a1e1eef563a9a67cc9
+commit=4afcfc988c92cb300e094c5a5da3dcc7c6c5006b


### PR DESCRIPTION
Rewrote overlay and highlight use to fix them not getting removed properly when plugin was disabled