### PR TITLE
Update chance-man to 1.1.2

### DIFF
--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=c083b362b1dcc62051836a0b3c372c38b1c8d8ea
+commit=65b6d4c4a8cc1c9bf8d9d4b24e0d941df2e1cd0b


### PR DESCRIPTION
Fix timing issue by deferring tradeable items refresh

- Add an "itemsInitialized" flag to ensure initialization only happens once.
- Remove the early call to refreshTradeableItems() in startUp().
- Update onGameTick() to initialize managers and UI (and call refreshTradeableItems) only when client.getLocalPlayer() is available and itemsInitialized is false.