### PR TITLE
Takeover request for dynamic-inventory-tags

### DIFF
--- a/plugins/dynamic-inventory-tags
+++ b/plugins/dynamic-inventory-tags
@@ -1,2 +1,3 @@
-repository=https://github.com/tenaibms/gear-switch-alert.git
+repository=https://github.com/braveh/gear-switch-alert.git
 commit=f01059063cad821d64efb68b2de037040f9d2ce9
+authors=braveh,daltonpearson,tenai

--- a/plugins/dynamic-inventory-tags
+++ b/plugins/dynamic-inventory-tags
@@ -1,2 +1,2 @@
-repository=https://github.com/BraveH/gear-switch-alert.git
+repository=https://github.com/tenaibms/gear-switch-alert.git
 commit=f01059063cad821d64efb68b2de037040f9d2ce9

--- a/plugins/dynamic-inventory-tags
+++ b/plugins/dynamic-inventory-tags
@@ -1,3 +1,3 @@
-repository=https://github.com/braveh/gear-switch-alert.git
+repository=https://github.com/BraveH/gear-switch-alert.git
 commit=f01059063cad821d64efb68b2de037040f9d2ce9
 authors=braveh,daltonpearson,tenai

--- a/plugins/dynamic-inventory-tags
+++ b/plugins/dynamic-inventory-tags
@@ -1,3 +1,3 @@
 repository=https://github.com/BraveH/gear-switch-alert.git
 commit=f01059063cad821d64efb68b2de037040f9d2ce9
-authors=braveh,daltonpearson,tenai
+authors=braveh,daltonpearson,tenaibms


### PR DESCRIPTION
https://github.com/BraveH/gear-switch-alert/issues/29 
I asked the author to add one of the main contributors as it doesn't seem like he is very available nowadays, but unfortunately neither responded within a week. Seeing as how the last commit was over a month ago, this plugin fits the criteria for a takeover request, so I am requesting to takeover management of this repository. Please let me know if there is anything I have missed.

