### PR TITLE
Death Dotter Plugin

### DIFF
--- a/plugins/deathdotter
+++ b/plugins/deathdotter
@@ -1,2 +1,2 @@
 repository=https://github.com/dmgear/deathdotterplugin.git
-commit=404148cfe54656a921f42c0d36ad1e0ddc87bb51
+commit=bc4cf26b98bdf4c6e3c98d9b91c94d55fa97590d

--- a/plugins/deathdotter
+++ b/plugins/deathdotter
@@ -1,0 +1,2 @@
+repository=https://github.com/dmgear/deathdotterplugin.git
+commit=4e9d611ae87b972973b2c82cfea5d4439cf7ec00

--- a/plugins/deathdotter
+++ b/plugins/deathdotter
@@ -1,2 +1,2 @@
 repository=https://github.com/dmgear/deathdotterplugin.git
-commit=bc4cf26b98bdf4c6e3c98d9b91c94d55fa97590d
+commit=ef7b4ba604f28944fb980dbb11e0a119258be4f7

--- a/plugins/deathdotter
+++ b/plugins/deathdotter
@@ -1,2 +1,2 @@
 repository=https://github.com/dmgear/deathdotterplugin.git
-commit=4e9d611ae87b972973b2c82cfea5d4439cf7ec00
+commit=f86baa5dbbe2bf67f4593b94e738bd1f3a5ab437

--- a/plugins/deathdotter
+++ b/plugins/deathdotter
@@ -1,2 +1,2 @@
 repository=https://github.com/dmgear/deathdotterplugin.git
-commit=f86baa5dbbe2bf67f4593b94e738bd1f3a5ab437
+commit=404148cfe54656a921f42c0d36ad1e0ddc87bb51

--- a/plugins/deathdotter
+++ b/plugins/deathdotter
@@ -1,2 +1,2 @@
 repository=https://github.com/dmgear/deathdotterplugin.git
-commit=ef7b4ba604f28944fb980dbb11e0a119258be4f7
+commit=e923b83614663ee8d36f60615f9c7b291f1630c5


### PR DESCRIPTION
This is a simple plugin that compares the radii of two players, and if the distance between two players falls below the threshold that is the sum of their radii, we hide the local client player similar to entity hider.

The purpose of this plugin is to perform the same function as entity hider + player outline in pvp, but without having to play with an invisible character. 