### PR TITLE
Update quest-helper to 4.7.4

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=0fb01f96e3e5610a862dc0d0f0bef856414d5f25
+commit=47d06cf98887b8771cb4666dd09306214bb02475


### PR DESCRIPTION
Fixes the panel causing RL to change, as well as a fix to the assist panel sometimes not appearing when searching helpers.