### PR TITLE
Update tob-predicted-hit

### DIFF
--- a/plugins/tob-predicted-hit
+++ b/plugins/tob-predicted-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/JaccodR/party-hits.git
-commit=928c0b6ff5c5dd9c223944c21ba2b48336f36395
+commit=cf9da776c9c2df3125f7ab1de6312191bda97eb6


### PR DESCRIPTION
Tiny bugfix. Fixing maiden only option still receiving hits while enabled