### PR TITLE
Toa Ghost Chat

### DIFF
--- a/plugins/toaghost-plugin
+++ b/plugins/toaghost-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/Langesund/ToA-Ghost-Chat.git
-commit=aecc79caee4d701fefa74dda155cb3e33acdcb03
+commit=d70f3ec90a31a944512288ba204965225d9f6f79

--- a/plugins/toaghost-plugin
+++ b/plugins/toaghost-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/Langesund/ToA-Ghost-Chat.git
+commit=aecc79caee4d701fefa74dda155cb3e33acdcb03

--- a/plugins/toaghost-plugin
+++ b/plugins/toaghost-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/Langesund/ToA-Ghost-Chat.git
-commit=d70f3ec90a31a944512288ba204965225d9f6f79
+commit=0895a6f0cdabe794be1f3c183686cb6d097306a4


### PR DESCRIPTION
Changes the fact that when players die in ToA they are able to type whatever freely, this plugin makes the ghostplayer say ghostly woooo's instead. its funny.