### PR TITLE
Update cox-scouting-qol

### DIFF
--- a/plugins/cox-scouting-qol
+++ b/plugins/cox-scouting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/Filofteia/FilosPlugins.git
-commit=4a0b0b06dd8243f0a30b95de518dbe1b5dda8bcc
+commit=82a5f59806e2b0692aa41a410997921a6d4be0c6


### PR DESCRIPTION
add Overload Positions.

Allows you to add a condition for an overload in the first room and an option to include Tightrope and Ice Demon in that decision.