### PR TITLE
Create distraction-reducer

### DIFF
--- a/plugins/distraction-reducer
+++ b/plugins/distraction-reducer
@@ -1,0 +1,2 @@
+repository=https://github.com/Car-Role/Distraction-Reducer.git
+commit=a0e016dab084fb28cc88861a4c862ccbd2b726b8


### PR DESCRIPTION
The Distraction Reducer plugin helps players focus on other things outside of OSRS by reducing visual distractions. When enabled, it overlays a customizable black screen while you're engaged in specific skilling actions, allowing you to concentrate on your task without being distracted by the game's visuals. When a click is needed the screen will return to normal.