### PR TITLE
Update clue-details to 2.0.1

### DIFF
--- a/plugins/clue-details
+++ b/plugins/clue-details
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/clue-details.git
-commit=f96b6817725c1e35aad89f472bfd24ad0bdf0afe
+commit=66575b78fb7e0581e8c17653652d138502b3e4a4


### PR DESCRIPTION
Removed a 1-line condition in an if which stopped clue name changing occurring.