### PR TITLE
Submit tile marker metronome

### DIFF
--- a/plugins/tile-marker-metronome
+++ b/plugins/tile-marker-metronome
@@ -1,2 +1,2 @@
 repository=https://github.com/RenaudBernon/tile-marker-metronome.git
-commit=aa37949e9a22577b5f8872048240046674ffc178
+commit=5f01834ffce27271d91c5ceaf80edde8da4f6d7b

--- a/plugins/tile-marker-metronome
+++ b/plugins/tile-marker-metronome
@@ -1,2 +1,2 @@
 repository=https://github.com/RenaudBernon/tile-marker-metronome.git
-commit=5f01834ffce27271d91c5ceaf80edde8da4f6d7b
+commit=7d5e294d8bc6679c42df6a79bb781b64964ab9b2

--- a/plugins/tile-marker-metronome
+++ b/plugins/tile-marker-metronome
@@ -1,2 +1,2 @@
 repository=https://github.com/RenaudBernon/tile-marker-metronome.git
-commit=d2e7848fbe0ce5d932e10bc7e8e021a0fe18dfbe
+commit=aa37949e9a22577b5f8872048240046674ffc178

--- a/plugins/tile-marker-metronome
+++ b/plugins/tile-marker-metronome
@@ -1,0 +1,2 @@
+repository=https://github.com/RenaudBernon/tile-marker-metronome.git
+commit=d2e7848fbe0ce5d932e10bc7e8e021a0fe18dfbe


### PR DESCRIPTION
Resubmit of https://github.com/runelite/plugin-hub/pull/6998

This plugin combines Tile markers with the visual metronome.
Marked tiles change color every X ticks.

In the last MR the comment was made that since I was only keeping track of ticks for loaded tiles, this would effectively sync the metronome with some boss encounters, making mechanics that happen after X ticks trivial.
To combat this I am now keeping a global tick counter. This hopefully alleviates that concern.