### PR TITLE
Update morghttpclient

### DIFF
--- a/plugins/morghttpclient
+++ b/plugins/morghttpclient
@@ -1,2 +1,2 @@
 repository=https://github.com/MorgApps/morghttpclient.git
-commit=2bd7029b3a3597f89ff0d494fd5177688d255202
+commit=e1e65ba9077af07cce9af20d574f838772388e71


### PR DESCRIPTION
commit=e1e65ba9077af07cce9af20d574f838772388e71

- fixed the plugin to work with the latest runelite version at this moment in time.
- added a cached threadpool so you won't run into socket errors if you call the endpoint too often.
- added a configurable port in case 8081 is already occupied.
- added an idle bool to the events endpoint.
- added special attack energy to the events endpoint.
- updated the build file to use runelite.latest rather than a set version.
- removed skill.overall from everything as it's deprecated.