### PR TITLE
mark dps-calculator unavailable

### DIFF
--- a/plugins/dps-calculator
+++ b/plugins/dps-calculator
@@ -1,2 +1,3 @@
 repository=https://github.com/LlemonDuck/dps-calculator.git
 commit=5b9e18cb952c574430ca33d3d72c6249db0bdb4e
+unavailable=Very outdated, consider using dps.osrs.wiki instead.


### PR DESCRIPTION
Marking as unavailable for now since it's extremely out-of-date, and an upcoming API change will break it.

For anyone interested, please see LlemonDuck/dps-calculator#136