### PR TITLE
Update fixed-resizable-hybrid

### DIFF
--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=1dfd3d622e7c2026aef1cd1056627613d51034bb
+commit=aa53977252a8fc73ca041e7c0439e0316d6b969d

--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=aa53977252a8fc73ca041e7c0439e0316d6b969d
+commit=467e84fd3b30ec33b516a21700f49d052d3f6fc6


### PR DESCRIPTION
- Changed gap widget to gap overlay to prevent overlays from rending through. Updated overlay since last pull request to be static final to prevent reloading resource images every frame.

- Added Wide Chat Mode, which stretches the chat and dialogue across the bottom of the viewport like in fixed mode. When open, it resizes the viewport to recenter the player on what is visible. Configurable in settings.

Wide chat mode:
<img width="904" alt="image" src="https://github.com/user-attachments/assets/ff71d236-6a7e-45ad-9e88-d09d409b60b8">
