### PR TITLE
update stealing-artefacts to v1.4

### DIFF
--- a/plugins/stealing-artefacts
+++ b/plugins/stealing-artefacts
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/StealingArtefacts.git
-commit=0cb35b204fb83efa099927603a5911aca4966585
+commit=38d5fe1bfdd998bb9ca32960573ee99a3c492df1
 authors=pajlada


### PR DESCRIPTION
adds a config toggle for showing the overlay
