### PR TITLE
update tick-counter to v1.2.0

### DIFF
--- a/plugins/tick-counter
+++ b/plugins/tick-counter
@@ -1,3 +1,3 @@
 repository=https://github.com/winterdaze/tick-counter.git
-commit=019ff81b35dca20f6abe3432163c7b2dbe7960d5
-authors=winterdaze,LlemonDuck
+commit=1757bfd7baa6d2e8080461b0425f1b073c0da4fc
+authors=LlemonDuck


### PR DESCRIPTION
adds:
* elder maul
* dual mac

fixes:
* missing break statements on shadow and zcb causing over-counting