### PR TITLE
Create leagues-announcement-filter

### DIFF
--- a/plugins/leagues-announcement-filter
+++ b/plugins/leagues-announcement-filter
@@ -1,0 +1,2 @@
+repository=https://github.com/Kanezaka/leagues-announcement-filter.git
+commit=45d8a68c4240d8c566844c542c42eb0230440933


### PR DESCRIPTION
This plugin filters out clan channel announcements stemming from Leagues. 

This benefits RuneLite users in that it filters out a large amount of unnecessary noise in clan chats where a large number of people are playing Leagues. Many players would rather that the clan channel not be inundated with large blasts of collection log slots, level ups, etc.