### PR TITLE
Update skills-tab-progress-bars to v1.4.0

### DIFF
--- a/plugins/skills-tab-progress-bars
+++ b/plugins/skills-tab-progress-bars
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/skills-tab-progress-bars.git
-commit=8f81a45de555fa0ddbc20d93e465b8ce73aaa201
+commit=4f723d702e5a729b91f5917ecd5887f093c40811


### PR DESCRIPTION
Reworks the darkening settings to be more customisable, includes migration from old keys to new enum style config item

(and fixes a minor bug where progress bars still showed at 200m XP, but added a setting to keep this behaviour as those with 200ms already are used to this)