### PR TITLE
Drop party chest version 1.0

### DIFF
--- a/plugins/drop-party-chest
+++ b/plugins/drop-party-chest
@@ -1,0 +1,3 @@
+repository=https://github.com/pgroenbaek/drop-party-chest.git
+commit=0f05e0998dd504241ce11e69ba33e784cf129325
+authors=pgroenbaek

--- a/plugins/drop-party-chest
+++ b/plugins/drop-party-chest
@@ -1,3 +1,3 @@
 repository=https://github.com/pgroenbaek/drop-party-chest.git
-commit=0f05e0998dd504241ce11e69ba33e784cf129325
+commit=1c7f0c8a89dc4f3ad6916df19ab730c629bd9441
 authors=pgroenbaek


### PR DESCRIPTION
Very simple plugin that adds total chest value to the title of the drop party chest interfaces in the party room and clan hall. 

This is quite similar to what the bank plugin does to the bank interface title.