### PR TITLE
Create blert v0.1.0

### DIFF
--- a/plugins/blert
+++ b/plugins/blert
@@ -1,0 +1,4 @@
+repository=https://github.com/blert-io/plugin.git
+commit=4bfe248f54f4c54520a8eeec44f0142553ef4774
+authors=frolv
+warning=This plugin sends data about your raids to a third-party server not controlled by the RuneLite developers.


### PR DESCRIPTION
Blert is a PvM tracking and data analysis system hosted at https://blert.io.

This plugin collects data about players' raids and transmits it to the Blert servers to be processed and visualized.