### PR TITLE
[Fix] Updated bank-tag-generation version

### DIFF
--- a/plugins/bank-tag-generation
+++ b/plugins/bank-tag-generation
@@ -1,2 +1,2 @@
 repository=https://github.com/MitchBarnett/wiki-bank-tag-integration.git
-commit=233f143f9994558bb44696411eccc6fd74d92d88
+commit=491d7054b3dfb34f66e7c30ed66712a973086128


### PR DESCRIPTION
The version of this plugin was out of date and the original develop seems to have gone MIA. So I decided to step in

I tested commit 491d7054b3dfb34f66e7c30ed66712a973086128 locally on my machine which is marked as the latest commit on the [original repo of the plugin](https://github.com/MitchBarnett/wiki-bank-tag-integration). This commit appears to work as expected with no errors.

I updated the commit to match this in this PR