### PR TITLE
Update marks-of-grace-counter to v1.2

### DIFF
--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=91dad8d8107769a603c049b82a91f1745c156c79
+commit=89f20ad4fc982b25065b8a891c81b62bff4d5968


### PR DESCRIPTION
Slight change in the Overlay class to remove deprecation warning

Added alternate timing method for when the marks spawn based on last agility lap finish time (https://github.com/Cyborger1/marks-of-grace-counter/issues/1).