### PR TITLE
[New Plugin] - Max-Hit Sounds - v1.0.0 - Sololegends

### DIFF
--- a/plugins/max-hit-sounds
+++ b/plugins/max-hit-sounds
@@ -1,0 +1,3 @@
+repository=https://github.com/sololegends/Runelite-Max-Hit-Sounds.git
+commit=8ada88c3efa0d7e58fb4713ea842ea1070b8d286
+authors=Sololegends


### PR DESCRIPTION
# Max-Hit Sounds
Add a special sound for when you hit max hit

- Set sound effects per range, mage, and or melee hits. 
- Whitelist only certain items to trigger the sounds (Looking at p2 wardens dds deafening you)