### PR TITLE
Update `hunter-rumours` to `1.3.0`

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,3 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=2028d000ab8520c7e65676bbf7dd631d6fd95dd9
+commit=6fa50059c6cd8c7e153a0310418f5b7c1ddebba2
 authors=geel9,DapperMickie

--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,3 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=6fa50059c6cd8c7e153a0310418f5b7c1ddebba2
+commit=ff6b60bcc41fbdfabcec6bb44334043d41bcfe45
 authors=geel9,DapperMickie


### PR DESCRIPTION
- Adds togglable "auto-scroll to fairy ring" feature
	- If the player is actively (within the past 2 minutes) engaged in hunter rumours, and the most-recommended location for a rumour has a fairy ring code, then the plugin will auto-scroll to and highlight the relevant fairy ring code on opening the panel
- Changes moonlight moth location order
- Changes default highlight color of rumour creature from bright green to pale blue

No, I do not have a sane or consistent versioning scheme