### PR TITLE
Update load-time to 1.0

### DIFF
--- a/plugins/load-time
+++ b/plugins/load-time
@@ -1,2 +1,2 @@
 repository=https://github.com/rsfost/load-time.git
-commit=3a16b60fc39b816646a77ff4935e442884758214
+commit=36a09044425257ffc3f777766190cda8e9877a54


### PR DESCRIPTION
Poll the map loader thread's state to estimate load times instead of measuring interval between game tick events.