### PR TITLE
update flipping-copilot to v1.6.4

### DIFF
--- a/plugins/flipping-copilot
+++ b/plugins/flipping-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/cbrewitt/flipping-copilot.git
-commit=d89c231ed1f66025ac629d5e6c42d86fb2dafc7f
+commit=fece04c90144d4eaa95981947ebf673fe8d89759
 warning=This plugin submits your grand exchange offers, grand exchange transactions, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Bug fixes:
- include 'sell' in the requestedSuggestionTypes when sell only mode is active
- ensure 'null' is not added to `FlipManager.displayNameToAccountId` map
- don't include flags in SavedOffer.equals method to ensure duplicate events are
  correctly filtered.
- Fix bugged logic in isUncollectedOutOfSync method - the GE home screen must
  be open not just GE for the collect button to be visible.