### PR TITLE
Update quest-helper to 4.7.0.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=092724258cf4ea58b5a464d02abf98a960d59a05
+commit=8d1e4693ac61368fdabd44360ecd6c98ecd0bb42

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=8d1e4693ac61368fdabd44360ecd6c98ecd0bb42
+commit=a00569023857a0a9622293ee8c692f84a8ab96ee

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=a00569023857a0a9622293ee8c692f84a8ab96ee
+commit=5bf04b41c9ebe3a2d55cdc1ad6b581370300694d


### PR DESCRIPTION
Tiny fix removing 4 lines for shortest path to ensure it gets cleared correctly in quest shutdown.