### PR TITLE
Update shortest-path to v1.17

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=41b34ae2ccda90a0db9f8433ddc6a50b36e3e588
+commit=0a9396e5ec024a7724037d003f56c6a9247d4b0b


### PR DESCRIPTION
- Item requirements are now properly handling quantities and item variations
- Added option to use minigame teleports
- Ferox Enclave and the peninsula north of Black Knights' Fortress is no longer considered as in the wilderness
- The avoid wilderness config option should now be respected when multiple targets are selected
- The collision map was updated to 2025-02-18 for the Royal Titans Combat Achievements update
- Added option to use the hot air balloon transportation system
- Added some missing stepping stone agility shortcuts
- Added missing entrance and exit for the Experiment cave and the Mausoleum