### PR TITLE
Create bankers-note-helper

### DIFF
--- a/plugins/bankers-note-helper
+++ b/plugins/bankers-note-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/robromanowski/bankersnotehelper.git
+commit=02e1cb9ddf4c1645b14e1929ff60f257f3c256eb

--- a/plugins/bankers-note-helper
+++ b/plugins/bankers-note-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/robromanowski/bankersnotehelper.git
-commit=eae4cc548bef0860b46b5e471c5a83514bfa4171
+commit=09c23aa45b8948cde992270649cfdfc2b77b36b7

--- a/plugins/bankers-note-helper
+++ b/plugins/bankers-note-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/robromanowski/bankersnotehelper.git
-commit=02e1cb9ddf4c1645b14e1929ff60f257f3c256eb
+commit=eae4cc548bef0860b46b5e471c5a83514bfa4171

--- a/plugins/better-bankers-note
+++ b/plugins/better-bankers-note
@@ -1,2 +1,0 @@
-repository=https://github.com/robromanowski/betterbankersnote.git
-commit=26064abade637305011a1eabbc6f941ac9fe9b41

--- a/plugins/better-bankers-note
+++ b/plugins/better-bankers-note
@@ -1,0 +1,2 @@
+repository=https://github.com/robromanowski/betterbankersnote.git
+commit=26064abade637305011a1eabbc6f941ac9fe9b41


### PR DESCRIPTION
This is a plugin for Banker's Note.

It will display an icon of the current item Banker's Note is using. (Similar to how Rune Pouch shows small icons for what Runes are currently in the pouch).