### PR TITLE
Update line-markers to v1.3.4

### DIFF
--- a/plugins/line-markers
+++ b/plugins/line-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=b7dcbc31c67620b9b3f8d988ac3e866cdad40a8f
+commit=7018d56710dfbc4f2de90fc368f0a13320059076


### PR DESCRIPTION
- The `Add line` menu option should no longer persist when the shift key was released when the client was out of focus.