### PR TITLE
Update shortest-path to v1.16.8

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=5714c5a0f9aa102fcb0f280c2f78a58cb2c1d56d
+commit=a4828d35672f7228d10fb664af0dfa50586932ab

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=a4828d35672f7228d10fb664af0dfa50586932ab
+commit=c9677ce3c3917e4bb5ce35102ea3d0539edf6d8e


### PR DESCRIPTION
- Fix paths that should go through caves  
![image](https://github.com/user-attachments/assets/86c6c949-e758-4b21-95cb-eea092872d49)
- Rewrite to create less WorldPoints
- Limit clue compass transports to league worlds