### PR TITLE
Update clue-details to 2.0.4

### DIFF
--- a/plugins/clue-details
+++ b/plugins/clue-details
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/clue-details.git
-commit=264cd9b8a2c62fbe06394df2f6dd9b25caa1f4b7
+commit=2eb001da71be7d039527fbfae066bd124c29f04b


### PR DESCRIPTION
- Fixes freeze where some clues didn't have a despawn attached, throwing a null error
- Makes the reset button consider current filters