### PR TITLE
Poisoned NPCs v0.3.0

### DIFF
--- a/plugins/poisoned-npcs
+++ b/plugins/poisoned-npcs
@@ -1,2 +1,2 @@
 repository=https://github.com/tautges/runelite-poisoned-npcs-plugin.git
-commit=b8e2c928ff3bbef07daacb563ca6418748a9c5ae
+commit=3dffea11df3b5a315ccd32bb4b8afa79f39aeba7


### PR DESCRIPTION
Poisoned NPCs v0.3.0

Three predominant changes, two features, one bug fix:

- When poison-effected NPCs occupy the same tile, their overlay poison text will stack rather than overlap each other: https://github.com/tautges/runelite-poisoned-npcs-plugin/commit/6ef2e82155621c960cd33e75f7534a1dbd8965d7
- A bug where any NPCs poison sequence getting reset by more than one poison damage caused Runelite to crash (because of NPE) is fixed: https://github.com/tautges/runelite-poisoned-npcs-plugin/commit/2127a5527043ed3510062cb8541d377eb64f54de
- When an NPC is not yet poisoned, the number of hits that can possibly poison the NPC is now tracked in the info box: https://github.com/tautges/runelite-poisoned-npcs-plugin/commit/3dffea11df3b5a315ccd32bb4b8afa79f39aeba7