### PR TITLE
Update Loot Logger to v4.2.2

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=4ef03128e0217cb1125b8bd163fd2543b6621c26
+commit=0730ec492ee41c8f1b23dea1276eb9495fd7c7ca


### PR DESCRIPTION
Fixed the reason the plugin was incompatible after the most recent game update....which was because jagex renamed `Cat mask` to `Cat h` for some reason.