### PR TITLE
Update invalid-movement to v1.1

### DIFF
--- a/plugins/invalid-movement
+++ b/plugins/invalid-movement
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=1f2a68a963f0811a3ca69e71558673da4f44c11f
+commit=879c390c835c4bb0b94173a736cfc8ccdc69e669


### PR DESCRIPTION
- Added an option to restrict the display to a radius around the player. Using -1 as the radius will show everything and not restrict to a radius.