### PR TITLE
README: Note that dependency changes add significantly to review time

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ be have their cryptographic hash verified during the build to prevent [supply ch
 To do this we rely on [Gradle's dependency verification](https://docs.gradle.org/nightly/userguide/dependency_verification.html).
 To add a new dependency, add it to the `thirdParty` configuration in [`package/verification-template/build.gradle`](https://github.com/runelite/plugin-hub/blob/master/package/verification-template/build.gradle),
 then run `../gradlew --write-verification-metadata sha256` to update the metadata file. A maintainer must then verify
-the dependencies manually before your pull request will be merged.
+the dependencies manually before your pull request will be merged. This process generally adds significantly to the amount of time it takes for a plugin submission or update to be reviewed, so we recommend avoiding adding any new dependencies unless absolutely necessary.
 
 ## My client version is outdated
 If your client version is outdated or your plugin suddenly stopped working after RuneLite has been updated, make sure that your `runeLiteVersion` is set to `'latest.release'` in `build.gradle`. If this is set correctly, refresh the Gradle dependencies by doing the following:


### PR DESCRIPTION
Adds a note to the Third-Party Dependencies section clarifying that dependency changes add significantly to review time and should be avoided unless strictly necessary.

This comes up fairly regularly in Discord, so stating it more clearly seems like it would be helpful.