### PR TITLE
Update npc-max-hit to 1.0.1

### DIFF
--- a/plugins/npc-max-hit
+++ b/plugins/npc-max-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/npc-max-hit.git
-commit=fe514c7ac2dd6095bcd5d8d373ce3c55c3b2b842
+commit=5107a4c8ad45b80f195a04b8ed2e62e868e2c5ba


### PR DESCRIPTION
fixes issue with re-sizising overlay by extending proper class