### PR TITLE
Update 1password plugin

### DIFF
--- a/plugins/onepassword-plugin
+++ b/plugins/onepassword-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/tymscar/runelite-1password-plugin.git
-commit=7bbe4d768aea89b467db93ae34fdd1cbd3e2d47d
+commit=dbe606552b86021a0ee684a115443ab6263a8679
 warning=You are required to install the 1Password CLI application to use this plugin.<br>Go to the support link for more info and examples!


### PR DESCRIPTION
Uses latest commit, which fixes the one password CLI not printing the correct details without an extra flag added recently