### PR TITLE
Create sound-alerts-expanded

### DIFF
--- a/plugins/sound-alerts-expanded
+++ b/plugins/sound-alerts-expanded
@@ -1,0 +1,2 @@
+repository=https://github.com/lewislarsen/sound-alerts-expanded
+commit=6845394b216bd14dcd127057869fcec7645048c3

--- a/plugins/sound-alerts-expanded
+++ b/plugins/sound-alerts-expanded
@@ -1,2 +1,2 @@
 repository=https://github.com/lewislarsen/sound-alerts-expanded.git
-commit=6845394b216bd14dcd127057869fcec7645048c3
+commit=8082263d14c042623e2a522f5acb2a8a2b2f4895

--- a/plugins/sound-alerts-expanded
+++ b/plugins/sound-alerts-expanded
@@ -1,2 +1,2 @@
-repository=https://github.com/lewislarsen/sound-alerts-expanded
+repository=https://github.com/lewislarsen/sound-alerts-expanded.git
 commit=6845394b216bd14dcd127057869fcec7645048c3


### PR DESCRIPTION
This plugin expands upon the sound alerts offered by plugins such as C-Engineer's Announcer plugin.

It offers sound alerts when you're missing a farming/max cape at herb patches currently but I'd like to add more in the future when I think of some more that'd be useful. :)

https://github.com/lewislarsen/sound-alerts-expanded