### PR TITLE
Bump wikisync - add missing return

### DIFF
--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,4 +1,4 @@
 repository=https://github.com/weirdgloop/WikiSync.git
-commit=2f11f5ab45a850e6dd3abec25aea727df26eed34
+commit=2c2d047ba55da9f0feed0413395c80cbe157c92a
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.
 authors=andmcadams,leejt,lezed1,jayktaylor


### PR DESCRIPTION
Adds a missing return that causes us to error out when the manifest loads after the cache is parsed