### PR TITLE
Update quest-helper to 4.4.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=6094083b2559e800b665ff68c7918d29828d1c40
+commit=376b0cf4e499a4395751cf2072c85e0c0eae2ce1


### PR DESCRIPTION
Various small fixes, notably one for helping to avoid the lag sometimes seen when starting up a helper.