### PR TITLE
Update nexus-map to 1.0.4

### DIFF
--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,2 +1,3 @@
 repository=https://github.com/Antipixel/nexus-map.git
 commit=5e0da5ffa193f1bc4936fcc2ea7055ac803d859f
+authors=Antipixel,Cyborger1

--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,2 +1,2 @@
 repository=https://github.com/Antipixel/nexus-map.git
-commit=3794df79b5bfaf03bd7de07800dae1fc9626ae51
+commit=5e0da5ffa193f1bc4936fcc2ea7055ac803d859f


### PR DESCRIPTION
@Antipixel has given me collaborator access to his repo so I could push this update:

Adds Varlamore's Fortis Teleport.

Seems there were some changes to MenuEntry's interface, for now I just added stub methods and it seems to work fine in the context of the menu entry being spoofed for compatibility with Better Teleport Menu (it only kicks in if that plugin is active), but if anyone thinks to could be causing issues please let me know.

Resolves https://github.com/Antipixel/nexus-map/issues/22 https://github.com/Antipixel/nexus-map/issues/20