### PR TITLE
Disable bog plugins

### DIFF
--- a/plugins/temple-trek-bog-helper
+++ b/plugins/temple-trek-bog-helper
@@ -1,2 +1,3 @@
 repository=https://github.com/sololegends/runelite-temple-trek-bog-helper.git
 commit=d85f8d0c9a0c49faf8a02bf93019de24a1fa4e4a
+disabled=true

--- a/plugins/tk-swamp-helper
+++ b/plugins/tk-swamp-helper
@@ -1,2 +1,3 @@
 repository=https://github.com/PlayerCoder1/Temple-Trekking-swamp.git
 commit=cc654788df2b41d3df700a7624805f74c8939382
+disabled=true


### PR DESCRIPTION
The bog has been removed in https://secure.runescape.com/m=news/a=97/araxxor-tweaks--poll-82-updates?oldschool=1
These plugins do nothing currently.