### PR TITLE
Takeover casket-saver

### DIFF
--- a/plugins/casket-saver
+++ b/plugins/casket-saver
@@ -1,2 +1,2 @@
-repository=https://github.com/Notespeon/casket-saver.git
+repository=https://github.com/TheLope/casket-saver.git
 commit=148ed57d406a4c3f8bb046df2343d35b6f138715


### PR DESCRIPTION
I would like to takeover the plugin.

I created an issue here that was not responded to in 7 days. https://github.com/Notespeon/casket-saver/issues/6

I also attempted to reach out to the author via the email used in the git commit history, but did not receive a response.