### PR TITLE
Create graardor-kc

### DIFF
--- a/plugins/graardor-kc
+++ b/plugins/graardor-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/Gavin-TC/GraardorKC.git
-commit=2442922dc8d059ed414325c48a4654204f7ee395
+commit=d72f953b06843b789084fed50fba8cad7e87b48e

--- a/plugins/graardor-kc
+++ b/plugins/graardor-kc
@@ -1,0 +1,2 @@
+repository=https://github.com/Gavin-TC/GraardorKC
+commit=2442922dc8d059ed414325c48a4654204f7ee395

--- a/plugins/graardor-kc
+++ b/plugins/graardor-kc
@@ -1,2 +1,2 @@
-repository=https://github.com/Gavin-TC/GraardorKC
+repository=https://github.com/Gavin-TC/GraardorKC.git
 commit=2442922dc8d059ed414325c48a4654204f7ee395


### PR DESCRIPTION
Small plugin that adds counter boxes to the screen to see Bandos KC. Mostly useful with groups where you're not always getting the kill and would like to see how many kills you're getting per trip.