### PR TITLE
Update pvp-performance-tracker to v1.5.9

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,3 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=9fb9a9a8630331a038248d7f76c9ca0e5f206569
-unavailable=This plugin is incompatible with the latest RuneLite version, and requires its author to update it.
+commit=f8304d22dcf1236e3a255405c4361fc62d382306


### PR DESCRIPTION
Includes hotfix for recent breaking issue, many thanks to discord user @ peenay for implementing and quickly testing the fix.

Not entirely tested by myself: Still have some unresolved gradle issues and wanted to get this hotfix out ASAP. The offset stuff was quickly tested by peenay and seemed to work, and that should be all that needed testing.

The other changes I added to this was simply changing the data folder name from `pvp-performance-tracker` to `pvp-performance-tracker2`, so that new data won't be mixed with the old, and I'll be able to migrate/update older data more viably in a future update. (Thanks to discord user @ redrumze for suggesting this, especially came in handy when I realized my gradle was borked)

Going to test it for real the moment I see it merged, but as I described it should be fine.