### PR TITLE
Update world-cycle

### DIFF
--- a/plugins/world-cycle
+++ b/plugins/world-cycle
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/world-cycle.git
-commit=e44d3443751e5b7deaec75cd0d7d17452c34e154
+commit=e64e601db7615410c3bdee2e87c1411b9b1f0f64


### PR DESCRIPTION
Various updates to clean up the plugin

**Changes** 

- Force input field to only allow numerical values and commas & prevent excessively large strings from being sent over party.
- Send game messages to indicate user or party member has updated the world set
- Remove custom hotkey as this was a workaround for the now solved 
   https://github.com/runelite/runelite/pull/17912
- Add tooltips to the panels input field to make correct usage more obvious
- Updated [readme](https://github.com/1Defence/world-cycle/blob/master/README.md) to be more helpful to new users

**_Additions_** 

- You can now optionally enable a panel showing neighboring worlds in the cycle; previous current and next