### PR TITLE
Update loot-filters: cherrypick fix for memory leak

### DIFF
--- a/plugins/loot-filters
+++ b/plugins/loot-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/riktenx/loot-filters.git
-commit=ec5ab587ba867c089b6c04b0478b2234a885a6bc
+commit=316fe0dbec1793b14d97bf6708f75e51cd1548f1

--- a/plugins/loot-filters
+++ b/plugins/loot-filters
@@ -1,3 +1,2 @@
 repository=https://github.com/riktenx/loot-filters.git
-commit=688d8d9c44c34f6ac75bb513a40c353f74f8d6af
-disabled=true
+commit=ec5ab587ba867c089b6c04b0478b2234a885a6bc


### PR DESCRIPTION
Fixes memory leak due to ground item entries / lootbeams staying around forever even as items fall out of scene.

See context in https://github.com/riktenx/loot-filters/issues/40.