### PR TITLE
Add Hide League Icons plugin

### DIFF
--- a/plugins/hide-league-icons
+++ b/plugins/hide-league-icons
@@ -1,0 +1,3 @@
+repository=https://github.com/ThePharros/hide-league-icons.git
+commit=374944fc7dca9e0c161631178435e31c35c94937
+authors=ThePharros


### PR DESCRIPTION
Hub plugin to force hide the league icons in Raging Echoes League so that the currently unsaved vanilla setting no longer needs to be re-set upon each login.