### PR TITLE
Update Twitch Live Loadout to v2.2.3

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=44937a3d917b665e734f9a44190c0ab973cbb516
+commit=58c8b1a2013756308c9c1666553c4c0751c6624a


### PR DESCRIPTION
Fixed a minor breaking change due to the recent collection log game update causing the collection log pages to not be detected properly anymore on open.