### PR TITLE
Disable GE Calc plugin

### DIFF
--- a/plugins/gecalc
+++ b/plugins/gecalc
@@ -1,3 +1,3 @@
 repository=https://github.com/cman8396/GECalc.git
 commit=963b9068de424daa4a8d3cb894241cc7607a6afc
-unavailable=This plugin is incompatible with the latest RuneLite version, and requires its author to update it.
+disabled=This plugin is incompatible with the latest RuneLite version, and requires its author to update it.

--- a/plugins/gecalc
+++ b/plugins/gecalc
@@ -1,3 +1,3 @@
 repository=https://github.com/cman8396/GECalc.git
 commit=963b9068de424daa4a8d3cb894241cc7607a6afc
-disabled=true
+unavailable=This plugin is incompatible with the latest RuneLite version, and requires its author to update it.

--- a/plugins/gecalc
+++ b/plugins/gecalc
@@ -1,2 +1,3 @@
 repository=https://github.com/cman8396/GECalc.git
 commit=963b9068de424daa4a8d3cb894241cc7607a6afc
+disabled=true


### PR DESCRIPTION
Replicated the issue but no luck on a fix.
Best to disable due to multiple reports on github and RuneLite discord of the plugin interfering with all quantity input fields.