### PR TITLE
tobqol - v1.3.3

### DIFF
--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=07f22dc1b02804503a3511fb18ddf09e6ec15529
+commit=b97688cd165cdc75aefdfe21eb380bd22b0cf545


### PR DESCRIPTION
- fixes: dry streak message displays to make it make more sense
- fixes: chest evaluation to determine if a purple is in the loot room to reset
- fixes: last item tracking memory would have null and could not evaluate string appropriately
- adjusts: config name for dryLootTracking to displayDryLootTracking since pivoting away from ENUM has caused users to go turn on the feature again (since enum to bool does not eval correctly)
- adds: resettobdry for users that are interested in resetting their streak due to the bug