### PR TITLE
Create skilling-boost-reminder

### DIFF
--- a/plugins/skilling-boost-reminder
+++ b/plugins/skilling-boost-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/JonneSaloranta/skilling-boost-reminder.git
+commit=9563a414f75dc1ac5d094dcc809a3f09813f1d11


### PR DESCRIPTION
This plugin reminds you to use your special attack to boost stats when skilling with appropriate tool in hand.
Incl. woodcutting, fishing and mining with e.g dragon axes which boosts woodcutting when special attack is used.
Didn't find any plugin that does this.