### PR TITLE
Update emblem-trader-skull-timer

### DIFF
--- a/plugins/emblem-trader-skull-timer
+++ b/plugins/emblem-trader-skull-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/Teekiz/skull-timer.git
-commit=e1a098ce68957049d8db89238b58820f903ed996
+commit=d6cad2bb2d1e566a5e1fe0d1ae14a6bc4129f52a

--- a/plugins/emblem-trader-skull-timer
+++ b/plugins/emblem-trader-skull-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/Teekiz/skull-timer.git
-commit=d6cad2bb2d1e566a5e1fe0d1ae14a6bc4129f52a
+commit=5761ef1ceccd3efd7f331161471ff5a490fb06e8

--- a/plugins/emblem-trader-skull-timer
+++ b/plugins/emblem-trader-skull-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/Teekiz/skull-timer.git
-commit=715b4331dc871bfc6376a0fd793d1176f7603f53
+commit=6b7cd35acde3be90516f97b2c7fe716dfcb4c659

--- a/plugins/emblem-trader-skull-timer
+++ b/plugins/emblem-trader-skull-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/Teekiz/skull-timer.git
-commit=6b7cd35acde3be90516f97b2c7fe716dfcb4c659
+commit=6aef17b51bff07cf599834c5b84b2ea561ee256d

--- a/plugins/emblem-trader-skull-timer
+++ b/plugins/emblem-trader-skull-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/Teekiz/skull-timer.git
-commit=5761ef1ceccd3efd7f331161471ff5a490fb06e8
+commit=715b4331dc871bfc6376a0fd793d1176f7603f53


### PR DESCRIPTION
Updated to version 2.0:
Added timer checks for entering the abyss, wearing items that provide skulls and PVP scenarios. Renamed plugin to 'Skulled Timer' to reflect new features.