### PR TITLE
Create fhes-ground-items

### DIFF
--- a/plugins/fhes-ground-items
+++ b/plugins/fhes-ground-items
@@ -1,0 +1,3 @@
+repository=https://github.com/AlfRayJacobs/fhes-ground-markers.git
+commit=acf4a347892bb98f791c25f7af77ee11719b6e46
+


### PR DESCRIPTION
New plugin to mark specific item IDs with their own coloured outlines & highlight drops by other players for brews/restores and their CoX equivalents