### PR TITLE
DiscordThreads plugin addition

### DIFF
--- a/plugins/discordthreads
+++ b/plugins/discordthreads
@@ -1,0 +1,2 @@
+repository=https://github.com/RumbleCrumbleRS/discord_thread_events.git
+commit=254b556c972515489f14f51e4136708d35555a04

--- a/plugins/discordthreads
+++ b/plugins/discordthreads
@@ -1,2 +1,2 @@
 repository=https://github.com/RumbleCrumbleRS/discord_thread_events.git
-commit=254b556c972515489f14f51e4136708d35555a04
+commit=1d7f70a82b4b75f1d032314d14b652304abf9c55


### PR DESCRIPTION
DiscordThreads is a achievement discord plugin that will through Webhook submit an achievment such as Level-Up, Collection Log, Combat Achievement, etc. 

The big difference between any of the others is this plugin is capable of posting the achievement to a Discord Threads/Forum, additionally you can specify tags both on the header and per achievement in which they can automatically be tagged.

This first image shows what they look like when the achievement is posted to a threads/forum
![RLPlugin1](https://github.com/user-attachments/assets/bf27a2a6-5b7a-4de0-b99b-f927e57a3084)

Second image shows what it looks like when you click into one of the threads
![RLPlugin2](https://github.com/user-attachments/assets/fb87500b-3149-42fc-a119-ae12fe26f754)

Third image shows off the tagging system
![RLPlugin3](https://github.com/user-attachments/assets/84b7139d-6654-407b-b313-7c1a43ec6e04)
