### PR TITLE
update star-lore to v1.1

### DIFF
--- a/plugins/star-lore
+++ b/plugins/star-lore
@@ -1,2 +1,2 @@
 repository=https://github.com/Enriath/external-plugins.git
-commit=9cbee4f144b6905ea76f8a28c237a71b502085ac
+commit=1b9588e19d64f0caefd4d6ed615fcaaeaeeccf83


### PR DESCRIPTION
At some point, Jagex added a comma and broke the entire plugin's detection. This fixes it, alongside adding the default text as an option (for variety)