### PR TITLE
add bracelet reminder

### DIFF
--- a/plugins/bracelet-reminder
+++ b/plugins/bracelet-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/chocobo-s/Slaughter-bracelet-reminder
+commit=7480dc92f31d39403098e344f1c52300072b329b

--- a/plugins/bracelet-reminder
+++ b/plugins/bracelet-reminder
@@ -1,2 +1,2 @@
-repository=https://github.com/chocobo-s/Slaughter-bracelet-reminder
+repository=https://github.com/chocobo-s/Slaughter-bracelet-reminder.git
 commit=7480dc92f31d39403098e344f1c52300072b329b


### PR DESCRIPTION
Plugin will remind the player to equip a bracelet if they are not wearing one (expeditious or slaughter) or if the NPC they are fighting drops below their desired threshold.