### PR TITLE
Create monsterstats

### DIFF
--- a/plugins/monsterstats
+++ b/plugins/monsterstats
@@ -1,2 +1,2 @@
 repository=https://github.com/Koitere/monster-stats.git
-commit=952aa6ba89f48fd9a8120a49c84ef0c032dfb449
+commit=3b75bd73c281d80d0948b75959829455f32be0ad

--- a/plugins/monsterstats
+++ b/plugins/monsterstats
@@ -1,0 +1,2 @@
+repository=https://github.com/Koitere/monster-stats.git
+commit=952aa6ba89f48fd9a8120a49c84ef0c032dfb449


### PR DESCRIPTION
My plugin Monster Stats allows users to quickly view information about NPCs defensive stats. 

It has a searchable side panel that allows you to pull up defensive stats for desired NPCs.
It adds a right click 'Stats' option that will open up the defensive stats in the side panel as well as hover tooltips that display defensive stats. 

These options are toggle-able with the default being hold down shift to see stat tooltips. 

Please let me know if anything needs to be adjusted.