### PR TITLE
npc-timer

### DIFF
--- a/plugins/npc-timer
+++ b/plugins/npc-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/sethks/npc-timer.git
-commit=9caf508479138e818c44c6f21b09560fa083b3fa
+commit=3022d30c42a0930c6d799be40676ec6cfb0848ce

--- a/plugins/npc-timer
+++ b/plugins/npc-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/sethks/npc-timer.git
-commit=f2d7f2e797f397d0c997b3a29904e94480b21726
+commit=9caf508479138e818c44c6f21b09560fa083b3fa

--- a/plugins/npc-timer
+++ b/plugins/npc-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/sethks/npc-timer.git
+commit=f2d7f2e797f397d0c997b3a29904e94480b21726


### PR DESCRIPTION
Adds a timer/tracker display to the screen so the player can track any NPC in RuneScape. Helps keep slayer tasks more engaging with personal bests, or helps the player see kill times with different gear setups. 