### PR TITLE
con qol update - prevent from working outside of POH

### DIFF
--- a/plugins/zom-con-qol
+++ b/plugins/zom-con-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=fcfb95e94b5dd6f06568c2d176ebc7eb6619a693
+commit=d1c4a30f63a04581ed93e683de939bdc75f41dc1

--- a/plugins/zom-con-qol
+++ b/plugins/zom-con-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=933edf2b57ead9d346dd7b4a9561e0960814b3a7
+commit=fcfb95e94b5dd6f06568c2d176ebc7eb6619a693


### PR DESCRIPTION
Since COX used the same building widget group id the swapper worked there, whoops. It will now check the varbit of building mode being set to 1 or not