### PR TITLE
Update/fix world-heatmap

### DIFF
--- a/plugins/world-heatmap
+++ b/plugins/world-heatmap
@@ -1,3 +1,3 @@
 repository=https://github.com/GrandTheftWalrus/RuneLite-World-Heatmap.git
-commit=21b66e1776e9935632b74f3869976ff6e369e786
+commit=00587c663ba2903c0a911d1614922d94a7fd638c
 authors=B1GGlECHEESE

--- a/plugins/world-heatmap
+++ b/plugins/world-heatmap
@@ -1,3 +1,3 @@
 repository=https://github.com/GrandTheftWalrus/RuneLite-World-Heatmap.git
-commit=18c1e43f0b46023c67dd66fccbb829a6fb4968e3
+commit=af4796d1b9c11077971af3e2db67015253e05595
 authors=B1GGlECHEESE

--- a/plugins/world-heatmap
+++ b/plugins/world-heatmap
@@ -1,3 +1,3 @@
 repository=https://github.com/GrandTheftWalrus/RuneLite-World-Heatmap.git
-commit=0278b3b743be43b302661d526d66f365f4d01da7
+commit=18c1e43f0b46023c67dd66fccbb829a6fb4968e3
 authors=B1GGlECHEESE

--- a/plugins/world-heatmap
+++ b/plugins/world-heatmap
@@ -1,3 +1,3 @@
 repository=https://github.com/GrandTheftWalrus/RuneLite-World-Heatmap.git
-commit=1ef119db63a303726518a4f5380f0bdf74e083cd
+commit=ddc5720702ac61ba19bf67ea74ceccbfee928faa
 authors=B1GGlECHEESE

--- a/plugins/world-heatmap
+++ b/plugins/world-heatmap
@@ -1,3 +1,3 @@
 repository=https://github.com/GrandTheftWalrus/RuneLite-World-Heatmap.git
-commit=af4796d1b9c11077971af3e2db67015253e05595
+commit=2cd374562ec5e97f21407cebd6920986878f7688
 authors=B1GGlECHEESE

--- a/plugins/world-heatmap
+++ b/plugins/world-heatmap
@@ -1,3 +1,3 @@
 repository=https://github.com/GrandTheftWalrus/RuneLite-World-Heatmap.git
-commit=2cd374562ec5e97f21407cebd6920986878f7688
+commit=21b66e1776e9935632b74f3869976ff6e369e786
 authors=B1GGlECHEESE

--- a/plugins/world-heatmap
+++ b/plugins/world-heatmap
@@ -1,3 +1,3 @@
 repository=https://github.com/GrandTheftWalrus/RuneLite-World-Heatmap.git
-commit=0172c632b6cbe7c409447556c879ea334daf1a5a
+commit=1ef119db63a303726518a4f5380f0bdf74e083cd
 authors=B1GGlECHEESE

--- a/plugins/world-heatmap
+++ b/plugins/world-heatmap
@@ -1,3 +1,3 @@
 repository=https://github.com/GrandTheftWalrus/RuneLite-World-Heatmap.git
-commit=ddc5720702ac61ba19bf67ea74ceccbfee928faa
+commit=0278b3b743be43b302661d526d66f365f4d01da7
 authors=B1GGlECHEESE


### PR DESCRIPTION
- Added a super dupers important fix that needs to go through before Leagues V is over in order to work (separating Leagues data from regular account data)
- Different gamemodes now have their own heatmaps
- Automatic fix for file naming scheme
- Heatmaps are now 3D instead of assuming it's all on plane 0
- Data upload time is now determined by age of oldest heatmap instead of individually
- Refactored a lot of code
- Legacy save file conversion now updates metadata

It's a pretty huge diff due to the refactoring. I'll sling the reviewer $50 CAD if they're able to review it by Wednesday

Update: It turns out there was a way to fix users' data without the update approval being time-sensitive (and it's much more comprehensive anyway), but I'll still honor the 50 zucks for Wednesday thing