### PR TITLE
Create Stopwatch and Timer plugin

### DIFF
--- a/plugins/stopwatch-timer
+++ b/plugins/stopwatch-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/pr0f3ss/StopWatch.git
+commit=e99aebef26e58e6ccc635066a74f3c9c3946f414

--- a/plugins/stopwatch-timer
+++ b/plugins/stopwatch-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/pr0f3ss/StopWatch.git
-commit=e99aebef26e58e6ccc635066a74f3c9c3946f414
+commit=e63db3d21dba130f3bcb253630f6088d1cb04047

--- a/plugins/stopwatch-timer
+++ b/plugins/stopwatch-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/pr0f3ss/StopWatch.git
-commit=cc38d5c8ee2f5139c138fb6c6c620a39779ad701
+commit=8799b9c45ce137901a1371339d13248178777d40

--- a/plugins/stopwatch-timer
+++ b/plugins/stopwatch-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/pr0f3ss/StopWatch.git
-commit=e63db3d21dba130f3bcb253630f6088d1cb04047
+commit=cc38d5c8ee2f5139c138fb6c6c620a39779ad701


### PR DESCRIPTION
This plugin adds a simple stopwatch and countdown timer to the plugin panel, ideal for speedrunning, skilling, and PvM encounters. The countdown timer finds use in specific PvM mechanics, such as ghost skipping at Cerberus or set spawning in the Inferno. It comes with multiple presets and optional sound notifications.