### PR TITLE
Update Stealing Artefacts to v1.5

### DIFF
--- a/plugins/stealing-artefacts
+++ b/plugins/stealing-artefacts
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/StealingArtefacts.git
-commit=38d5fe1bfdd998bb9ca32960573ee99a3c492df1
+commit=6007deb5482ba5a674264ea4ec7aad2fcfad6bf1
 authors=pajlada


### PR DESCRIPTION
Fixes a bug where Captain Khaled did not always get an arrow pointing to him due to him having 2 different IDs

Adds two new features:
1. Highlight Khaled if you don't have an active task in an attempt to prevent people from leaving Khaled without a task. Can be disabled with the "Highlight Khaled without task" option.
1. Only show unlured guards in the overlay. Can be configured in the new "Show guard lures" option if you set it to "Only unlured"
