### PR TITLE
Update the-gauntlet

### DIFF
--- a/plugins/the-gauntlet
+++ b/plugins/the-gauntlet
@@ -1,2 +1,2 @@
 repository=https://github.com/rdutta/runelite-gauntlet.git
-commit=de3298b016fbcddcbf396294c114bd47770ed4c2
+commit=594c3bf973c94ee512ff890f0b4648d092180029


### PR DESCRIPTION
Added config

* Change the tile outline color of the Hunllef corresponding to its npc id

This replicates functionality of the [Better NPC Highlight](https://github.com/MoreBuchus/buchus-plugins/tree/better-npc-highlight) plugin.

Essentially allows tile color changing based on what overhead prayer the hunllef is using.