### PR TITLE
Create PrayerClock

### DIFF
--- a/plugins/PrayerClock
+++ b/plugins/PrayerClock
@@ -1,0 +1,2 @@
+repository=https://github.com/FionnODoc/PrayerClock
+commit=e978263301bf052043596d2bc23617f7977b0f96


### PR DESCRIPTION
Creates an infobox that begins counting ticks from activation of prayer that can be configured to flash at X amount of ticks.

Example use cases are at the Alchemical Hydra it's attack style changes after every 3 attacks, but this attack change animation can be overridden with it's other animations causing the player to take damage if not paying attention. With this plugin for hydra on a 6 tick attack cycle that means if we set the threshold for the infobox to flash to 18 ticks having to count just incase we miss the animation is no longer necessary.

https://i.imgur.com/pkwN6d5.gif