### PR TITLE
new bank-black-list plugin

### DIFF
--- a/plugins/bank-black-list
+++ b/plugins/bank-black-list
@@ -1,2 +1,2 @@
 repository=https://github.com/spektrum1/bank-black-list.git
-commit=f58f164499d73a9bc2f8351caa751142e676ddba
+commit=58716bb438eba86b40b7174840574f32ff557983

--- a/plugins/bank-black-list
+++ b/plugins/bank-black-list
@@ -1,2 +1,2 @@
 repository=https://github.com/spektrum1/bank-black-list.git
-commit=b7cf1027841feea632e84ecd3d4ba383d09b30e8
+commit=671114571363e3fac7d5916de330076a5ca9d715

--- a/plugins/bank-black-list
+++ b/plugins/bank-black-list
@@ -1,2 +1,2 @@
 repository=https://github.com/spektrum1/bank-black-list.git
-commit=d041b5759aadade3283af84b2069fdb4c9e45ece
+commit=dcf5dd7e230af1de34ba48e29bdd4cb244e19b6e

--- a/plugins/bank-black-list
+++ b/plugins/bank-black-list
@@ -1,0 +1,2 @@
+repository=https://github.com/spektrum1/bank-black-list.git
+commit=d041b5759aadade3283af84b2069fdb4c9e45ece

--- a/plugins/bank-black-list
+++ b/plugins/bank-black-list
@@ -1,2 +1,2 @@
 repository=https://github.com/spektrum1/bank-black-list.git
-commit=58716bb438eba86b40b7174840574f32ff557983
+commit=3a7903026531d62ddc502f25d0dd4ffed099a5e1

--- a/plugins/bank-black-list
+++ b/plugins/bank-black-list
@@ -1,2 +1,2 @@
 repository=https://github.com/spektrum1/bank-black-list.git
-commit=671114571363e3fac7d5916de330076a5ca9d715
+commit=f58f164499d73a9bc2f8351caa751142e676ddba

--- a/plugins/bank-black-list
+++ b/plugins/bank-black-list
@@ -1,2 +1,2 @@
 repository=https://github.com/spektrum1/bank-black-list.git
-commit=dcf5dd7e230af1de34ba48e29bdd4cb244e19b6e
+commit=b7cf1027841feea632e84ecd3d4ba383d09b30e8


### PR DESCRIPTION
This plugin allows you to blacklist certain items, causing a warning every time you leave them in your bank. Helpful for group ironmen forgetting to put their items back in the group storage. 