### PR TITLE
Update "Resizable Chat" to v1.1.0

### DIFF
--- a/plugins/resizable-chat
+++ b/plugins/resizable-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/Thource/resizable-chat.git
-commit=33a290e725d6b087820de0f28c36524d7b28a1af
+commit=348359de9e59afc925d8651c2ae000d273023152


### PR DESCRIPTION
## What's New?

### New features
- thource/resizable-chat#7 - Opaque chatbox can now be resized (Thanks @Mark7625)
- thource/resizable-chat#11 - Add ability to hold a button to double the chatbox height (keybind assignable in plugin config)

### Improvements
- Resizing handles are now widgets with a right click menu that provides a "Reset" option (Thanks @Mark7625)
- Resizing handles now have a config option for when they are displayed (always or with a keybind), rather than using the RL widget repositioning mode
- thource/resizable-chat#9 thource/resizable-chat#10 - Allow chat to be made smaller than the original size
- thource/resizable-chat#5 - Chatbox buttons now stretch with the chatbox (or will be spaced out, depending on plugin config)
- thource/resizable-chat#2 - Revert chatbox to original size while (most) overlays are open

### Bugfixes
- thource/resizable-chat#13 - Stop chatbox scrolling about when resizing (by locking the chat scroll to the bottom line of text)

**Full Changelog**: https://github.com/Thource/resizable-chat/compare/33a290e725d6b087820de0f28c36524d7b28a1af...v1.1.0