### PR TITLE
🔥 Custom Emoji Plugin Submission

### DIFF
--- a/plugins/custom-emoji
+++ b/plugins/custom-emoji
@@ -1,0 +1,3 @@
+repository=https://github.com/TheLouisHong/runelite-custom-emoji.git
+commit=0a7b3c1763db25d35aa9435c15229660804fa172
+authors=LouisHong


### PR DESCRIPTION
- does not distribute emoji files
- does not network
- machine local files, requires the user to copy emoji files manually

Carefully abiding by the hub decree

> Twitch/BTTV/FFZ/7TV emote plugins: Distributing the emotes for these plugins would likely require skirting over the legal agreements of these services, and thus won't be accepted.
