### PR TITLE
Update combat-logger to v1.3.0

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=0012dc3dab5726aafa7e0a82ed55003cd7b70f73
+commit=3396b7e6da0e3418255f57844e5690401dbf3833


### PR DESCRIPTION
- No longer delete your logs when resetting configuration 
- Various logs to support Runelogs fight replay
  - Track NPC positions
  - Share equipment with other players in the party
  - Share prayers with other players in the party
  - Share base and boosted stats with other players in the party
  - Track party member overhead prayer and visible equipment even if they do not have the plugin installed