### PR TITLE
Update attack-ranges to 1.0.1

### DIFF
--- a/plugins/attack-ranges
+++ b/plugins/attack-ranges
@@ -1,2 +1,2 @@
 repository=https://github.com/tylerwgrass/attack-ranges.git
-commit=fd9b21dfaae894ae7645376c375023fcd75139b4
+commit=3c8795a5a03fad27a7bb35951cb29c0369841392


### PR DESCRIPTION
- Add option to only display in instances starting with a small set
- Fix issue where unequiping items didn't clear the overlay
- Fix the `visiblePoints` matrix being initialized with negative length
- Update plugin description
- Add icon