### PR TITLE
add loot-filters plugin

### DIFF
--- a/plugins/loot-filters
+++ b/plugins/loot-filters
@@ -1,0 +1,2 @@
+repository=https://github.com/riktenx/loot-filters.git
+commit=46599d566a5ec7b4620c5c21bd8cbc4843db97d6

--- a/plugins/loot-filters
+++ b/plugins/loot-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/riktenx/loot-filters.git
-commit=46599d566a5ec7b4620c5c21bd8cbc4843db97d6
+commit=f201028edc69d606e03494dd122c2c532e7aec05


### PR DESCRIPTION
Adds the "Loot Filters" plugin, a re-imagined implementation of the base Ground Items plugin experience which supports user-scriptable item overlay rules known as loot filters.

The upstream [readme](https://github.com/riktenx/loot-filters/blob/main/README.md) describes the plugin in greater detail and includes a link to a guide for the filter scripting language.