### PR TITLE
Update quest-helper to 4.5.4.2

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=dafa79cbb472f45fbc61f187db68dc69f84c5d63
+commit=5f3e412c52b09613833585b83fb5ecb1fe61f1cc


### PR DESCRIPTION
Small patch which I hope is a lot easier to review prior to the [4.6.0 release](https://github.com/runelite/plugin-hub/pull/6636). This fixes bugs which are effecting quite a lot of users for a selection of annoying quests which rely on the quest log to sync. This fix should mean those quest helpers work as expected again.

This fixes:
- Quest Log ID change from RL version 1.10.38.1
- Model changes for cheerers from an update
- Fix for the Guthixian Temple puzzle in WGS