### PR TITLE
Create runesense

### DIFF
--- a/plugins/runesense
+++ b/plugins/runesense
@@ -1,0 +1,2 @@
+repository=https://github.com/RuthlessRacoon/RuneSense.git
+commit=9a9395745b360393d05593acf1aac483edee1c81


### PR DESCRIPTION
A plugin to integrate with the [Lovesense Standard API](https://developer.lovense.com/docs/standard-solutions.html)

The plugin allows you to link to the Lovense Remote app on a device via Game Mode LAN.