### PR TITLE
update maple-xp-bar

### DIFF
--- a/plugins/maple-xp-bar
+++ b/plugins/maple-xp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/SirHitech/MapleXPBar.git
-commit=7e407452138507e049587cd41e5c4609a6b5d287
+commit=6c3f76a2d90306696535323d7d16365d1167a133


### PR DESCRIPTION
Added config option to ignore hitpoints XP when "Show Most Recent Skill" is also selected. This allows the other combat skills (strength, attack, defence, ranged, magic) to be displayed instead of hitpoints as the progress bar when these options are selected.

![image](https://github.com/user-attachments/assets/2e367cb9-7167-4f0f-b42a-ee31fac214a9)