### PR TITLE
Update prop-hunt

### DIFF
--- a/plugins/prop-hunt
+++ b/plugins/prop-hunt
@@ -1,3 +1,3 @@
 repository=https://github.com/willrobaggins/prop-hunt.git
-commit=0576b9ad9c007ac9f5c58d810bd5cff5055ce32a
+commit=386d6bf1370cdd3c2c3621c4b8fe000176c3ddc3
 warning=This plugin sends player data, including usernames, plugin configuration, and IP address to a third-party server for communication between clients.

--- a/plugins/prop-hunt
+++ b/plugins/prop-hunt
@@ -1,3 +1,3 @@
 repository=https://github.com/willrobaggins/prop-hunt.git
-commit=386d6bf1370cdd3c2c3621c4b8fe000176c3ddc3
+commit=2c31353a14ad46a32e369b497f5aef9aa103caea
 warning=This plugin sends player data, including usernames, plugin configuration, and IP address to a third-party server for communication between clients.

--- a/plugins/prop-hunt
+++ b/plugins/prop-hunt
@@ -1,3 +1,3 @@
 repository=https://github.com/willrobaggins/prop-hunt.git
-commit=1eac50380135c3fcde73ab53d7b0e5bbb85fbcde
+commit=2109701fb203d548159ca579a7b6346d5840e9f5
 warning=This plugin sends player data, including usernames, plugin configuration, and IP address to a third-party server for communication between clients.

--- a/plugins/prop-hunt
+++ b/plugins/prop-hunt
@@ -1,3 +1,3 @@
 repository=https://github.com/willrobaggins/prop-hunt.git
-commit=2109701fb203d548159ca579a7b6346d5840e9f5
+commit=0576b9ad9c007ac9f5c58d810bd5cff5055ce32a
 warning=This plugin sends player data, including usernames, plugin configuration, and IP address to a third-party server for communication between clients.


### PR DESCRIPTION
Fixed a bug causing the guess option to appear where it shouldnt -limited now specifically for anything not a player, npc, menu item, inventory item, or an in game object - ideally the option should only appeard when "walk" or "cancel" are the only typical options.