### PR TITLE
Update Lizardman Shaman Minion Alert for RuneLite v1.11.2

### DIFF
--- a/plugins/lizardman-shaman-minion-alert
+++ b/plugins/lizardman-shaman-minion-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/baloooouu/lizardman-shaman-minion-alert.git
-commit=72c99d5ccea094e16053d94cb0c270793dde4d10
+commit=86e111c356f30bed4191fed36ef6c29f6533e9d3


### PR DESCRIPTION
Functionality unchanged. Just updated the plugin since it was no longer working with the current RuneLite version