### PR TITLE
Update soulreaper-axe-qol

### DIFF
--- a/plugins/soulreaper-axe-qol
+++ b/plugins/soulreaper-axe-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/seacelery/soulreaper-axe-qol.git
-commit=061b36dd5a31033dcacc3b6d7169b5ce44044225
+commit=42d882f3f9870b08b0fda65b6e231997878d8704


### PR DESCRIPTION
Small fix to make the overlay use runescapeSmallFont rather than Runelite's overlay setting.