### PR TITLE
update tob-notice-board repository

### DIFF
--- a/plugins/tob-notice-board
+++ b/plugins/tob-notice-board
@@ -1,2 +1,3 @@
-repository=https://github.com/Broooklyn/runelite-external-plugins.git
+repository=https://github.com/gtjamesa/runelite-external-plugins.git
 commit=40af4de25e32af05a1ce15befd62d4afbe6af696
+authors=gtjamesa


### PR DESCRIPTION
Hello,

I am looking to takeover the ToB Notice Board plugin. There has been no activity on the main repository, and I cannot get in touch with Brooklyn to be added as a contributor on the main repository. If anyone sees this and happens to know how to get in touch, I would be happy to be added as a collaborator on the main repo instead of a transfer. If there is anything else I need to do, then please let me know :)

- Initial PR: https://github.com/Broooklyn/runelite-external-plugins/pull/168
- Request for Collaboration issue: https://github.com/Broooklyn/runelite-external-plugins/issues/171

Assuming the transfer goes as expected, can I rename the repository and update it here without any issues later? I didn't want to update it now, just in case it broke the open PR
