### PR TITLE
Create guilt-tripper

### DIFF
--- a/plugins/guilt-tripper
+++ b/plugins/guilt-tripper
@@ -1,0 +1,2 @@
+repository=https://github.com/Kimpulla/guilt-tripper.git
+commit=f6528d1fd7f94d7ba4e539b5a2623c2e7615ee44


### PR DESCRIPTION
Guilt Tripper is a Runelite plugin designed for Old School Runescape, adding a unique twist to the gaming experience. This plugin periodically sends messages to players, humorously "accusing" them of playing too much and suggesting they take a break. And much more!

1. When the player starts the game, the plugin sends a welcome message in the chat.

2. Every 15 minutes, the plugin humorously reprimands the player for playing too much.

3. The plugin features 7 different sound effects, which can be turned off if desired. There is also a volume control for these sounds.

4. When the player dies, the plugin plays a custom sound effect.

**Epic feature:**

The plugin includes "pet" drop rates from bosses, such as the "Pet Kraken" which can be obtained with a 1/3000 chance upon defeating the Kraken boss. This meme feature displays the message "You have a funny feeling like you're being followed" in the chat, similar to what would happen if you were actually about to receive a pet. However, about 5 seconds later, a new message appears in the chat saying "Turns out it was just a lost kitten."

