### PR TITLE
Update Lunar Chest value plugin

### DIFF
--- a/plugins/lunar-chest-value
+++ b/plugins/lunar-chest-value
@@ -1,2 +1,2 @@
 repository=https://github.com/bradur/lunar-chest-value.git
-commit=980470510dffa7c1833c20e94e478491be1f2610
+commit=f2fcf41c96befe139fa5b1734ce7a7da1fa88d4a


### PR DESCRIPTION
I received an excellent PR from [RealityWinner](https://github.com/RealityWinner): https://github.com/bradur/lunar-chest-value/pull/1

This adds Wyrmling bones to the Prayer XP calculation and also an option to display
1) Both the Gold / Prayer XP value
2) Only the Gold value
3) Only the Prayer XP value

This PR is to update the plugin with that new feature.