### PR TITLE
Update Mahogany Homes to v1.7.2

### DIFF
--- a/plugins/mahogany-homes
+++ b/plugins/mahogany-homes
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Mahogany-Homes.git
-commit=e5d2336c109e9c3a22e84745e276813db1ccadb2
+commit=7414153a1fb00acbf38119426c2814b18b8ef995


### PR DESCRIPTION
* Fixed an error where `client.getItemContainer` was being called off the client thread
* Added support for the contract reminder text from Amy