### PR TITLE
Update Inventory Setups to v1.20.0 and update Bank Tag Layouts to 1.4.33 (Core BTL Migration)

### DIFF
--- a/plugins/bank-tag-layouts
+++ b/plugins/bank-tag-layouts
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/bank-tag-custom-layouts.git
-commit=49b8cd3734f4e932d6267ea8b7a02f8c0169c9bc
+commit=81f16b5d3ed5b089a383de2961f7ed821ab187f1

--- a/plugins/inventory-setups
+++ b/plugins/inventory-setups
@@ -1,2 +1,2 @@
 repository=https://github.com/dillydill123/inventory-setups.git
-commit=d33a81f7be04b7a477bc69f22daf1d7fb8af8e5c
+commit=8ccb3f09d8255a3ca436a7e519a66b04ddc872c1


### PR DESCRIPTION
Core BTL migration for inventory setups.

Disable inventory setups integration in hub BTL