### PR TITLE
add block-tracker

### DIFF
--- a/plugins/block-tracker
+++ b/plugins/block-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/block-tracker.git
-commit=2c8e4997aa63f0992bb8b5cb1b8cb12a3131d331
+commit=473784a89f2a6a65066b1df7bbb01ed7fff50a18

--- a/plugins/block-tracker
+++ b/plugins/block-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/1Defence/block-tracker.git
+commit=2c8e4997aa63f0992bb8b5cb1b8cb12a3131d331


### PR DESCRIPTION
# Block Tracker
Track tile blocking status of npcs and players.
Intended for both practical use and for users to attain a better understanding of the blocking system in game.

* Entity moves? previous tiles are released, new tiles are blocked
* Player runs? In addition to the above, the in-between tiles of the ran path are also released; these tiles line up with what the character would walk if run was not enabled.
* Entity despawns? previous tiles are released
* Entity spawns? current tiles are blocked
* NPC attempts movement but can't move? current tiles are re-blocked (this specific situation will occur every tick)

Some examples below, more are located in the [Read Me](https://github.com/1Defence/block-tracker/blob/master/README.md)

https://github.com/user-attachments/assets/710c6f47-3c4f-4084-9c52-7c80c7c58261

https://github.com/user-attachments/assets/34a3d3e1-00cd-472d-9aaf-55b91aadc0fa

https://github.com/user-attachments/assets/ddd9c80d-cbcc-414d-8411-b15a405667a9