### PR TITLE
Create recommended-equipment

### DIFF
--- a/plugins/recommended-equipment
+++ b/plugins/recommended-equipment
@@ -1,2 +1,2 @@
 repository=https://github.com/t8or/runelite-recommended-equipment.git
-commit=648398d386948d6aef39975d91a8f1a2c4f2c632
+commit=da919e4bb4394c4d2de186561017a979a00ff541

--- a/plugins/recommended-equipment
+++ b/plugins/recommended-equipment
@@ -1,2 +1,2 @@
 repository=https://github.com/t8or/runelite-recommended-equipment.git
-commit=1fb3ea49fcdc572cf089e814085ab40532898147
+commit=a41ed77fe623873159332087e76af9bdf2af49eb

--- a/plugins/recommended-equipment
+++ b/plugins/recommended-equipment
@@ -1,0 +1,2 @@
+repository=https://github.com/t8or/runelite-recommended-equipment.git
+commit=1fb3ea49fcdc572cf089e814085ab40532898147

--- a/plugins/recommended-equipment
+++ b/plugins/recommended-equipment
@@ -1,2 +1,2 @@
 repository=https://github.com/t8or/runelite-recommended-equipment.git
-commit=a41ed77fe623873159332087e76af9bdf2af49eb
+commit=648398d386948d6aef39975d91a8f1a2c4f2c632


### PR DESCRIPTION
Added Recommended Equipment plugin. This awesome plugin takes your OSRS gameplay to the next level by seamlessly integrating equipment recommendations from the wiki, via the approved wiki scraper, directly into your RuneLite client and then filtering your bank, similar to Quest Helper.

It helps you gear up quickly for bossing and mini-games by using wiki data without ever leaving RuneLite.