### PR TITLE
disable collection-log

### DIFF
--- a/plugins/collection-log
+++ b/plugins/collection-log
@@ -1,2 +1,3 @@
 repository=https://github.com/evansloan/collection-log.git
 commit=da62ba7d9c3a6dd28b708af545c54ad0e0701d88
+disabled=unmaintained


### PR DESCRIPTION
Plugin is essentially non-functional as author has shut down website and archived associated repos:
https://collectionlog.net
https://github.com/evansloan/collectionlog.net
https://github.com/evansloan/collection-log-api