### PR TITLE
Create better-xp-tracker

### DIFF
--- a/plugins/better-xp-tracker
+++ b/plugins/better-xp-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/chiefbean/better-xp-tracker.git
+commit=59a5c525880bc5cad680d0e3f7ca6e3330e86f2c


### PR DESCRIPTION
XP tracker plugin that brings back the kills to next level/goal that were removed from official runelite tracker plugin