### PR TITLE
Update `hunter-rumours` to `1.3.1`

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,3 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=1ffe7b24124953641aab1833aace18aadcbffea4
+commit=173ef2b34e12c8e225f88d695e6c4d4e100cc4b7
 authors=geel9,DapperMickie

--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,3 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=ff6b60bcc41fbdfabcec6bb44334043d41bcfe45
+commit=1ffe7b24124953641aab1833aace18aadcbffea4
 authors=geel9,DapperMickie


### PR DESCRIPTION
- Several bugfixes / polish
	- Fixes infobox appearing erroneously for N minutes after login, where N is the configured infobox timeout period
	- Fixes back-to-back state change being missed if the user is 2fast2quick
	- Fixes favorited fairy ring codes not being factored in
- Misc refactors / code cleanup
- Adds `DapperMickie` as author on public plugin hub list 

Apologies for the flurry of updates, maintainers -- this should be the last of it for a bit