### PR TITLE
Bugfix: Update flipping-copilot to v1.5.1

### DIFF
--- a/plugins/flipping-copilot
+++ b/plugins/flipping-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/cbrewitt/flipping-copilot.git
-commit=fc20370cfb29825156b04cdd364dccb9fe2d6fd4
+commit=88a355581b0059f7120280f4781cdc5343f01fc3
 warning=This plugin submits your grand exchange offers, grand exchange transactions, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Small fix for bug introduced in v1.5.0

- Ensure that client methods are called on client thread in onLoggedInGameState() 