### PR TITLE
v1.2.0 release - Fight Caves Spawn Predictor

### DIFF
--- a/plugins/spawnpredictor
+++ b/plugins/spawnpredictor
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/spawn-predictor.git
-commit=f8f92c298f0876ce1dd7ddb92fcf79c0f612f225
+commit=8714834524fb1e07b02c9456b7b62581fc1fb0d6

--- a/plugins/spawnpredictor
+++ b/plugins/spawnpredictor
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/spawn-predictor.git
-commit=6000b5035579b9a4a4ecf2508c53c1117411650d
+commit=f8f92c298f0876ce1dd7ddb92fcf79c0f612f225


### PR DESCRIPTION
v1.2.0 - 11/28/24

- Removes: Config Item for Displaying Lobby Information (this was causing confusion as to why people did not know what they were getting or when to enter)
- Removes: UTC Server Time Display as this is no longer relevant with assisted measures
- Adds: Command '::setrotation {#1-15}' to serve as an override if a player is in the caves without a predicted rotation (for various reasons)
- Adds: Assistance Messages if it is not a confirmed rotation OR if they were in the caves when the plugin first started on that account
- Adds: First and Last 5 seconds of a minute is protected and serves as a "cushion" for Jagex server time not always being precise to real-time
- Adds: Fight Caves Entrance label to assist with when a player should wait to enter for less risk to predicting a rotation