### PR TITLE
Raids Death Indicator additional kephri fixes

### DIFF
--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=fea6d86e2ffa966b90d6ead3c739af920a3b9498
+commit=354be9dbe8b94830ff98bee69970e23bd75c4cd9

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,4 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=354be9dbe8b94830ff98bee69970e23bd75c4cd9
+commit=558a3f3fc1036bf47b06350b9bda3144e13c3f48
+
+


### PR DESCRIPTION
- Do not reset on interaction change, turns out you'll always receive range xp. Instead reset on range xp.

- Fix kephri reinforcement stats