### PR TITLE
Create last-stand-timer

### DIFF
--- a/plugins/last-stand-timer
+++ b/plugins/last-stand-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/BtwDas/last-stand
+commit=c5250d12a30835127eac0b343d43919d0ef128b7


### PR DESCRIPTION
This simple plugin adds a 3min timer when the player dies. 

This is made to give players an indication when their last stand timer is about to come up.