### PR TITLE
Create tob-predicted-hit

### DIFF
--- a/plugins/tob-predicted-hit
+++ b/plugins/tob-predicted-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/JaccodR/party-hits.git
-commit=71afdd38a6bc35a96a945dd150be4f5d417a4cc8
+commit=9e6d03f8a7535797df4c652eb06c21b9cf3c44ce

--- a/plugins/tob-predicted-hit
+++ b/plugins/tob-predicted-hit
@@ -1,0 +1,2 @@
+repository=https://github.com/JaccodR/party-hits.git
+commit=71afdd38a6bc35a96a945dd150be4f5d417a4cc8


### PR DESCRIPTION
A plugin that shows party members predicted hits above their heads in ToB.