### PR TITLE
Add Quick Search plugin

### DIFF
--- a/plugins/quick-search
+++ b/plugins/quick-search
@@ -1,0 +1,2 @@
+repository=https://github.com/hirzalla/quick-search.git
+commit=7b22611b9008a693ec4d5aed4b3caab2ed0337da

--- a/plugins/quick-search
+++ b/plugins/quick-search
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/quick-search.git
-commit=7fe7b771f7fb7a8ab5e92dd4efd27ac5a9783217
+commit=ddd20911a28c39efb19944811a74732fcf507813

--- a/plugins/quick-search
+++ b/plugins/quick-search
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/quick-search.git
-commit=7b22611b9008a693ec4d5aed4b3caab2ed0337da
+commit=7130025bc6933483e0aba33baea8ce534da59472

--- a/plugins/quick-search
+++ b/plugins/quick-search
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/quick-search.git
-commit=bc23659eaf16dad41aad2c3348b338a0873df45d
+commit=060e0fc65e427eed33f6d0d3f6bffdcaea209a23

--- a/plugins/quick-search
+++ b/plugins/quick-search
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/quick-search.git
-commit=ddd20911a28c39efb19944811a74732fcf507813
+commit=bc23659eaf16dad41aad2c3348b338a0873df45d

--- a/plugins/quick-search
+++ b/plugins/quick-search
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/quick-search.git
-commit=7130025bc6933483e0aba33baea8ce534da59472
+commit=9486fce25f9a115fb095b97019642b82fccd430d

--- a/plugins/quick-search
+++ b/plugins/quick-search
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/quick-search.git
-commit=9486fce25f9a115fb095b97019642b82fccd430d
+commit=7fe7b771f7fb7a8ab5e92dd4efd27ac5a9783217


### PR DESCRIPTION
# Quick Search Plugin

Adds chat commands for quick searching of OSRS-related platforms:
- OSRS Wiki (::wiki, ::osrs)
- YouTube (::yt, ::youtube) 
- Twitch (::twitch, ::ttv)
- Kick (::kick)

Each platform can be toggled on/off.

Examples:
- `::wiki abyssal whip`
- `::yt zulrah guide`
- `::ttv woox`
- `::kick odablock`