### PR TITLE
Create improved-fixed-hide-chat plugin file

### DIFF
--- a/plugins/improved-fixed-hide-chat
+++ b/plugins/improved-fixed-hide-chat
@@ -1,0 +1,2 @@
+repository=https://github.com/MetalMan196/improved-fixed-hide-chat.git
+commit=dd77fee4386a94bacc50fd9827766105eaadfacd

--- a/plugins/improved-fixed-hide-chat
+++ b/plugins/improved-fixed-hide-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/MetalMan196/improved-fixed-hide-chat.git
-commit=dd77fee4386a94bacc50fd9827766105eaadfacd
+commit=38b273e5e076bf302c7a3ae0968a435ea7301bbb


### PR DESCRIPTION
This is a clone of the Fixed Mode Hide Chat plugin. The base plugin gives users the ability to collapse the chatbox while in "Fixed - Classic" display mode. This plugin adds a feature that automatically un-hides the chatbox when a chatbox-dialog is opened requiring user input.