### PR TITLE
Update drop-party-chest to v1.0.1

### DIFF
--- a/plugins/drop-party-chest
+++ b/plugins/drop-party-chest
@@ -1,3 +1,3 @@
 repository=https://github.com/pgroenbaek/drop-party-chest.git
-commit=1c7f0c8a89dc4f3ad6916df19ab730c629bd9441
+commit=68401d599f20fc716ad3f01f7dcf8953be3b7f6b
 authors=pgroenbaek


### PR DESCRIPTION
Changed the author name to my GitHub username because 'ø' and 'æ' gets mangled when listed in the plugin hub list inside runelite.