### PR TITLE
Update visual-sounds

### DIFF
--- a/plugins/visual-sounds
+++ b/plugins/visual-sounds
@@ -1,3 +1,3 @@
 repository=https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds.git
-commit=bd5163fa29f383b7f0c202942dbd62b4628f28a7
+commit=cfad2a63556086e373e14b051b2644cfb8c24437
 


### PR DESCRIPTION
Updates:

## Add missing sound IDs from wiki

The full sound list was leaked and added to the wiki on 28/02/2025. I've updated the list used by the plugin to include all of these new sounds.

https://oldschool.runescape.wiki/w/List_of_sound_IDs

Closes https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds/issues/20

##  Show message when plugin is blocked in a banned area

![image](https://github.com/user-attachments/assets/19542f95-9306-43e3-a37f-516ccc658621)

Closes https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds/issues/23

