### PR TITLE
Update cannon-highlighter

### DIFF
--- a/plugins/cannon-highlighter
+++ b/plugins/cannon-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/ConorLeckey/Cannon-Highlighter.git
-commit=46c2659d82aa5ed80c5f9187ec0a4102982107ba
+commit=63aab3565b7302fd8530ad6aab8c653686c53478


### PR DESCRIPTION
Removes usage of deprecated methods. See https://github.com/ConorLeckey/Cannon-Highlighter/pull/11
