### PR TITLE
Update Dink to v1.10.20

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=8bb38a8ab6cf180d91c66aab7a2fe16d6bc60a00
+commit=112d1a77bbaabcaf17356fd8c2e9211356a72bb3
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.10.20 most notably allows hiding just split private chat from screenshots.

Full release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.10.20
