### PR TITLE
Update firstperson to 2.0.1

### DIFF
--- a/plugins/first-person
+++ b/plugins/first-person
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/FirstPerson.git
-commit=464a774299b06146d65dd9932160d0f9db5bea21
+commit=3f277eee42521f1ad1f69f8231bc2da4b653242a


### PR DESCRIPTION
Removes FirstPersonIntProjection implementation due to obfuscated RL change causing it to fail now.