### PR TITLE
Create First Person perspective plugin

### DIFF
--- a/plugins/first-person
+++ b/plugins/first-person
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/FirstPerson.git
-commit=4caaa6034523becb29dc7f1a649ba2ca07471c1c
+commit=574b43bb7ad93bdb346348a2baebc6f1cb497235

--- a/plugins/first-person
+++ b/plugins/first-person
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/FirstPerson.git
-commit=9be8ed5ee8414d407cc8bf88c5842a91f05f1ee2
+commit=4caaa6034523becb29dc7f1a649ba2ca07471c1c

--- a/plugins/first-person
+++ b/plugins/first-person
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/FirstPerson.git
-commit=574b43bb7ad93bdb346348a2baebc6f1cb497235
+commit=3b96e94810dbfcdbcb9a64481877c476adb149ae

--- a/plugins/first-person
+++ b/plugins/first-person
@@ -1,0 +1,2 @@
+repository=https://github.com/Zoinkwiz/FirstPerson.git
+commit=9be8ed5ee8414d407cc8bf88c5842a91f05f1ee2


### PR DESCRIPTION
Adds a First Person perspective plugin. This makes use of the detached camera state, so nothing can be interacted with whilst in first person. It's intended to just be a fun way to explore around the game.

It makes use of KeyListeners, and applies the changes itself to yaw and pitch. This is due to otherwise the initial rotation without a change of focus being applied, then suddenly next frame it snapping back to the intended perspective. This made looking around very jittery.