### PR TITLE
Create global-nest-tracker

### DIFF
--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=a1bb786c4bac50dca5abc43a988a244365889e9f
+commit=5007a6dbfc0e46810c69e6945e000cec206393cc
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=5007a6dbfc0e46810c69e6945e000cec206393cc
+commit=955749194afc6faee45642bab8d68af7484f815c
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=86d15f064092325503281960861709da6cd8694f
+commit=9cbef80c52233d6f44e25c269ed871c07ad2bd63
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/Zoinkwiz/global-nest-tracker.git
+commit=668be8b929f5aea6926df5c6ff0f2d4db4a123d5
+warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=668be8b929f5aea6926df5c6ff0f2d4db4a123d5
+commit=3cdb56a83494b1a0bfc1dc7fb9be6171ce5b92fe
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=3cdb56a83494b1a0bfc1dc7fb9be6171ce5b92fe
+commit=930fe2f2b7710baee72b21c4ebf6620bc546e8ad
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=616fc1fd8bd6cc6a2795ad19957520e200be1bd3
+commit=118670474433509b47ff61dd0dafe6169b8bcd14
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=9cbef80c52233d6f44e25c269ed871c07ad2bd63
+commit=5007a6dbfc0e46810c69e6945e000cec206393cc
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=5007a6dbfc0e46810c69e6945e000cec206393cc
+commit=a1bb786c4bac50dca5abc43a988a244365889e9f
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=f604f5bb264276aade7dd071347d13ab6c8a4aa0
+commit=616fc1fd8bd6cc6a2795ad19957520e200be1bd3
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=955749194afc6faee45642bab8d68af7484f815c
+commit=f604f5bb264276aade7dd071347d13ab6c8a4aa0
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/global-nest-tracker
+++ b/plugins/global-nest-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/global-nest-tracker.git
-commit=930fe2f2b7710baee72b21c4ebf6620bc546e8ad
+commit=86d15f064092325503281960861709da6cd8694f
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Adds tracking for what items have been used on the Aldarin nest. It has a sidebar for showing items and their known/unknown status for the nest. It makes use of a server with a DB behind it for storing interactions, and to be queried by clients.

![Screenshot 2024-09-27 013437](https://github.com/user-attachments/assets/54d94c92-1805-4217-a96e-e7cbd3c2d3d2)
