### PR TITLE
cox scouting

### DIFF
--- a/plugins/cox-scouting
+++ b/plugins/cox-scouting
@@ -1,2 +1,2 @@
 repository=https://github.com/aghasemi78/cox-scouting-plugin.git
-commit=392cf4f9ee927c6bc0e2fe5124ad1fa7b19491fb
+commit=3445bdc909395c92eec61da7dc14abe6d0ff761e

--- a/plugins/cox-scouting
+++ b/plugins/cox-scouting
@@ -1,2 +1,2 @@
 repository=https://github.com/aghasemi78/cox-scouting-plugin.git
-commit=032a98a31a6cb96e0ee07e0b0bead9cffe15aadc
+commit=ce574c7e03b6e1c3e35e7c8c1c9a0e6524ec2260

--- a/plugins/cox-scouting
+++ b/plugins/cox-scouting
@@ -1,0 +1,2 @@
+repository=https://github.com/aghasemi78/cox-scouting-plugin.git
+commit=2da1e5e3484eaaf5f7b9544570c768471ba9ccc9

--- a/plugins/cox-scouting
+++ b/plugins/cox-scouting
@@ -1,2 +1,2 @@
 repository=https://github.com/aghasemi78/cox-scouting-plugin.git
-commit=3445bdc909395c92eec61da7dc14abe6d0ff761e
+commit=3766dd4e7b2426c5152e2c61fe78424d17b0f2b4

--- a/plugins/cox-scouting
+++ b/plugins/cox-scouting
@@ -1,2 +1,2 @@
 repository=https://github.com/aghasemi78/cox-scouting-plugin.git
-commit=5b7294caf36509fbc17ab4b112b9c794c70188cf
+commit=032a98a31a6cb96e0ee07e0b0bead9cffe15aadc

--- a/plugins/cox-scouting
+++ b/plugins/cox-scouting
@@ -1,2 +1,2 @@
 repository=https://github.com/aghasemi78/cox-scouting-plugin.git
-commit=ce574c7e03b6e1c3e35e7c8c1c9a0e6524ec2260
+commit=392cf4f9ee927c6bc0e2fe5124ad1fa7b19491fb

--- a/plugins/cox-scouting
+++ b/plugins/cox-scouting
@@ -1,2 +1,2 @@
 repository=https://github.com/aghasemi78/cox-scouting-plugin.git
-commit=2da1e5e3484eaaf5f7b9544570c768471ba9ccc9
+commit=5b7294caf36509fbc17ab4b112b9c794c70188cf


### PR DESCRIPTION
This is plugin works very similar to cox scouting QoL however it is much simpler to operate. Simply select all of the raid requirements you want (number of rooms, specific rooms, and/or raid start layout) and the plugin will deprioritize the "reload" option on the steps leading out of cox so that it can't be misclicked once a raid meeting all of your selected criteria is scouted.