### PR TITLE
update tombs-of-amascut to v2.10.2

### DIFF
--- a/plugins/tombs-of-amascut
+++ b/plugins/tombs-of-amascut
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/tombs-of-amascut.git
-commit=df4484fb12d166662d4ed44a1b3035d781ac9f6a
+commit=f76a79fe37576bcd7dd627ef27ed77a6212ec6b0


### PR DESCRIPTION
fixes a possible NPE in the skip obelisk overlay