### PR TITLE
Add load-time plugin

### DIFF
--- a/plugins/load-time
+++ b/plugins/load-time
@@ -1,2 +1,2 @@
 repository=https://github.com/rsfost/load-time.git
-commit=53ee7f58be021e2133014aeccf16927aa3b6d172
+commit=3a16b60fc39b816646a77ff4935e442884758214

--- a/plugins/load-time
+++ b/plugins/load-time
@@ -1,2 +1,2 @@
-repository=https://github.com/rsfost/load-time
+repository=https://github.com/rsfost/load-time.git
 commit=53ee7f58be021e2133014aeccf16927aa3b6d172

--- a/plugins/load-time
+++ b/plugins/load-time
@@ -1,0 +1,2 @@
+repository=https://github.com/rsfost/load-time
+commit=53ee7f58be021e2133014aeccf16927aa3b6d172


### PR DESCRIPTION
This plugin attempts to calculate the client's load time when loading into a new area. Load time can be useful awareness in situations where you have to react to something on the first tick of loading into an area.