### PR TITLE
Add Lunar Chest value plugin

### DIFF
--- a/plugins/lunar-chest-value
+++ b/plugins/lunar-chest-value
@@ -1,0 +1,2 @@
+repository=https://github.com/bradur/lunar-chest-value.git
+commit=980470510dffa7c1833c20e94e478491be1f2610


### PR DESCRIPTION
Lunar Chest value is a plugin for showing the GE & HA value of the Lunar Chest when it is opened. It also shows potential prayer XP from shards and is fully configurable to only display the GE value for example.

![screenshot](https://github.com/user-attachments/assets/9d36d449-a50c-450c-8e43-1cba8612012f)
