### PR TITLE
update tob-notice-board to 1.3.0

### DIFF
--- a/plugins/tob-notice-board
+++ b/plugins/tob-notice-board
@@ -1,3 +1,3 @@
 repository=https://github.com/gtjamesa/tob-notice-board-plugin.git
-commit=78183fe55495b7237989c610612a4db9b923f64a
+commit=881390203ab6a1fee8f5d44383656ddec7e43c18
 authors=gtjamesa


### PR DESCRIPTION
This PR adds an integration with the default "Friend Notes" plugin from RuneLite. I have copied some source files (`FriendNoteOverlay`, `HoveredFriend`) and have left the licenses intact - hope this is ok! :smile: 

![image](https://github.com/user-attachments/assets/d113600b-dc9f-458d-a103-451f0c667b35)
