### PR TITLE
Create dialog-font-changer plugin

### DIFF
--- a/plugins/dialog-font-changer
+++ b/plugins/dialog-font-changer
@@ -1,0 +1,2 @@
+repository=https://github.com/andrewmenich/dialog-font-changer.git
+commit=ed4f5ef3fdc15c33bec9c4bbacd420d7b75cd2ba

--- a/plugins/dialog-font-changer
+++ b/plugins/dialog-font-changer
@@ -1,2 +1,2 @@
 repository=https://github.com/andrewmenich/dialog-font-changer.git
-commit=ed4f5ef3fdc15c33bec9c4bbacd420d7b75cd2ba
+commit=7edfd33479ed512d8ea8e992f9cbcbb3d3d6e98a


### PR DESCRIPTION
This plugin replaces the standard dialog box quill font with a list of other font options. The goal of this plugin is to make the dialog box more legible and customizable, particularly for those with vision impairments. It works by hiding the original widget and creates a new overlay in its place. It currently only handles NPC and optionally Player dialog.