### PR TITLE
Added POHTreasureChestGEValue plugin.

### DIFF
--- a/plugins/poh-treasure-chest-ge-value
+++ b/plugins/poh-treasure-chest-ge-value
@@ -1,0 +1,2 @@
+repository=https://github.com/nicDamours/POHTreasureChestGEValue.git
+commit=c9ddb43dcaa1226852108f72313cc385b9906c83

--- a/plugins/poh-treasure-chest-ge-value
+++ b/plugins/poh-treasure-chest-ge-value
@@ -1,2 +1,2 @@
 repository=https://github.com/nicDamours/POHTreasureChestGEValue.git
-commit=c9ddb43dcaa1226852108f72313cc385b9906c83
+commit=1def1f75c940ccdfcc57a2d2769921dbb4d3914a


### PR DESCRIPTION
### Summary
A plugin that add the GE and / or High Alch value of the items present in the POH Treasure chest, to the title bar. 
This plugin is heavily inspired by [Runelite's bank plugin](https://github.com/runelite/runelite/wiki/Bank). 

![screenshot](https://github.com/user-attachments/assets/5ebbd1c2-addc-41cc-b1bc-7e1eac1f75a4)

[See here for the full README and Repo](https://github.com/nicDamours/POHTreasureChestGEValue)