### PR TITLE
update gnome childify to 0.2.1

### DIFF
--- a/plugins/gnomechildify
+++ b/plugins/gnomechildify
@@ -1,2 +1,2 @@
 repository=https://github.com/Himonn/gnome-childify.git
-commit=e3ea98f55f4e0b08ed3b09bd445a4a49ab63a8ba
+commit=6c07447a5f52a960f1d8963f2acf532d0209f1b3


### PR DESCRIPTION
remove usage of client.getCachedPlayers() in favour of client.getTopLevelWorldView().players()