### PR TITLE
Update consumable-cooldowns to 1.2.1

### DIFF
--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,2 +1,2 @@
 repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
-commit=dda330b4d6d45af5982a4718c389173b2f3a7c6c
+commit=885e610b3ef78cce6cbfd8c053b01a527bf30537


### PR DESCRIPTION
- Remove delayed heal infobox on consecutive eat within the duration of the first infobox
- Remove delayed heal infobox on plugin shutdown