### PR TITLE
Update clue-details to 2.0.0

### DIFF
--- a/plugins/clue-details
+++ b/plugins/clue-details
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/clue-details.git
-commit=39f6136363436afac3676a0b51452192213b25a2
+commit=89692fe4f3b6a24fa93d3a6aa50f0d80e5071cd8

--- a/plugins/clue-details
+++ b/plugins/clue-details
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/clue-details.git
-commit=89692fe4f3b6a24fa93d3a6aa50f0d80e5071cd8
+commit=f96b6817725c1e35aad89f472bfd24ad0bdf0afe

--- a/plugins/clue-details
+++ b/plugins/clue-details
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/clue-details.git
-commit=349fab994b96e4a1ce5bffc0c23c69555278ea59
+commit=39f6136363436afac3676a0b51452192213b25a2


### PR DESCRIPTION
Adds beginner and master clue tracking
- This tracks them once read in your inventory, on the floor, and in the bank. Edge-cases such as dying with a clue will likely result in the tracking failing.

Add new Varlamore clues

Changes the sidebar to render more efficiently
- more clues meant more processing in the sidebar, meant a bit of chugging sometimes. This should be noticably improved.

Adds a reset button for customised tags