### PR TITLE
Update plugin version to v1.0.5

### DIFF
--- a/plugins/milestone-levels
+++ b/plugins/milestone-levels
@@ -1,2 +1,2 @@
 repository=https://github.com/Antimated/milestone-levels.git
-commit=dd1980ae1cfc2ddec9474766c7e101805b36efdd
+commit=3759054e37017936c80e4b48bdff39a8fa830428


### PR DESCRIPTION
- Fixes a bug where a bunch of notifications would be displayed whenever hopping from leagues worlds to main worlds.
- Fixed badges in README