### PR TITLE
Bank Tag Layouts 1.4.27 - bugfix.

### DIFF
--- a/plugins/bank-tag-layouts
+++ b/plugins/bank-tag-layouts
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/bank-tag-custom-layouts.git
-commit=5e0db28274ae2f847ed7a1d26816283136f418bc
+commit=8caece61e3fd6fccc464e1b4872c8799b1974faa

--- a/plugins/bank-tag-layouts
+++ b/plugins/bank-tag-layouts
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/bank-tag-custom-layouts.git
-commit=0d168895788e8ec1d8176810514983ec486e3d7b
+commit=5e0db28274ae2f847ed7a1d26816283136f418bc


### PR DESCRIPTION
You are supposed to use equals instead of ==, except when you're not.