### PR TITLE
Add Missed Clues plugin

### DIFF
--- a/plugins/missed-clues
+++ b/plugins/missed-clues
@@ -1,2 +1,2 @@
 repository= https://github.com/lalochazia/missed-clues.git
-commit=a734db56ba3049bdb05dd8d2ad08ea42bd55dcd6
+commit=58202e65fabc5141b6ac1cec5c7b9f9e2be854e5

--- a/plugins/missed-clues
+++ b/plugins/missed-clues
@@ -1,0 +1,2 @@
+repository= https://github.com/lalochazia/missed-clues.git
+commit=de5f0f697255170ff4321902377215e91df5bb89

--- a/plugins/missed-clues
+++ b/plugins/missed-clues
@@ -1,2 +1,2 @@
 repository= https://github.com/lalochazia/missed-clues.git
-commit=58202e65fabc5141b6ac1cec5c7b9f9e2be854e5
+commit=433dac3538c9f8b8d246dc66506f6f096c843ec2

--- a/plugins/missed-clues
+++ b/plugins/missed-clues
@@ -1,2 +1,2 @@
 repository= https://github.com/lalochazia/missed-clues.git
-commit=de5f0f697255170ff4321902377215e91df5bb89
+commit=658bdff97f3dff8222da15969997d9f9915314c3

--- a/plugins/missed-clues
+++ b/plugins/missed-clues
@@ -1,2 +1,2 @@
 repository= https://github.com/lalochazia/missed-clues.git
-commit=ea17277f13d61876019930692376b431e6c7a548
+commit=a734db56ba3049bdb05dd8d2ad08ea42bd55dcd6

--- a/plugins/missed-clues
+++ b/plugins/missed-clues
@@ -1,2 +1,2 @@
 repository= https://github.com/lalochazia/missed-clues.git
-commit=658bdff97f3dff8222da15969997d9f9915314c3
+commit=ea17277f13d61876019930692376b431e6c7a548


### PR DESCRIPTION
Adds a small fun plugin that, upon receiving a "sneaking suspicion" message, simulates a clue of that tier. This then displays the items generated in an "incinerator clue scroll" overlay, alongside the items values.