### PR TITLE
update tob-notice-board to v1.2.0

### DIFF
--- a/plugins/tob-notice-board
+++ b/plugins/tob-notice-board
@@ -1,3 +1,3 @@
-repository=https://github.com/gtjamesa/runelite-external-plugins.git
-commit=40af4de25e32af05a1ce15befd62d4afbe6af696
+repository=https://github.com/gtjamesa/tob-notice-board-plugin.git
+commit=8a25904abb40a31856595796090e7f425ccddf91
 authors=gtjamesa


### PR DESCRIPTION
Adds lobby highlighting to the party screen, expanding on the default functionality that only highlighted the list of available parties

![image](https://github.com/user-attachments/assets/950be10e-a8b0-402d-a966-fd52a1456aba)

I have also updated the repository and branch after the transfer in https://github.com/runelite/plugin-hub/pull/7496
