### PR TITLE
add chatbox-scroll-to-zoom plugin

### DIFF
--- a/plugins/chatbox-scroll-to-zoom
+++ b/plugins/chatbox-scroll-to-zoom
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/chatbox-scroll-to-zoom.git
-commit=ef91495caf123921edee79adc48acf5a0e730c7f
+commit=5ddfe8bb42f816a6de7539e7877ca1701b43494f

--- a/plugins/chatbox-scroll-to-zoom
+++ b/plugins/chatbox-scroll-to-zoom
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/chatbox-scroll-to-zoom.git
-commit=ce119deb4111133924155651c1c7c26c3ae58668
+commit=22db1cf19a847647f0a049ff9f6eb8246fedd76c

--- a/plugins/chatbox-scroll-to-zoom
+++ b/plugins/chatbox-scroll-to-zoom
@@ -1,0 +1,2 @@
+repository=https://github.com/96jonesa/chatbox-scroll-to-zoom.git
+commit=ef91495caf123921edee79adc48acf5a0e730c7f

--- a/plugins/chatbox-scroll-to-zoom
+++ b/plugins/chatbox-scroll-to-zoom
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/chatbox-scroll-to-zoom.git
-commit=5ddfe8bb42f816a6de7539e7877ca1701b43494f
+commit=ce119deb4111133924155651c1c7c26c3ae58668

--- a/plugins/chatbox-scroll-to-zoom
+++ b/plugins/chatbox-scroll-to-zoom
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/chatbox-scroll-to-zoom.git
-commit=b570cc2da770ff6a7b11df670128943af16c1c18
+commit=2bcdfd673a1c4c601834a73ea63248a6521cae83

--- a/plugins/chatbox-scroll-to-zoom
+++ b/plugins/chatbox-scroll-to-zoom
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/chatbox-scroll-to-zoom.git
-commit=22db1cf19a847647f0a049ff9f6eb8246fedd76c
+commit=b570cc2da770ff6a7b11df670128943af16c1c18


### PR DESCRIPTION
When enabled, if scroll-to-zoom is enabled (in the game's settings), then scrolling the mouse wheel while hovering over the chatbox will zoom instead of scrolling through the chat history.

If the user is holding the CONTROL key, then scrolling the mouse wheel while hovering over the chatbox will scroll through the chat history instead of zooming.