### PR TITLE
Create boostnotifier

### DIFF
--- a/plugins/boostnotifier
+++ b/plugins/boostnotifier
@@ -1,0 +1,2 @@
+repository=https://github.com/rikbreukers/boostnotifier.git
+commit=f4472c82c77e42c4778dba7156b2b5051ec027ea


### PR DESCRIPTION
Boost Notifier is a handy RuneLite plugin designed to keep track of your skill boosts. You can set up customizable level thresholds for different skills, and the plugin will send you alerts — even email notifications 