### PR TITLE
Update attack-ranges to 1.1.0

### DIFF
--- a/plugins/attack-ranges
+++ b/plugins/attack-ranges
@@ -1,2 +1,2 @@
 repository=https://github.com/tylerwgrass/attack-ranges.git
-commit=3c8795a5a03fad27a7bb35951cb29c0369841392
+commit=1d3663f8e2102a2b9305000c3524dc971276b6d4


### PR DESCRIPTION
- Fix some missing weapons & add halberds
- Adds support for myopia modifier in the colosseum
- Adds config option to filter weapons applied to
- Adds new display mode for tiles only on the edges
- Adds toggleable option for whether to display while manually casting

Apologies for the near daily PRs, trying to address some common things brought up right after releasing 