### PR TITLE
Update nexus-map (Codestyle changes)

### DIFF
--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,3 +1,3 @@
 repository=https://github.com/Antipixel/nexus-map.git
-commit=5e0da5ffa193f1bc4936fcc2ea7055ac803d859f
+commit=b32ef343da90ca0c468bba670899b74765f4d297
 authors=Antipixel,Cyborger1


### PR DESCRIPTION
This is a cleanup PR to fix codestyle inconsistencies (tabs instead of spaces, C# style braces everywhere), typos and etc. before making further changes. Nothing urgent.

The only thing I'm wondering about is in the `build.gradle` file, the `group =` option was still set to `com.example`, which I changed to be `net.antipixel.nexus` like in `runelite-plugin.properties`.

I don't think this really changes much, as far as I know this is related to Maven artifacts? I just want to confirm, thanks.