### PR TITLE
Update amulet-of-bounty-alerter to 1.3

### DIFF
--- a/plugins/amulet-of-bounty-alerter
+++ b/plugins/amulet-of-bounty-alerter
@@ -1,2 +1,2 @@
 repository=https://github.com/michaelma4/AmuletOfBountyAlerter.git
-commit=5d39f9c668cdf11d4004e49a3d1b0e37de016ba6
+commit=0d76b433882b0fc4db21faeb1ea835d60df50981


### PR DESCRIPTION
Update amulet-of-bounty-alerter to 1.3

-Adding support for all allotment seed types
-Adding new item highlight feature to highlight the amulet of bounty if you are not wearing 1