### PR TITLE
update varlamore-house-thieving to v1.4.0

### DIFF
--- a/plugins/varlamore-house-thieving
+++ b/plugins/varlamore-house-thieving
@@ -1,2 +1,2 @@
 repository=https://github.com/sololegends/runelite-varlamore-house-thieving.git
-commit=e3a5aa7a60d9d4640ecfe5364f978300411463f4
+commit=cc5badc6a9a30d07560db27dc9edba7650513edc

--- a/plugins/varlamore-house-thieving
+++ b/plugins/varlamore-house-thieving
@@ -1,2 +1,2 @@
 repository=https://github.com/sololegends/runelite-varlamore-house-thieving.git
-commit=5dd7c6dd18e998abb4774fe9310037dc6d8ee777
+commit=e3a5aa7a60d9d4640ecfe5364f978300411463f4

--- a/plugins/varlamore-house-thieving
+++ b/plugins/varlamore-house-thieving
@@ -1,2 +1,2 @@
 repository=https://github.com/sololegends/runelite-varlamore-house-thieving.git
-commit=479df9b681f93231a3255b19052cd20a6e61ed5c
+commit=5dd7c6dd18e998abb4774fe9310037dc6d8ee777


### PR DESCRIPTION
# Release v1.4.0

Added time since bonus chest and other minor changes

- Added overlay option for time since last bonus chest
- Added option to turn off the flashing of the distracted citizen icon
- Added option to turn off distracted icon whilst in a house
- Bettered the owner left overlay rest detection
- Resolved some edge cases for distraction notifications re-emitting when not needed

Implements Issue: https://github.com/sololegends/runelite-varlamore-house-thieving/issues/10
Resolves Issue: https://github.com/sololegends/runelite-varlamore-house-thieving/issues/9