### PR TITLE
Update nylo-death-indicators to v1.0.13

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=c41816bcc95285e556538dbd5cce7885513ee42a
+commit=3c133a12666519738de350746dc8818b09713201


### PR DESCRIPTION
Adds Warped Sceptre and Accursed Sceptre as powered staves