### PR TITLE
Create friends-house

### DIFF
--- a/friends-house
+++ b/friends-house
@@ -1,0 +1,2 @@
+repository=https://github.com/EwyBoy/Friends-House.git
+commit=a1435085f8d29e3b557c152dd0bbcdf0f84afbf9

--- a/friends-house
+++ b/friends-house
@@ -1,2 +1,0 @@
-repository=https://github.com/EwyBoy/Friends-House.git
-commit=a1435085f8d29e3b557c152dd0bbcdf0f84afbf9

--- a/plugins/friends-house
+++ b/plugins/friends-house
@@ -1,0 +1,2 @@
+repository=https://github.com/EwyBoy/Friends-House.git
+commit=a1435085f8d29e3b557c152dd0bbcdf0f84afbf9


### PR DESCRIPTION
Adds a simple and lightweight RuneLite plugin that lets you save a friend's name, so you can easily access their house by clicking a widget in the chatbox container to autofill their name in the POH portal user interface. 