### PR TITLE
Update click-to-minimize

### DIFF
--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=a74fda91d879df931e97fe1278b5496485b6807f
+commit=40105daa568c34b000cb6fdffa67d03befaeaa15

--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=468efc65dd9b78234a0c65a458989ae471ce6684
+commit=a74fda91d879df931e97fe1278b5496485b6807f

--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=40105daa568c34b000cb6fdffa67d03befaeaa15
+commit=6e548bb6b3c4a1220a01b1ebd6277a5c0b1b381e

--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=6e548bb6b3c4a1220a01b1ebd6277a5c0b1b381e
+commit=ac730fa35a3751f746db234980bf9d33b2eb0692

--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=536c4473442d20c79772df7f5e64d792500142b9
+commit=a82615e60104b801be2a66090c9f309f1aac619f

--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=a82615e60104b801be2a66090c9f309f1aac619f
+commit=468efc65dd9b78234a0c65a458989ae471ce6684


### PR DESCRIPTION
This changes the plugin's config from:
key: value 
to
key: list\<value\> 

so that players can have multiple of the same action leading to other actions.

e.g. 
search: chest,
search: wardrobe

previously it would overwrite the first value causing it to fail.