### PR TITLE
Update dt2-mistake-tracker

### DIFF
--- a/plugins/dt2-mistake-tracker
+++ b/plugins/dt2-mistake-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/DT2-Boss-Failure.git
-commit=01b4e1ed58c6aa56562a0cacef4b79d2ec46b051
+commit=6bc2ec5bead8223cebcd2ff76394eca790233dd9
 authors=DominickCobb


### PR DESCRIPTION
Add Vardorvis pillar hider (thank you @JZomDev)
Add Whisperer projectile swap -- Took code from @InfernoStats and their Vardorvis Projectiles. Licensing should be correct where applicable, will correct if needed. Per their request I have not integrated their plugin into mine and added a note in the config to use their plugin.

E: Rebranded to DT2 Boss Utilities as well.