### PR TITLE
Update loot-filters to v1.7.3

### DIFF
--- a/plugins/loot-filters
+++ b/plugins/loot-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/riktenx/loot-filters.git
-commit=bae105cedba93acbe8e7e9ca7d86db5d2c9ff335
+commit=077bdedccae9012b95169b1fd62e78cef4808a4f


### PR DESCRIPTION
no-op release, this is just a treeshake that removes dead code / deletes unused files