### PR TITLE
Update flipping-copilot to v1.6.1

### DIFF
--- a/plugins/flipping-copilot
+++ b/plugins/flipping-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/cbrewitt/flipping-copilot.git
-commit=b0bf18e3227b43e58fc539bf244d3fbe755dc946
+commit=94d634549f465f0e58a40c58784e168225cd64a6
 warning=This plugin submits your grand exchange offers, grand exchange transactions, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
 Bugfixes:
 - Truncate the item names by 2 more chars to prevent rare width issues
 - Ensure the first status is not sent immediately on login whilst the GE slots are not correct.