### PR TITLE
Create npc-stack-reorderer

### DIFF
--- a/plugins/npc-stack-reorderer
+++ b/plugins/npc-stack-reorderer
@@ -1,0 +1,2 @@
+repository=https://github.com/Skretzo/runelite-plugins.git
+commit=c17645d587ae3cfe406d6c58c7c7e58901a31bfd


### PR DESCRIPTION
Reorders NPC stacks with invisible NPCs from showing the oldest NPCs to instead show the newest NPCs.

There is a limit of 5 NPCs bigger than 1x1 that can be rendered in the same stack. The 6th, 7th, ... will turn invisible, even in the right-click menu. This plugin uses entity hiding to hide the 1st, 2nd, ... NPCs to make the 6th, 7th, ... NPCs become visible. This is useful for niche accounts without access to aoe attacks that e.g. wants to tag magers during zuk. 