### PR TITLE
add white-knight-rank

### DIFF
--- a/plugins/white-knight-rank
+++ b/plugins/white-knight-rank
@@ -1,0 +1,3 @@
+repository=https://github.com/gtjamesa/white-knight-rank-plugin.git
+commit=198e4b52924b1a39ec1af822954e27c7d64bcfd1
+authors=gtjamesa


### PR DESCRIPTION
Adding a plugin to track your White Knight ranking (kills/rank) - useful for the elite Falador diary