### PR TITLE
Update combat-logger to v1.3.3

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=7865755bbf78a4219b30c9be6cf9d2d110fe3091
+commit=1d1bf33ade476f6adbd3598e59977d9fb9d2ba3c


### PR DESCRIPTION
- Fix splash logs. Bosses don't show splash animations so relying just on our spell animation and getting 0 hp xp.