### PR TITLE
update missing-pet-notifier

### DIFF
--- a/plugins/missing-pet-notifier
+++ b/plugins/missing-pet-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/tylerwgrass/missing-pet-notifier.git
-commit=37f8f8779d797d91d7da9060240c02890f0debae
+commit=1917132f2e4ea11b3e8f9d4e073db68096982ffb


### PR DESCRIPTION
Clears overlay when whistle button is clicked if tracking gets messed up