### PR TITLE
added deathdotter

### DIFF
--- a/plugins/deathdotter
+++ b/plugins/deathdotter
@@ -1,0 +1,2 @@
+repository=https://github.com/dmgear/deathdotterplugin.git
+commit=4e9d611ae87b972973b2c82cfea5d4439cf7ec00


### PR DESCRIPTION
This is a simple plugin similar to entity hider. It compares the radius of two players and hides the local client player if the radius surpasses a certain threshold.