### PR TITLE
Update click-minimap-orbs

### DIFF
--- a/plugins/click-minimap-orbs
+++ b/plugins/click-minimap-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/Macweese/runelite-external-plugins.git
-commit=1c6475b9c5ece741364319adf6d589a3c019b951
+commit=aa0623b3920d8c2cebd23964ab89c0aa97a85014


### PR DESCRIPTION
Accommodates the plugin behaviour to the prayer orb as well.
Fixes Macweese/runelite-external-plugins#1