### PR TITLE
tobqol - v1.2.3

### DIFF
--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=a642a3fc89e214a4727ef840f7156ecd86490d1b
+commit=5948c2006c2537cd6fb601abad6f000ae34154e1


### PR DESCRIPTION
- fixes: -3.3% verzik red crabs HP display due to tracking
- fixes: salve warning displayed when salve is equipped