### PR TITLE
Update Essence Pouch Tracker to v1.5.11

### DIFF
--- a/plugins/essence-pouch-tracking
+++ b/plugins/essence-pouch-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/essence-pouch-tracking.git
-commit=1282d120e40c0ff8d092d62e7f6a233c06023e86
+commit=97ad272303cb4dd95969bb405e3218da03246ea6


### PR DESCRIPTION
# Fixes
- Fixes the issue where when attempting to do double+ of the same pouch action, RuneScape would reverse it and act as if it never happened.

# Features

# Other Changes