### PR TITLE
[Update] - Varlamore House Thieving - v1.2.0 - Sololegends

### DIFF
--- a/plugins/varlamore-house-thieving
+++ b/plugins/varlamore-house-thieving
@@ -1,2 +1,2 @@
 repository=https://github.com/sololegends/runelite-varlamore-house-thieving.git
-commit=3d82558cc4d8a670791a71355f0a34d1be2a7b05
+commit=ae0edab3875efaaff5973d13573d3a1ff1331401


### PR DESCRIPTION
Various updates to configuration and bug fixes

- Added config to enable count up overlays but no notifications
- Added alpha to color configuration variables
- Resolved distraction count up overlay dependence on highlighting citizens
- Resolved door arrow taking over wealthy citizens
- Resolved some deprecated function use
- Resolved some instances of distraction overlay not being cleared
  - When disabled
  - When leaving the area with wealthy citizens
- Added out-of-region optimizations
  - Didn't have any real impact on performance, now even less impact ^.^