### PR TITLE
[Hotfix] Updates Emote Clue Items to v4.3.2.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=31e4e52d44fdddbade81792f029ea2b342f9458e
+commit=978e59df9b3d3301337cd7e7ee7cf53fb5c52ced


### PR DESCRIPTION
This update of Emote Clue Items features the following updates.

- Conforms to breaking changes in the RuneLite API. (see [emote-clue-items#112](https://github.com/larsvansoest/emote-clue-items/issues/112))
- Changes blue moon item requirement to take into account all variants. (see [emote-clue-items#108](https://github.com/larsvansoest/emote-clue-items/issues/108))
- Changes the sunfire fanatic armour item requirement to no longer require the full set. (see [emote-clue-items#109](https://github.com/larsvansoest/emote-clue-items/issues/109))
- Corrects AIQ fairy ring, adds wizard's tower fairy ring. (see [emote-clue-items/pull110](https://github.com/larsvansoest/emote-clue-items/pull/110))