### PR TITLE
Watchdog v3.6.0

### DIFF
--- a/plugins/watchdog
+++ b/plugins/watchdog
@@ -1,2 +1,2 @@
 repository=https://github.com/adamk33n3r/runelite-watchdog.git
-commit=06abfa093496c9b6a480e3667ca5fcb43f8cf900
+commit=dcd910e9b89988b3caa7279485290a814fefbcd5


### PR DESCRIPTION
* feat: popup notification by @adamk33n3r in https://github.com/adamk33n3r/runelite-watchdog/pull/171
* fix: only disable watchdog in hydra instance by @adamk33n3r in https://github.com/adamk33n3r/runelite-watchdog/pull/172

I added a flag for the alchemical hydra to only disable the plugin when you are in its region **and** in an instance. This prevents it falsely disabling when you are fighting Drakes in the floor above.