### PR TITLE
Update mlm-upper-level-markers to 1.4

### DIFF
--- a/plugins/mlm-upper-level-markers
+++ b/plugins/mlm-upper-level-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/mlm-upper-level-markers.git
-commit=9e0b5c11294b3702c5deccd6897ee21cbe814af7
+commit=a63e1ad9130451af0b382b87129b2e6a26a3e84a


### PR DESCRIPTION
Updates for the MLM rebalance changes (https://secure.runescape.com/m=news/project-rebalance-skilling--poll-81-mta-changes?oldschool=1)

Plugin was renamed to "MLM Mining Markers" superficially, but classes, code and the github still refers to it as "mlm-upper-level-markers".

Added some replacement configs for the timeouts, now there's two separate ones for upper and lower level with their respective defaults.

Changed "Only show on upper level" config to a selector (Both, Upper Only, Lower Only) and a boolean (Show only on same level as player).

Also noticed there was some deprecated bit related to overlay priority, so fixed that up.