### PR TITLE
Update Dink to v1.11.3

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=2ca2ed1627bd35573ab62e4ee30851d6eae681ca
+commit=2a348498862a7808e8abc479d00718757b36fa9a
 authors=Mm2PL,pajlada,Felanbird,iProdigy

--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=b3e4975d43ee3a4d7663ad23252ed1be5f1b874c
+commit=f8a04a74d33e0a38bb36a46b30988e2cceb84280
 authors=Mm2PL,pajlada,Felanbird,iProdigy

--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=f8a04a74d33e0a38bb36a46b30988e2cceb84280
+commit=2ca2ed1627bd35573ab62e4ee30851d6eae681ca
 authors=Mm2PL,pajlada,Felanbird,iProdigy

--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=1a35ecf8a06e6e551f003f496b41f08370a962c2
+commit=b3e4975d43ee3a4d7663ad23252ed1be5f1b874c
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.11.0 allows other plugins to trigger webhook notifications via `PluginMessage`

https://github.com/pajlads/DinkPlugin/releases/tag/v1.11.0
https://github.com/pajlads/DinkPlugin/releases/tag/v1.11.1
https://github.com/pajlads/DinkPlugin/releases/tag/v1.11.2
https://github.com/pajlads/DinkPlugin/releases/tag/v1.11.3
