### PR TITLE
Update prevent-sgm to v1.0.1

### DIFF
--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=8e26285d5ed0a59945dc49044733479f63148e87
+commit=1fa96b108b86a0b9ec1f7444f6df9dedd31d77f6

--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=e6f5f7ebfdefe45040d371782339641762929b98
+commit=e3b44a97487fadf26fc3d353822a8876cdb12aa0

--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=87f3c9036a73173e9808eb5021c5daa7658d5699
+commit=9d99b2b1e1a45b364ea5a611fe76d5614efabe55

--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=e3b44a97487fadf26fc3d353822a8876cdb12aa0
+commit=8e26285d5ed0a59945dc49044733479f63148e87

--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=b68a438de6e2f178962ba04f48653477412c84db
+commit=87f3c9036a73173e9808eb5021c5daa7658d5699

--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=9d99b2b1e1a45b364ea5a611fe76d5614efabe55
+commit=75eae9764d5dac454e7609505be3547164180234

--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=c57c494f52183f91e10ecc6fcaec720222ec1d8c
+commit=129e88e7e0441da244f84b52a09c33fcc7372ee1

--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=75eae9764d5dac454e7609505be3547164180234
+commit=e6f5f7ebfdefe45040d371782339641762929b98

--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,0 +1,2 @@
+repository=https://github.com/Zippilipy/prevent-sgm.git
+commit=b68a438de6e2f178962ba04f48653477412c84db

--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=1fa96b108b86a0b9ec1f7444f6df9dedd31d77f6
+commit=c57c494f52183f91e10ecc6fcaec720222ec1d8c


### PR DESCRIPTION
Now reads the inventory to initialize amount of sand and seaweed. Config range has also been added, to ensure only valid amount of seaweed and sand can be set with the plugin. Also now has a version number, so it will display version number in runelite plugin hub instead of commit hash.