### PR TITLE
Update "Easy Teleports" plugin to v2.3.0

### DIFF
--- a/plugins/easy-pharaoh-sceptre
+++ b/plugins/easy-pharaoh-sceptre
@@ -1,2 +1,2 @@
 repository=https://github.com/dappermickie/easy-teleports.git
-commit=3386fc76336b7d2248cff9501a3fd452fb153660
+commit=36941f54bf891f33f3baf2261c123ef4e4b40953


### PR DESCRIPTION
In this update I've:
- Added support for mini menus
- Added Necklace Of Passage teleports
- Added Fortis Colosseum to Ring of Dueling 
- Fixed PvP arena/Emir's arena TP

And on another note:
- No more deprecation warnings