### PR TITLE
wilderness-course-ticket-reminder plugin

### DIFF
--- a/plugins/wilderness-course-ticket-reminder
+++ b/plugins/wilderness-course-ticket-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/neafey/Wilderness-course-ticket-reminder.git
+commit=46514096866e017fb3018971ba8d4810ca603989

--- a/plugins/wilderness-course-ticket-reminder
+++ b/plugins/wilderness-course-ticket-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/neafey/Wilderness-course-ticket-reminder.git
-commit=46514096866e017fb3018971ba8d4810ca603989
+commit=d5936826824bcf0c48233d4b1baefd9bcb201b15


### PR DESCRIPTION
Plugin that reminds the player to claim a ticket after completing a lap in the Wilderness Agility Course.
Highlights the dispenser after completing a lap to help player remember to claim your ticket.
Also changes the default left-click action on the pipe to "Walk here" if no ticket has been claimed.






