### PR TITLE
Update clear-unsent-messages

### DIFF
--- a/plugins/clear-unsent-messages
+++ b/plugins/clear-unsent-messages
@@ -1,2 +1,2 @@
 repository=https://github.com/lightningboltemoji/clear-unsent-messages.git
-commit=fe2dc6fdc3d2caa547f2ca13584c98e6ef165109
+commit=e90b3eabd6aa70e4ee395b549874ba7419c2ef49


### PR DESCRIPTION
* Fixes compatibility with latest RuneLite version
  * I was injecting a `ScheduledExecutorService` and expecting it to run on the client thread which was probably a bad idea