### PR TITLE
Update click-to-minimize

### DIFF
--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=60aecc3d610ea0a1ae63352627299dea3dd1df06
+commit=15395702e81a84517413c3159840bfd4c0b1dbb5

--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=15395702e81a84517413c3159840bfd4c0b1dbb5
+commit=2accc6cffee372e10e9fc91c98d1f0dba4925877


### PR DESCRIPTION
**Bug Fix:**

- Adding game message when window is minimized to help players understand the action being triggered. Toggleable in settings default on.
  - People were reaching out for support in discord / github, not understanding why the plugin was minimizing.

**Feature addition:**

- Adding support for new config option to log all player actions to chat, to make it easier to know what action:target to add to the config
- Adding new option to have a modifier key to prevent the game being minimized when used.
