### PR TITLE
Disable Essence Pouch Tracker

### DIFF
--- a/plugins/essence-pouch-tracking
+++ b/plugins/essence-pouch-tracking
@@ -1,2 +1,3 @@
 repository=https://github.com/Infinitay/essence-pouch-tracking.git
 commit=f66f241eb12359e39f4b840b96220c145bcc0442
+disabled=true


### PR DESCRIPTION
RuneLite now supports tracking essence pouches within the Runecrafting plugin, so this plugin isn't needed anymore.