### PR TITLE
Watchdog v3.8.0

### DIFF
--- a/plugins/watchdog
+++ b/plugins/watchdog
@@ -1,2 +1,2 @@
 repository=https://github.com/adamk33n3r/runelite-watchdog.git
-commit=69f42f119b4636db52aba9d69179fd37e36198b7
+commit=d864f96c34fc50d03c6e5ae81402d615f4336d73


### PR DESCRIPTION
Add support for Dink external notifications. Has checks for having dink installed and the dink external setting on. 