### PR TITLE
Creating plugin to display average total level

### DIFF
--- a/plugins/average-total-level
+++ b/plugins/average-total-level
@@ -1,2 +1,2 @@
 repository=https://github.com/SamuelDev/average-total-level.git
-commit=b9c8d666e71733b7acc2f69ea430873e71a800fa
+commit=14bc012e2b78f35c2c5fb3d634dd84dbc770fa4c

--- a/plugins/average-total-level
+++ b/plugins/average-total-level
@@ -1,0 +1,2 @@
+repository=https://github.com/SamuelDev/average-total-level.git
+commit=b9c8d666e71733b7acc2f69ea430873e71a800fa


### PR DESCRIPTION
I have created a plugin that displays the average total level of all skills, including support for the virtual level plugin.

Default:
![image](https://github.com/user-attachments/assets/5e25cc07-88b2-4934-8037-9097ae5b4c15)

Average total level plugin enabled:
![image](https://github.com/user-attachments/assets/b8db6aa2-dc56-4bb3-b59f-46e2e83a8af3)

Average total level plugin AND virtual levels enabled:
![image](https://github.com/user-attachments/assets/43ba35ce-8da4-4876-9161-7390ed1c4961)

Average total level plugin AND virtual levels enabled, but virtual levels disabled for average level plugin:
![image](https://github.com/user-attachments/assets/7f3c4e53-1c08-47b9-90f1-39386b77869b)

I used the virtual level plugin as a baseline guide on how to do basically everything in this plugin, so it probably looks similar. Priority was set lower on the script callback event so that way I would have the virtual total level string already in the string stack, maintaining compatibility with that plugin.