### PR TITLE
Update health-notifications

### DIFF
--- a/plugins/health-notifications
+++ b/plugins/health-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/TommyAndy/health-notifications.git
-commit=f6142082d93c3a24946909946baa963d4ac9b0d7
+commit=f1230c7bc817b50eeb807800fa7b438cdfbd0912


### PR DESCRIPTION
Added an option to set re-notification timer

Allows users to choose how often a notification will fire for breaching a threshold