### PR TITLE
Update wintertodt-scouter

### DIFF
--- a/plugins/wintertodt-scouter
+++ b/plugins/wintertodt-scouter
@@ -1,3 +1,3 @@
 repository=https://github.com/Nouser/wintertodt-scouter.git
-commit=41003ee2a8953819d9179acc247f581d30496452
+commit=45b3195d2561e2d9b71251480965837cb1529d13
 warning=This plugin shares your IP with a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
The new commit hash fixes pre-existing users' uplink and downlink settings. It also fixes the config listener.

Previously, if you had the plugin installed before it changed ownership, you would have the old endpoints populated.

Now, you will have the new endpoints populated because the config values don't clash with pre-existing ones.