### PR TITLE
Update Bingo Team Indicators

### DIFF
--- a/plugins/bingo-team-indicators
+++ b/plugins/bingo-team-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/BingoTeamIndicators.git
-commit=163d2ea6bfeda2f0a24cbd8f5920816f2d46f37d
+commit=39393779b6069ed23ce5531daedabcca92931c52


### PR DESCRIPTION
Plugin now loads images using an inputstream rather than ImageUtil.loadImageResource.
Hoping this will fix the plugin adding "null" in front of names or downright remove the messages from the chatbox.