### PR TITLE
Update banked-experience to v2.6

### DIFF
--- a/plugins/banked-experience
+++ b/plugins/banked-experience
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/banked-experience.git
-commit=6142dc9b6aff8b4894e391fb827869a538c43438
+commit=4c3f2e3eaae53ef109b8f1d645468b86cc897107


### PR DESCRIPTION
- Fixed level requirement for `oak shortbow (u)`
- Fixed Experience for creating `Weapon Poison (+)` potions
- Added `Perfect Shell` to the crafting calculator
- Fixed how the `Carpenter's Outfit` applies to Mahogany Homes Contracts
    - This was changed by jagex on June 19th, 2024 https://secure.runescape.com/m=news/hallowed-sepulchre-instances--more?oldschool=1
    - > Carpenters’ Clothing now boosts XP when completing Mahogany Homes Construction contracts, with a 2.5% boost when wearing the full set.

- Modifier selections are now preserved between calculator refreshes
    - This only applies when the `Refresh Calculator` button is clicked. These are still not being saved between sessions
-  Added an `Xp Rate Multiplier` input that multiples all xp values by the input value
    - Mainly meant for DMM & Leagues
