### PR TITLE
Add process-priority plugin

### DIFF
--- a/plugins/process-priority
+++ b/plugins/process-priority
@@ -1,0 +1,3 @@
+repository=https://github.com/rsfost/process-priority.git
+commit=ade96e8608b1e853cbbccc1ca498ab54008e4fdb
+authors=Foster


### PR DESCRIPTION
This plugin lets Windows users set the priority class of the RuneLite process without having to open Task Manager.