### PR TITLE
Add Plugin 'Vineyard Helper'

### DIFF
--- a/plugins/vineyard-helper
+++ b/plugins/vineyard-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/SurfaceCode/vineyard-helper.git
-commit=ee6db4babf91c184178313e5bf2a7dc0bf81021d
+commit=a0cfd4c68204b2ca68c498734f71dc3adf5eaaa6

--- a/plugins/vineyard-helper
+++ b/plugins/vineyard-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/SurfaceCode/vineyard-helper.git
-commit=a0cfd4c68204b2ca68c498734f71dc3adf5eaaa6
+commit=4aa71651b13003133ff9792642acf5f2815acc04

--- a/plugins/vineyard-helper
+++ b/plugins/vineyard-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/SurfaceCode/vineyard-helper.git
+commit=ee6db4babf91c184178313e5bf2a7dc0bf81021d


### PR DESCRIPTION
Vineyard Helper highlights tiles containing pickable grapevines in Aldarin vineyard. In addition, the highlight changes colour depending on whether or not the Grape barrel is full. Currently the animation which indicates pickable grapevines is extremely hard to see. This plugin increases the accessibility of the Aldarin vineyard content and greatly improves the experience, which is useful to interested players and, in particular, snowflake accounts.