### PR TITLE
Update Archipelago - Removes gson 2.8.6+ dependency

### DIFF
--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=fcb7899c1035c1ac980aa62c532bcb71243e8466
+commit=7ed7e1000d76cc47ece0902c57963b42d723b71f


### PR DESCRIPTION
Archipelago plugin used GSON 2.8.6+ functionality, notably `JsonParser.parseString`. This was not included in the Runelite-included gson 2.8.5 library. Despite including the 2.8.6 jar as a dependency, once deployed, the plugin will attempt to use the included 2.8.5 library and throw an error. This issue does not occur when running locally or through shadowjar, so was not noticed before initial merge.

I have forked the Archipelago MultiClient repository and built a version of the jar that uses gson 2.8.5 by replacing the one use of `parseString` with `parse`. The change can be found here:
[https://github.com/digiholic/Archipelago.MultiClient.Java/commit/07bc24816074803f0ac3389147e65aad92c732fc](https://github.com/digiholic/Archipelago.MultiClient.Java/commit/07bc24816074803f0ac3389147e65aad92c732fc)