### PR TITLE
Update 117HD to v1.3.3.6

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=eca2aa5456b5b7d231f4204c4ffd6a5a7f748edd
+commit=60276679eaeb7c8be9e8d83a368cdc015576a538
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Fixes a shader compile error on Nvidia Quadro 1000M GPUs which has apparently been there for a while.