### PR TITLE
Update Unbalanced Trade Prevention to v1.2.1

### DIFF
--- a/plugins/unbalanced-trade-prevention
+++ b/plugins/unbalanced-trade-prevention
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/unbalanced-trade-prevention.git
-commit=9fbdd52611dc06865e1501c1e7077a846687149b
+commit=61d8da55eb776f2902524db53a11bd02fcff1969


### PR DESCRIPTION
Small update to consider trades where you are giving nothing to always be balanced (ignores whitelisting & blacklisting)