### PR TITLE
Update rogues-chest to v1.0.1

### DIFF
--- a/plugins/rogues-chest
+++ b/plugins/rogues-chest
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
-commit=6eb2e7c989387d36681d363b9c6ed84e7a264cae
+commit=530ad4bcef9c2e8270d5c046d7be4cac40a80bf1


### PR DESCRIPTION
-Fix respawn timer
-Fix 1 deprecated api call
-Remove redundant east chest ignore feature