### PR TITLE
Update agility-pyramid-slider-block-timer

### DIFF
--- a/plugins/agility-pyramid-slider-block-timer
+++ b/plugins/agility-pyramid-slider-block-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/WesleyM77/agility-pyramid-slider-block-timer.git
-commit=cdd2b7c64b479a8b4e20e4464aaba4933fd6ea34
+commit=544ba93ea36a969523485de96a326e03de5b97c6

--- a/plugins/agility-pyramid-slider-block-timer
+++ b/plugins/agility-pyramid-slider-block-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/WesleyM77/agility-pyramid-slider-block-timer.git
-commit=544ba93ea36a969523485de96a326e03de5b97c6
+commit=08e99c4bb39a2e4b5fc6f4436e463502df1ea8cd


### PR DESCRIPTION
Update hash to fix issue with deprecated calls.

See https://github.com/WesleyM77/agility-pyramid-slider-block-timer/pull/3 for more information