### PR TITLE
Add ironclad clan goals

### DIFF
--- a/plugins/ironclad-clan-goals
+++ b/plugins/ironclad-clan-goals
@@ -1,4 +1,4 @@
 repository=https://github.com/ironclad-osrs/runelite-plugin.git
-commit=601ef36263f6a15bab48bf3357e789936dd9ec8d
+commit=80d39c0d9e3f0dffeea5395962434419493f50ee
 authors=dextermb
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex.

--- a/plugins/ironclad-clan-goals
+++ b/plugins/ironclad-clan-goals
@@ -1,2 +1,2 @@
 repository=https://github.com/ironclad-osrs/runelite-plugin.git
-commit=adf6e5a87946c01ad38520a6f9a547a20eef321a
+commit=ef47a6d6f8912bc497306834682a1ef3db8118ee

--- a/plugins/ironclad-clan-goals
+++ b/plugins/ironclad-clan-goals
@@ -1,2 +1,4 @@
 repository=https://github.com/ironclad-osrs/runelite-plugin.git
 commit=601ef36263f6a15bab48bf3357e789936dd9ec8d
+authors=dextermb
+warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex.

--- a/plugins/ironclad-clan-goals
+++ b/plugins/ironclad-clan-goals
@@ -1,2 +1,2 @@
 repository=https://github.com/ironclad-osrs/runelite-plugin.git
-commit=ef47a6d6f8912bc497306834682a1ef3db8118ee
+commit=601ef36263f6a15bab48bf3357e789936dd9ec8d

--- a/plugins/ironclad-clan-goals
+++ b/plugins/ironclad-clan-goals
@@ -1,2 +1,2 @@
 repository=https://github.com/ironclad-osrs/runelite-plugin.git
-commit=e8acb56c078cba0193c5508c2ea424977f6a13f6
+commit=adf6e5a87946c01ad38520a6f9a547a20eef321a

--- a/plugins/ironclad-clan-goals
+++ b/plugins/ironclad-clan-goals
@@ -1,0 +1,2 @@
+repository=https://github.com/ironclad-osrs/runelite-plugin.git
+commit=e8acb56c078cba0193c5508c2ea424977f6a13f6


### PR DESCRIPTION
Ironclad are an ironman focused OldSchool RuneScape clan and we're looking for new and inventive ways to include clan members in community activities.

We currently want to create OldSchool skill xp goals – the best way to do this, we thought, would be to create a RuneLite plugin that can keep track of clan member xp gains.

This plugin allows for a RuneLite user to add an API key to the "Ironclad Clan Goals" configuration panel.

If the API key is valid (checked on plugin start up and configuration change) then we log:
- Which account is using the API key
- Which skills they are currently training

Outside of the plugin the backend service (https://progress.quest) will keep track of the information above along with any contributions towards an ongoing goal.

The backend service also outputs contributions to a Discord channel where people can see how everyone is doing.