### PR TITLE
Add legacy-escape plugin

### DIFF
--- a/plugins/legacy-escape
+++ b/plugins/legacy-escape
@@ -1,0 +1,2 @@
+repository=https://github.com/rsfost/legacy-escape.git
+commit=0a7ad67ff8bdc7649bb2162331eee42f136ada1b


### PR DESCRIPTION
Restores the old behavior of closing interfaces with the escape button where it doesn't close chatbox interfaces.