### PR TITLE
Update Smart Chat Input Color to 1.5.2

### DIFF
--- a/plugins/input-recolor
+++ b/plugins/input-recolor
@@ -1,3 +1,3 @@
 repository=https://github.com/MarbleTurtle/Color-Coordinator.git
-commit=0cb5eaab0434ee9a928b96aa771e17863edfdd8a
+commit=0022b2b309462771cf8f401971dd5c9121f56343
 authors=Ririshi,MarbleTurtle


### PR DESCRIPTION
Changes in this version, mostly bugfixes and internal changes:


* Fix bug introduced in 1.5.1 that ignored chat mode
* Switch to reading a VarClientInt to handle chat mode instead of using input widget text
* Add GIM checks to Slash Swapper bug handling and Trade/GIM chat panel handling
* Use JagexColors where possible, otherwise use new DefaultColors class
* Add automatic tests that check most scenarios