### PR TITLE
Create combat-level-indicators

### DIFF
--- a/plugins/combat-level-indicators
+++ b/plugins/combat-level-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/Tyler5934/CombatLevelIndicators.git
+commit=dad200967f88f65e891d6bcfaa646ce789e92f19


### PR DESCRIPTION
Adds a plugin similar to Player Indicators, which highlights players in the wilderness that can attack the local player.