### PR TITLE
Update shortest-path to 1.16.5

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=40dc1000de666292a8d326c65c83837626392b82
+commit=1dc08d0c9cb7798f71468f559a218f245272fd81


### PR DESCRIPTION
- Fix inventory item check incorrectly using rune pouch enum id instead of item id