### PR TITLE
Update clear-unsent-messages

### DIFF
--- a/plugins/clear-unsent-messages
+++ b/plugins/clear-unsent-messages
@@ -1,2 +1,2 @@
 repository=https://github.com/lightningboltemoji/clear-unsent-messages.git
-commit=bff43b839a1b0095cb291af2723262baaec2e91e
+commit=2e9d94b80055168e11367f3c8ed65083623ddeaf


### PR DESCRIPTION
A recent game update changed the interface ID for `chatbox->input` from 55 to 56 https://github.com/runelite/runelite/commit/26e332bffd9559949d2e564a75ed727230d5c9b4

Just updating to account for that/no longer use hardcoded IDs