### PR TITLE
Change better-gwd-overlay repo

### DIFF
--- a/plugins/better-godwars-overlay
+++ b/plugins/better-godwars-overlay
@@ -1,2 +1,2 @@
-repository=https://github.com/Adam-/runelite-plugins.git
+repository=https://github.com/abd-khrubi/better-godwars-overlay.git
 commit=bdc119f6e42a30d36b6c9598a26858c463376e1d

--- a/plugins/better-godwars-overlay
+++ b/plugins/better-godwars-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/abd-khrubi/better-godwars-overlay.git
-commit=bdc119f6e42a30d36b6c9598a26858c463376e1d
+commit=67c815f3e0ba499f1bd26744be873282430dcbe6


### PR DESCRIPTION
As discussed in #6589, I will move ownership of [better-godwars-overlay](https://runelite.net/plugin-hub/show/better-godwars-overlay) plugin to me in order to add a new feature (#6589) and keep maintaining the plugin.

This PR only changes the repo to my fork of the original plugin and does not contain any changes. I'll open another PR with my changes

Edit: Fixed build error without changing any of the plugin logic