### PR TITLE
Update wom-utils

### DIFF
--- a/plugins/wom-utils
+++ b/plugins/wom-utils
@@ -1,4 +1,4 @@
 repository=https://github.com/wise-old-man/wiseoldman-runelite-plugin.git
-commit=8eb87054c5feeb2e05b09e2155a667789e09ca5f
+commit=53e63eb6d3c4e9b6f2250078012d6562d68bf8c5
 warning=This plugin submits the names of you, your friends and members of your clan chat to wiseoldman.net.
 authors=dekvall,rorro,psikoi


### PR DESCRIPTION
This PR changes how competitions are handled in the plugin. They are moved from just being InfoBoxes that are added on login to being displayed in the side panel with an option to add them to the canvas (like how xp tracker does it). I believe there are some white space changes in this due to me touching the files and auto formatting is happening. We also changed to use the same metric icons we use for the side panel, for the competition info boxes, hence the mass deletion of metric icons.

Most of the plugin config options have been set to be off by default so any new user of the plugin doesn't get their client cluttered with menu options they might not know come from our plugin.