### PR TITLE
DropTracker 3.1

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=adf08446309bc5f85ac7ee62e032e0a505cfe6fa
+commit=f1d484a12aca7102b9208ea1f9d7ef350c4ed502
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=f1d484a12aca7102b9208ea1f9d7ef350c4ed502
+commit=2664ae67229914fd3e2354f4079bc7f83a1daab8
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=2664ae67229914fd3e2354f4079bc7f83a1daab8
+commit=4446825f5a40545332f385ed73e3189451821b35
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
Re-wrote the Time tracking functionality to be able to support bosses that send a time message prior to the kill count message.

Also added a plugin version to be sent across with the embeds to help recognize what verison users are on.

Also added in support for Team sizes