### PR TITLE
Update raid-data-tracker to 1.4.3

### DIFF
--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Raitab/raid-data-tracker.git
-commit=afe3b5c6e205f889a09fed13ffc5df29d419de35
+commit=0386eba23ce63b06c0de1e6776b1b80552521d86

--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,3 +1,2 @@
 repository=https://github.com/Raitab/raid-data-tracker.git
-commit=e0a37ea564a6af0b064359890d27a5396a305c08
-unavailable=crashes on beta worlds
+commit=47118ebd45be0c82b1edff267c50afcd54bbb992

--- a/plugins/raid-data-tracker
+++ b/plugins/raid-data-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Raitab/raid-data-tracker.git
-commit=47118ebd45be0c82b1edff267c50afcd54bbb992
+commit=afe3b5c6e205f889a09fed13ffc5df29d419de35


### PR DESCRIPTION
Added some checks to disable plugin functionality when on Beta worlds and reduced icon size.