### PR TITLE
add wiki-bank-tags plugin

### DIFF
--- a/plugins/wiki-bank-tags
+++ b/plugins/wiki-bank-tags
@@ -1,0 +1,2 @@
+repository=https://github.com/karearl/wiki-bank-tags.git
+commit=27227d72a00e514715d26106a350c7bdbf45acb2

--- a/plugins/wiki-bank-tags
+++ b/plugins/wiki-bank-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/karearl/wiki-bank-tags.git
-commit=27227d72a00e514715d26106a350c7bdbf45acb2
+commit=5c82620c62584adeb6e4e2273682fc57e6b83471

--- a/plugins/wiki-bank-tags
+++ b/plugins/wiki-bank-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/karearl/wiki-bank-tags.git
-commit=5c82620c62584adeb6e4e2273682fc57e6b83471
+commit=05252336c4e6f0a571352a7326943a6b2c4c224f


### PR DESCRIPTION
This plugin adds the ability to generate bank tags by querying https://oldschool.runescape.wiki/