### PR TITLE
Update runepouch-loadouts to `v1.0.1`

### DIFF
--- a/plugins/runepouch-loadouts
+++ b/plugins/runepouch-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/DapperMickie/runepouch-loadout-names.git
-commit=6ac6403342589e2a97c1e6eda26d2ddcd7f556e0
+commit=a420b8725a703957163972707cbdf3fff5cf2820


### PR DESCRIPTION
Improves quality of rune icons
Makes name texts smaller