### PR TITLE
Create dizana-alert

### DIFF
--- a/plugins/dizana-alert
+++ b/plugins/dizana-alert
@@ -1,0 +1,2 @@
+repository=https://github.com/Servilabs/dizana-alert.git
+commit=ad7a6f30c92b84c2d217b812075b26fcc8a016e0

--- a/plugins/dizana-alert
+++ b/plugins/dizana-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/Servilabs/dizana-alert.git
-commit=e06a0ba17b10f28d8bbaa770e67d99cba0adbc9c
+commit=05a3c21c5e84eb208cab98fa9af3d1022d482832

--- a/plugins/dizana-alert
+++ b/plugins/dizana-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/Servilabs/dizana-alert.git
-commit=ad7a6f30c92b84c2d217b812075b26fcc8a016e0
+commit=e6e597f616084cc42d79db76e5deec22eeeef743

--- a/plugins/dizana-alert
+++ b/plugins/dizana-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/Servilabs/dizana-alert.git
-commit=f6d488dcb78e6f4f6a5b8aedc362b60bb94c2112
+commit=e06a0ba17b10f28d8bbaa770e67d99cba0adbc9c

--- a/plugins/dizana-alert
+++ b/plugins/dizana-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/Servilabs/dizana-alert.git
-commit=ed1ac85daa7faef232c5f59df82641b17da1f39c
+commit=f6d488dcb78e6f4f6a5b8aedc362b60bb94c2112

--- a/plugins/dizana-alert
+++ b/plugins/dizana-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/Servilabs/dizana-alert.git
-commit=e6e597f616084cc42d79db76e5deec22eeeef743
+commit=ed1ac85daa7faef232c5f59df82641b17da1f39c


### PR DESCRIPTION
This plugin is meant for people who use the quiver for raids and wish to avoid going into it and find it is empty because of a recent death or other event.