### PR TITLE
Create goblin-scape-clan-plugin

### DIFF
--- a/plugins/goblin-scape-clan-plugin
+++ b/plugins/goblin-scape-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/s0lved/goblin-scape-clan-plugin.git
-commit=e1ccf433e42e05b22795328bb80b00d46a6b05ae
+commit=3a902fea5ec517237feb5d24680641c8e7b2fcf4

--- a/plugins/goblin-scape-clan-plugin
+++ b/plugins/goblin-scape-clan-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/s0lved/goblin-scape-clan-plugin.git
+commit=e1ccf433e42e05b22795328bb80b00d46a6b05ae


### PR DESCRIPTION
Plugin used to track clan activities for Goblin Scape Clan Members. This currently tracks clan members world map locations and then sends the data to our website on a virtual world map. We will be using this website for clan events throughout leagues and other upcoming events. 