### PR TITLE
Create crabman-group-bronzeman-plugin

### DIFF
--- a/plugins/crabman-group-bronzeman-plugin
+++ b/plugins/crabman-group-bronzeman-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/mvdicarlo/osrs-crabman-mode.git
-commit=b23e857a02cd0bec5c7a35d2ec631252ca9cd652
+commit=f6e23c2a6e6cfd2dcd52bfa61d77383ae4f732d3

--- a/plugins/crabman-group-bronzeman-plugin
+++ b/plugins/crabman-group-bronzeman-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/mvdicarlo/osrs-crabman-mode.git
-commit=09e8095d0897c1d3d259be060b454eda62b4ed78
+commit=7b2cf9c45f4ee5ca68620932f283f46c2a66f3fd

--- a/plugins/crabman-group-bronzeman-plugin
+++ b/plugins/crabman-group-bronzeman-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/mvdicarlo/osrs-crabman-mode.git
-commit=7b2cf9c45f4ee5ca68620932f283f46c2a66f3fd
+commit=0b7b550e355748e4be61b99143d0623be8e06309

--- a/plugins/crabman-group-bronzeman-plugin
+++ b/plugins/crabman-group-bronzeman-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/mvdicarlo/osrs-crabman-mode.git
-commit=d77d2f7e77e9ac820d1dd79496c7ef456a8a770a
+commit=9333442a3a2139e6f39242a06f641ae16e3c6d4b

--- a/plugins/crabman-group-bronzeman-plugin
+++ b/plugins/crabman-group-bronzeman-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/mvdicarlo/osrs-crabman-mode.git
+commit=09e8095d0897c1d3d259be060b454eda62b4ed78

--- a/plugins/crabman-group-bronzeman-plugin
+++ b/plugins/crabman-group-bronzeman-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/mvdicarlo/osrs-crabman-mode.git
-commit=0b7b550e355748e4be61b99143d0623be8e06309
+commit=d77d2f7e77e9ac820d1dd79496c7ef456a8a770a

--- a/plugins/crabman-group-bronzeman-plugin
+++ b/plugins/crabman-group-bronzeman-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/mvdicarlo/osrs-crabman-mode.git
-commit=9333442a3a2139e6f39242a06f641ae16e3c6d4b
+commit=b23e857a02cd0bec5c7a35d2ec631252ca9cd652


### PR DESCRIPTION
This plugin introduces a group version of the bronzeman plugins.

Originally based off of [another-bronzeman-mode](https://github.com/CodePanter/another-bronzeman-mode) but with heavy modification and changes.

Group collaboration is enabled by users providing an Azure Storage Account SAS Token. I understand this is somewhat limiting, but trying to configure for multiple databases is currently not within scope. As far as setup and costs go are relatively cheap.

Apologies if the setup is a little messy as I forked, and just figured things out from there. Any further guidance is welcome.