### PR TITLE
Update npc-accessibility-tagger

### DIFF
--- a/plugins/npc-accessibility-tagger
+++ b/plugins/npc-accessibility-tagger
@@ -1,2 +1,2 @@
 repository=https://github.com/R-Y-M-R/NpcAccessibilityTaggerPlugin.git
-commit=b374750b39b5a6b6b0cb770451660833e4659b4a
+commit=4a6819fff08fb3ad43aed342ce0d08a2ad1d79c4


### PR DESCRIPTION
- Restored functionality, issue was caused by (old) ``getCachedNPCs()`` method.