### PR TITLE
Enable Essence Pouch Tracker and update to v1.6.2

### DIFF
--- a/plugins/essence-pouch-tracking
+++ b/plugins/essence-pouch-tracking
@@ -1,3 +1,3 @@
 repository=https://github.com/Infinitay/essence-pouch-tracking.git
-commit=f66f241eb12359e39f4b840b96220c145bcc0442
-disabled=true
+commit=4ed75b6ec7cffcf1bad8b85b29f82e79672ef554
+disabled=false

--- a/plugins/essence-pouch-tracking
+++ b/plugins/essence-pouch-tracking
@@ -1,3 +1,2 @@
 repository=https://github.com/Infinitay/essence-pouch-tracking.git
 commit=4ed75b6ec7cffcf1bad8b85b29f82e79672ef554
-disabled=false


### PR DESCRIPTION
# Fixes

# Features
- Add option to only show tracker overlay for the Colossal pouch

# Other Changes
- Re-enabled the Essence Pouch Tracker due to requests