### PR TITLE
Tooltip visibility fix for seed vault & inventory

### DIFF
--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,2 +1,2 @@
 repository=https://github.com/climbridecode/herblore-recipes.git
-commit=eb118ade6466afdafeb88b42b4553a3f173e147d
+commit=7f89e74b4ef7a6fbf61315a58e65d312601071c3


### PR DESCRIPTION
Resolves a tooltip visibility bug where disabling tooltips in inventories would also remove them from the Seed Vault.

Also clarifies the usage of a config option. "Show tooltip on Seeds" -> "Show tooltip on Primary/Herb seeds".