### PR TITLE
Update Mahogany Homes to v1.7.1

### DIFF
--- a/plugins/mahogany-homes
+++ b/plugins/mahogany-homes
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Mahogany-Homes.git
-commit=122a0a4fe3153a59e91e30ed2a26aa69122669cd
+commit=e5d2336c109e9c3a22e84745e276813db1ccadb2


### PR DESCRIPTION
Fixes the contract tier tracking when the new `Last-tier contract` menu option is selected. Thanks @Patrick852 