### PR TITLE
Update tasks-tracker (Leagues 5 prep)

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=7a30111ad4950a37b57517eabf6c1b28b82243b4
+commit=3fda114bd5b81eef14efebc5ca32eeeab7206466
 authors=tylerthardy

--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=f5b5ce55e6457c33f04c963a32268a38e9c3c915
+commit=a32f8deb2dcf3ff94cc65eff00765d9397fbd10f
 authors=tylerthardy

--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=3fda114bd5b81eef14efebc5ca32eeeab7206466
+commit=82d26b26659dd18f3bb7053563dd345617472a74
 authors=tylerthardy

--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=82d26b26659dd18f3bb7053563dd345617472a74
+commit=f5b5ce55e6457c33f04c963a32268a38e9c3c915
 authors=tylerthardy

--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=a32f8deb2dcf3ff94cc65eff00765d9397fbd10f
+commit=2bc27e069d2ef8966c28a2acc988c66104392570
 authors=tylerthardy


### PR DESCRIPTION
Relevance:
This PR lets us handle League updates going forward without having to update the plugin. This includes configuring filters for task data. The plugin is essentially driven by our [task-json-store](https://github.com/osrs-reldo/task-json-store)

Changes:
- Removed all hard-coded task data
- Refactored task services to pull all task data from [task-json-store](https://github.com/osrs-reldo/task-json-store) and Client structs
- Refactored filters to pull from [task-json-store](https://github.com/osrs-reldo/task-json-store)

![image](https://github.com/user-attachments/assets/64b67714-76b5-485b-bd9b-a95b7d86d613)
