### PR TITLE
Create boostnotifier

### DIFF
--- a/plugins/boostnotifier
+++ b/plugins/boostnotifier
@@ -1,0 +1,2 @@
+repository=https://github.com/rikbreukers/boostnotifier.git
+commit=15fe6b158694ac4d619de21a5d5dcac28740876b


### PR DESCRIPTION
Boost Notifier Plugin
Boost Notifier is a plugin designed to help players keep track of their stat boosts. It lets you set custom thresholds for skills like Strength, Attack, and Defense, and notifies you when your boosts fall to those levels. This way, you’ll never miss a chance to reapply your potions during gameplay. The plugin is fully customizable, allowing you to choose which skill to monitor and set multiple boost levels. You can also opt-in for email alerts to get notified even when you’re away from your screen. It's a simple but effective way to stay on top of your game.