### PR TITLE
Amulet of bounty alerter

### DIFF
--- a/plugins/amulet-of-bounty-alerter
+++ b/plugins/amulet-of-bounty-alerter
@@ -1,2 +1,2 @@
 repository=https://github.com/michaelma4/AmuletOfBountyAlerter.git
-commit=f73b2e95ca5f2ac776871d44897f9224bf3ef2d0
+commit=25badc9545433313b985716c3d8e6bcbd3463c56

--- a/plugins/amulet-of-bounty-alerter
+++ b/plugins/amulet-of-bounty-alerter
@@ -1,0 +1,2 @@
+repository=https://github.com/michaelma4/AmuletOfBountyAlerter.git
+commit=1dbc7f8db6b87bac4a2fd228b364c66baf7b59b3

--- a/plugins/amulet-of-bounty-alerter
+++ b/plugins/amulet-of-bounty-alerter
@@ -1,2 +1,2 @@
 repository=https://github.com/michaelma4/AmuletOfBountyAlerter.git
-commit=d30e3f79142548f4aec9631a04a162db6f3cf90a
+commit=f73b2e95ca5f2ac776871d44897f9224bf3ef2d0

--- a/plugins/amulet-of-bounty-alerter
+++ b/plugins/amulet-of-bounty-alerter
@@ -1,2 +1,2 @@
 repository=https://github.com/michaelma4/AmuletOfBountyAlerter.git
-commit=1dbc7f8db6b87bac4a2fd228b364c66baf7b59b3
+commit=d30e3f79142548f4aec9631a04a162db6f3cf90a


### PR DESCRIPTION
This plugin will display an overlay when you're not wearing your Amulet of bounty.
There is the option to display the overlay globally or you can toggle it to only show when you're near an allotment patch.

![image](https://github.com/user-attachments/assets/62f2d535-54c9-4690-8e60-5bc3bb2b59eb)

![Screenshot 2025-03-08 233810](https://github.com/user-attachments/assets/76be0f7c-2b35-4460-99e3-a5b4204ac1f2)

