### PR TITLE
Add new plugin compass-camera-control

### DIFF
--- a/plugins/compass-camera-control
+++ b/plugins/compass-camera-control
@@ -1,2 +1,2 @@
 repository=https://github.com/RaazKH/CompassCameraControl.git
-commit=89c5db6d0df80c774076ba747cea4109116277f4
+commit=2615e8fce3d3e6d7edc7ae6d2eb990c5b768d4da

--- a/plugins/compass-camera-control
+++ b/plugins/compass-camera-control
@@ -1,2 +1,2 @@
 repository=https://github.com/RaazKH/CompassCameraControl.git
-commit=9fd62ab310a16e99f1319dfc08d5ee03922da8ee
+commit=89c5db6d0df80c774076ba747cea4109116277f4

--- a/plugins/compass-camera-control
+++ b/plugins/compass-camera-control
@@ -1,0 +1,2 @@
+repository=https://github.com/RaazKH/CompassCameraControl.git
+commit=9fd62ab310a16e99f1319dfc08d5ee03922da8ee


### PR DESCRIPTION
A RuneLite plugin that allows you to control the camera direction by simply clicking the compass orb, cycling through cardinal directions without using the arrow keys. Ideal for trackpad users!

This is my first plugin so please let me know what adjustments need to be made.