### PR TITLE
Update wilderness player alarm

### DIFF
--- a/plugins/wilderness-player-alarm
+++ b/plugins/wilderness-player-alarm
@@ -1,2 +1,2 @@
 repository=https://github.com/adhansen/plugin-repo.git
-commit=b30930b9a80809d63c0a23a4cbdfad093f8b02f1
+commit=acf721f8d9372b0524b05c438c8ad0c4ee4121b0


### PR DESCRIPTION
## Overview
Apologies for the back-to-back PRs on the same plug-in. There was a slight regression in #6239 that I slipped in:
With the homemade timeout functionality that I removed, there was logic to check the players in range each tick such that the alarm would go off whenever someone new entered the alarm radius. With the migration to notification overrides, I deleted a lot of that. As a consequence, once a user has been notified of a player nearby, they won't get notified again until they are completely alone or exit & re-enter the dangerous area.

This small change will cause the alarm to trip anew when more players enter the alarm radius, which is useful for places like chaos altar or revs where there may be individuals co-existing and then a new player shows up.