### PR TITLE
Update chat-success-rates

### DIFF
--- a/plugins/chat-success-rates
+++ b/plugins/chat-success-rates
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=917c971ef4b6651cceaed377d0c4549ae90ae80f
+commit=0ef5c8cbfd2bd9d4f8cc693cbbce04bbada17fb1


### PR DESCRIPTION
- Only show the chat box copy data menu option when there is data to copy and the chat box is visible