### PR TITLE
Update nexus-map to 1.1.1

### DIFF
--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,3 +1,3 @@
 repository=https://github.com/Antipixel/nexus-map.git
-commit=ef5ef48da9e283f6be45092f07f7e20b2d006f0d
+commit=2dfc8291dc93f417ed00080f1b806ce0ff3f9395
 authors=Antipixel,Cyborger1

--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,3 +1,3 @@
 repository=https://github.com/Antipixel/nexus-map.git
-commit=10b042de2128461066627abec3e4e405042600c6
+commit=ef5ef48da9e283f6be45092f07f7e20b2d006f0d
 authors=Antipixel,Cyborger1


### PR DESCRIPTION
First, reorder Wilderness to be in the back so Misthalin's top doesn't get snipped off when hovered (RegionDef.json).

Otherwise, this update fixes issues with keybinds no longer working after I reworked the plugin.

Turns out the key event widgets need to be visible for keyevents to work. I didn't realize, that's my bad.

They leave do leave a tiny 1x1 pixel on the screen. Moving them around or changing their properties so they're unseen is difficult, as anything that causes them not to be rendered makes the keybinds not work.

I have resorted to moving the entire inside panel widget so that the pixel is within the drop shadow of the "Show Map" button...

I absolutely hate this but this is the best I could come up with for now short of leaving the pixel there.

Fun fact, in previous versions of the plugin, this pixel was always there, we just never noticed it 👀 

Resolves https://github.com/Antipixel/nexus-map/issues/26.