### PR TITLE
Added Gielinor Translations plugin

### DIFF
--- a/plugins/gielinor-translations
+++ b/plugins/gielinor-translations
@@ -1,0 +1,2 @@
+repository=https://github.com/jaredlinklater/gielinor-translations.git
+commit=973f97c109c806c70712f409d5774d70be979b99


### PR DESCRIPTION
# Gielinor Translations
Gielinor Translations translates various in-game language (Ancient Gnomish, Desert) interfaces to real-life languages, currently English & Literal English.

Currently works on the Pharaoh's Sceptre teleport menu and the Gnome Glider interface:

## Pharaoh's Sceptre
Original:
![image](https://github.com/user-attachments/assets/99165231-a3f1-4bd7-bdfa-a1e027f533ca)

English:
![image](https://github.com/user-attachments/assets/855293cf-21f1-41fa-b56d-89b614a152cb)

Literal English:
![image](https://github.com/user-attachments/assets/04ed2cc1-d70d-43bd-9323-e190d87e3ce9)

Completely Replace example:
![image](https://github.com/user-attachments/assets/f1553542-4dac-43c8-a219-1f2405231716)


## Gnome Glider
Original:
![image](https://github.com/user-attachments/assets/5bd6b400-08dc-4946-96eb-b598053b293a)

English:
![image](https://github.com/user-attachments/assets/74f717ea-9644-4d11-9ec1-89755d93003e)

Literal English:
![image](https://github.com/user-attachments/assets/c58fe64c-b862-4801-83fe-4f932a62e32a)
