### PR TITLE
Update quest-helper to 4.7.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=5bf04b41c9ebe3a2d55cdc1ad6b581370300694d
+commit=567fbc5883b1db0ef9b395dba80ecc812bd4af9d


### PR DESCRIPTION
Removes HTML usage in sidebar.

Fixed a few remaining issues with the quest journal ID change.

Added new Varlamore boosting items.

Small fixes to existing helpers.