### PR TITLE
Add chugging-barrel v1.0.0

### DIFF
--- a/plugins/chugging-barrel
+++ b/plugins/chugging-barrel
@@ -1,0 +1,2 @@
+repository=https://github.com/Syhlex/chugging-barrel.git
+commit=e68896a0581c1a773cefd64bf56a702806be6597

--- a/plugins/chugging-barrel
+++ b/plugins/chugging-barrel
@@ -1,2 +1,2 @@
 repository=https://github.com/Syhlex/chugging-barrel.git
-commit=e68896a0581c1a773cefd64bf56a702806be6597
+commit=35f416de37f86f447f14d7970a0838055351f074


### PR DESCRIPTION
Adds loadout names to the Chugging barrel interface.

![demo](https://github.com/user-attachments/assets/d5e2727b-ba65-4046-88c9-b422008686ea)
