### PR TITLE
[Update] Quest Voiceover Plugin - v1.0

### DIFF
--- a/plugins/quest-voiceover
+++ b/plugins/quest-voiceover
@@ -1,3 +1,3 @@
 repository=https://github.com/KevinEdry/runelite-quest-voiceover.git
-commit=f46bc6a8daa1fe34d3f72b3eb78e6c8ef49bb8ea
+commit=75199280c2fce2970fa70625a1d71a5f0e30abe6
 jarSizeLimitMiB=15

--- a/plugins/quest-voiceover
+++ b/plugins/quest-voiceover
@@ -1,3 +1,3 @@
 repository=https://github.com/KevinEdry/runelite-quest-voiceover.git
-commit=75199280c2fce2970fa70625a1d71a5f0e30abe6
+commit=0511aa777a73de37b81583224f37530c510f0b90
 jarSizeLimitMiB=15


### PR DESCRIPTION
Hello, 
Since my plugin got published, iv'e noticed an issue were JDBC isn't being registered when downloading the plugin from the hub, but everything works perfectly when testing.
After some digging and a ton of help from people in our community, the issue boiled down to including the `Class.forName("org.sqlite.JDBC");` line when using the driver.

### In depth explanation
>I am still not 100% sure if my understanding of the problem is correct, so feel free to comment if I've missed something.

For a dependency to be available, it needs to registers itself to the with the `DriverManager`, I didn't catch on to this in testing because my IDE does this automagically (This is where the testing vs production environments discrepancy comes from).
Usually dependencies do this automatically, but if they don't, we need to register them manually by including the aforementioned `Class.forName` line.
Specifically for `xerial/sqlite-jdbc` you can either include the `Class.forName` line or add a transformer so it will do it by itself, you can look at that transformer [here](https://github.com/xerial/sqlite-jdbc#hint-for-maven-shade-plugin).

### Testing
Me and @nucleon have tested this fix by sideloading a `shadowJar` of this plugin to a compiled version of the `runelite-client` in developer mode.
We tested both:
-  A `shadowJar` of the current version of the plugin without the fix (which failed successfully I might add 😅).
-  A `shadowJar` containing the `Class.forName("org.sqlite.JDBC");` fix in the `DatabaseManager.java` file - which was able to load and connect to the local `sqlite` instance.

### What has changed?
- Fixed driver manager JDBC registration issue.
- Moved Jaco player jar to libs folder to keep with plugin conventions.
- Fixed SoundEngine engine sound stop detection to check if player initialized.
- **Decoupled database updates from plugin updates by versioning database based on the incoming `etag`.**
	- Now database will redownload itself if there is an `etag` mismatch between the local version and the remote version.
- Removed unnecessary logs.
- Fixed issue when the playback won't stop if you cancel it by walking off.
- Initialized database connection on startup rather than on first chat message.
- Changed default database filename
- Changed download directory name.
