### PR TITLE
Add Unmovable Plugin

### DIFF
--- a/plugins/unmovable
+++ b/plugins/unmovable
@@ -1,0 +1,2 @@
+repository=https://github.com/fireflowerr/unmovable.git
+commit=4968db9e7c22b648714c8d2e41275dc14a5bfa7c


### PR DESCRIPTION
The Unmovable plugin, when enabled, disables left-click to walk. To walk, you must shift + left-click. This behavior is useful for preventing misclicks when kiting, and possibly other cases as well. 