### PR TITLE
update tombs-of-amascut to v2.8.0

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tombs-of-amascut.git
-commit=d482d057966b4110160873e6989d7ed7b233fb5b
+commit=fba783989b65a030b710a59bc0192fcd292f939b


### PR DESCRIPTION
* exposes a points event for raid data tracker to consume
* adds a smelling salt crush cooldown to prevent double use