### PR TITLE
Update undying-retribution-timer

### DIFF
--- a/plugins/undying-retribution-timer
+++ b/plugins/undying-retribution-timer
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/undying-retribution-timer.git
-commit=5aade42ee2055951653827f8214b96dd3a6bcd02
+commit=e8f5caa19de3a677baedeeeaadb9dcb775fbca62
 authors=DominickCobb


### PR DESCRIPTION
Update runelite-plugin.properties to use last stand nomenclature instead of undying retribtion