### PR TITLE
Create attack-ranges

### DIFF
--- a/plugins/attack-ranges
+++ b/plugins/attack-ranges
@@ -1,0 +1,2 @@
+repository=https://github.com/tylerwgrass/attack-ranges.git
+commit=3aa4f6e9b088276479fc8ed5dc799065e89adf8b

--- a/plugins/attack-ranges
+++ b/plugins/attack-ranges
@@ -1,2 +1,2 @@
 repository=https://github.com/tylerwgrass/attack-ranges.git
-commit=3aa4f6e9b088276479fc8ed5dc799065e89adf8b
+commit=263896b7efef4268f7b14c3814859f696961fe57

--- a/plugins/attack-ranges
+++ b/plugins/attack-ranges
@@ -1,2 +1,2 @@
 repository=https://github.com/tylerwgrass/attack-ranges.git
-commit=263896b7efef4268f7b14c3814859f696961fe57
+commit=fd9b21dfaae894ae7645376c375023fcd75139b4


### PR DESCRIPTION
Displays the player's attack range for their currently equipped weapon.

This is similar to some of the other line of sight plugins/settings but automatically renders on weapon or attack style changes. I did a best-effort attempt to catalog all weapons but I am sure I missed some and I have not done extensive testing.

I tested:
- Bowfa
- Rune cbow
- magic shortbow (i)
- Red chin
- Dragon knife/thrownaxe
- Air battlestaff
- Dorgeshuun cbow

The general idea was given an OK, but will call out anyways that I could see this potentially violating the following Jagex guideline:

> Anything that automatically indicates where to stand, or not to stand. This applies to only automatic indicators, and not tiles which have been manually marked.

I plan to extend this to NPCs at some point, but decided to prune out what I had in progress for now, so there might be some remnants of that that work in the current case, but might not exactly look right in the current state (e.g. the tile visibility check).
