### PR TITLE
Fix autotags config group name

### DIFF
--- a/plugins/autotags
+++ b/plugins/autotags
@@ -1,2 +1,2 @@
 repository=https://github.com/i/rl-plugins.git
-commit=62c0cee673e43d157f3b577fdb887c4a5e2c9a97
+commit=dc55666acf00ae76b3efb7252455932dd3fb3637

--- a/plugins/autotags
+++ b/plugins/autotags
@@ -1,2 +1,2 @@
 repository=https://github.com/i/rl-plugins.git
-commit=1c1c8da209751e773f8b736ad004eb8b88f7408f
+commit=62c0cee673e43d157f3b577fdb887c4a5e2c9a97


### PR DESCRIPTION
Config name was mismatching the plugin name, so tag overrides were not doing anything.