### PR TITLE
Fix left click dropper

### DIFF
--- a/plugins/zom-leftclick-dropper
+++ b/plugins/zom-leftclick-dropper
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=8e05b074ad3e3db139137ad3318c33f765c40da8
+commit=4b9cf0c6a0aae967b4580f64ad6e4155e0e12c66


### PR DESCRIPTION
Prior to this fix, if users put in the same item more than once it would swap again to not be left click drop.  Thanks @technicbuff for the report.