### PR TITLE
Update firstperson to 2.0.2

### DIFF
--- a/plugins/first-person
+++ b/plugins/first-person
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/FirstPerson.git
-commit=3f277eee42521f1ad1f69f8231bc2da4b653242a
+commit=750e0d32a53ed090f105f1e6d700d90be4cc3ce7


### PR DESCRIPTION
Removes GPU code, makes the GPU mode rely on an existing renderer, or else defaults to detached mode. This should hopefully make it more stable after the internal changes for perspective.