### PR TITLE
Add fixed-resizable-hybrid to plugin hub

### DIFF
--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=12624af03084ac114b6c8c671f4f215d2972d8aa
+commit=1dfd3d622e7c2026aef1cd1056627613d51034bb

--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=9e53cfdd12f4384c4ebb3b2d69fc727857086956
+commit=12624af03084ac114b6c8c671f4f215d2972d8aa

--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,0 +1,2 @@
+repository=https://github.com/Lapask/fixed-resizable-hybrid.git
+commit=9e53cfdd12f4384c4ebb3b2d69fc727857086956


### PR DESCRIPTION
Plugin that reskins the "Resizable - Classic Layout" by styling it to match the aesthetics of Fixed Mode. It provides a faithful representation of the fixed mode interface, while preserving the benefits of resizable mode, such as a larger game viewport and minimizable chat.
![exampleuse](https://github.com/user-attachments/assets/8d13783f-d869-4a98-8e5a-c7508d1f232f)
