### PR TITLE
Update first-person to 1.0.2

### DIFF
--- a/plugins/first-person
+++ b/plugins/first-person
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/FirstPerson.git
-commit=b7f25373188cb89666c69b73839318659fe09c76
+commit=464a774299b06146d65dd9932160d0f9db5bea21


### PR DESCRIPTION
Adds the GpuPlugin's content, to allow for the scene to be rendered through that as an alternative to the detached camera mode.

I'd appreciate if the following Jagex guidelines can be considered when reviewing this PR, as I think this could count as conflicting with one of the following. I can't imagine the plugin itself providing any benefit to players, given it's just effectively a more cleaner version of zooming in a lot, but it might still fall under these:

* Any movement or resizing of click zones for 3d components

Because the camera in the GPU mode is different from what is it actually is in the game, I could imagine this being in conflict.

* Offers world interaction in any detached camera mode 

This doesn't provide interactions in detached mode, but having the camera seem like it's somewhere its not is kinda similar in effect.