### PR TITLE
Create LITE Regen meters

### DIFF
--- a/plugins/lite-regen-meter
+++ b/plugins/lite-regen-meter
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/literegenmeter.git
-commit=41f9982a0e5516713225bbe9c88226564429b535
+commit=687e3cbc7a1e6046e53b9783876484f36a443437

--- a/plugins/lite-regen-meter
+++ b/plugins/lite-regen-meter
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/literegenmeter.git
-commit=e428ac48b8269221ccaa03045507478831ed65c2
+commit=c26a1b5269743be4d234358978a1b3ee8d2fb993

--- a/plugins/lite-regen-meter
+++ b/plugins/lite-regen-meter
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/literegenmeter.git
-commit=0d780485152d151085527040b3289ec37bf8f8b0
+commit=41f9982a0e5516713225bbe9c88226564429b535

--- a/plugins/lite-regen-meter
+++ b/plugins/lite-regen-meter
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/literegenmeter.git
-commit=687e3cbc7a1e6046e53b9783876484f36a443437
+commit=e428ac48b8269221ccaa03045507478831ed65c2

--- a/plugins/literegenmeter
+++ b/plugins/literegenmeter
@@ -1,0 +1,2 @@
+repository=https://github.com/Varietyz/literegenmeter
+commit=0d780485152d151085527040b3289ec37bf8f8b0

--- a/plugins/literegenmeter
+++ b/plugins/literegenmeter
@@ -1,2 +1,2 @@
-repository=https://github.com/Varietyz/literegenmeter
+repository=https://github.com/Varietyz/literegenmeter.git
 commit=0d780485152d151085527040b3289ec37bf8f8b0


### PR DESCRIPTION
Provides an altered version of the regeneration meters plugin to fit the orbs in the RuneLITE theme pack.
