### PR TITLE
Update quest-helper to 4.6.0

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=5f3e412c52b09613833585b83fb5ecb1fe61f1cc
+commit=d4f280bb05dec3acbcbf5b3012dabf24412e49d4

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=d4f280bb05dec3acbcbf5b3012dabf24412e49d4
+commit=66f0c02391a6ce22a531033c0a10e244efa1c6ec

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=66f0c02391a6ce22a531033c0a10e244efa1c6ec
+commit=57bff726c737a00955c46403ce44202e40cd331e


### PR DESCRIPTION
- Adds Barbarian Training
- Adds assistance options which'll show when a player first tries to open a helper after the update from the sidebar. This'll let them choose the level of assistance they want the QH to provide.

Edit: **NOTE**: There's another PR currently up JUST with small bug fixes (https://github.com/runelite/plugin-hub/pull/6669). If this gets merged in, that should be closed if it hasn't already been added.