### PR TITLE
Update shortest-path to v1.15.1

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=2e34520adb4093bf1e0f78d180e1d0ff896e59b0
+commit=f3b4511c05b949c9c0a562f48be2b7b3d510270f


### PR DESCRIPTION
- Fixed a NullPointerException when pathing between non-instanced and instanced areas with the line path style enabled.