### PR TITLE
Update target-true-tile

### DIFF
--- a/plugins/target-true-tile
+++ b/plugins/target-true-tile
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/runelite-target-true-tile.git
-commit=3c9ada86252f046d6b2c698a77062e265a3300aa
+commit=0106767506d762e5d9f98b2fce4624e08c7326cb
 authors=Notloc


### PR DESCRIPTION
Just adds a null check to fix an NPE that could occur during the boat travel cutscene.