### PR TITLE
Create valuable-drop-prices

### DIFF
--- a/plugins/valuable-drop-prices
+++ b/plugins/valuable-drop-prices
@@ -1,0 +1,2 @@
+repository=https://github.com/Anderzenn/valueable-drop-prices.git
+commit=24ccad83606ae612a12fde14650ab1be1d87f61e


### PR DESCRIPTION
Simple plugin that is meant to replace the default drop notifications while adding high alch prices to the chat notification.
User can change whether to see high alch or grand exchange prices, or to just show them both. Other than this they can also decide if ha or ge is is deemed valuable, or if it should use both (highest valued item).
Colour of chat notification can also be modified.