### PR TITLE
[HOTFIX] Update `hunter-rumours` to `v1.1.3`

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,2 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=d8fadf47a31ad194389fee8b824294afc235f107
+commit=0c1cbbcb4a8d9e04b37349ae227dba9024d19260
+authors=geel9,DapperMickie


### PR DESCRIPTION
This update includes a few small changes and some hotfixes.
- Adds support for individual pieces of the hunter guild outfit
- Hotfixes herbiboar kc tracking (for pity rate)
- Hotfixes herbiboar pity rate value
- Hotfixes caught value reset after completing rumour