### PR TITLE
Dodgy Deals Plugin

### DIFF
--- a/plugins/Dodgy Deals
+++ b/plugins/Dodgy Deals
@@ -1,0 +1,2 @@
+repository=https://github.com/MouldySamuel/DodgyDeals.git
+commit=42587ee1649b423701f208a655aa02aa78dc6f56


### PR DESCRIPTION
Dodgy Deals will display a 11x11 square around you to assist with NPC pickpocketing.
It also displays the total number of pickpocketable NPCs within the 11x11 square using their true tiles.
Players can customise the colour & opacity of both the tiles of the square and the NPCs tile indicators.