### PR TITLE
Update bank-tag-generation (plugin takeover)

### DIFF
--- a/plugins/bank-tag-generation
+++ b/plugins/bank-tag-generation
@@ -1,2 +1,2 @@
-repository=https://github.com/MitchBarnett/wiki-bank-tag-integration.git
+repository=https://github.com/gbarnh/wiki-bank-tag-integration.git
 commit=233f143f9994558bb44696411eccc6fd74d92d88


### PR DESCRIPTION
Takeover of plugin with inactive author.

Main repo for the plugin has had open comments and PRs for well over 6 months.

We have attempted to reach out via Discord and Github with no response.

We also put the time into fix the plugin and have it in a working state.

Open PRs: https://github.com/MitchBarnett/wiki-bank-tag-integration/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen

Open Issues: https://github.com/MitchBarnett/wiki-bank-tag-integration/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen

Long Thead of multiple users trying to reach out for months: https://github.com/MitchBarnett/wiki-bank-tag-integration/issues/19