### PR TITLE
add poison-moo

### DIFF
--- a/plugins/poison-moo
+++ b/plugins/poison-moo
@@ -1,0 +1,2 @@
+repository=https://github.com/remindful7560/OSRS-Plugins.git
+commit=db2d34f6c0aabbbac579c17042f7e76e5087ed62

--- a/plugins/poison-moo
+++ b/plugins/poison-moo
@@ -1,2 +1,2 @@
 repository=https://github.com/remindful7560/OSRS-Plugins.git
-commit=db2d34f6c0aabbbac579c17042f7e76e5087ed62
+commit=ad9d0b358f83771c5dc73f3eb0e869d5ebf95def


### PR DESCRIPTION
Plugin request for Poison Moo.

Causes your character to moo (using overheads) on the poison timer, like cows do (according to Mod Ash).