### PR TITLE
Added empty-hands-indicator

### DIFF
--- a/plugins/empty-hands-indicator
+++ b/plugins/empty-hands-indicator
@@ -1,0 +1,2 @@
+repository=https://github.com/ciaagent/Empty-Hands-Indicator.git
+commit=df802c8f3c28964f2c18078b5f7d19c71852047d


### PR DESCRIPTION
A new plugin that highlights players who do not have any weapons quipped allow them to be hang egged.