### PR TITLE
Update clue-details to 2.3.1

### DIFF
--- a/plugins/clue-details
+++ b/plugins/clue-details
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/clue-details.git
-commit=68c7d6a1b4089517e9411f1dbc3574c727935fb3
+commit=df5617db5732a6ac73994980a13ca96d5a89f006


### PR DESCRIPTION
Removewarning for ground clue timers.