### PR TITLE
Update marks-of-grace-counter to v1.3.2

### DIFF
--- a/plugins/marks-of-grace-counter
+++ b/plugins/marks-of-grace-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/marks-of-grace-counter.git
-commit=b1e702a00c0b626d07ff6eaf64a712823e509789
+commit=f7c3d8594ec69a001e4f3338fd1ca3be0cfbadc4


### PR DESCRIPTION
Should be the last one for now, unless the user who requested this feature reports issues with it.

Essentially just adds an experimental settings section with configs to display an extra line on the overlay which counts the time passed since the beginning of the minute when a mark last spawned. Done by simply truncating the time to the minute with an option to offset the "start" of the minute in case the in-game ticks aren't lining up quite right.

The idea revolves around the marks' spawning mechanics, where the cooldown timer is not based on the exact moment of the mark spawning, but rather the first tick for the minute it spawned in.