### PR TITLE
Update dt2-mistake-tracker

### DIFF
--- a/plugins/dt2-mistake-tracker
+++ b/plugins/dt2-mistake-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/DT2-Boss-Failure.git
-commit=0c59fc3b12bb14eabf4324ece34adcb4d828932c
+commit=e6792347a8f36bc3e70943f8ba10b478232c5172
 authors=DominickCobb


### PR DESCRIPTION
Add reset of perfection status based on game messages, on death and on kill increment
Remove Vardorvis projectile failure condition
Remove deprecated method of getting regionID
