### PR TITLE
Update fixed-resizable-hybrid

### DIFF
--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=ac680dd6b4ecaade15839fec02375150fb9ae3f8
+commit=b52f456f381325805ae333c3daa3becd4ad2c7c8


### PR DESCRIPTION
Option to reposition minimap orbs
- Resizable mode has a larger minimap than fixed mode in the III and IV quadrants. Because of this, it's possible to click the run/spec orbs and have the click transmit through and also move the character via the minimap. This adds an optional setting to move the run and spec orbs slightly further away to prevent click-through.

Failsafe sprite loader
- Rarely, the minimap sprites fail to load. This adds a fail-safe check when inventory tabs are changed to ensure that the widgets are loaded, assuming the game is in fixed-resizable mode.