### PR TITLE
Add music-favourites plugin

### DIFF
--- a/plugins/music-favourites
+++ b/plugins/music-favourites
@@ -1,0 +1,2 @@
+repository=https://github.com/Syhlex/music-favourites.git
+commit=cb1b16151fe51fc2f76821faa98d0ebc68173123


### PR DESCRIPTION
Adds a plugin that allows users to favourite music tracks and view them in a separate list in the Music tab.

Please take a look at the [README](https://github.com/Syhlex/music-favourites?tab=readme-ov-file#music-favourites) in the plugin repo for more details.