### PR TITLE
[no-op]: Update loot-filters: point release commit back to main branch

### DIFF
--- a/plugins/loot-filters
+++ b/plugins/loot-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/riktenx/loot-filters.git
-commit=5acff1c2d459fe33dc7608795621b44fef32ca29
+commit=234743ec5dc8a05814aba263e700d0654f3f1ff0


### PR DESCRIPTION
Ever since #7378 releases have been cut from a separate branch from our `main` (basically, I decided to hold back some features from release that I had in main, so I just kept cherrypicking to the branch after that).

The temporary release branch and `main` have now fully reconverged, this change just switches the commit hash back to the top of main.

**FYI: the autodiff is misleading. It's using `...`-style diff which shows new commits relative to common ancestor. Since the branches have diverged from a while back it's re-showing changes from all releases since #7378.**

**The actual line-by-line diff (`..`-style diff, or "absolute" diff) is https://github.com/riktenx/loot-filters/compare/5acff1c2d459fe33dc7608795621b44fef32ca29..riktenx:234743ec5dc8a05814aba263e700d0654f3f1ff0 - which as you can see is nothing.**