### PR TITLE
Update c-engineer-completed to v1.0.9

### DIFF
--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=80080208b9505783b13a2f1b5c54e4116922af32
+commit=301f1a80858472a5ae7ca20010ee02ede76037f7


### PR DESCRIPTION
- Do non-parchmented infernal warning each time wildy is entered, except with a 1 minute cooldown
- Disable non-parchmented infernal warning at bounty hunter