### PR TITLE
Update Twitch Live Loadout to v2.2.2

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=ccd87e1dc1ddace60168888228f2d8393acf6fce
+commit=44937a3d917b665e734f9a44190c0ab973cbb516


### PR DESCRIPTION
Fixed a breaking API change with todays client update when checking the amount of players in the area for tracking combat statistics.