### PR TITLE
Create Hide-Anything

### DIFF
--- a/plugins/Hide-Anything
+++ b/plugins/Hide-Anything
@@ -1,0 +1,3 @@
+repository=https://github.com/RuneAd/Hide-Anything.git
+commit=1511639817b58f3122a52466e21a745211071da4
+authors=Col Log


### PR DESCRIPTION
The Hide Anything plugin is a RuneLite plugin that allows you to hide specific players and NPCs in the game. It provides an easy way to customize your in-game experience by removing distractions or focusing on what you find important. You can use the right-click menu to select the entities you wish to hide.