### PR TITLE
Update fixed-resizable-hybrid

### DIFF
--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=0545f1eb5c670cfc7cd9968f8fe6feaa8e02a848
+commit=086abd2a30092472f5c888c95024cfefcfec1e34


### PR DESCRIPTION
Stats Guide Centering
- When a stat is clicked on and the guide appears, it will center it on the viewport, like with most other widgets (e.g. bank interface)
- Restructured some of the code for onWidgetLoad/Unload, should keep the same functionality