### PR TITLE
Update bot-detector (small README changes)

### DIFF
--- a/plugins/bot-detector
+++ b/plugins/bot-detector
@@ -1,4 +1,4 @@
 repository=https://github.com/Bot-detector/bot-detector.git
-commit=0b33949f8e73c296aee0dd64417e0f5c5f68b65a
+commit=d935825f817d1a96345742ca219fd1ddaaf23879
 warning=This plugin submits the names, locations, and gear of encountered Players, and your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic,Cyborger1


### PR DESCRIPTION
Changed plugin badges to use the API now provided by Runelite directly (Thanks @TheStonedTurtle for the original API).

Added some links to the badges (website, discord, x/twitter).

Swapped out a dead jagex support link towards the end.