### PR TITLE
Update improved-tile-indicators

### DIFF
--- a/plugins/improved-tile-indicators
+++ b/plugins/improved-tile-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/LeikvollE/tileindicators.git
-commit=961d1fd80ced17b3351bfb8ccdf8f6b8654edd7d
+commit=893036dd978d4c7583d9cdbe61b8bba428b41d17


### PR DESCRIPTION
Update to support runelite 1.10.32.
Updates vertices to be floats instead of ints.
Uses new floating point value for overlay priority instead of enum.