### PR TITLE
Update tool-required to v1.1.4

### DIFF
--- a/plugins/tool-required
+++ b/plugins/tool-required
@@ -1,2 +1,2 @@
 repository=https://github.com/Unmoon/tool-required.git
-commit=e19a904f0583d2605521e2e5f4ee7d3620444834
+commit=4c167dde26f0ffdafa207db3529a906bbc6e3b57


### PR DESCRIPTION
Fixes https://github.com/Unmoon/tool-required/issues/7 and removes league-only items.