### PR TITLE
Update amulet-of-bounty-alerter to 1.1

### DIFF
--- a/plugins/amulet-of-bounty-alerter
+++ b/plugins/amulet-of-bounty-alerter
@@ -1,2 +1,2 @@
 repository=https://github.com/michaelma4/AmuletOfBountyAlerter.git
-commit=25badc9545433313b985716c3d8e6bcbd3463c56
+commit=7e49e4383c900c795d20e8cdca5804fb82cd56c2

--- a/plugins/amulet-of-bounty-alerter
+++ b/plugins/amulet-of-bounty-alerter
@@ -1,2 +1,2 @@
 repository=https://github.com/michaelma4/AmuletOfBountyAlerter.git
-commit=7e49e4383c900c795d20e8cdca5804fb82cd56c2
+commit=ed8716b83667b5ecf3ad068f70615b265612d022


### PR DESCRIPTION
-Removed all references to example in all naming
-Fixed typo in plugin name alterter -> alerter
-Start using versioning starting with 1.1
-Added 2 more tags in runelite-plugin.properties
(no other changes to existing plugin functionality for user)