### PR TITLE
tasks-tracker: fix hang on profile swap

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=6d07c87cff462ff87047a8c96e2ff08f4d096629
+commit=a259b5045e2ce2cc916b7f8e302fa7912eb8ccf0
 authors=tylerthardy


### PR DESCRIPTION
Fixes issue where the plugin hangs the clients when switching between profiles with plugin present or absent