### PR TITLE
add playernames plugin

### DIFF
--- a/plugins/playernames
+++ b/plugins/playernames
@@ -1,0 +1,2 @@
+repository=https://github.com/MatthewA/playernames.git
+commit=2dbab50715f461911728ef9d42529ff436600aee


### PR DESCRIPTION
PlayerNames Plugin is a player name indicator, shows player name info and color codes the text based on combat brackets.
The colors are customisable in the plugin settings.