### PR TITLE
Update Dink to v1.10.22

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=3877e56c82e7cb491088f759e6f66678b42789c3
+commit=22a4a0dd63455c3ac2739bec10acc97d5d0641f7
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Prepare support for RuneLite's Barbarian Assault high gambles, and treat
`SPAM` messages as matchable game messages for the chat notifier.
