### PR TITLE
Create gg-hammer-reminder

### DIFF
--- a/plugins/gg-hammer-reminder
+++ b/plugins/gg-hammer-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/SoaresPT/gg-hammer-reminder.git
-commit=c2d5653cf0b68393b8b783b0b36520198ee5a454
+commit=463d0da3271f0a6b93ecbbe468e7d857be31285d

--- a/plugins/gg-hammer-reminder
+++ b/plugins/gg-hammer-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/SoaresPT/gg-hammer-reminder.git
+commit=c2d5653cf0b68393b8b783b0b36520198ee5a454


### PR DESCRIPTION
A plugin designed for the Grotesque Guardians boss encounter.

Provides an overlay indicating you're missing a rock hammer and prevents you from ringing the bell to start the encounter if you do not have the appropriate hammer item to finish the kill.