### PR TITLE
Update tasks-tracker

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=f7977432f12a02c1ad76e7f82a1f6db55978a25f
+commit=1f8d2b36e44ef80b88345a3b38117424a8983324
 authors=tylerthardy

--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=897664c66f23cc08a21c460f78c667e8e0d399bd
+commit=f7977432f12a02c1ad76e7f82a1f6db55978a25f
 authors=tylerthardy

--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,4 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=b57d548986e211fdd1b77d7af6826cda7ffef3dc
+commit=897664c66f23cc08a21c460f78c667e8e0d399bd
 authors=tylerthardy
-unavailable=freezes the client when switching profiles


### PR DESCRIPTION
Replaced the last instance of `clientThread::invokeLater` called during plugin startup with `clientThread::invoke` to prevent a hang on auto profile switch as indicated by https://github.com/runelite/runelite/issues/18618#issuecomment-2548912538

We were not able to recreate the freeze/hang to confirm this fix but a similar change in the previous commit (https://github.com/osrs-reldo/tasks-tracker-plugin/commit/b57d548986e211fdd1b77d7af6826cda7ffef3dc) fixed an instance of the hang we were able to replicate.