### PR TITLE
Create click-move-options

### DIFF
--- a/plugins/click-move-options
+++ b/plugins/click-move-options
@@ -1,2 +1,2 @@
 repository=https://github.com/DuncanClotfelter/click-move-options.git
-commit=2dc9c74b3922b2daacff87aa60d562053509672e
+commit=f8cf6f0c6886fb818d23ba32f73e0141f4f0d08c

--- a/plugins/click-move-options
+++ b/plugins/click-move-options
@@ -1,0 +1,2 @@
+repository=https://github.com/DuncanClotfelter/click-move-options.git
+commit=2dc9c74b3922b2daacff87aa60d562053509672e


### PR DESCRIPTION
Adds the ability to disable movement options and menu items to prevent misclicks

Allows the following changes to movement:

 - Toggling left click to move
 - Toggling the function of Walk Here in the right click menu
 - Toggling middle click to move
 - Toggling Shift + Click to move
 - Toggling left click to move on tiles marked by the Ground Markers plugin

Allows the user to declutter menu items via:

 - Deprioritizing ground item/NPC/object options
 - Removing "Walk Here", Cancel, and Examine options