### PR TITLE
update white-knight-rank to 1.0.3

### DIFF
--- a/plugins/white-knight-rank
+++ b/plugins/white-knight-rank
@@ -1,3 +1,3 @@
 repository=https://github.com/gtjamesa/white-knight-rank-plugin.git
-commit=783163e4555506371e796dc51aac6bc328dd465c
+commit=da43b2b4e24e04970460dbc25cdaeffa7d7be410
 authors=gtjamesa


### PR DESCRIPTION
Fixes a quest log parsing bug when the logged kills are over 1000 and a comma is introduced
