### PR TITLE
Update shortest-path to v1.16.3

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=bcb844211869270db1f87f01f158c5464a858fdd
+commit=42b7900e330b20dd9f1811c6289855c59a3e672f

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=1ccffbddb9d60d9484103d8d58967a993a70d0cd
+commit=bcb844211869270db1f87f01f158c5464a858fdd


### PR DESCRIPTION
- The draw transports option should now work when you don't have an active shortest path, correctly respect your config options, and no longer include teleports
- The wilderness ditch has been extended with 11 tiles to reflect the Defender of Varrock update