### PR TITLE
[Archipelago Randomizer] Parses Legacy item names from older versions of the randomizer

### DIFF
--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=ab218e925baf97458c048d180cf8e8c04d9fc5ea
+commit=3d8c2e8985f4415380a784d5fdfab472dee1ad2c


### PR DESCRIPTION
The names of the Items "Progressive Ranged Weapon" and "Progressive Magic Spells" have changed since the earliest released version of the Archipelago World file, and people with runs on that oldest version are not seeing their items in the plugin. Added support for the older names, treating them the same as their current counterparts.