### PR TITLE
Add osrs-soapstones plugin file.

### DIFF
--- a/plugins/osrs-soapstones
+++ b/plugins/osrs-soapstones
@@ -1,0 +1,2 @@
+repository=https://github.com/KevinJDurant/osrs-soapstones.git
+commit=87e663b04762669b767fa0168dd67fffe4fb4bd4


### PR DESCRIPTION
If you're familiar with the Dark Souls series, then you know players can use a Soaptone to leave messages for other players.

This basically (in a very simple way) does the same thing but then with tiles. It's in a very barebones state.

There's no way for people to actually use / test this plug-in unless they write their own backend to support the HTTP-calls this plug-in needs. Which are documented in the README.md. 

I didn't add a master service yet because I lack the resources to provide the infrastructure at this moment. Also, to provide this unfiltered, uncached, etc. doesn't seem like a good idea right now.

My main goal is to share this plug-in with my friends without sharing shaded builds.

Example (the white boxes are the player usernames):

![image](https://github.com/runelite/plugin-hub/assets/19962554/8d20fff0-7b25-4b44-93e5-9d9480735d65)

The code lacks tests.