### PR TITLE
Update impling-saver to 2.0.0

### DIFF
--- a/plugins/impling-saver
+++ b/plugins/impling-saver
@@ -1,2 +1,2 @@
 repository=https://github.com/TheLope/ImplingSaver.git
-commit=1935f480a4b0583fe8e21cef86d93999737f6e8b
+commit=27c131f04288a218554d88f346dccb542849a1d5

--- a/plugins/impling-saver
+++ b/plugins/impling-saver
@@ -1,2 +1,2 @@
 repository=https://github.com/TheLope/ImplingSaver.git
-commit=e0159e5c80518343aa2643354655aa04268ab234
+commit=1935f480a4b0583fe8e21cef86d93999737f6e8b


### PR DESCRIPTION
Complete refactor of the plugin to provide functionality of saving implings only when the associated clue is found in the bank
This is because the prior functionality was only checking the players inventory, which was since added to the core game.
Large portions of the functionality mirror what was done for the Casket Saver refactor.