### PR TITLE
Update Loot Logger to v4.2

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=c7243902334c6fc88621eed7f1f8db53bce36d44
+commit=2e246932e1aa5079983adeb590a73e48f6c4353c


### PR DESCRIPTION
Adds Moons of Peril & Fortis Colosseum to boss tabs