### PR TITLE
Create quiver-buddy

### DIFF
--- a/plugins/quiver-buddy
+++ b/plugins/quiver-buddy
@@ -1,0 +1,2 @@
+repository=https://github.com/MapleBytes/QuiverBuddyPlugin.git
+commit=06fab60a4a185a24a1125ed569d3d5a75e2e2207


### PR DESCRIPTION
A simple plugin made to display the ammo inside your quiver. (I would love C engineer to do a snarky voice comment when entering a raid without ammo) something like "Raids are more fun with ammo in your quiver"