### PR TITLE
various fixes for the 24/07/24 game update

### DIFF
--- a/plugins/master-scroll-book
+++ b/plugins/master-scroll-book
@@ -1,2 +1,2 @@
 repository=https://github.com/Enriath/external-plugins.git
-commit=f46cd0b2728d44aabe2a38240d44edc979f96644
+commit=c6cb611b05de5b69cbf3ee703bb7138d2c316600

--- a/plugins/plank-sack
+++ b/plugins/plank-sack
@@ -1,2 +1,2 @@
 repository=https://github.com/Enriath/external-plugins.git
-commit=5c460f8ffa6a1d7ec33e74f9c1efef73196ae104
+commit=b1a0883ac77bf7009bb2a3d55965d4f2b01fdc6d

--- a/plugins/transmog
+++ b/plugins/transmog
@@ -1,2 +1,2 @@
 repository=https://github.com/Enriath/external-plugins.git
-commit=803d992ea60b50a05cd67825354374177a9df7d8
+commit=b0afe7783c844df1a9da0fafbb1cf3164b73af75


### PR DESCRIPTION
Transmog:
- (Hopefully) Fixed a new issue where cutscenes forced a rebuild of the vanilla equipment interface. (Thanks to @korvisio for reporting, though please, 1 issue per issue in future)

Master Scroll Book:
- Fixed the selected scroll varbit being changed in the last update (thanks @YvesW for reporting, and @null-zero for providing a fix)

Plank Sack:
- Added support for Piscarillius Cranes (thanks to @notheowner for the original PR... back in February. I'd completely forgotten about it >.> )