### PR TITLE
Update loot-lookup to v1.1.11

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=f15b789db22deaf7b4bafddfbb9e91a7e9f6852c
+commit=df4b51a01bc9bfea0e48d582cec99cf34a3d9381


### PR DESCRIPTION
- Avoid deprecated getCachedNPCs call 
- Close input stream in downloadImage util

Thanks @iProdigy 