### PR TITLE
Add remove-chat-options plugin

### DIFF
--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=84afa66dd865eb3f53cd5ff341268b587922efdc
+commit=879a2a323f2cd83f800a507d0715fdbfa6518ea1

--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=881f8ef8a478503cd02f6554a6bcbf9d194ad85d
+commit=d1070ef0568fd3d412a2808eb88182d2e366b02b

--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=5542319e4a6bae39f1b6d00210b8e1213f2edf9a
+commit=4f1e8c39233361c53b9f8f9774296d53b32d2c2f

--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=d1070ef0568fd3d412a2808eb88182d2e366b02b
+commit=5542319e4a6bae39f1b6d00210b8e1213f2edf9a

--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=879a2a323f2cd83f800a507d0715fdbfa6518ea1
+commit=a34d3b5ed3c90dabfaedf21c8064e2a2201baecf

--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,0 +1,2 @@
+repository=https://github.com/96jonesa/remove-chat-options.git
+commit=84afa66dd865eb3f53cd5ff341268b587922efdc

--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=4f1e8c39233361c53b9f8f9774296d53b32d2c2f
+commit=5ac5976980a166f2c6ccdfadc44b8823043750b8

--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=a34d3b5ed3c90dabfaedf21c8064e2a2201baecf
+commit=881f8ef8a478503cd02f6554a6bcbf9d194ad85d


### PR DESCRIPTION
Removes all chatbox menu options.

Useful when the chatbox is transparent, allowing the user to interact with the rest
of the game as if the chatbox were not there at all.