### PR TITLE
Update nylo-death-indicators to v1.0.14

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=3c133a12666519738de350746dc8818b09713201
+commit=f181129398f99a5803d2570d0ef414e8fd624fb3


### PR DESCRIPTION
Adds Sulphur blades and Glaical temotli to the list of expected weapons.