### PR TITLE
update tob-notice-board to 1.2.1

### DIFF
--- a/plugins/tob-notice-board
+++ b/plugins/tob-notice-board
@@ -1,3 +1,3 @@
 repository=https://github.com/gtjamesa/tob-notice-board-plugin.git
-commit=8a25904abb40a31856595796090e7f425ccddf91
+commit=78183fe55495b7237989c610612a4db9b923f64a
 authors=gtjamesa


### PR DESCRIPTION
Skips highlighting of the local player as its defaulting to the clan colour
