### PR TITLE
Create closed-door-highlighter

### DIFF
--- a/plugins/closed-door-highlighter
+++ b/plugins/closed-door-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/cabrilliant/DoorHighlighter.git
+commit=1ad2157bd4a20adaac241698b76b9b0b8026c5f4


### PR DESCRIPTION
Closed Door Highlighter is a simple plugin that will highlight closed doors within a specified radius. This helps unattentive people like me remember to open doors before going into buildings.