### PR TITLE
Update inventory-notifier

### DIFF
--- a/plugins/inventory-notifier
+++ b/plugins/inventory-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/dandylyon/inventory-notifier.git
-commit=6cda6ca14d4479dc750c2816784560e5acbfa3c7
+commit=8edf16970696fd4f06409755305e55c47a5b8859

--- a/plugins/inventory-notifier
+++ b/plugins/inventory-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/dandylyon/inventory-notifier.git
-commit=deaece871b6b767424702149c3671b2ffd48b781
+commit=6cda6ca14d4479dc750c2816784560e5acbfa3c7


### PR DESCRIPTION
Updated to restore functionality.
No longer spams notifications when performing actions with an already full inventory such as fletching bows or cutting gems.