### PR TITLE
Take over trouble-brewing plugin

### DIFF
--- a/plugins/trouble-brewing
+++ b/plugins/trouble-brewing
@@ -1,2 +1,2 @@
-repository=https://github.com/Biffo89/Trouble-Brewing.git
+repository=https://github.com/MaxPhilips/Trouble-Brewing.git
 commit=4d983508ad442aeb7ed4357f22ffd658ae853721


### PR DESCRIPTION
I'd like to take over the Trouble Brewing plugin. It has new development in its history that I'd like to get published, ref: #7572 

I reached out to the author to be added as a collaborator on 2025-03-03 and have not heard back: https://github.com/Biffo89/Trouble-Brewing/issues/6

Issues are enabled on my new fork