### PR TITLE
Bump wikisync to pick up fail backoff and equality check bugfix

### DIFF
--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,4 +1,4 @@
 repository=https://github.com/weirdgloop/WikiSync.git
-commit=6aadd82a8e133127c0ee369879f339651db692d0
+commit=8ab0ddc6cba3a157d992d2a4f814c29177640b0b
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.
 authors=andmcadams,leejt,lezed1,jayktaylor


### PR DESCRIPTION
* Adds backoff on failures so we don't just keep retrying submit every 10s
* Fixes bug caused by equality check when we really wanted a subset check (if we removed something from the manifest anyone who picked up the new one would continue to submit every 10s even if they didnt have updates)