### PR TITLE
Add scythe-crush-warning plugin

### DIFF
--- a/plugins/scythe-crush-warning
+++ b/plugins/scythe-crush-warning
@@ -1,0 +1,3 @@
+repository=https://github.com/gtjamesa/scythe-crush-warning-plugin.git
+commit=fabde2837c8c6213d1ee1a2fa68da5c905aa720b
+authors=gtjamesa


### PR DESCRIPTION
Adds a simple plugin that shows a warning overlay if you Scythe is set to Crush when outside of Araxxor/Nightmare (and banking) regions

Edit: this plugin does not show which style to use when attacking bosses, only an overlay warning that you've stupidly left your scythe on crush when outside of the boss regions
