### PR TITLE
Add farming guild overview plugin

### DIFF
--- a/plugins/farming-guild-overview
+++ b/plugins/farming-guild-overview
@@ -1,0 +1,2 @@
+repository=https://github.com/wouterrutgers/farming-guild-overview.git
+commit=95ce2740cb054759a26b734b7b004e210fdfa583


### PR DESCRIPTION
This add an overview, when in the farming guild, with all the patches. To quickly see what's empty and what's completed.

![image](https://github.com/user-attachments/assets/fbb19650-4b16-494d-b563-0a41299a6873)
