### PR TITLE
Update shift-remapping to v1.0.2

### DIFF
--- a/plugins/shift-remapping
+++ b/plugins/shift-remapping
@@ -1,2 +1,2 @@
 repository=https://github.com/WhatATopic/Shift-Remapping.git
-commit=c5d085a6d89046321a8e1cfaaab30399cd23fa24
+commit=dda7dd84ecedea3f8f8dfe7f694c55bf7f3decd9

--- a/plugins/shift-remapping
+++ b/plugins/shift-remapping
@@ -1,2 +1,2 @@
 repository=https://github.com/WhatATopic/Shift-Remapping.git
-commit=cb1964f8e81588ec0db889eecbe2bc61b67513ea
+commit=c5d085a6d89046321a8e1cfaaab30399cd23fa24


### PR DESCRIPTION
Include config option to disable shift remapping when dialog option menu or bank pin interface is open.