### PR TITLE
Update Unpotted reminder to v1.0.5

### DIFF
--- a/plugins/unpotted-reminder
+++ b/plugins/unpotted-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/unpotted-reminder.git
-commit=526db7a2b5e76299162a3d1f0a7087080c86b418
+commit=3e04a9b8f3a438261f8dbb384d3f8f8dd1b60df5


### PR DESCRIPTION
Update to v1.0.5:
- Add new options for which style to check the boost for when using melee. You can choose between strength only or both attack and strength. Defense boost is effectively no longer being checked.
- Add saturated heart and fix the logic that determines if your imbued or saturated heart is available.
- Add Divine magic potions.
- Fix issue where sipping potions or using smelling salts in TOA caused an alert or failed to clear an existing one.
- Fix longrange on Tumeken's shadow, which was incorrectly tracking as melee.