### PR TITLE
Updated afk marks canifis to marks cooldown

### DIFF
--- a/plugins/afk-marks-canafis
+++ b/plugins/afk-marks-canafis
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLAfkMarksCanafis.git
-commit=afbd393a1a027fe7145b1d7a4bd30bab1e336e4b
+commit=d31418239cc5039cfba36c0a06e27dfa09c387c5

--- a/plugins/afk-marks-canafis
+++ b/plugins/afk-marks-canafis
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLAfkMarksCanafis.git
-commit=70042605df393d2e3459df0a0306b3cbf082dd5c
+commit=afbd393a1a027fe7145b1d7a4bd30bab1e336e4b

--- a/plugins/afk-marks-canafis
+++ b/plugins/afk-marks-canafis
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLAfkMarksCanafis.git
-commit=dd0ef80c8822d817b250d805f166d844f53cd6c8
+commit=70042605df393d2e3459df0a0306b3cbf082dd5c

--- a/plugins/afk-marks-canafis
+++ b/plugins/afk-marks-canafis
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLAfkMarksCanafis.git
-commit=020a9488957f913e3452e3b6e88529961e96c123
+commit=68641ba89a3c2a2296b9ad1664399c5aa21a1692

--- a/plugins/afk-marks-canafis
+++ b/plugins/afk-marks-canafis
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLAfkMarksCanafis.git
-commit=d31418239cc5039cfba36c0a06e27dfa09c387c5
+commit=bc2aaa1c9e4cf3f432fcf90cef1e82061e2efbf5

--- a/plugins/afk-marks-canafis
+++ b/plugins/afk-marks-canafis
@@ -1,2 +1,2 @@
 repository=https://github.com/powerus117/RLAfkMarksCanafis.git
-commit=68641ba89a3c2a2296b9ad1664399c5aa21a1692
+commit=dd0ef80c8822d817b250d805f166d844f53cd6c8


### PR DESCRIPTION
After some feedback on the AFK canifis marks plugin, I have added other courses so it no longer is a canifis specific plugin but rather a general mark of grace cooldown tracker. And that's exactly what it does, while running laps, after finding your first mark, you should see a cooldown for when the next mark could spawn.

There were also previously some issues with computer with their time out of sync, which are now resolved using NTP.

Let me know if I can improve anything or if you have any questions, thanks in advance 🙏 