### PR TITLE
Update quest-helper to 4.7.0

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=57bff726c737a00955c46403ce44202e40cd331e
+commit=092724258cf4ea58b5a464d02abf98a960d59a05


### PR DESCRIPTION
This adds support for the 4 newest quests added in Varlamore.

It also allows quest helper to use the new PluginMessage to integrate with the shortest path plugin.