### PR TITLE
Update: lite-regen-meter (Config setting)

### DIFF
--- a/plugins/lite-regen-meter
+++ b/plugins/lite-regen-meter
@@ -1,2 +1,2 @@
 repository=https://github.com/Varietyz/literegenmeter.git
-commit=318e59970fa052074223b0782f77dfd451d64d11
+commit=e5d674635adf5c04e8d61b9b5852d20ad2bcb599


### PR DESCRIPTION
Changed 'Hide After' config to display by default. (Requested by users)

Re-ordered the 'Skill colors' config section to the bottom.