### PR TITLE
Create cox-scouting

### DIFF
--- a/plugins/cox-scouting
+++ b/plugins/cox-scouting
@@ -1,0 +1,2 @@
+repository=https://github.com/aghasemi78/cox-scouting-plugin.git
+commit=2da1e5e3484eaaf5f7b9544570c768471ba9ccc9

--- a/plugins/cox-scouting
+++ b/plugins/cox-scouting
@@ -1,2 +1,2 @@
 repository=https://github.com/aghasemi78/cox-scouting-plugin.git
-commit=2da1e5e3484eaaf5f7b9544570c768471ba9ccc9
+commit=5b7294caf36509fbc17ab4b112b9c794c70188cf


### PR DESCRIPTION
this plugin works similar to the COX scout QoL but in a simpler fashion. It will ask the player to select specific rooms, number of rooms per raid and even the raid start order and then remove the reload option on the step leading out of the raid if the criteria are met in a layout.