### PR TITLE
Add raids death indicator

### DIFF
--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=bc9e3cb81e4f34f7693a36f0cd9f6ec4b0bbbfc2
+commit=1f1282c9d6c9450882e4a1c55cc9ef72f06e63c1

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,5 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
 commit=55732dd9b9883c50fa76cb8c271ee36f0f9b4aa7
-authors=Fisu
-tags=raids
-description=Tries to accurately show when mobs die in raids (currently only ToA)

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=42e6b82f1ccdeaf8fce7f5bc4b89b3d0e51ec9a9
+commit=d566cd962a40504a22ddfe483bf4e618e8d76f32

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,4 +1,4 @@
-repository=https://github.com/vikke1234/raids-death-indicator
+repository=https://github.com/vikke1234/raids-death-indicator.git
 commit=55732dd9b9883c50fa76cb8c271ee36f0f9b4aa7
 authors=Fisu
 tags=raids

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=4bfa7a2842ca7940790298e8097f43cfef97f1d6
+commit=642d3f5a38000d8f6dfd0dc772cf519ae3ec9a4b

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=1f1282c9d6c9450882e4a1c55cc9ef72f06e63c1
+commit=4bfa7a2842ca7940790298e8097f43cfef97f1d6

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=dcb1db78a53bf33d8dd614e46257a00e4768eab7
+commit=42e6b82f1ccdeaf8fce7f5bc4b89b3d0e51ec9a9

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,0 +1,5 @@
+repository=https://github.com/vikke1234/raids-death-indicator
+commit=55732dd9b9883c50fa76cb8c271ee36f0f9b4aa7
+authors=Fisu
+tags=raids
+description=Tries to accurately show when mobs die in raids (currently only ToA)

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=642d3f5a38000d8f6dfd0dc772cf519ae3ec9a4b
+commit=dcb1db78a53bf33d8dd614e46257a00e4768eab7

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=55732dd9b9883c50fa76cb8c271ee36f0f9b4aa7
+commit=834a0ba5ed95b368624374a7c700128a8f4243e7

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=834a0ba5ed95b368624374a7c700128a8f4243e7
+commit=bc9e3cb81e4f34f7693a36f0cd9f6ec4b0bbbfc2


### PR DESCRIPTION
Similarly to nylo death indicators and tzhaar hp, this plugin is a death indicator for ToA. The idea is to make it able to reliably confirm whether an enemy dies or not. It highlights akkha as a range (e.g. shadow) hit procs shadows.

It accomplishes this by computing the internal fraction for hitpoints.

Currently this only supports Ampken and Akkha. The enemy data for other rooms is a placeholder for v1.x, this is an initial PoC.