### PR TITLE
Update health-notifications

### DIFF
--- a/plugins/health-notifications
+++ b/plugins/health-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/TommyAndy/health-notifications.git
-commit=f6142082d93c3a24946909946baa963d4ac9b0d7
+commit=990a1970cf155d57289edefdd14e4ba41f1a1a6b


### PR DESCRIPTION
Follow up after the discussion in https://github.com/runelite/plugin-hub/pull/6575

I'm setting the default behavior back to what it had been for over a year, reverting the recent "fix" in https://github.com/TommyAndy/health-notifications/commit/f1230c7bc817b50eeb807800fa7b438cdfbd0912

Prayer notifications are disabled by default, so this default behavior change is unlikely to disrupt any new users in the last few weeks this particular change has been out.

For existing users this will align with their existing expectations of behavior as well as the ability to spam notifications for both hitpoints and prayer.

Frankly, the recent change in default behavior was a mistake on my part. I should have been more aware of how the plugin was being used instead of hastily making a change based on the original intention of use.

