### PR TITLE
screen-marker-groups

### DIFF
--- a/plugins/screen-marker-groups
+++ b/plugins/screen-marker-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/Bloopser/screen-marker-groups.git
-commit=be2e2fd8f6123d4ecd5d83c7a520dbfe245e8007
+commit=cdba5b5ba27ae8b4f1dd51884535b393e222df77

--- a/plugins/screen-marker-groups
+++ b/plugins/screen-marker-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/Bloopser/screen-marker-groups.git
-commit=cdba5b5ba27ae8b4f1dd51884535b393e222df77
+commit=9c8fa61f77cb3ec3a8236912a1a4313cde55eff5

--- a/plugins/screen-marker-groups
+++ b/plugins/screen-marker-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/Bloopser/screen-marker-groups.git
-commit=9c8fa61f77cb3ec3a8236912a1a4313cde55eff5
+commit=1500060640bfe7976cfad96641f31e2969eee45e

--- a/plugins/screen-marker-groups
+++ b/plugins/screen-marker-groups
@@ -1,0 +1,2 @@
+repository=https://github.com/Bloopser/screen-marker-groups.git
+commit=ed45b39442e31c999e490dd0f361a9a26883b740

--- a/plugins/screen-marker-groups
+++ b/plugins/screen-marker-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/Bloopser/screen-marker-groups.git
-commit=ed45b39442e31c999e490dd0f361a9a26883b740
+commit=8fd35519471fdd12a5c301df900b60bf61bc4637

--- a/plugins/screen-marker-groups
+++ b/plugins/screen-marker-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/Bloopser/screen-marker-groups.git
-commit=8fd35519471fdd12a5c301df900b60bf61bc4637
+commit=be2e2fd8f6123d4ecd5d83c7a520dbfe245e8007


### PR DESCRIPTION
Building upon the functionality of the original RuneLite Screen Markers plugin, this enhanced version introduces the ability to organize your markers into distinct groups. This feature is particularly useful for managing different sets of markers for various activities, such as specific bosses, skilling tasks, or minigames, allowing you to easily switch between relevant markers and keep your screen uncluttered. You can create, rename, reorder, and delete groups, as well as move markers between them. It also retains the core features of the original plugin. Additionally, it offers a simple way to import existing markers from the original Screen Markers plugin.