### PR TITLE
Update tree-despawn-timer to 1.4.5

### DIFF
--- a/plugins/tree-despawn-timer
+++ b/plugins/tree-despawn-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/tree-despawn-timer.git
-commit=e5f02b627274e1f67aec01cc9e4751c9a5b836a6
+commit=527344ecf41c9b213741ae4f20fc02012f1bb945


### PR DESCRIPTION
Re-add Yew Tree ID behind Varrock Castle (it's listed in RuneLite as a NullObjectID for some reason)