### PR TITLE
New plugin/rune lite duplicator osx

### DIFF
--- a/plugins/runelite-duplicator-osx
+++ b/plugins/runelite-duplicator-osx
@@ -1,2 +1,2 @@
 repository=https://github.com/NickSpaghetti/runelite-duplicator-osx.git
-commit=bf3e6ee6e247c325b034ace75d1a04e83b779479
+commit=217339d31fe7b346e90739ec8efe92630eb24d29

--- a/plugins/runelite-duplicator-osx
+++ b/plugins/runelite-duplicator-osx
@@ -1,2 +1,2 @@
 repository=https://github.com/NickSpaghetti/runelite-duplicator-osx.git
-commit=148d83256729bbbd41f7d0d810f2a47b29bdf389
+commit=bf3e6ee6e247c325b034ace75d1a04e83b779479

--- a/plugins/runelite-duplicator-osx
+++ b/plugins/runelite-duplicator-osx
@@ -1,0 +1,2 @@
+repository=https://github.com/NickSpaghetti/runelite-duplicator-osx.git
+commit=148d83256729bbbd41f7d0d810f2a47b29bdf389


### PR DESCRIPTION
This plugin allows Mac Os Users to open up a new runelite client without having to go into the terminal and use open command or shift click on Runelite.app.  