### PR TITLE
OSRS DataLog

### DIFF
--- a/plugins/osrs-data-log
+++ b/plugins/osrs-data-log
@@ -1,0 +1,2 @@
+repository=https://github.com/DeadAlready/OSRSDataLog.git
+commit=4f824e7f0309d17a983629c9309bfbd3bf445ff2


### PR DESCRIPTION
Lets you send the log of state changes in varbits and varplayers to either a file or a custom server. 

It is basically WikiSync plugin, but with controls over manifest and output target.