### PR TITLE
Update quest-helper to 4.7.7.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=2f1af1cf3e223018ac0aca2e85a25ada48c5be03
+commit=259f591acab97e8b8ac24c117400babe2e46620d


### PR DESCRIPTION
Tiny fix to make the WGS placeholder appear correctly.