### PR TITLE
Create sound-muffler

### DIFF
--- a/plugins/sound-muffler
+++ b/plugins/sound-muffler
@@ -1,0 +1,2 @@
+repository=https://github.com/ACarnesi/runelite-sound-muffler-plugin.git
+commit=5898a9b9df07b66ba532f09d2f2805a6be174f36


### PR DESCRIPTION
This plugin provides the option to mute other player's sound effects for activities that commonly have overlapping and compound sounds. This way, you are still able to hear your own character's sound effects while skilling in the activity vs muting everything. Currently it is limited to woodcutting (for forestry), mining (for stars and guardians of the rift), and fishing. 