### PR TITLE
Update action-progress

### DIFF
--- a/plugins/action-progress
+++ b/plugins/action-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/guillaume009/runelite-plugin-action-progress.git
-commit=b4ecf55e590f0e3908e97378e02dae4e64a03522
+commit=3ad358cea636df8bc04984d70c09f276ddb147f3


### PR DESCRIPTION
- Fix NPE on indexToItemId.get
- Fix this.client.getItemContainer(InventoryID.EQUIPMENT); not being ran on client thread

Should address the smithing part of this issue

https://github.com/guillaume009/runelite-plugin-action-progress/issues/51