### PR TITLE
Update thrall-helper to v1.9.1

### DIFF
--- a/plugins/thrall-helper
+++ b/plugins/thrall-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/PortAGuy/thrall-helper.git
-commit=07728a44153aea90e603fe32cd3b010b51a9cd3d
+commit=91efaee9926efc5dd47a30a6e8ab8c9287c0ddd2


### PR DESCRIPTION
Updates thrall helper to v1.9.1

- Adds a new reminder style that supports custom text
- Fixes a bug where the infobox reminder style wouldn't appear
     - (During testing of the different styles I was using a regex to make the reminder appear and I had never tested waiting for the thrall to actually despawn, oops)