### PR TITLE
Update chat-success-rates to v1.2.4

### DIFF
--- a/plugins/chat-success-rates
+++ b/plugins/chat-success-rates
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=df560310b6f09993f1214537643c7499ce7b3020
+commit=c8ebe28ec8d230a97a1f1b247897c8a6b67b7f27


### PR DESCRIPTION
- Display tracked message box messages in the chat box as if they were standard chat messages