### PR TITLE
Update `custom-item-hovers` to `1.2.3`

### DIFF
--- a/plugins/custom-item-hovers
+++ b/plugins/custom-item-hovers
@@ -1,2 +1,2 @@
 repository=https://github.com/geel9/runelite-custom-item-hovers.git
-commit=7dd5b9f2fa34463cf459cbbfe1d1daa21d6ccba3
+commit=82fe4f0f8b1f44f26cbdc3a1964724ec3cb9ecf6


### PR DESCRIPTION
- Fixes null reference exception in overlay
- Removes tutorial message which would accidentally spam users if they didn't have any hovers defined