### PR TITLE
Add idle-status

### DIFF
--- a/plugins/idle-status
+++ b/plugins/idle-status
@@ -1,0 +1,2 @@
+repository=https://github.com/Christley/Idle-Status.git
+commit=6b1c401c0a400a0496489d0584c7fea68200ee19


### PR DESCRIPTION
This plugin shows your current idle status, how long you've been idling in ticks and the percentage of the login session where you've idling.