### PR TITLE
Update shortest-path to v1.15

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=c529f439f33a4b3179fd336791760db0c81d91f9
+commit=2e34520adb4093bf1e0f78d180e1d0ff896e59b0


### PR DESCRIPTION
- Added support for the [`PluginMessage`](https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/events/PluginMessage.java) event, which allows other plugins to request the Shortest Path plugin to display a path to a given target location.