### PR TITLE
ban-list-export plugin

### DIFF
--- a/plugins/ban-list-export
+++ b/plugins/ban-list-export
@@ -1,2 +1,2 @@
 repository=https://github.com/P2GR/ban-list-export.git
-commit=288986176daf1b6fdc953dd4560659da5fdbedd2
+commit=20f61a2506927092c8c2d96ace6383f1666e2580

--- a/plugins/ban-list-export
+++ b/plugins/ban-list-export
@@ -1,0 +1,2 @@
+repository=https://github.com/P2GR/ban-list-export.git
+commit=288986176daf1b6fdc953dd4560659da5fdbedd2


### PR DESCRIPTION
Plugin to easily export your clan's ban list to CSV or JSON.