### PR TITLE
Add Prayer or Restore plugin.

### DIFF
--- a/plugins/prayer-or-restore
+++ b/plugins/prayer-or-restore
@@ -1,0 +1,2 @@
+repository=https://github.com/Gnuder/prayer-or-restore.git
+commit=6b8966bb7f76628a1b7f5a1c7d840e5ce89160e9


### PR DESCRIPTION
Plugin adds a side panel which, when clicked on, displays a sorted list of the current wiki price per does of all prayer pots (1-4) and super restores (1-4).

This plugin can help decide if it is worth buying  prayer potions or super restores.