### PR TITLE
Update monster-monitor tp v1.4.4

### DIFF
--- a/plugins/monster-monitor
+++ b/plugins/monster-monitor
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/monster-monitor.git
-commit=1058146743d4b775149a17169174472514ae2da1
+commit=7eb61be9339e796d0c6a48837defb1be19b1cb74


### PR DESCRIPTION
Implement kill limit popup notifications & improve special NPC tracking

- Added MonsterMonitorPopup to display a popup when an NPC kill limit is reached.
- Added a configurable toggle in MonsterMonitorConfig to enable/disable popup notifications.
- Ensured multiple popups queue properly and appear in order.
- Integrated popup calls into MonsterMonitorPlugin to trigger on kill limit reach.
- Improved special NPC tracking:
  - Fixed Hueycoatl logging by ensuring only its final phase (ID 14012) is logged.
  - Optimized updateTrackedNpcs() to reset logs per tick and ensure only valid NPCs remain.
  - Implemented onHitsplatApplied() to re-track special NPCs when hit again.
- Removed the unused stopTrackingNpc() method.
- Added shutdown() in SpecialNpcTracker to clear all tracked/logged NPCs on shutdown.
- Improved thread safety for NPC tracking operations using a single lock.
- Fixed an issue where special NPCs were sometimes double logged.