### PR TITLE
Update marks-of-grace-counter to v1.3

### DIFF
--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=291f88ffe7979a14dbee8d9a55b4f378c385cf4c
+commit=20587f159c758d175068a32cc1412cb6a0b13e7f

--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=c952bcfdde6d323b21e04b4486e5a957d26e9b54
+commit=cc7c45ba2467dd265713e57e00853bfc2c6d5a23

--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=f549e7692b6d5caccdd29de30ea40fe1802a68f6
+commit=291f88ffe7979a14dbee8d9a55b4f378c385cf4c

--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=20587f159c758d175068a32cc1412cb6a0b13e7f
+commit=c952bcfdde6d323b21e04b4486e5a957d26e9b54


### PR DESCRIPTION
This update is mostly a refactor of the plugin, moving all the MOGSession class stuff into the main plugin class, just so it's a bit easier to manage.

It was originally done this way because the code was heavily based on the Agility plugin's session object, where it makes sense to separate it from the main plugin code as it does a lot more than just provide a lap counter.

Since this plugin's entire purpose is the counter, I figured it didn't make sense to use a Session class like the Agility plugin, so I got rid of it.

Other than that, it's mostly tweaks here and there as well as adding a way to keep track of individual mark stack spawns for the notification function. It's now possible to get a notification for an older separate stack on the other courses that aren't the Ardougne course.