### PR TITLE
Update dynamic-inventory-tags

### DIFF
--- a/plugins/dynamic-inventory-tags
+++ b/plugins/dynamic-inventory-tags
@@ -1,3 +1,3 @@
 repository=https://github.com/BraveH/gear-switch-alert.git
-commit=f01059063cad821d64efb68b2de037040f9d2ce9
+commit=8ae6e9511354b4df7f14bdf9f467027a7747cb3d
 authors=braveh,daltonpearson,tenaibms


### PR DESCRIPTION
Uses latest commit, which fixes powered staff bug / deprecated API usage.