### PR TITLE
Update `hunter-rumours` to `1.2.1`

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,3 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=5b9603780a93aa43f605e48fb285a1f1052b704a
+commit=2028d000ab8520c7e65676bbf7dd631d6fd95dd9
 authors=geel9,DapperMickie

--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,3 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=8b620dfbc7b9729f35a024e127c59d613c715f28
+commit=5b9603780a93aa43f605e48fb285a1f1052b704a
 authors=geel9,DapperMickie


### PR DESCRIPTION
- Adds new tags to plugin
- Infobox should no longer be "stuck on" or refuse to appear
- Checking the active rumour via Quetzal Whistle will now trigger the infobox to re-appear
- Recommends Necropolis over Uzer for Orange Salamanders
	- Also clarifies that BCS is required for Necropolis
- Fixes invalid statistics presented by end-of-rumour message due to event order processing inconsistency