### PR TITLE
Update preventsgm

### DIFF
--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=129e88e7e0441da244f84b52a09c33fcc7372ee1
+commit=b931ab67fca842019f73cd6d7d6000ec72051340


### PR DESCRIPTION
Adds a feature requested where it disables the withdraw option when clicking on a seaweed or sand if you have the correct amount of seaweed or sand by consuming the event.