### PR TITLE
tobqol - v1.3.2

### DIFF
--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=7070587bc9fa483797d67c109ed6c2b71d80744b
+commit=07f22dc1b02804503a3511fb18ddf09e6ec15529


### PR DESCRIPTION
- fixes: config not controlling loot announcements to player