### PR TITLE
Update marks-of-grace-counter to v1.3.1

### DIFF
--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=cc7c45ba2467dd265713e57e00853bfc2c6d5a23
+commit=b1e702a00c0b626d07ff6eaf64a712823e509789


### PR DESCRIPTION
Sorry for the multiple back to back updates, but I've been receiving a few requests lately to add more features to this plugin, there's going to be another one coming later that I still have to test and play around with before I push it here.

Anyway, this one is a follow up to https://github.com/Cyborger1/marks-of-grace-counter/issues/2, the user asked to include the number of marks in the stack that's about to despawn to the notification message.

That's pretty much it for this one, except I also added an edge case for when multiple stacks are about to despawn at the exact same time. This really shouldn't happen with normal usage, but it is possible if someone turns on the plugin with multiple stacks present on screen.