### PR TITLE
Update `hunter-rumours` to `v1.2.0`

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,3 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=0c1cbbcb4a8d9e04b37349ae227dba9024d19260
+commit=8b620dfbc7b9729f35a024e127c59d613c715f28
 authors=geel9,DapperMickie


### PR DESCRIPTION
This version includes these fixes:
- Resetting caught creatures for some of the masters
- Update pity rate calculation

It also includes some new features:
- Better testing of the plugin (more to come)
- Infobox disabling after x minutes of inactivity (5 mins by default)
- Worldmap overlay disabling after x minutes of inactivity (5 mins by default)
- Added configuration for the colors we use throughout the plugin