### PR TITLE
Update agility-pyramid-slider-block-timer

### DIFF
--- a/plugins/agility-pyramid-slider-block-timer
+++ b/plugins/agility-pyramid-slider-block-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/WesleyM77/agility-pyramid-slider-block-timer.git
-commit=08e99c4bb39a2e4b5fc6f4436e463502df1ea8cd
+commit=999807742c52adeb9e24407c25b1bdcbc25d138d


### PR DESCRIPTION
Fixed issue with assuming a variable wasn't null. Thanks @iProdigy!
See https://github.com/WesleyM77/agility-pyramid-slider-block-timer/pull/5 for more details