### PR TITLE
Update commit sha

### DIFF
--- a/plugins/fixed-mode-hide-chat
+++ b/plugins/fixed-mode-hide-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/deathbeam/example-plugin.git
-commit=ee46c8685d4bc3efaed7287b5ac342c2fa51c224
+commit=3b95ce66a59437565e9a3766108ca024d36b16a9
 authors=deathbeam,supyosup


### PR DESCRIPTION
Improve chatbox widget pop-up coverage via recursive call

This fixes a number of bugs within the plugin where the dialog box would not show during specific interactions/events including:
1. Gauntlet Exit Prompt 
2. Skill level ups 
3. Combat level level ups
4. GOTR 'no available inventory space' popup
5. Fairy ring dialog box

Original MR: https://github.com/deathbeam/example-plugin/pull/60

If you need additional info on the changes please reach out here or on Discord via u/n: oont