### PR TITLE
Update friends-house

### DIFF
--- a/plugins/friends-house
+++ b/plugins/friends-house
@@ -1,2 +1,2 @@
 repository=https://github.com/EwyBoy/Friends-House.git
-commit=621c9534a8a5d2bfe13c7a18fdb44bc5be3b4adf
+commit=c5ebb39d4e2498d12c82469e9081fe46b4c5997b


### PR DESCRIPTION
fixes: https://github.com/EwyBoy/Friends-House/issues/7
Auto-filled username shows up on the Grand Exchange search menu
