### PR TITLE
runecrafting-tracker Takeover

### DIFF
--- a/plugins/runecrafting-tracker
+++ b/plugins/runecrafting-tracker
@@ -1,2 +1,2 @@
-repository=https://github.com/hBurt/runecrafting-tracker.git
+repository=https://github.com/BlueSoapTurtle/runecrafting-tracker.git
 commit=b97bae275880eadb53edac0140f9bdf2b56a123b


### PR DESCRIPTION
I'd like to take over the runecrafting-tracker plugin, followed the Plugin takeover policy and the project has no code changes for 2 years and doesn't really work anymore and is missing some runes.

Created an issue on the plugin repo https://github.com/hBurt/runecrafting-tracker/issues/11
unanswered for 2 weeks now



