### PR TITLE
Update Essence Pouch Tracker to v1.5.10

### DIFF
--- a/plugins/essence-pouch-tracking
+++ b/plugins/essence-pouch-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/essence-pouch-tracking.git
-commit=f8aec844f6e952089bae6d6028f0c8f7dbcc4db2
+commit=1282d120e40c0ff8d092d62e7f6a233c06023e86


### PR DESCRIPTION
# Fixes

- Fixed an issue where depositing more essence than you had from your inventory to the bank resulted in negative essence stored in your inventory and later broke the state of pouches with an incorrect stored/decay count.

# Features

# Other Changes

-  Resolved lamba expression checkstyle warnings
- Modified existing and added upon logging with regards to bank related `onMenuOpenClicked` & `onBankEssenceTaskCreated `