### PR TITLE
Add gauntlet-chest-popup

### DIFF
--- a/plugins/gauntlet-chest-popup
+++ b/plugins/gauntlet-chest-popup
@@ -1,0 +1,2 @@
+repository=https://github.com/ldavid432/gauntlet-loot-popup.git
+commit=2a41f5ad85ee67d5c8cc34e4b9bb46893736b0f5


### PR DESCRIPTION
Adds gauntlet-chest-popup

Displays a barrows-chest style loot UI when you loot the gauntlet chest

![readme_pic](https://github.com/user-attachments/assets/a0ad2dae-179b-43e6-9204-f12cb925d8f3)
