### PR TITLE
Create Action Logger v0.1.0

### DIFF
--- a/plugins/action-logger
+++ b/plugins/action-logger
@@ -1,0 +1,3 @@
+repository=https://github.com/pajlads/ActionLogger.git
+commit=8b059e3efb47b05bbd939c902dd689bac8886191
+authors=pajlada


### PR DESCRIPTION
This plugin intends to be a Quest Helper Helper, or potentially other helper helper in the future.

It writes json blobs to disk whenever actions occur (e.g. varbit changed, player started a dialogue).
This allows us to ask a less technically inclined person to enable this plugin, complete a quest, then send the created file to us to inspect & update an older Quest Helper guide with more confidence.
