### PR TITLE
Create linux-custom-cursor

### DIFF
--- a/plugins/linux-custom-cursor
+++ b/plugins/linux-custom-cursor
@@ -1,2 +1,2 @@
 repository=https://github.com/nwerblun/runelite_linux_custom_cursor.git
-commit=8906f672879cbb2b338c55b92718c33426ad6280
+commit=864b10a2a3056974839ecd11a2239516d6ae3b5d

--- a/plugins/linux-custom-cursor
+++ b/plugins/linux-custom-cursor
@@ -1,0 +1,2 @@
+repository=https://github.com/nwerblun/runelite_linux_custom_cursor.git
+commit=505442980aee20d803744a8cb20457e8c4bf2b0d

--- a/plugins/linux-custom-cursor
+++ b/plugins/linux-custom-cursor
@@ -1,2 +1,2 @@
 repository=https://github.com/nwerblun/runelite_linux_custom_cursor.git
-commit=864b10a2a3056974839ecd11a2239516d6ae3b5d
+commit=be5579c20400805bdc87a0225644c12cd3f9dd72

--- a/plugins/linux-custom-cursor
+++ b/plugins/linux-custom-cursor
@@ -1,2 +1,2 @@
 repository=https://github.com/nwerblun/runelite_linux_custom_cursor.git
-commit=505442980aee20d803744a8cb20457e8c4bf2b0d
+commit=8906f672879cbb2b338c55b92718c33426ad6280


### PR DESCRIPTION
Quick workaround/extension of the custom cursor plugin on Linux to have >2 color cursors. Renders an image on the cursor position while setting the cursor transparent.