### PR TITLE
Update Dink to v1.11.4

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=2a348498862a7808e8abc479d00718757b36fa9a
+commit=ae6f7ff06fad3ce103c41b95b012b6736ccf3400
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.11.4 avoids firing notifications based on game messages created by other external plugins, thanks to @LlemonDuck 

Full release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.11.4

