### PR TITLE
Update region-chat to 1.0.3

### DIFF
--- a/plugins/region-chat
+++ b/plugins/region-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/region-chat.git
-commit=f079da3a18b7bd4a125ddc685f5d81082549c83b
+commit=28b17444775cf30d7ad57819e2ae81b725525876
 warning=This plugin submits your IP Address, in-game name, and chat messages in certain regions to a server not controlled or verified by the RuneLite developers.

--- a/plugins/region-chat
+++ b/plugins/region-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/region-chat.git
-commit=65988f443ea09e1431956b5d6ce13e93269142d7
+commit=f079da3a18b7bd4a125ddc685f5d81082549c83b
 warning=This plugin submits your IP Address, in-game name, and chat messages in certain regions to a server not controlled or verified by the RuneLite developers.

--- a/plugins/region-chat
+++ b/plugins/region-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/region-chat.git
-commit=28b17444775cf30d7ad57819e2ae81b725525876
+commit=81d3e6674b57818d75a2491579003893777bde41
 warning=This plugin submits your IP Address, in-game name, and chat messages in certain regions to a server not controlled or verified by the RuneLite developers.

--- a/plugins/region-chat
+++ b/plugins/region-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/region-chat.git
-commit=aed70a0bf1c14c7742cd92c9a12fb01e0ac4fa52
+commit=65988f443ea09e1431956b5d6ce13e93269142d7
 warning=This plugin submits your IP Address, in-game name, and chat messages in certain regions to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Asides from the region changes, this is mainly due to the [issue with the global-chat plugin](https://github.com/runelite/plugin-hub/commit/9f331caab55f672ad96ea8d69e55d33bae08da57), where restricted icons could be used in malicious ways. This should ensure that players can't see these even if the messages being sent spoof them.

I don't think the parts about private chats should be applying here, as only public chat is checked, but it's possible I'm overlooking a type of should-be private chat which is captured by PUBLICCHAT, so I'd appreciate in a review of this PR that this is considered.

Changes:
- Adds client-side limitations on the icons players can represent themselves with to ironman icons. This should ensure no-one can fake a JMod or PMod icon.
- Adds a dev mode overlay on the map to help make sure regions are as expected.
- Fixes the Zalcano region ID, adds zeah catacombs and Wyrms.