### PR TITLE
Update average-total-level plugin to add option for decimal places

### DIFF
--- a/plugins/average-total-level
+++ b/plugins/average-total-level
@@ -1,2 +1,2 @@
 repository=https://github.com/SamuelDev/average-total-level.git
-commit=14bc012e2b78f35c2c5fb3d634dd84dbc770fa4c
+commit=12ace123b7df7743f296a5a773edd9101bd8f4aa


### PR DESCRIPTION
Pushing an update that adds the ability to show/hide decimal places in the average shown.