### PR TITLE
Update wilderness-player-alarm

### DIFF
--- a/plugins/wilderness-player-alarm
+++ b/plugins/wilderness-player-alarm
@@ -1,2 +1,2 @@
 repository=https://github.com/adhansen/plugin-repo.git
-commit=c234e6d20492e483bf22893d0861ed25d5d53829
+commit=438d44140068b64520cbdc22400b4e8a3e5b9d38


### PR DESCRIPTION
## Summary
New version of the wilderness player alarm with improvements to the way the alarm overlay is implemented, and a user-requested feature to ignore players based on their RSN.

## Detail
* AlarmOverlay changes: As suggested by YvesW in #6314, this changes the overlay to use  `graphics.fillRect` instead of filling up the screen with line components. Users are also reporting that after that PR the wilderness player alarm [would push other GUI elements around](https://github.com/adhansen/plugin-repo/issues/42). I wasn't able to repro it, but I suspect that the AlarmOverlay implementation is the culprit.

* Custom ignore list: There are a few config items currently to ignore players that are in your friends chat, clan, ignore list, etc. But this feature allows ignoring players on an arbitrary comma-separated list which should improve the usability of the plugin. I used the custom left-click dropper plugin as a reference for implementing this: https://github.com/JZomDev/zom-external-plugins