### PR TITLE
update flipping-copilot to v1.6.3

### DIFF
--- a/plugins/flipping-copilot
+++ b/plugins/flipping-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/cbrewitt/flipping-copilot.git
-commit=be0aacff6bdcec9c3c9ff79ebff7a5fdc2aaf9db
+commit=13c563c4e71223d60a882d0ae0a849f48857835e
 warning=This plugin submits your grand exchange offers, grand exchange transactions, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/flipping-copilot
+++ b/plugins/flipping-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/cbrewitt/flipping-copilot.git
-commit=13c563c4e71223d60a882d0ae0a849f48857835e
+commit=d89c231ed1f66025ac629d5e6c42d86fb2dafc7f
 warning=This plugin submits your grand exchange offers, grand exchange transactions, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
- Include new accounts in display name drop down.
- Don't refresh stats panel if session stats haven't changed
- Show item icon next to the suggestion
- Rename 'reset' button to 'Reset session'
- Better handle when copilot isn't logged in
- Deduplicate saved transactions on loading
- Ensure when GE is opened or closed a new suggestion is fetched to support buy activities only being created when at GE
- Add was_copilot_suggestion flag and propagate to transactions