### PR TITLE
[clan-halls-plugin] Update README.md

### DIFF
--- a/plugins/clan-halls-plugin
+++ b/plugins/clan-halls-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/raphpion/clan-halls-plugin.git
-commit=c0cf1b8071bed0cbea733875c2c08ce8b24e7ce8
+commit=569b37674ba8c6ab8bb95060f2cc94c32d322915
 warning=This plugin sends your IP address, members' names and ranks, as well as the name and titles of your clan chat, to clanhalls.net, a third-party website not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This is a simple update to the plugin's README that:

- adds a Discord and Ko-Fi badge;
- blurs a client ID displayed on an image.