### PR TITLE
update entrana to v1.0.1

### DIFF
--- a/plugins/entrana
+++ b/plugins/entrana
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
-commit=e47f1433babb39bb3b2b1f08563412c2cb31121f
+commit=9d40c22c90241e37d6a20a740b5b91f7dfae9863


### PR DESCRIPTION
Add allowed exception items:
- tome of water
- twitchers gloves

Fix deprecated api usage
Enable plugin when the balloon transport interface is open