### PR TITLE
Add RuneShare plugin

### DIFF
--- a/plugins/runeshare
+++ b/plugins/runeshare
@@ -1,3 +1,3 @@
 repository=https://github.com/kcdragon/runeshare-plugin.git
-commit=bf214caeab474cf9ef40d61974b1c21dc20b86f4
+commit=f84a42f818694a38252035f5b1b81f0d0cf9639a
 warning=This plugin submits your bank tag tab data and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/runeshare
+++ b/plugins/runeshare
@@ -1,0 +1,3 @@
+repository=https://github.com/kcdragon/runeshare-plugin.git
+commit=6c3ae1bf6f710995bb2110f6d52af8b2b6765007
+warning=This plugin submits your bank tag tab data and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/runeshare
+++ b/plugins/runeshare
@@ -1,3 +1,3 @@
 repository=https://github.com/kcdragon/runeshare-plugin.git
-commit=f84a42f818694a38252035f5b1b81f0d0cf9639a
+commit=94bc765e077b786f18730624727908819258f39e
 warning=This plugin submits your bank tag tab data and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/runeshare
+++ b/plugins/runeshare
@@ -1,3 +1,3 @@
 repository=https://github.com/kcdragon/runeshare-plugin.git
-commit=33fc5890ffc8cd51a0fabec3c0ab295a2641c58c
+commit=00fa4ac1ba9bfc7f2bb9c87f420aa47a71cdddad
 warning=This plugin submits your bank tag tab data and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/runeshare
+++ b/plugins/runeshare
@@ -1,3 +1,3 @@
 repository=https://github.com/kcdragon/runeshare-plugin.git
-commit=00fa4ac1ba9bfc7f2bb9c87f420aa47a71cdddad
+commit=bf214caeab474cf9ef40d61974b1c21dc20b86f4
 warning=This plugin submits your bank tag tab data and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/runeshare
+++ b/plugins/runeshare
@@ -1,3 +1,3 @@
 repository=https://github.com/kcdragon/runeshare-plugin.git
-commit=6c3ae1bf6f710995bb2110f6d52af8b2b6765007
+commit=33fc5890ffc8cd51a0fabec3c0ab295a2641c58c
 warning=This plugin submits your bank tag tab data and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
RuneShare is a [web app](https://osrs.runeshare.app/) and [plugin](https://github.com/kcdragon/runeshare-plugin) I'm developing to share and discover bank tabs. This plugin sends bank tag tab data (from the Bank Tabs plugin) to https://osrs.runeshare.app/. Each player has their own account on RuneShare and they use an API token to configure the plugin. It's currently a one way sync. Changes are sent to the web app but not from the web app to the plugin.

There are two sync modes: auto sync and manual sync. By default, manual sync is enabled and the player chooses which bank tag tabs to sync. If auto sync is enabled, the active bank tag tab will be synced.

The [README](https://github.com/kcdragon/runeshare-plugin/blob/master/README.md) describes the setup instructions for the plugin.

Let me know if I can add any more details to help the review process. I appreciate you reviewing. Thanks!