### PR TITLE
Update fixed-resizable-hybrid

### DIFF
--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=7df64282c74b944a8712727e4a53a7611b9d41f4
+commit=732ec1482ae33e20980f3fad38f96600f112d339


### PR DESCRIPTION
Fixed minimap widget bug with world hopping in specific areas (e.g. wildy / tormented demons)