### PR TITLE
Update sandstone-buckets-counter

### DIFF
--- a/plugins/sandstone-buckets-counter
+++ b/plugins/sandstone-buckets-counter
@@ -1,3 +1,3 @@
 repository=https://github.com/wookkeey/sandstone-buckets-counter.git
-commit=c209f750543a5a3670a838ae13127ca28d96e91d
+commit=68e2f5f7c1f8681e36d89f953e83a5c8256b8ccf
 authors=lukaszklis


### PR DESCRIPTION
Fixes a regression of regex pattern not picking up counts properly (i.e. 3,900).