### PR TITLE
Update 117HD to v1.3.3.10

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=1854dbbd0b3b5aa34f0f04fa4a4facc3d7b1a9c9
+commit=b2c2510ccb58a73e3ce729a86c5dc58058135d95
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Removes temporary Christmas event changes and deprecated API usage.