### PR TITLE
Add GotR Helper continued

### DIFF
--- a/plugins/guardians-of-the-rift-helper-continued
+++ b/plugins/guardians-of-the-rift-helper-continued
@@ -1,0 +1,2 @@
+repository=https://github.com/Togtja/Guardians-of-the-Rift-Helper.git
+commit=a9ebb9495472ea2bf7be282601df2f5321c15283


### PR DESCRIPTION
The old Guardian of the Rift Helper is no longer being actively updated. I forked the repo and merged some of the outstanding pull request. I created a new entry, but if its better if I take over the old ones entry I can do that.
If the original author ever decided he want to continue the development, I will try to merge our two repos back to one.

For an easier compare, you can compare changed to to this repos vs the old release commits
https://github.com/DatBear/Guardians-of-the-Rift-Helper/compare/29b4d0b...Togtja:a9ebb94?expand=1