### PR TITLE
Update slayer assistant readme

### DIFF
--- a/plugins/slayer-assistant
+++ b/plugins/slayer-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeOkeefe/slayer-assistant-plugin.git
-commit=f1b1224e0372ec0ec3fa32ff7e1ce9dd44434653
+commit=1bd2e8b2ca9d4a165c90a6053ec17c498fd74b38


### PR DESCRIPTION
This PR is to update the README file to use up-to-date images, and to update the badge links to prevent them breaking when the service is shut down on 1st November.