### PR TITLE
update attack-ranges to 1.2.6

### DIFF
--- a/plugins/attack-ranges
+++ b/plugins/attack-ranges
@@ -1,2 +1,2 @@
 repository=https://github.com/tylerwgrass/attack-ranges.git
-commit=ef547842798c1afa6560aed4b74d589b0110988c
+commit=2019d207da9c680724ae8bab40de3b3efafe1131


### PR DESCRIPTION
fixes drag protection only checking target's southwest tile