### PR TITLE
Add multi-metronome plugin

### DIFF
--- a/plugins/multi-metronome
+++ b/plugins/multi-metronome
@@ -1,0 +1,2 @@
+repository=https://github.com/Pwootage/runelite-multi-metronome.git
+commit=29b8fbd49730ab6009f9e43331f045144a51eafa


### PR DESCRIPTION
This is a plugin which contains multiple configurable metronomes, which can be configured to run at arbitrary offsets form a tick. 

Handy for when you're trying to input in the middle of a tick, so you don't accidentally cross tick borders.

![Screenshot 2024-09-15 at 12 22 38 PM](https://github.com/user-attachments/assets/47d86bcf-6982-4e2b-8ef9-7a201631d313)
