### PR TITLE
Create prayer-regeneration-helper

### DIFF
--- a/plugins/prayer-regeneration-helper
+++ b/plugins/prayer-regeneration-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Supalosa/prayer-regeneration-timer.git
+commit=e457ca48c9a425ef9624ec94669d43d50b5571f0

--- a/plugins/prayer-regeneration-helper
+++ b/plugins/prayer-regeneration-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Supalosa/prayer-regeneration-timer.git
-commit=e457ca48c9a425ef9624ec94669d43d50b5571f0
+commit=68c59a2ae83e5d2dd472d0e5168593a0af7e1fd8

--- a/plugins/prayer-regeneration-helper
+++ b/plugins/prayer-regeneration-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Supalosa/prayer-regeneration-timer.git
-commit=68c59a2ae83e5d2dd472d0e5168593a0af7e1fd8
+commit=3e27e25bb8b80984a783b3d81921c7256e458739


### PR DESCRIPTION
This is a plugin to remind the player that their Prayer Regeneration Potion has expired. The reminder text and color can be customised. The reminder only appears when the player actually has a regen pot in their inventory.

Also includes an option to count down to the next prayer regeneration tick: this occurs on "12" (when the number turns green).

![image](https://github.com/user-attachments/assets/518d058c-48ed-4982-89b7-8424bb3dd51f)


Example video: https://streamable.com/ce9wt4