### PR TITLE
Watchdog - update build incrementer to not run on deploy

### DIFF
--- a/plugins/watchdog
+++ b/plugins/watchdog
@@ -1,2 +1,2 @@
 repository=https://github.com/adamk33n3r/runelite-watchdog.git
-commit=eb8d5d4cb1814cd029ca6923ecfe395beef6dd95
+commit=32809cd5135015b1c84d3b6ecc24dc3fa8ac74df

--- a/plugins/watchdog
+++ b/plugins/watchdog
@@ -1,2 +1,2 @@
 repository=https://github.com/adamk33n3r/runelite-watchdog.git
-commit=b0fe53c9cba7717989528984ff57e77edfd950f5
+commit=eb8d5d4cb1814cd029ca6923ecfe395beef6dd95


### PR DESCRIPTION
Per conversation here https://discord.com/channels/301497432909414422/419891709883973642/1273977480956477440 abex approved this solution.

Sorry, I forgot to make a PR for this after I made the fix! 