### PR TITLE
update monster-monitor to v1.4.1

### DIFF
--- a/plugins/monster-monitor
+++ b/plugins/monster-monitor
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/monster-monitor.git
-commit=8113042502ef0a8b2342be98f6be40f9d955edd2
+commit=d2c28f759fffdc969192308caf09fc346e51a0d5

--- a/plugins/monster-monitor
+++ b/plugins/monster-monitor
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/monster-monitor.git
-commit=dc50787b3db2ee43cfc5dc5f86eedf0532ec50f3
+commit=8113042502ef0a8b2342be98f6be40f9d955edd2


### PR DESCRIPTION
Fix race conditions and add Amoxliatl to DeathTracker

- Addressed potential race conditions and data corruption during simultaneous kills.
- Added 'Amoxliatl' to the DeathTracker for kill tracking.