### PR TITLE
Update nexus-map to 1.1.0

### DIFF
--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,3 +1,3 @@
 repository=https://github.com/Antipixel/nexus-map.git
-commit=b32ef343da90ca0c468bba670899b74765f4d297
+commit=10b042de2128461066627abec3e4e405042600c6
 authors=Antipixel,Cyborger1


### PR DESCRIPTION
Pretty big update here, in two parts.

The first part is changing the way the plugin identifies available teleports by looking at sprite IDs instead of teleport names, which should hopefully fix any outstanding issues with plugins changing teleport names. Here's to hoping there aren't any plugins changing the sprite IDs, though. (Edit: Achievement diary teleports do use the same sprites as their regular version, but thankfully are loaded in a separate widget, so as long as we mark these teleports as such, we can still ID them.)

The second part is both a reorganization of the map files and sprite definitions as well as the addition of Kourend and Varlamore proper. I also resaved most of the images using a more efficient bit depth (if anyone is wondering about why some of the images are seemingly unchanged).

I did add a `pdn` folder with some working paint.net files that I used to create some of the new images so I can go back and more easily edit the map files if need be, but those aren't being used by the plugin. Unless I'm wrong, these shouldn't appear in build files.