### PR TITLE
Bump WikiSync - Hopefully fix the null pointer exceptions that cause the wikisync button to silently fail

### DIFF
--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,4 +1,4 @@
 repository=https://github.com/weirdgloop/WikiSync.git
-commit=9508cd779c1cc74433fe250a2bb752ef3b12a177
+commit=2f11f5ab45a850e6dd3abec25aea727df26eed34
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.
 authors=andmcadams,leejt,lezed1,jayktaylor


### PR DESCRIPTION
https://github.com/weirdgloop/WikiSync/pull/27#issue-2840697638

> We were getting reports of some random submission failures with no obvious issues. In some of the logs we could see the attached stack traces, which seemed to point to client.getEnum erroring out. I think this has to do with the cache parse being attempted before the gamestate check, which might put us in a state where we try to get the enum before the cache is ready.

> I moved the cache parsing to wait until we are at least at the LOGIN_SCREEN state and made it so failing to parse the cache will not stop us from sending data. In addition, I made it so that we will attempt to set up the item id -> bitset bit index after we finish parsing the cache (in case the manifest finished first) and after we finish retrieving the manifest (in case the cache finished first).

```
[Client] ERROR n.r.client.callback.ClientThread - Exception in invoke
wg: 
	at td.ah(td.java:20884)
	at hd.ah(hd.java:30)
	at client.rl(client.java:16785)
	at client.getEnum(client.java:6272)
	at com.andmcadams.wikisync.WikiSyncPlugin.parseCacheForClog(WikiSyncPlugin.java:497)
	at com.andmcadams.wikisync.WikiSyncPlugin.lambda$startUp$0(WikiSyncPlugin.java:136)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:226)
	at client.fr(client.java:2261)
	at client.bd(client.java)
	at bt.ap(bt.java:393)
	at bt.av(bt.java)
	at bt.run(bt.java:19683)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.NullPointerException: null
	at hd.ah(hd.java:31)
	... 13 common frames omitted
[Client] ERROR n.r.client.callback.ClientThread - Exception in invoke
java.lang.NullPointerException: null
	at com.andmcadams.wikisync.WikiSyncPlugin$2.lambda$onResponse$1(WikiSyncPlugin.java:446)
	at net.runelite.client.callback.ClientThread.lambda$invoke$0(ClientThread.java:49)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:226)
	at client.fr(client.java:2261)
	at client.bd(client.java)
	at bt.ap(bt.java:393)
	at bt.av(bt.java)
	at bt.run(bt.java:19683)
	at java.base/java.lang.Thread.run(Unknown Source)
```