### PR TITLE
Update JebScape to v0.2.9

### DIFF
--- a/plugins/jebscape
+++ b/plugins/jebscape
@@ -1,3 +1,3 @@
 repository=https://github.com/JebScape/JebScape-Client.git
-commit=bf8bbc6eb7cec8b4c93137564f8cead6073f2bf9
+commit=b1d43960714355d2d4be0626673c6ba6be7297f9
 warning=This plugin sends game data and your IP address to a third party server to facilitate communication between clients across separate worlds.


### PR DESCRIPTION
Part 2 of fixes to have plugin work with latest kit cache changes by Jagex, incorporating in the new additions. Will also now automatically incorporate in future changes to the cache.