### PR TITLE
Update nexus-map to 1.1.2

### DIFF
--- a/plugins/nexus-map
+++ b/plugins/nexus-map
@@ -1,3 +1,3 @@
 repository=https://github.com/Antipixel/nexus-map.git
-commit=2dfc8291dc93f417ed00080f1b806ce0ff3f9395
+commit=65be92862e191b7e5561ab1894f4d815e6052a2e
 authors=Antipixel,Cyborger1


### PR DESCRIPTION
Swapped Frem/Kandarin in the regions definition file to avoid the top of Kandarin being cut off by Fremennik when hovered.