### PR TITLE
adds bingo helper

### DIFF
--- a/plugins/bingo-helper
+++ b/plugins/bingo-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/IronEvil478/Bingo-Helper.git
-commit=2b96d678f6fe32eed5511cefc47ce283ac7e5202
+commit=4313d1259b35857df4712b65bfee7838bb00441f

--- a/plugins/bingo-helper
+++ b/plugins/bingo-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/IronEvil478/Bingo-Helper.git
-commit=bd43f9bb62b13ce58dc7105a3814435bf62e8cdf
+commit=2b96d678f6fe32eed5511cefc47ce283ac7e5202

--- a/plugins/bingo-helper
+++ b/plugins/bingo-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/IronEvil478/Bingo-Helper.git
+commit=bd43f9bb62b13ce58dc7105a3814435bf62e8cdf


### PR DESCRIPTION
A plugin to help support clan bingo events through runelite. This takes in a Json string defining all the items of the bingo and when one of the items is gained it will send a screenshot to discord through a web hook.