### PR TITLE
Update temple-osrs tiny bug fix

### DIFF
--- a/plugins/temple-osrs
+++ b/plugins/temple-osrs
@@ -1,4 +1,4 @@
 repository=https://github.com/SMaloney2017/Temple-OSRS-Plugin.git
-commit=2be12ec9b75d228832ba056169f2ed791824370f
+commit=7e010de6d1614054d47ec1f93afc13a6e1e59767
 authors=SMaloney2017,44Mikael
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Fixing bug that caused players with more than ~1300 collections regularly fail most of their collection log syncs due to sync request prematurely firing.