### PR TITLE
Create blast-mine-dynamite-restriction

### DIFF
--- a/plugins/blast-mine-dynamite-restriction
+++ b/plugins/blast-mine-dynamite-restriction
@@ -1,2 +1,2 @@
 repository=https://github.com/Fabletownn/blast-mine-dynamite-restriction.git
-commit=aa6767028a9a3c5812ac7ec91782338106642320
+commit=6391475916bbce58adf83debdcec65f5e5794b0f

--- a/plugins/blast-mine-dynamite-restriction
+++ b/plugins/blast-mine-dynamite-restriction
@@ -1,0 +1,2 @@
+repository=https://github.com/Fabletownn/blast-mine-dynamite-restriction.git
+commit=aa6767028a9a3c5812ac7ec91782338106642320


### PR DESCRIPTION
If the player runs out of dynamite in the Blast Mine, this plugin will alert the player (with a sound effect and chat message) and deprioritize chiseling Hard Rock (set it to right-click only) until they have it again. This way, they don't waste time chiseling the next rock if they can't load it, and helps with increasing efficiency.