### PR TITLE
Add toa-pb-tracker v1.0.0

### DIFF
--- a/plugins/toa-pb-tracker
+++ b/plugins/toa-pb-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Syhlex/toa-pb-tracker.git
+commit=d676134e17920111dec62e978289fdbccc319fcb

--- a/plugins/toa-pb-tracker
+++ b/plugins/toa-pb-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Syhlex/toa-pb-tracker.git
-commit=d676134e17920111dec62e978289fdbccc319fcb
+commit=e9be5053579b2fa9e1fd45c45fe8072ee3aef89d


### PR DESCRIPTION
Adds a plugin that tracks personal bests per raid level and team size for Tombs of Amascut.

Please see the [README](https://github.com/Syhlex/toa-pb-tracker?tab=readme-ov-file#toa-pb-tracker) for more details.