### PR TITLE
Update clear-unsent-messages

### DIFF
--- a/plugins/clear-unsent-messages
+++ b/plugins/clear-unsent-messages
@@ -1,2 +1,2 @@
 repository=https://github.com/lightningboltemoji/clear-unsent-messages.git
-commit=e90b3eabd6aa70e4ee395b549874ba7419c2ef49
+commit=bff43b839a1b0095cb291af2723262baaec2e91e


### PR DESCRIPTION
Summary of changes:
* Feature: add hotkey for clearing unsent messages
* Fix: switches from `@Subscribe onVarClientStrChanged` to `KeyListener` for detecting typing activity - this allows ignoring certain key codes that we don't want to reset the timer (e.g. arrows, F keys)
* Fix: `@ConfigGroup("cfg")` => `@ConfigGroup("clear-unsent-messages")` - based on other plugins, it seems I was supposed to put a unique identifier