### PR TITLE
Update combat-logger to v1.1.0

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=63292d5b636e3f6de7ccac115d2f8305ad4dc0cd
+commit=043b6b286e580e3d2353345a75f221dffbe21e78

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=cd5dbbdb68c6ef1ebbb9b697cbf0ba4f31014651
+commit=2ada2694f77f99c35313504b2f16c4997044767c

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=78c77e70c7ab647b883de9335f9b00583c239bfb
+commit=63292d5b636e3f6de7ccac115d2f8305ad4dc0cd

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=043b6b286e580e3d2353345a75f221dffbe21e78
+commit=9d361252207dd5010ce1efe70dd47def6cb0e877

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=9d361252207dd5010ce1efe70dd47def6cb0e877
+commit=cd5dbbdb68c6ef1ebbb9b697cbf0ba4f31014651


### PR DESCRIPTION
- Add a built-in damage meter
- Log Damage messages from Party
- All logs now go in a queue with a 2 tick delay before they are written so that previously unknown hitsplat sources can now be matched up with a Party members hitsplat
- Create a death log for end of Verzik P1