### PR TITLE
Update GP-Per-Hour to 1.9

### DIFF
--- a/plugins/gp-per-hour
+++ b/plugins/gp-per-hour
@@ -1,3 +1,3 @@
 repository=https://github.com/MosheBenZacharia/GP-Per-Hour.git
-commit=f83d377dbf08bd65ab31ceb842c2cd279d9a25db
+commit=ca75f6a9d8348df5d7b1b74b481863c5c401806c
 authors=MosheBenZacharia


### PR DESCRIPTION
Fix incorrect assumption that the flattened ID was unique and equivalent to group + child ID. This was leading to new trips starting when switching to different menu tabs.