### PR TITLE
update ba-tiles: use createSubMenu instead of setParent

### DIFF
--- a/plugins/ba-tiles
+++ b/plugins/ba-tiles
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/ba-tiles.git
-commit=16727036f297622988b35835a70ee04dd9360d3d
+commit=62e3f073537a35c07122caf06a0b8ad7e9af8840


### PR DESCRIPTION
The use of setParent was deprecated, breaking the plugin.

This change migrates from using setParent to using the new createSubMenu.