### PR TITLE
Update max-hit-calculator to v2.0.1

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=683020e7839409e7ef1b2ef0e7e434c694040d67
+commit=3a9a7ad89a3f0069d25b81e17a9ce21ad7b7e257


### PR DESCRIPTION
v2.0.1 Update:
* Fix element type for surge spells
* Fix Blowpipe dart setting not saving consistently
* Update Inquisitor Mace dmg bonus
* Add Varlamore Pt2 NPC spell element weaknesses