### PR TITLE
Transfer Ownership of Normal-Ancient-Teleports

### DIFF
--- a/plugins/ancient-teleports-renamed
+++ b/plugins/ancient-teleports-renamed
@@ -1,2 +1,0 @@
-repository=https://github.com/zoltander/ancient-teleports-renamed.git
-commit=9b8c3adda11450239b3ae577d498a2617697f49f

--- a/plugins/ancient-teleports-renamed
+++ b/plugins/ancient-teleports-renamed
@@ -1,0 +1,2 @@
+repository=https://github.com/zoltander/ancient-teleports-renamed.git
+commit=9b8c3adda11450239b3ae577d498a2617697f49f

--- a/plugins/normal-ancient-teleports
+++ b/plugins/normal-ancient-teleports
@@ -1,2 +1,2 @@
-repository=https://github.com/IdylRS/runelite-plugins.git
-commit=b874aef14928ef78a1b3afe15c21710c05eae37c
+repository=https://github.com/zoltander/Normal-Ancient-Teleports.git
+commit=8f1b6528f9ef7ef8cc781f953ab561304ef19ff2


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a39c545d-1b6b-4152-a212-27d625415763)

The purpose of this plugin is to sensibly rename the teleports of the ancient spellbook to their map/p.o.i. locations, similarly to Nexus Menu Map.