### PR TITLE
update dps-calculator to v2.4.1

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
-commit=2547e353563f4820b2105951b37860af793df446
+commit=5b9e18cb952c574430ca33d3d72c6249db0bdb4e


### PR DESCRIPTION
filters out the new unused EquipmentInventorySlots to prevent a startup failure