### PR TITLE
Update click-to-minimize || Added edge case support

### DIFF
--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=2accc6cffee372e10e9fc91c98d1f0dba4925877
+commit=8f12e9dd255c7e7ba40adbb1b5f531c1303b5ce1


### PR DESCRIPTION
Added edge case support for when actions have ':' within their names
Came up when someone was trying to make cannonballs, and the logs were showing it as:

Make sets:: Cannonballs

Messes up the logic as I used ":"'s to separate targets and actions