### PR TITLE
Create cooking-buddy

### DIFF
--- a/plugins/cooking-buddy
+++ b/plugins/cooking-buddy
@@ -1,0 +1,2 @@
+repository=https://github.com/MapleBytes/CookingBuddy.git
+commit=e38a40625c3ffc912a67695cafd5346791b0bf9c


### PR DESCRIPTION
CookingBuddy is a RuneLite plugin for players with 99 Cooking. It flashes a customizable screen notification when you try to cook burnable food (assuming level 99) at the Myths' Guild or Rogues' Den.