### PR TITLE
Added gauntlet performance tracker plugin

### DIFF
--- a/plugins/gauntlet-performance-tracker
+++ b/plugins/gauntlet-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLCGPerformanceTracker.git
-commit=a92408c6ad6b7c7beffaced8dd59e407dfe49956
+commit=7dc0dc341010025d6b41165a142d2e891ba10439

--- a/plugins/gauntlet-performance-tracker
+++ b/plugins/gauntlet-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLCGPerformanceTracker.git
-commit=7dc0dc341010025d6b41165a142d2e891ba10439
+commit=028b0c9e9b90970ede604d006cc1f79c62ede1d0

--- a/plugins/gauntlet-performance-tracker
+++ b/plugins/gauntlet-performance-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/powerus117/RLCGPerformanceTracker.git
+commit=9e2197b1f73dd9ea60d0cb2c9ba699762317b244

--- a/plugins/gauntlet-performance-tracker
+++ b/plugins/gauntlet-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLCGPerformanceTracker.git
-commit=9e2197b1f73dd9ea60d0cb2c9ba699762317b244
+commit=a92408c6ad6b7c7beffaced8dd59e407dfe49956


### PR DESCRIPTION
As described on the plugin page, this plugin adds an overlay that shows statistics about your fight with Hunllef in the (corrupted) gauntlet. It will not show anything until Hunllef is fought and will show a number of statistics mentioned on the plugin page.

Thanks for checking in advance 🙏 