### PR TITLE
Bump wikisync to include clog support

### DIFF
--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,4 +1,4 @@
 repository=https://github.com/weirdgloop/WikiSync.git
-commit=c3da71fda190ee935fc5048e80d5173f994883b0
+commit=d258146462e80f5cbeb7f20bab7c68272a3345db
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.
 authors=andmcadams,leejt,lezed1,jayktaylor

--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,4 +1,4 @@
 repository=https://github.com/weirdgloop/WikiSync.git
-commit=d258146462e80f5cbeb7f20bab7c68272a3345db
+commit=e9809f35bd7cfba21402cd693b4f7502b9f02d96
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.
 authors=andmcadams,leejt,lezed1,jayktaylor

--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,4 +1,4 @@
 repository=https://github.com/weirdgloop/WikiSync.git
-commit=8ab0ddc6cba3a157d992d2a4f814c29177640b0b
+commit=c3da71fda190ee935fc5048e80d5173f994883b0
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.
 authors=andmcadams,leejt,lezed1,jayktaylor


### PR DESCRIPTION
Adds collection log support. This is streamed up to our server and can be pulled down on the wiki. The server change is live so if you test this out and use my [in progress wiki page](https://oldschool.runescape.wiki/w/User:Andmcadams/Collection) you should see your data pull through.

In order to sync collection log data, you need to go to the collection log interface and click the WikiSync button. We do not track partial updates, so in order to resync, you need to press the sync button again. Note that there is a flash because we have to run a client script after firing the menu action to avoid ending up on the search interface.