### PR TITLE
Update chance-man to 1.1.5

### DIFF
--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=7acac77128579663fbd02bc34343fb52ac0838a4
+commit=1c011059f78f5530c09c5b09a783bd6970becaf4

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=1c011059f78f5530c09c5b09a783bd6970becaf4
+commit=92d2a3408b45116474882700dd18352ff457016f

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=92d2a3408b45116474882700dd18352ff457016f
+commit=aea012371867d9d94c44735cc46907f10eb9db0c

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=65b6d4c4a8cc1c9bf8d9d4b24e0d941df2e1cd0b
+commit=7acac77128579663fbd02bc34343fb52ac0838a4


### PR DESCRIPTION
fix: reset plugin state, enhance UI with count labels and colored messages, and update ItemsFilter

- Reset plugin state in shutDown() by nullifying managers, panels, navButton, and fileExecutor, and setting itemsInitialized to false. This fixes the issue where toggling the plugin off/on required a client restart.
- Update refreshTradeableItems() to filter items with isNotTracked()
- Modify chat message output to display the unlocked item in green and the rolled item in red.
- Add rolled/unlocked count labels to ChanceManPanel, updating counts as "Rolled: X/Y" and "Unlocked: X/Y".
- Update init() and updatePanel() methods to integrate the new UI components.
- Update ItemsFilter to include additional blocked items