### PR TITLE
Update examine-log

### DIFF
--- a/plugins/examine-log
+++ b/plugins/examine-log
@@ -1,2 +1,2 @@
 repository=https://github.com/CarlOmega/examine-log.git
-commit=a98a481ff65b8e8c7090474f3404abf1f3eb3a4d
+commit=51408b09be11d3590995ac3e9aefc96938e619ea


### PR DESCRIPTION
Fixes: [Issue](https://github.com/CarlOmega/examine-log/issues/3) 

Uses `getTopLevelInterfaceId` instead of hardcoded value.