### PR TITLE
Create combat-log-timer 

### DIFF
--- a/plugins/combat-log-timer
+++ b/plugins/combat-log-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/flyback-rs/combatlogtimer.git
+commit=aaacd5644f6341bc003a8b6279aaed39541e61da

--- a/plugins/combat-log-timer
+++ b/plugins/combat-log-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/flyback-rs/combatlogtimer.git
-commit=aaacd5644f6341bc003a8b6279aaed39541e61da
+commit=80b36ed4642392d5407e5c76e3a882248e55eaef


### PR DESCRIPTION
Plugin that provides a variety of configurable visual indicators for when a player can log out after combat. Can be configured to only activate in PvP worlds/in the wilderness, to linger UI elements after the timer expires, and to display the time remaining in a variety of formats and ways. (It's really just a glorified 9.6 second timer). 