### PR TITLE
update scythe-crush-warning to v1.1.1

### DIFF
--- a/plugins/scythe-crush-warning
+++ b/plugins/scythe-crush-warning
@@ -1,3 +1,3 @@
 repository=https://github.com/gtjamesa/scythe-crush-warning-plugin.git
-commit=5f93380ec760876289e1653afa7c491e5fc34dd7
+commit=71b0111283b5bef87447dd0b638d40b8a77570cf
 authors=gtjamesa


### PR DESCRIPTION
Adds the Scythe kit IDs that I thought were already included in the `ItemVariationMapping`
