### PR TITLE
Update `Odablock Plugin` to `v1.1.2`

### DIFF
--- a/plugins/odablock
+++ b/plugins/odablock
@@ -1,2 +1,2 @@
 repository=https://github.com/DapperMickie/odablock-sounds.git
-commit=da3acc78441cc2a6c9a10dc55f5b27b39a1e0022
+commit=49eaeaf2a17075800635cd49b33519c0a5cf1de9


### PR DESCRIPTION
Adds the Odablock Warriors sound track to the plugin.