### PR TITLE
Minimap Bug Fixes

### DIFF
--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=732ec1482ae33e20980f3fad38f96600f112d339
+commit=a2699df772e6d8f42383470c280bff38e9824f84


### PR DESCRIPTION
Previous commit caused new bug with the minimap which caused it to be deleted, presumably because it was editing their position/sizes prior to being fully loaded. Bugs fixed with this commit:

- Minimap disappearing when switching interface styles
- Minimap orb icons not resetting properly