### PR TITLE
Create examine-log plugin

### DIFF
--- a/plugins/examine-log
+++ b/plugins/examine-log
@@ -1,2 +1,2 @@
 repository=https://github.com/CarlOmega/examine-log.git
-commit=def48ff42699d34bd8b6957145aa6f70c0b10931
+commit=f0c845b3d3027407523b3640bd953aa48013cec3


### PR DESCRIPTION
This plugin adds an examine log tracker. It's only local and in early stages but fully functional. Tracks world point and timestamp for validation maybe later. 
### Inspiration
Inspired from this reddit [post](https://www.reddit.com/r/2007scape/comments/1dzrodt/using_the_examine_option_on_absolutely_everything/)
Community seem to really want it (So apologies if this was rushed):
https://www.reddit.com/r/2007scape/comments/1eq944w/new_examine_log_plugin_dexamine_im_working_on/

### Tracking
https://github.com/user-attachments/assets/fa0199ca-5b9c-4f68-848f-365d9ea9dd52

### Collection Log Entries
https://github.com/user-attachments/assets/70ce4775-91f7-4c14-9981-4ace3a97a1f4
