### PR TITLE
hotfix:natural speech windows-1252 process stream crash 

### DIFF
--- a/plugins/naturalspeech
+++ b/plugins/naturalspeech
@@ -1,3 +1,4 @@
 repository=https://github.com/phyce/rl-natural-speech.git
 commit=c7a5e0d63b18e8214acd35ed0fbd332eefc6c907
 warning=This plugin downloads voice model files from, (and sends your IP address in the process, to) huggingface.co, a 3rd party website not controlled or verified by the RuneLite Developers.
+authors=phyce,TheLouisHong

--- a/plugins/naturalspeech
+++ b/plugins/naturalspeech
@@ -1,3 +1,3 @@
 repository=https://github.com/phyce/rl-natural-speech.git
-commit=52d0915efe9e8ee14befc515f1ea75287cf8c165
+commit=3d1e0b6ed6f42fe2927d923906caecf515b8e4bd
 warning=This plugin downloads voice model files from, (and sends your IP address in the process, to) huggingface.co, a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/naturalspeech
+++ b/plugins/naturalspeech
@@ -1,3 +1,3 @@
 repository=https://github.com/phyce/rl-natural-speech.git
-commit=3d1e0b6ed6f42fe2927d923906caecf515b8e4bd
+commit=c7a5e0d63b18e8214acd35ed0fbd332eefc6c907
 warning=This plugin downloads voice model files from, (and sends your IP address in the process, to) huggingface.co, a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
RuneLite JVM launches with `-Dfile.encoding=windows-1252`

We're unsure when/if this change occurred, but Natural Speech now crashes piper text-to-speech engine when writing to standard stream with `windows-1252` encoding. Natural Speech no longer works!

The changes in this PR are a couple lines, but will immediately restore Natural Speech functionality.


## changelist
- **hotfix: UTF-8 IO stream for piper, prevent crash, correctly speak ä accents**
- remove rich-text-modifier tags from ChatMessages
- expand alphanumeric detection to accept diacritics alphabet