### PR TITLE
update quick-prayer-preview to v1.1

### DIFF
--- a/plugins/quick-prayer-preview
+++ b/plugins/quick-prayer-preview
@@ -1,2 +1,2 @@
 repository=https://github.com/Enriath/external-plugins.git
-commit=26b9cc5438abbb18b550da76aaf24cca7aa32278
+commit=589c89a5f8286f0c04d6d835d0b6e9a35e1bee8d


### PR DESCRIPTION
The overlay background now uses the core RuneLite config's Overlay colour (contributed by @JamesGronowski)