### PR TITLE
Update bank-equipment-stat-filter

### DIFF
--- a/plugins/bank-equipment-stat-filter
+++ b/plugins/bank-equipment-stat-filter
@@ -1,2 +1,2 @@
 repository=https://github.com/adamgiles1/bank-equipment-stat-filter.git
-commit=5f663188f42e0f92565987a4f72c2c92092d80f2
+commit=5c64c3a6797fdaa0eb3324bb92fec7c8d990ddb4


### PR DESCRIPTION
- Adds toggle to show all slots at once, rather than one at a time
- Formats equipment slot and stat names to look more normal, IE: "Stab Attack" rather than "STAB_ATTACK"