### PR TITLE
transfer ownership of the-gauntlet

### DIFF
--- a/plugins/the-gauntlet
+++ b/plugins/the-gauntlet
@@ -1,2 +1,2 @@
-repository=https://github.com/rdutta/runelite-gauntlet.git
-commit=594c3bf973c94ee512ff890f0b4648d092180029
+repository=https://github.com/LlemonDuck/the-gauntlet.git
+commit=db78c98e2a2e41fd0367f0804b76f55e8f4895f9


### PR DESCRIPTION
upstream repo was deleted, so transferring ownership of the plugin to keep it alive.

Since the git history was not preserved, the commit hash has changed, although I have not actually modified the plugin.