### PR TITLE
Update line-markers to v1.3.6 and npc-id to v1.3.4

### DIFF
--- a/plugins/line-markers
+++ b/plugins/line-markers
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=427b5f4f4ff04c4f571206e169426fd58005065a
+commit=0accca3b5c5bec8a9d4cb19c0c2a86d365db5932

--- a/plugins/npc-id
+++ b/plugins/npc-id
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=d147cef9bef029517d73a754613698748bbdb219
+commit=83c338db6a3370eeb44f4e27f54932ec2271d20a


### PR DESCRIPTION
- No longer show line markers on the wrong floor on the minimap
----
- Added options to show npc id and index in the right-click menu