### PR TITLE
Update Dink to v1.10.4

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=0b2d9a1d6697f489357ad83df18ec09756a705f5
+commit=d84e0436513517355e92f67b3fee2af71eb32bd7
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.10.4 fixes an edge case where death and loot notifiers could send too many item icon embeds for Discord

Release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.10.4
