### PR TITLE
Update clan-halls-plugin

### DIFF
--- a/plugins/clan-halls-plugin
+++ b/plugins/clan-halls-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/raphpion/clan-halls-plugin.git
-commit=569b37674ba8c6ab8bb95060f2cc94c32d322915
+commit=0c57aa4bbc2f872ff7d8214302651f5d5bb28172
 warning=This plugin sends your IP address, members' names and ranks, as well as the name and titles of your clan chat, to clanhalls.net, a third-party website not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
✨ Feature: automatically send settings if clan has not been synced

* Includes a rework of `ClanHallsClient` with typed `APIResponses` without callbacks.

* Requests are now sent using OAuth (access token in authorization header) instead of putting the credentials in the body of every request.

* Request payloads have been simplified to reflect this change.