### PR TITLE
Create removeupperfloorstob

### DIFF
--- a/plugins/removeupperfloorstob
+++ b/plugins/removeupperfloorstob
@@ -1,0 +1,2 @@
+repository=https://github.com/ppyLEK/RemoveUpperFloorsTob.git
+commit=ee5c01f8d1a5dbca03b363233e028a6f8b60da6a

--- a/plugins/removeupperfloorstob
+++ b/plugins/removeupperfloorstob
@@ -1,2 +1,2 @@
 repository=https://github.com/ppyLEK/RemoveUpperFloorsTob.git
-commit=ee5c01f8d1a5dbca03b363233e028a6f8b60da6a
+commit=c2ce132e37f750c43cb10479a42d08bc4227aaab


### PR DESCRIPTION
This plugin removes tiles on upper floors (1-3) at tob bank improving visibility at the bank and preventing clicks on scenery.