### PR TITLE
Update boaty-hype-man

### DIFF
--- a/plugins/boaty-hype-man
+++ b/plugins/boaty-hype-man
@@ -1,2 +1,2 @@
 repository=https://github.com/Devdeve/boatyHypeMan-plugin.git
-commit=8ed3c0a2483be998a56a90cb74a1d09e15f47b62
+commit=4bd18735110742d818169e9314e1747174776336


### PR DESCRIPTION
update boaty-hype-man plugin to allow the plugin to activate on leagues tasks when enabled