### PR TITLE
Create clue-details plugin

### DIFF
--- a/plugins/clue-details
+++ b/plugins/clue-details
@@ -1,0 +1,2 @@
+repository=https://github.com/Zoinkwiz/clue-details.git
+commit=5461a5beb2e71c9f3227f1e51e3401fbdbd08796


### PR DESCRIPTION
This plugin is intended to provide a couple utility bits for clues. Firstly, for easy, medium, hard, and elite clues, it will let you hover over a clue to see what the step is. I hope this should be useful for people who're stacking clues or accidentally mixing up their stacks.

![Screenshot 2024-06-04 180849](https://github.com/runelite/plugin-hub/assets/29153234/98a0cb66-ad35-4a55-8047-a824cbed16bd)

The second feature is one to allow for selective highlighting and notifying for certain clues. This is intended to be useful to various snowflake ironmen who want to only pick up clues with consideration for say region restrictions. With this in mind there's an optional sidebar where a player can filter clues and choose which to highlight. Currently Region is the main filter, but I'd probably look to add more in the future if there's any demand (I imagine a 'meets reqs' check or something could be useful).

![Screenshot 2024-06-04 180612](https://github.com/runelite/plugin-hub/assets/29153234/4968bd12-9089-46d5-b054-97c115d11f3c)