### PR TITLE
Update max-hit-calculator to v2.0.2

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=e21f1366f9ff10a887d1522457d73b439f0e0504
+commit=0bed5e42da5494cafd4ac841d1ff1d3ada393cb5

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=3a9a7ad89a3f0069d25b81e17a9ce21ad7b7e257
+commit=e21f1366f9ff10a887d1522457d73b439f0e0504


### PR DESCRIPTION
- Fixed issues with finding spell weaknesses for NPCs with names deriving from others (e.g. baby black dragon)