### PR TITLE
Create bank-highlighter

### DIFF
--- a/plugins/bank-highlighter
+++ b/plugins/bank-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/Evamist/Bank-Highlighter.git
-commit=ffb5cfca55ed8f82fbbe68d259c35e35185cf6ec
+commit=28492546d3b73901d1d4f0fd02465fdaa1605751

--- a/plugins/bank-highlighter
+++ b/plugins/bank-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/Evamist/Bank-Highlighter.git
-commit=6ed4d76a3f368ba1e61b6630536b99342a8410c7
+commit=5adca8bb16a52913b4585865d0e8216db6bb5e4f

--- a/plugins/bank-highlighter
+++ b/plugins/bank-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/Evamist/Bank-Highlighter.git
+commit=b08a03d02ed4c38a06570afeeab9da79a4fd305e

--- a/plugins/bank-highlighter
+++ b/plugins/bank-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/Evamist/Bank-Highlighter.git
-commit=28492546d3b73901d1d4f0fd02465fdaa1605751
+commit=6ed4d76a3f368ba1e61b6630536b99342a8410c7

--- a/plugins/bank-highlighter
+++ b/plugins/bank-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/Evamist/Bank-Highlighter.git
-commit=b08a03d02ed4c38a06570afeeab9da79a4fd305e
+commit=196afbe31b0575f45b587969dcd450e4a40ae464

--- a/plugins/bank-highlighter
+++ b/plugins/bank-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/Evamist/Bank-Highlighter.git
-commit=196afbe31b0575f45b587969dcd450e4a40ae464
+commit=ffb5cfca55ed8f82fbbe68d259c35e35185cf6ec


### PR DESCRIPTION
Bank Highlighter, inspired by RuneLite's "Inventory Tags," lets you color-code items in your bank or inventory (while the bank is open) for easier visibility. This feature is particularly useful for organizing skill/combat gear sets and quickly finding the items you need. Simply hold Shift, right-click on 'Bank Highlight,' and select your desired color.