### PR TITLE
Update Twitch Live Loadout to v2.2.1

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=f4d58930599d2f6eb579d6679297df2fd6a8d6fa
+commit=ccd87e1dc1ddace60168888228f2d8393acf6fce


### PR DESCRIPTION
- Added Leagues 5: Raging Echos support through syncing of the relics, areas and masteries you have unlocked to Twitch (see attachment).
- Minor bugfixes for collection log pop-up and disabled some settings that cause some in-game spam when linking Twitch Channel Events.


https://github.com/user-attachments/assets/6451d596-670f-4ae4-9695-0d1d6bd6ea01

