### PR TITLE
Update marks-of-grace-counter to 1.2.1

### DIFF
--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=094d5debe10b45a387126271451e2438a1e09af8
+commit=f549e7692b6d5caccdd29de30ea40fe1802a68f6

--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=89f20ad4fc982b25065b8a891c81b62bff4d5968
+commit=094d5debe10b45a387126271451e2438a1e09af8


### PR DESCRIPTION
Added an option to send a RuneLite notification after an amount of time has passed since last mark spawned, mostly intended for the Ardougne course if someone goes afk and risks losing their stack.

Related issue: https://github.com/Cyborger1/marks-of-grace-counter/issues/2