### PR TITLE
update remove-chat-options

### DIFF
--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=7d27952ea6196449c05d7beab1eeb55f4596e02c
+commit=65f0a4b017be332bf9820d119b7f226dcecb2633

--- a/plugins/remove-chat-options
+++ b/plugins/remove-chat-options
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/remove-chat-options.git
-commit=91a5544c60e8371a677f569dedaf8fad0c20e86f
+commit=7d27952ea6196449c05d7beab1eeb55f4596e02c


### PR DESCRIPTION
don't remove chat options if CONTROL key is pressed

provides the user with a convenient hotkey (CONTROL) to temporarily toggle the plugin's behavior off