### PR TITLE
Update Essence Pouch Tracker to v1.6.0

### DIFF
--- a/plugins/essence-pouch-tracking
+++ b/plugins/essence-pouch-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/essence-pouch-tracking.git
-commit=97ad272303cb4dd95969bb405e3218da03246ea6
+commit=cbcc27116dd703899d41d7698207c8dbe11d8452


### PR DESCRIPTION
# Fixes

- Fixed an issue with outdated tracking states overriding a newly degraded pouch

# Features

- Added support for tracking colossal pouches appropriately after the [latest (Nov 13th 2024) OSRS game update](https://secure.runescape.com/m=news/guardians-of-the-rift-changes-out-now?oldschool=1) that allowed players to use a colossal pouch starting at a Runecrafting level of 25

# Other Changes

-  Updated README with an example of how the pouch state could go wrong and how to potentially solve it