### PR TITLE
Create six-hour-reminder

### DIFF
--- a/plugins/six-hour-reminder
+++ b/plugins/six-hour-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/Richardant/Six-Hour-Reminder.git
+commit=d97e60a03514dd9ba191c637c7c73a876528ca72

--- a/plugins/six-hour-reminder
+++ b/plugins/six-hour-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/Richardant/Six-Hour-Reminder.git
-commit=ae4328b89bfe30ac78b6b751501be928d0eecc85
+commit=dad2b209345b1693cf3cd97294e3b419b7f92b89

--- a/plugins/six-hour-reminder
+++ b/plugins/six-hour-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/Richardant/Six-Hour-Reminder.git
-commit=d97e60a03514dd9ba191c637c7c73a876528ca72
+commit=ae4328b89bfe30ac78b6b751501be928d0eecc85


### PR DESCRIPTION
This plugin adds a countdown reminder when you're about to get 6h force logout

![pic1](https://i.imgur.com/yh46FUb.png)

Very useful for an explicit overlay that helps to know exactly how much time left you have until 6h logout, so people can use a different option than "Login Timer" in the "Report button" plugin, it also prevents some players who use “Chat notifications” from confusing the 6h logout notification with other notifications for low pray, low run energy, low health, etc.

This overlay appears by default when player has 30 minutes left before getting 6h logout and it's customizable from 1 minute to 60 minutes.