### PR TITLE
Update another-bronzeman-mode

### DIFF
--- a/plugins/another-bronzeman-mode
+++ b/plugins/another-bronzeman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/CodePanter/another-bronzeman-mode.git
-commit=2b326dfd7778143dbc66899b7707fee6cfc841bf
+commit=a4d349693ea49bd95250f5e4801740fe097d638b


### PR DESCRIPTION
Did two small fixes in the bronzeman icon code:
- Fixed the icon never showing up in the clan and guest channels.
- Fixed the channel name being omitted even if the setting is set in the base game.