### PR TITLE
Create hide-and-seek-tracker

### DIFF
--- a/plugins/hide-and-seek-tracker
+++ b/plugins/hide-and-seek-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/jeromkiller/HideAndSeekTracker.git
+commit=7e4c488b0e46c0d2851cf1db8af6f325e98895ad

--- a/plugins/hide-and-seek-tracker
+++ b/plugins/hide-and-seek-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/jeromkiller/HideAndSeekTracker.git
-commit=7e4c488b0e46c0d2851cf1db8af6f325e98895ad
+commit=3282b63f96d1e3dbd117ee77c8e57710ff4323f5

--- a/plugins/hide-and-seek-tracker
+++ b/plugins/hide-and-seek-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/jeromkiller/HideAndSeekTracker.git
-commit=3282b63f96d1e3dbd117ee77c8e57710ff4323f5
+commit=656d7af8219d4831c0667c4426b383cfe42a3e1b


### PR DESCRIPTION
This plugin is to be used by the hiders during the Hide and Seek (GieliGuessr) events hosted on the official osrs discord server.

Hiders setup their tracking area around them, enter the list of participants and hide somewhere.

Hint images are sent out over discord every couple of minutes

when participants find the hider and enter the tracking area their placement and number of hints posted will be logged.
The placement of players and their amount of hints used can be coppied to the clipboard for easy sharing with the host

![afbeelding](https://github.com/user-attachments/assets/7921e73d-1970-47a5-8bd6-ff336d909799)

![afbeelding](https://github.com/user-attachments/assets/49c0e769-ea5b-422b-832e-8ad2d1f59b00)

