### PR TITLE
Update world-cycle : Bugfixes

### DIFF
--- a/plugins/world-cycle
+++ b/plugins/world-cycle
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/world-cycle.git
-commit=e64e601db7615410c3bdee2e87c1411b9b1f0f64
+commit=5aa24f43e270b7f87bbebe2d3ddf4459e1be1c6b


### PR DESCRIPTION
- Resolves [Overlay not displaying after restarting plugin](https://github.com/1Defence/world-cycle/issues/5)
- World overlay now initializes with the correct worlds.