### PR TITLE
Update Smart Chat Input Color to 1.5.1

### DIFF
--- a/plugins/input-recolor
+++ b/plugins/input-recolor
@@ -1,3 +1,3 @@
 repository=https://github.com/MarbleTurtle/Color-Coordinator.git
-commit=1de5ab055335c634d24637c22d9f76e55eb40345
+commit=0cb5eaab0434ee9a928b96aa771e17863edfdd8a
 authors=Ririshi,MarbleTurtle


### PR DESCRIPTION
In this update:
* At least a partial fix for https://github.com/MarbleTurtle/Color-Coordinator/issues/15
* Reformat code to 120 characters per line 
* Improved Slash Swapper compatibility
* Simplify parsing of chat channel color VarPlayers
* Remove `contains` calls before using `split`
* Use `@Varp` on some ChatChannel field getters