### PR TITLE
Update c-engineer-completed to v1.2.1 (add leagues tasks)

### DIFF
--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=0e1139480e262a25fbf053db5858c75e96aa2229
+commit=4393ce760bd17c0407bc2ff2e727a0acd0d7ea2d


### PR DESCRIPTION
Adds leagues task announcements with new sound, toggleable as usual.
Also notifies user the **first** time this triggers that they can disable leagues task announcements without disabling the whole plugin.