### PR TITLE
Update quest-helper to 4.7.6.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=04a6a0fc814ee79d98a97143eda79a3f99f15315
+commit=6fda77c0a9935859265ff92cea203b6d50c324b6


### PR DESCRIPTION
Fixes an issue with npcs being looped within a drawCallback. This was happening due to NpcRequirement being used as a render condition for Hopleez.