### PR TITLE
Update 117HD to v1.3.3.4

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=08f48026f6783b8d382b80acacf4459246ee056c
+commit=e689a402248a5969e9a9979349065f071cd6d54e
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This includes some texture changes which should've been part of another version bump, but I'm sneaking those in alongside these more pressing fixes:
- Catch exceptions for missing varbits when adding lights to impostors.
- Make the plugin usable again while developing other plugins.
- Fix lights disappearing from Tekton and possibly other NPCs which trigger NpcChange events.
- Fix misaligned lights at Ferox Enclave.
- Fix filling of gaps in the terrain which broke in the move to float vertex positions.