### PR TITLE
[Archipelago Randomizer] Updates Item APIs for Group Ironman Gear

### DIFF
--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=7ed7e1000d76cc47ece0902c57963b42d723b71f
+commit=18d04a9b8dbd3f925176366f19b4077bcf7402a5


### PR DESCRIPTION
Some Item names changed on the backend, causing the plugin to no longer compile. Updated all these Item names to the current version. No functionality changes.