### PR TITLE
Updated afk canafis marks

### DIFF
--- a/plugins/afk-marks-canafis
+++ b/plugins/afk-marks-canafis
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLAfkMarksCanafis.git
-commit=ecb775029561dce0013cd08dc5e7614a27f11794
+commit=222884ffde8884f57dbaa78746c81723d53f6f4a

--- a/plugins/afk-marks-canafis
+++ b/plugins/afk-marks-canafis
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLAfkMarksCanafis.git
-commit=222884ffde8884f57dbaa78746c81723d53f6f4a
+commit=609d38d3be413562e66a801659ea21c13cb2aea7

--- a/plugins/afk-marks-canafis
+++ b/plugins/afk-marks-canafis
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLAfkMarksCanafis.git
-commit=609d38d3be413562e66a801659ea21c13cb2aea7
+commit=020a9488957f913e3452e3b6e88529961e96c123


### PR DESCRIPTION
Made some changes to the afk canafis marks plugin:
- No longer resets on game state changes. This was triggered when "LOADING" was triggered and caused the plugin to reset timings. Removed the game state subscription.
- Made leeway seconds configurable for unaccurate PC timings.
- Added feature request to swap menu entry when plugin suggests to wait to prevent jumping down the course unintentionally. Default disabled

Thanks for checking 🙏 