### PR TITLE
Update casket saver to 1.2.0

### DIFF
--- a/plugins/casket-saver
+++ b/plugins/casket-saver
@@ -1,3 +1,3 @@
 repository=https://github.com/Notespeon/casket-saver.git
-commit=2d402fa397ed8b3c1f8e0f556d024f1a92c5181e
+commit=b61e0c2c162b5583a9c5fad03d02f7a73613a245
 authors=Notespeon,TheLope


### PR DESCRIPTION
Removed Master Clue Cooldown functionality, as this behavior is no longer present in the game

> Removed a restriction which prevented players from receiving Master Clues for 30 seconds after they last received one.

[January 8, 2025 Game Update](https://secure.runescape.com/m=news/run-energy-changes?oldschool=1)