### PR TITLE
patch naturalspeech

### DIFF
--- a/plugins/naturalspeech
+++ b/plugins/naturalspeech
@@ -1,4 +1,4 @@
 repository=https://github.com/phyce/rl-natural-speech.git
-commit=61f9d13f9aa514e80c325ae9a1c9647e29dd3194
+commit=7050422c26191279fc11a49c552140460713f591
 warning=This plugin downloads voice model files from, (and sends your IP address in the process, to) huggingface.co, a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=phyce,TheLouisHong

--- a/plugins/naturalspeech
+++ b/plugins/naturalspeech
@@ -1,4 +1,4 @@
 repository=https://github.com/phyce/rl-natural-speech.git
-commit=7050422c26191279fc11a49c552140460713f591
+commit=59443319df159a498af4b983be2aa1c7fbe39fa4
 warning=This plugin downloads voice model files from, (and sends your IP address in the process, to) huggingface.co, a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=phyce,TheLouisHong


### PR DESCRIPTION
updated the link in UI that takes users to the instructions on github. master branch has been replaced with 2.0.0, which is currently pending review, and has different instructions to the old version.
while the big upgrade is under review, this should take the users to the current version's instructions.