### PR TITLE
added spec jingle

### DIFF
--- a/plugins/spec-jingle
+++ b/plugins/spec-jingle
@@ -1,0 +1,3 @@
+repository=https://github.com/Servilabs/spec-jingle
+commit=60eef5a36cde92679a7e04fc02db4656e4b91e4a
+authors=servido


### PR DESCRIPTION
The spec jingle plugin plays a jingle sound whenever the special attack energy reaches a value on the user-specified list. Main usecase is for remembering to equip dps rings on time.