### PR TITLE
Revert "update shortest-path (#6901)"

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=ab9e926b24b99be3ee5969086e9b109d088beeb3
+commit=42b7900e330b20dd9f1811c6289855c59a3e672f


### PR DESCRIPTION
This reverts commit [3c4b107daa88903b1782841cf56b59bcc885945c](https://github.com/runelite/plugin-hub/commit/3c4b107daa88903b1782841cf56b59bcc885945c).

Currently the plugin cannot start due to:
```
net.runelite.client.plugins.PluginInstantiationException: java.lang.NumberFormatException: For input string: ""
```
