### PR TITLE
Create forager-pouch-alerts

### DIFF
--- a/plugins/forager-pouch-alerts
+++ b/plugins/forager-pouch-alerts
@@ -1,2 +1,2 @@
 repository=https://github.com/austinleblanc/forager-pouch-alerts.git
-commit=5adede58022858697f662c89eb87839e1a75d5b3
+commit=805f7c4b57bd710e3095fb475ae417a5147a8221

--- a/plugins/forager-pouch-alerts
+++ b/plugins/forager-pouch-alerts
@@ -1,0 +1,2 @@
+repository=https://github.com/austinleblanc/forager-pouch-alerts.git
+commit=5adede58022858697f662c89eb87839e1a75d5b3


### PR DESCRIPTION
This is a simple plugin that watches chat to see if you receive the notification that you failed to insert an herb into your forager's pouch, and then notifies you. 