### PR TITLE
Create zoom-keybinding

### DIFF
--- a/plugins/zoom-keybinding
+++ b/plugins/zoom-keybinding
@@ -1,2 +1,2 @@
 repository=https://github.com/R4lfE/zoom-keybinding.git
-commit=46b5b21eaa330549ee39ad0589a34eade366d0df
+commit=d195594e21acbbb876995a8982ce69e4f9b13df0

--- a/plugins/zoom-keybinding
+++ b/plugins/zoom-keybinding
@@ -1,0 +1,2 @@
+repository=https://github.com/R4lfE/zoom-keybinding.git
+commit=46b5b21eaa330549ee39ad0589a34eade366d0df


### PR DESCRIPTION
A plugin to set custom zoom keybings other than the scroll wheel.
My scroll wheel broke and as far as I know there is no option or plugin to do this yet.