### PR TITLE
Bump to increase whitelists for sailing alpha npcs/items

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=a193334ba028539462a860d9863e42fc81962bac
+commit=ef394a6d774e51964d4d01aa55c608551f0ee8a1
 authors=leejt,andmcadams


### PR DESCRIPTION
- Adds some new messages to crowdsourcing for agi rates
- Adds a bunch of npcs and items from the sailing alpha to the whitelist so we dont rate limit them