### PR TITLE
Update quest-helper to 4.7.2

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=567fbc5883b1db0ef9b395dba80ecc812bd4af9d
+commit=204fae43261d0337d50675ecb0b2160b24fa9b09


### PR DESCRIPTION
Adds Curse of Arrav.

Also adds reward hiding, and various small fixes.