### PR TITLE
Add barrows-path plugin

### DIFF
--- a/plugins/barrows-path
+++ b/plugins/barrows-path
@@ -1,0 +1,2 @@
+repository=https://github.com/HectorMF/barrows-path.git
+commit=bdf10aa868eca973253035425b08ef68938f9b91


### PR DESCRIPTION
This plugin highlights the doorways that lead to the barrows chest. 