### PR TITLE
Watchdog v3.4.1 - Fix create alerts issue

### DIFF
--- a/plugins/watchdog
+++ b/plugins/watchdog
@@ -1,2 +1,2 @@
 repository=https://github.com/adamk33n3r/runelite-watchdog.git
-commit=8b5830064856b371b9fbfbfcf82a8fadd01aab7c
+commit=bf2f863239c22a2ad0a29a8ba41760e25828b8b7


### PR DESCRIPTION
Fixes plugin-breaking issue. Would be forever grateful if this could be merged quickly.

A lot of the code change is running Organize Imports, so you can see the core fix here https://github.com/adamk33n3r/runelite-watchdog/commit/797ef7cf4d6abe41fddc21fc5e5ded9e474b8e86 basically it's just removing lombok's superbuilder