### PR TITLE
NPC Timer

### DIFF
--- a/plugins/npc-timer
+++ b/plugins/npc-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/sethks/npc-timer.git
+commit=178cb776d11c2897d05d4c87fe4f1245a035ef0d


### PR DESCRIPTION
Allows players to track the kill times of any NPC. Specifically useful in slayer tasks when you want to compare kill times in different gear, or add engagement to mundane slayer tasks by tracking average kill times and personal bests.