### PR TITLE
Splashing helper plugin

### DIFF
--- a/plugins/splashing-helper
+++ b/plugins/splashing-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Tybo24/splashing-helper.git
+commit=e584ca49883165a31f7d77cfb0be6814efa0d038

--- a/plugins/splashing-helper
+++ b/plugins/splashing-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Tybo24/splashing-helper.git
-commit=e584ca49883165a31f7d77cfb0be6814efa0d038
+commit=a960eb32cba75a46cfcdb62976a6fa12764000cc


### PR DESCRIPTION
Done some splashing training on my pure, the idle notifier plugin is good, but does not account for all scenarios (20 minute auto-retaliate timer being one).

This is the build for a very basic plugin to help with splashing notifications a bit more. I've tested it from 85-95 mage on my pure and this is a pretty reliable version which really helped me AFK it.