### PR TITLE
Update quest-helper to 4.4.3.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=eafce9d0cc518b2294b4a54d04f8c0cdf624dae1
+commit=ca9c76477e95b392f1b5c119cf4048e102f0d880


### PR DESCRIPTION
Only contains fix for the NPC ID for Lunar Diplomacy.