### PR TITLE
Add chunk-tasks plugin

### DIFF
--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=e13db3ca771fed70c5d970c31aff6af2e47de874
+commit=db96b63c3334d3377a3c72810f1cc402b2990314

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=c0638b651e5c328845a34e46c7121eab079746d8
+commit=e13db3ca771fed70c5d970c31aff6af2e47de874

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,0 +1,2 @@
+repository=https://github.com/nathanreidok/chunk-tasks.git
+commit=c0638b651e5c328845a34e46c7121eab079746d8

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=419ca3497e1433de1090660550723ed0f8f894c3
+commit=46c5e4a9d774d46970449633353901f0f17fed12

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=46c5e4a9d774d46970449633353901f0f17fed12
+commit=9cf767a8b3f3ae00ad1cc7dac950cf5c99fe4982

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=db96b63c3334d3377a3c72810f1cc402b2990314
+commit=8977584dd96c77c6420501047f05a9a516f321d0

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=50872f225a2b8377b7c80750f3af3c34a5fd993d
+commit=525b2254da096fcaf91176d97dce78d694fb63be

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=9cf767a8b3f3ae00ad1cc7dac950cf5c99fe4982
+commit=5da993810bbdf3f000a7bffa891c6ed4ffeeca65

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=8977584dd96c77c6420501047f05a9a516f321d0
+commit=419ca3497e1433de1090660550723ed0f8f894c3

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=82fb67a58d308ed67419b129f185d7dd46730a7a
+commit=4514ed324ec2d6c0094de01082058e2fcce2c7cc

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=5da993810bbdf3f000a7bffa891c6ed4ffeeca65
+commit=82fb67a58d308ed67419b129f185d7dd46730a7a

--- a/plugins/chunk-tasks
+++ b/plugins/chunk-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/nathanreidok/chunk-tasks.git
-commit=4514ed324ec2d6c0094de01082058e2fcce2c7cc
+commit=50872f225a2b8377b7c80750f3af3c34a5fd993d


### PR DESCRIPTION
Plugin for one-chunk accounts to track tasks imported from the chunk picker site. Player will be notified with a collection log style popup when a task is either auto-detected as complete or manually checked off.