### PR TITLE
Update sound-alerts-expanded

### DIFF
--- a/plugins/sound-alerts-expanded
+++ b/plugins/sound-alerts-expanded
@@ -1,2 +1,2 @@
 repository=https://github.com/lewislarsen/sound-alerts-expanded.git
-commit=8082263d14c042623e2a522f5acb2a8a2b2f4895
+commit=ac563f65b07155cf54567872cdadca583471627f


### PR DESCRIPTION
Here's the commit link: https://github.com/lewislarsen/sound-alerts-expanded/commit/ac563f65b07155cf54567872cdadca583471627f

This commit is solely refactoring to make the naming inside the plugin clearer; I made the changes a while ago but forgot to submit the changes to the plugin-hub.

Please let me know if you have any questions. Thank you!