### PR TITLE
update nex nostalgia

### DIFF
--- a/plugins/nexnostalgia
+++ b/plugins/nexnostalgia
@@ -1,2 +1,2 @@
 repository=https://github.com/hex-agon/runelite-plugins.git
-commit=b5591971bff2a65ddd85638720b22cc171e9502b
+commit=8d779dd07773e813ca2cc0f59ba9ab940f1589d8


### PR DESCRIPTION
Updates the nex nostalgia plugin to be compatible with the latest OSRS changes.

**Requires waiting for the next RuneLite release**