### PR TITLE
Add mixology-helper plugin

### DIFF
--- a/plugins/mixology-helper
+++ b/plugins/mixology-helper
@@ -1,0 +1,3 @@
+repository=https://github.com/BlueSoapTurtle/mixology-helper.git
+commit=fe497a9fd3ac32fe7ba61f04aae3fb8dceaa092a
+authors=BlueSoapTurtle


### PR DESCRIPTION
Added version 1.0 of the Mixology Helper plugin. 
This plugin helps players optimize their performance in the Mastering Mixology minigame by highlighting key game elements, picking the best potion order based on Herblore level and configured priorities(exp or specific resin focused), and tracking progress through customizable infoboxes. 
It also provides notifications for special events like mature digweed spawns.