### PR TITLE
Update tob-predicted-hit

### DIFF
--- a/plugins/tob-predicted-hit
+++ b/plugins/tob-predicted-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/JaccodR/party-hits.git
-commit=9e6d03f8a7535797df4c652eb06c21b9cf3c44ce
+commit=e5c6c7df2b2ef480c64356e3ab7e1f5cdcc3764a

--- a/plugins/tob-predicted-hit
+++ b/plugins/tob-predicted-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/JaccodR/party-hits.git
-commit=e5c6c7df2b2ef480c64356e3ab7e1f5cdcc3764a
+commit=928c0b6ff5c5dd9c223944c21ba2b48336f36395


### PR DESCRIPTION
Updates:
* Fix fake xp drops for multi-hit weapons like scythe being grouped instead of processing seperately
* Exclude multi tick weapons from maidens damage queue
* Add a config option to only update maidens live hp every tick, instead of on every xp drop
* Make maiden only option still sent hits to other party members, but not display any
* Ensure maidenHandler deactivates when the party wipes