### PR TITLE
Create camera keyframe plugin

### DIFF
--- a/plugins/keyframecamera
+++ b/plugins/keyframecamera
@@ -1,2 +1,2 @@
 repository=https://github.com/mlgudi/rl-plugins.git
-commit=d90a67bcc431078cb633850287e72a96e657da44
+commit=eda3b712785ed482719c6bca67186e1349bb0f0b

--- a/plugins/keyframecamera
+++ b/plugins/keyframecamera
@@ -1,2 +1,2 @@
 repository=https://github.com/mlgudi/rl-plugins.git
-commit=eda3b712785ed482719c6bca67186e1349bb0f0b
+commit=a6455af947b927650f251cfc62cdbc6b962da9cd

--- a/plugins/keyframecamera
+++ b/plugins/keyframecamera
@@ -1,2 +1,2 @@
 repository=https://github.com/mlgudi/rl-plugins.git
-commit=a6455af947b927650f251cfc62cdbc6b962da9cd
+commit=11b2a6dc43fa4f84ff947418de8016bd2dc93343

--- a/plugins/keyframecamera
+++ b/plugins/keyframecamera
@@ -1,0 +1,2 @@
+repository=https://github.com/mlgudi/rl-plugins.git
+commit=d90a67bcc431078cb633850287e72a96e657da44


### PR DESCRIPTION
Adds a camera keyframing plugin. Users can create sequences of camera positions using the side-panel, and then play them back with customisable durations/easing between each point.