### PR TITLE
Public chat and npc overhead remover branch

### DIFF
--- a/plugins/public-chat-and-npc-overhead-remover
+++ b/plugins/public-chat-and-npc-overhead-remover
@@ -1,0 +1,2 @@
+repository=https://github.com/LeeT96/public-chat-and-npc-overhead-remover.git
+commit=eb80536bfb773880590a6db787f0d4c88723e7ff

--- a/plugins/rogue-husher
+++ b/plugins/rogue-husher
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeT96/rogue-husher.git
-commit=391b1f911278cfb75c7457b880c78c41af4cd572
+commit=8a578d8f6c6c8939740ed675833d1a67b78e63c5

--- a/plugins/rogue-husher
+++ b/plugins/rogue-husher
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeT96/rogue-husher.git
-commit=c3db5c6c00728276bb0e4514fc5280c430942e91
+commit=86ab26ef7cda3edb82786545f590e39dbc965388

--- a/plugins/rogue-husher
+++ b/plugins/rogue-husher
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeT96/rogue-husher.git
-commit=0b84c952838be2619c6d6d44d1e832755f6af2c3
+commit=c3db5c6c00728276bb0e4514fc5280c430942e91

--- a/plugins/rogue-husher
+++ b/plugins/rogue-husher
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeT96/rogue-husher.git
-commit=38065b156df4696027193b0384314ed213e255f2
+commit=0b84c952838be2619c6d6d44d1e832755f6af2c3

--- a/plugins/rogue-husher
+++ b/plugins/rogue-husher
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeT96/rogue-husher.git
-commit=ac4e3b5d6d1bc1c0c5666d535ec7a7399f32896e
+commit=391b1f911278cfb75c7457b880c78c41af4cd572

--- a/plugins/rogue-husher
+++ b/plugins/rogue-husher
@@ -1,0 +1,2 @@
+repository=https://github.com/LeeT96/rogue-husher.git
+commit=ac4e3b5d6d1bc1c0c5666d535ec7a7399f32896e

--- a/plugins/rogue-husher
+++ b/plugins/rogue-husher
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeT96/rogue-husher.git
-commit=8a578d8f6c6c8939740ed675833d1a67b78e63c5
+commit=38065b156df4696027193b0384314ed213e255f2


### PR DESCRIPTION
Removes Selected Automatic Public Chat Entries and NPC Overhead Chat Messages

Wasn't able to re-create the functionality using Chop Chop Stop or Chat Filter