### PR TITLE
Update click-to-minimize

### DIFF
--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=ac730fa35a3751f746db234980bf9d33b2eb0692
+commit=60aecc3d610ea0a1ae63352627299dea3dd1df06


### PR DESCRIPTION
**Bug Fix:**
 - Current method for checking full inventory would trigger if an item was placed in the last slot.
 - New method checks the count of items in the inventory >= 28