### PR TITLE
Add valuable-drop-prices

### DIFF
--- a/plugins/valuable-drop-prices
+++ b/plugins/valuable-drop-prices
@@ -1,0 +1,2 @@
+repository=https://github.com/Anderzenn/valuable-drop-prices.git
+commit=6912eb2a2ae4f4671369422e4614e461001f240f


### PR DESCRIPTION
Simple plugin that replaces the default "coins" value with HA and GE prices to the valuable drop notifications.

Now completely rewritten with the changes recommended in pull request #6877, without having to disable the default notifications! :)