### PR TITLE
Update Mahogany Homes (v1.8)

### DIFF
--- a/plugins/mahogany-homes
+++ b/plugins/mahogany-homes
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Mahogany-Homes.git
-commit=7414153a1fb00acbf38119426c2814b18b8ef995
+commit=89bdbcd4a7f0661457deadf3b0f2d9ea38f5fb29


### PR DESCRIPTION
* Added config option for checking if you have enough supplies for the contract, defaulting to true. Supports plank sack plugin.
* Reworked stair highlight logic to be smarter and only highlight if necessary.