### PR TITLE
tasks-tracker: Add co-owner to authors

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
 commit=1f8d2b36e44ef80b88345a3b38117424a8983324
-authors=tylerthardy
+authors=tylerthardy,JamesShelton140


### PR DESCRIPTION
## Changes

- Added co-owner Elixir140 as a plugin author
- No plugin changes

## Notes
I'm going to be pretty busy with projects going forward. I wanted to make sure our plugin co-author was marked as an author in the hub, so the PRs are easier to make if I'm not available.

We're still working on updating the past PR based on the feedback.