### PR TITLE
Update combat-logger to v1.1.1

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=2ada2694f77f99c35313504b2f16c4997044767c
+commit=0a88833c7cfb1474659989e1741b77aab6505b6f


### PR DESCRIPTION
- Only call setRenderer once in the constructor. This was creating unnecessary duplicate objects
- Add ability to stop a fight in progress
- Better handling of ToA paths and Wardens