### PR TITLE
Added Soul Wars Plugin

### DIFF
--- a/plugins/soul-wars
+++ b/plugins/soul-wars
@@ -1,0 +1,2 @@
+repository=https://github.com/Lucidare/soul-wars.git
+commit=2a38ac3d524de7ff6bfbcbb3183dc3179b76fb72

--- a/plugins/soul-wars
+++ b/plugins/soul-wars
@@ -1,2 +1,2 @@
 repository=https://github.com/Lucidare/soul-wars.git
-commit=53c3822e8cd3230aaade792ea03816df8147e166
+commit=985672773b57aa05540d12177a75a2be901970ec

--- a/plugins/soul-wars
+++ b/plugins/soul-wars
@@ -1,2 +1,2 @@
 repository=https://github.com/Lucidare/soul-wars.git
-commit=0bf7252ef0532b3cdde4332672bd5e7623ef6877
+commit=53c3822e8cd3230aaade792ea03816df8147e166

--- a/plugins/soul-wars
+++ b/plugins/soul-wars
@@ -1,2 +1,2 @@
 repository=https://github.com/Lucidare/soul-wars.git
-commit=e0aa85636d289ee1981958ad5fc373443fab1169
+commit=0bf7252ef0532b3cdde4332672bd5e7623ef6877

--- a/plugins/soul-wars
+++ b/plugins/soul-wars
@@ -1,2 +1,2 @@
 repository=https://github.com/Lucidare/soul-wars.git
-commit=2a38ac3d524de7ff6bfbcbb3183dc3179b76fb72
+commit=b79acea0d570179d34c05d479ea091bf5b50df8c

--- a/plugins/soul-wars
+++ b/plugins/soul-wars
@@ -1,2 +1,2 @@
 repository=https://github.com/Lucidare/soul-wars.git
-commit=b79acea0d570179d34c05d479ea091bf5b50df8c
+commit=e0aa85636d289ee1981958ad5fc373443fab1169


### PR DESCRIPTION
# Soul Wars

A RuneLite plugin to track in-game progress during the Soul Wars minigame, keeping a count of:
- Fragments sacrificed
- Avatar damage dealt
- Bones buried
- Areas captured

Set the target goals in the config.

Addition features:
- Prevents fragment sacrifices when obelisk is not captured
- Prevents bone buries when graveyard is not captured
- Highlight capture areas

Images in README.md