### PR TITLE
Update Essence Pouch Tracker to v1.6.1

### DIFF
--- a/plugins/essence-pouch-tracking
+++ b/plugins/essence-pouch-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/essence-pouch-tracking.git
-commit=cbcc27116dd703899d41d7698207c8dbe11d8452
+commit=f66f241eb12359e39f4b840b96220c145bcc0442


### PR DESCRIPTION
# Fixes
- Fixes the issue where disabling any overlay config option will disable any overlay from rendering over the pouch

# Features

# Other Changes