### PR TITLE
update remove-menu-options

### DIFF
--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=5ac5976980a166f2c6ccdfadc44b8823043750b8
+commit=fae2c5c1e2107fd027a572fb1942a5672e11a8f7

--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=fae2c5c1e2107fd027a572fb1942a5672e11a8f7
+commit=91a5544c60e8371a677f569dedaf8fad0c20e86f


### PR DESCRIPTION
remove 'Copy to clipboard' menu option

this is added by the Chat History plugin by default, and is not attached to the CHATBOX group

may in a future change update the Chat History plugin to properly set param1 on the `Copy to clipboard` menu option, but a glance it's pretty confusing with talk of static vs dynamic IDs