### PR TITLE
Update legacy-escape to v0.2

### DIFF
--- a/plugins/legacy-escape
+++ b/plugins/legacy-escape
@@ -1,2 +1,2 @@
 repository=https://github.com/rsfost/legacy-escape.git
-commit=0a7ad67ff8bdc7649bb2162331eee42f136ada1b
+commit=c65cb9bf948958ac54df0d60ecc16076c48b1f7e


### PR DESCRIPTION
Fixes an issue preventing the plugin from working when client layout is set to Modern Resizable.