### PR TITLE
Update stopwatch-timer plugin

### DIFF
--- a/plugins/stopwatch-timer
+++ b/plugins/stopwatch-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/pr0f3ss/StopWatch.git
-commit=8799b9c45ce137901a1371339d13248178777d40
+commit=49bf8899fc372008f4dfaf2847123400476e3b8d


### PR DESCRIPTION
Updated the side panel icon path to work in the prod build:  `"/stopwatch_icon.PNG"` to `"/images/stopwatch_icon.png".`