### PR TITLE
Create red-clicks-only plugin

### DIFF
--- a/plugins/red-clicks-only
+++ b/plugins/red-clicks-only
@@ -1,2 +1,2 @@
 repository=https://github.com/SamBenn/RL_RedClicksOnly.git
-commit=ab43044864809bfde19cddc2ffa093b3fbcb756e
+commit=3856624df925b236551807f3a78a6ff79d7e98cf

--- a/plugins/red-clicks-only
+++ b/plugins/red-clicks-only
@@ -1,0 +1,2 @@
+repository=https://github.com/SamBenn/RL_RedClicksOnly.git
+commit=ab43044864809bfde19cddc2ffa093b3fbcb756e


### PR DESCRIPTION
Adds the Red Clicks Only plugin, which removes the function of the "Walk here" option