### PR TITLE
Create hide-chat-buttons

### DIFF
--- a/plugins/hide-chat-buttons
+++ b/plugins/hide-chat-buttons
@@ -1,0 +1,2 @@
+repository=https://github.com/salemwatkins/HideChatButtons.git
+commit=cccaabc76ba03acbcb53fdd8627ef3624a0b9b2e


### PR DESCRIPTION
A plugin that hides the chat buttons inside the chatbox to remove clutter off the screen.