### PR TITLE
Create lfghelper

### DIFF
--- a/plugins/lfghelper
+++ b/plugins/lfghelper
@@ -1,2 +1,2 @@
 repository=https://github.com/Lorkrakt/lfg-helper.git
-commit=8ef4f326ce1f3bdd18fa7af41d725531520880a7
+commit=8dc9af2de8e05d6589cb7a85a17ad76fc776cfa0

--- a/plugins/lfghelper
+++ b/plugins/lfghelper
@@ -1,0 +1,2 @@
+repository=https://github.com/Lorkrakt/lfg-helper.git
+commit=124fbbb4b5ec887812f2a5776b8d435ffcbcc197

--- a/plugins/lfghelper
+++ b/plugins/lfghelper
@@ -1,2 +1,2 @@
 repository=https://github.com/Lorkrakt/lfg-helper.git
-commit=124fbbb4b5ec887812f2a5776b8d435ffcbcc197
+commit=3f597f12611a7291bca7cc5e4ff759eab6648375

--- a/plugins/lfghelper
+++ b/plugins/lfghelper
@@ -1,2 +1,2 @@
 repository=https://github.com/Lorkrakt/lfg-helper.git
-commit=3f597f12611a7291bca7cc5e4ff759eab6648375
+commit=8ef4f326ce1f3bdd18fa7af41d725531520880a7

--- a/plugins/lfghelper
+++ b/plugins/lfghelper
@@ -1,2 +1,2 @@
 repository=https://github.com/Lorkrakt/lfg-helper.git
-commit=8dc9af2de8e05d6589cb7a85a17ad76fc776cfa0
+commit=9ef3b3296c9b3ea396a5c3621244dfec01283dd1

--- a/plugins/lfghelper
+++ b/plugins/lfghelper
@@ -1,2 +1,2 @@
 repository=https://github.com/Lorkrakt/lfg-helper.git
-commit=9ef3b3296c9b3ea396a5c3621244dfec01283dd1
+commit=f2662d26b4aba3e2b40b654e48b650cc1691af06

--- a/plugins/lfghelper
+++ b/plugins/lfghelper
@@ -1,2 +1,2 @@
 repository=https://github.com/Lorkrakt/lfg-helper.git
-commit=f2662d26b4aba3e2b40b654e48b650cc1691af06
+commit=9b0d64b2ad28809c273bd492852af12f1f8f7d2c


### PR DESCRIPTION
The LFG Helper plugin helps RuneScape players quickly find groups for PVM content by providing a simple, user-friendly interface in the RuneLite sidebar. Players can specify group details like boss name, team size, clanchat, and world, and submit these details to a designated Discord channel via a webhook.

Features:
Simple Form Interface: Enter boss name, team size, clanchat, and more.
Discord Integration: Sends LFG request to a Discord channel with a custom webhook.
Role Support: Sends a message tagging the specified "PVMer" role on Discord.
Automatic Data Population: Includes the player’s in-game name in the request.

This plugin streamlines the process of looking for PVM groups, making it easier for players to coordinate and find groups within their communities