### PR TITLE
Update Essence Pouch Tracker to v1.5.9 & Update repo URL

### DIFF
--- a/plugins/essence-pouch-tracking
+++ b/plugins/essence-pouch-tracking
@@ -1,2 +1,2 @@
-repository=https://github.com/Infinitay/essence-pouch-tracking.git
-commit=bbc4c83fd2dee9935dd6d460185d345ebe686277
+repository=https://github.com/Infinitay/essence-pouch-tracker.git
+commit=000c2f0d461cf9e18a9908d0e6680a7a94219647

--- a/plugins/essence-pouch-tracking
+++ b/plugins/essence-pouch-tracking
@@ -1,2 +1,2 @@
-repository=https://github.com/Infinitay/essence-pouch-tracker.git
-commit=000c2f0d461cf9e18a9908d0e6680a7a94219647
+repository=https://github.com/Infinitay/essence-pouch-tracking.git
+commit=f8aec844f6e952089bae6d6028f0c8f7dbcc4db2


### PR DESCRIPTION
(Hopefully) Fixed a few issues since releasing Essence Pouch Tracker initially onto the plugin hub (https://github.com/Infinitay/essence-pouch-tracker/tree/bbc4c83fd2dee9935dd6d460185d345ebe686277 v1.4.0) as well as add a few new features

# Fixes
- Fixed the plugin being broken/uninitialized when using using it for the first time when the player is already logged in with essence already in their inventory
	- Refactored resetting config and plugin start up/initialization 
- Only manipulate pouches that are currently within the player's inventory and not every pouch regardless if it's in the inventory or not
- Mitigate wrong pouch states by changing the behavior to not update the pouch's respective states if a property (stored/decay count) is unknown
- Fix game stutters that would be caused when withdrawing large quantities of stackable items
	- Also optimized EssencePouches type retrieval
- Fixed some cases in which pouches weren't being reflected as repaired due to missing dialog options
	- Fixed not being able to repair colossal pouches, and added some of Cordelia's wrong/missing repair options

# Features
- Add support for specialized equipment preventing pouch decay such as Runecrafting/Max capes and the Abyssal Lantern
- Add a chat message when a user has a pouch with any unknown state in their inventory on a new login session (similar to Daily Tasks Plugin IIRC)
- Add support for pouch state resetting when a user upgrades their pouch from a regular pouch to a colossal pouch or downgrades from a colossal pouch to a regular pouch

# Other Changes

- Renamed the plugin (Plugin Description) from `Essence Pouch Tracking` to `Essence Pouch Tracker`
- Renamed the GH repo and updated the URL to reflect the changes: `https://github.com/Infinitay/essence-pouch-tracker.git`
- Removed left-over debug statements that occurred on every MenuOptionClicked