### PR TITLE
Create cox-scouting

### DIFF
--- a/plugins/cox-scouting
+++ b/plugins/cox-scouting
@@ -1,0 +1,2 @@
+repository=https://github.com/aghasemi78/cox-scouting-plugin.git
+commit=337d8fee9da7e7c4529a90607abecca0a6889b07


### PR DESCRIPTION
Makes it easier to scout for specific raid layout. Makes default option on the steps leaving the cox raid "reload." Takes options from players about specific rooms wanted in the raid. When all criteria are met, it will make the default option on the steps "walk here" so that it can't be accidentally clicked.