### PR TITLE
Add castle war afk to plugin-hub

### DIFF
--- a/plugins/castle-war-afk
+++ b/plugins/castle-war-afk
@@ -1,0 +1,2 @@
+repository=https://github.com/Togtja/castle_war_afk.git
+commit=0e28878877152a5c209ebd80130c575f806948d1


### PR DESCRIPTION
It simply gives you a notification when you join the Castle War minigame so you can get out of the starting room
Then Gives you a notification when it ends so you can join get ready for the next game you are about to AFK.

It sends the notification when the Caste War widgets loads and when they unload