### PR TITLE
DropTracker 2.3.1 (Bug Fixes)

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=c98b94b4800790ee0196d7b5209588ac45cabdf7
+commit=ebb7b93219edc8e355796b095124f8943ded2d91
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
Updated to version 2.3.1

Recognized my patterns didn't contain the pattern for colosseum so updated that accordingly. Also had to implement a fix to properly reset team size to null after sending a webhook