### PR TITLE
Update bank-tag-generation

### DIFF
--- a/plugins/bank-tag-generation
+++ b/plugins/bank-tag-generation
@@ -1,2 +1,2 @@
 repository=https://github.com/MitchBarnett/wiki-bank-tag-integration.git
-commit=333d1a66bff3f389c9c4a63e5ff7e85fe575449f
+commit=89e7e3151d8b462764e7cc06007f32442665112b

--- a/plugins/bank-tag-generation
+++ b/plugins/bank-tag-generation
@@ -1,2 +1,2 @@
 repository=https://github.com/MitchBarnett/wiki-bank-tag-integration.git
-commit=d3d5fd2e0a57b8c00a0b2c3b4140e045dfd94e24
+commit=333d1a66bff3f389c9c4a63e5ff7e85fe575449f

--- a/plugins/bank-tag-generation
+++ b/plugins/bank-tag-generation
@@ -1,2 +1,2 @@
 repository=https://github.com/MitchBarnett/wiki-bank-tag-integration.git
-commit=233f143f9994558bb44696411eccc6fd74d92d88
+commit=d3d5fd2e0a57b8c00a0b2c3b4140e045dfd94e24


### PR DESCRIPTION
Updated to the wiki bank tag generation plugin with fixes so it is back to working order.

The plugin is currently marked as unavailable and incompatible on the plugin hub, I'm not sure if that is an automatic thing or if someone will need to also update that.