### PR TITLE
Update raids death indicator with chambers support

### DIFF
--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,4 +1,4 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=a5920fbc405aa9ba29a73a5dbf45795c1189c13e
+commit=cd4d5bcaa5ed1c96302c1363f159531b753f7435
 
 

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,4 +1,4 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=1a5adf24129e83ebc7bbd0005294d1d42bee933d
+commit=20c957f7f4ee5b480eea39aa4b57d24ae036b765
 
 

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,4 +1,4 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=cd4d5bcaa5ed1c96302c1363f159531b753f7435
+commit=5d6a5435c5c9be2cbeefcf793f290e375ca4f905
 
 

--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,4 +1,4 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=20c957f7f4ee5b480eea39aa4b57d24ae036b765
+commit=a5920fbc405aa9ba29a73a5dbf45795c1189c13e
 
 


### PR DESCRIPTION
This PR adds chambers support (olm mage hand and vespula portal) along with some misc fixes.