### PR TITLE
Update nylo-death-indicators to v1.0.12

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=408a6e2f3827fc1dc3b8210913b5e9aea54217e7
+commit=c41816bcc95285e556538dbd5cce7885513ee42a


### PR DESCRIPTION
Adds the Dual Macuahuitl and Elder Maul to the list of supported melee weapons