### PR TITLE
Create current-spellbook

### DIFF
--- a/plugins/current-spellbook
+++ b/plugins/current-spellbook
@@ -1,0 +1,2 @@
+repository=https://github.com/IceIceFuego/current-spellbook.git
+commit=a24d46b70dacffa692f5553e3443c4a137fb96cc


### PR DESCRIPTION
Adds current-spellbook, a plugin which adds an overlay to tell you the spellbook you are currently on

![image](https://github.com/user-attachments/assets/cf7f5c7c-005c-4f98-836a-6e064de8286b)
