### PR TITLE
Add menu-highlighting plugin

### DIFF
--- a/plugins/menu-highlighting
+++ b/plugins/menu-highlighting
@@ -1,0 +1,3 @@
+repository=https://github.com/mejrs/menu-highlighting.git
+commit=b67f6815595ec7a7607419448c77c890ebebe548
+authors=mejrs


### PR DESCRIPTION
This is like how the ground items plugin changes the color of menu entries, but with hotkeys and filters.

I believe highlighting player entries violates the plugin guidelines, so this is disabled.