### PR TITLE
Update fixed-resizable-hybrid

### DIFF
--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=a2699df772e6d8f42383470c280bff38e9824f84
+commit=4822dbc31ac7182267abac5d03048448efb8e751

--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=4822dbc31ac7182267abac5d03048448efb8e751
+commit=ac680dd6b4ecaade15839fec02375150fb9ae3f8


### PR DESCRIPTION
Improvements to Cutscene Handling and Wide Chatbox
- Switched wide chatbox from using overlays to instead using widgets, allowing for interface styles or resource packs to be compatible with the chatbox.
- Added option for repositioning chat buttons in wide chatbox mode (stretched vs centered options).
- Generalized fixFairyWidget function to also fix other widgets with dynamic/full screen backgrounds (e.g. canoe)
- Added cutscene handling (varbit 542) which allows for widget positioning during cutscenes. This also prevents the inventory widget from being hidden similar to in fixed mode.

Improved ingame overlay handling
- TOB party overlay bounding restriction
- MTA clipping

Properly handling transparent chatbox
- Prevents viewport resizing when chatbox is transparent.
- Expands height of viewport to extend under the chat buttons in transparent chatbox.

Default plugin config settings
- set centerChatboxButtons to true by default

Restored border overlay png file (deleted by accident)
- also updated overlay to only load the image once (static final)