### PR TITLE
Update xp-drop-notify v1.0.1 (one liner bug fix)

### DIFF
--- a/plugins/xp-drop-notify
+++ b/plugins/xp-drop-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
-commit=0e5e9396f65873d0c7292393032f6bf7489a6d62
+commit=64783f149ca866c1a7e3fa0ec8145b57218b9713


### PR DESCRIPTION
Fix array index out of bounds exception with wrong array size