### PR TITLE
Create HideAndSeekTracker

### DIFF
--- a/plugins/HideAndSeekTracker
+++ b/plugins/HideAndSeekTracker
@@ -1,0 +1,2 @@
+repository=https://github.com/jeromkiller/HideAndSeekTracker.git
+commit=7e4c488b0e46c0d2851cf1db8af6f325e98895ad


### PR DESCRIPTION
This plugin is to be used by the hiders during the Hide and Seek events hosted on the official osrs discord server.

Hiders setup their tracking area around them, enter the list of participants and hide somewhere.

when one of the participants finds the hider and enters the tracking area their placement will be logged.
The placement of players and their amount of hints used can be coppied to the clipboard for easy sharing with the host

![afbeelding](https://github.com/user-attachments/assets/11dd7d91-02c3-4cba-96fb-a4d812544127)

![afbeelding](https://github.com/user-attachments/assets/aaf5cbe7-1b9f-46e8-b22f-d4a186b2d51d)
