### PR TITLE
Raids death indicator party bugfix

### DIFF
--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,4 +1,4 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=34cdd13b09f41931f74a50cadf212207e6773cbf
+commit=ebd0f054f7a35409d761f062136deac576832b38
 
 


### PR DESCRIPTION
Adds a hp overlay for debug purposes and fixes party.