### PR TITLE
Disable tictac7x-rooftops

### DIFF
--- a/plugins/tictac7x-rooftops
+++ b/plugins/tictac7x-rooftops
@@ -1,2 +1,3 @@
 repository=https://github.com/TicTac7x/runelite-plugins.git
 commit=59949827897caabf4822d3089340a8e583af1002
+disabled=marks_of_graces leaks memory


### PR DESCRIPTION
RooftopsCourseManager has a marks_of_graces ArrayaList that has multiple elements with around a 30 MB size which makes peoples' clients crash.