### PR TITLE
item-stats-banking: add warning

### DIFF
--- a/plugins/item-stats-banking
+++ b/plugins/item-stats-banking
@@ -1,3 +1,3 @@
 repository=https://github.com/Boredska/bank-item-stats-toggle.git
 commit=b9d65c7472e59224895ff13b05bd459c81661a32
-warning=This plugin disables item stats, dont install it if you want to see item stats.
+warning=This plugin can disable the Item Stats plugin, don't install it if you want to see item stats.

--- a/plugins/item-stats-banking
+++ b/plugins/item-stats-banking
@@ -1,2 +1,3 @@
 repository=https://github.com/Boredska/bank-item-stats-toggle.git
 commit=b9d65c7472e59224895ff13b05bd459c81661a32
+warning=This plugin disables item stats, dont install it if you want to see item stats.


### PR DESCRIPTION
users constantly complain in #support that they install this and then are confused why item stats are now disabled