### PR TITLE
Create Style-Alert

### DIFF
--- a/plugins/better-style-indicators
+++ b/plugins/better-style-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/Varietyz/betterstyleindicator-plugin.git
+commit=ab184be1ad81670b44c04182a848f034ee186876

--- a/plugins/better-style-indicators
+++ b/plugins/better-style-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/betterstyleindicator-plugin.git
-commit=1cab028b2ac171f309cb32e55496491e60eba55d
+commit=0a3a16e24ff3d21d683d706aa7318a20b8c7358d

--- a/plugins/better-style-indicators
+++ b/plugins/better-style-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/betterstyleindicator-plugin.git
-commit=ab184be1ad81670b44c04182a848f034ee186876
+commit=1cab028b2ac171f309cb32e55496491e60eba55d

--- a/plugins/better-style-indicators
+++ b/plugins/better-style-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/betterstyleindicator-plugin.git
-commit=0a3a16e24ff3d21d683d706aa7318a20b8c7358d
+commit=357845fd1e6b65fd3e98af54abe8d3942cb22f9e

--- a/plugins/better-style-indicators
+++ b/plugins/better-style-indicators
@@ -1,2 +1,0 @@
-repository=https://github.com/Varietyz/betterstyleindicator-plugin.git
-commit=357845fd1e6b65fd3e98af54abe8d3942cb22f9e

--- a/plugins/style-alert
+++ b/plugins/style-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/stylealert.git
-commit=dc3152e5ce977b46aac66d10914f9c4fa5271dac
+commit=b1c44ade641785771002c6a7e42a6193e67997ec

--- a/plugins/style-alert
+++ b/plugins/style-alert
@@ -1,0 +1,2 @@
+repository=https://github.com/Varietyz/stylealert.git
+commit=e49c455c649ac83a7a4ec3f626dd2c9d79eb2a90

--- a/plugins/style-alert
+++ b/plugins/style-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/stylealert.git
-commit=e49c455c649ac83a7a4ec3f626dd2c9d79eb2a90
+commit=dc3152e5ce977b46aac66d10914f9c4fa5271dac

--- a/plugins/style-alert
+++ b/plugins/style-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/stylealert.git
-commit=b1c44ade641785771002c6a7e42a6193e67997ec
+commit=39b94285418d19ac32aa9ead51e9698f4cd3168e


### PR DESCRIPTION
Added a plugin that allows users to configure uninterupted screen flashen whilest a combat style is selected that the user configured to be warned about. Also provides the option to change its speed, opacity and wether or not a notification sound should be played on every flash.

This was requested by 1 Def pures.