### PR TITLE
Update crabman-group-bronzeman-plugin

### DIFF
--- a/plugins/crabman-group-bronzeman-plugin
+++ b/plugins/crabman-group-bronzeman-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/mvdicarlo/osrs-crabman-mode.git
-commit=f6e23c2a6e6cfd2dcd52bfa61d77383ae4f732d3
+commit=0c1790ad489449750ce66d15946cd6321ac3d6c0


### PR DESCRIPTION
Changed the plugin icon to distinguish itself from single bronzeman versions and attempts to fix the broken version string displayed in the ui.