### PR TITLE
Update purchase-progress to v1.2.2

### DIFF
--- a/plugins/purchase-progress
+++ b/plugins/purchase-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/BrastaSauce/purchase-progress.git
-commit=facf1e2b51462fee6c7ba4e85012ff961635756c
+commit=6cb4a878b083a12e18345820190782cb2bf46373


### PR DESCRIPTION
- Adds option to only track progress of first item listed
- Adds option to move groups
- Adds option to delete items alongside deleted group