### PR TITLE
Update shortest-path to v1.16.6

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=1dc08d0c9cb7798f71468f559a218f245272fd81
+commit=28ff6b56b6431682596f222645c03b92dd821a73


### PR DESCRIPTION
- Most spirit trees no longer incorrectly require completion of The Grand Tree quest
- No longer incorrectly assume that a higher than required Varbit/VarPlayer value gives access (typically only true for quests progress)