### PR TITLE
Add Lucky Clan Bingo plugin

### DIFF
--- a/plugins/lucky-clan-bingo
+++ b/plugins/lucky-clan-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/LuckyClanBingo.git
-commit=561c41e72f5eb9f2c4b7ce86551bf6f891cd916f
+commit=0c5b30e3f8865b6da889b188133d74e4e63d5148

--- a/plugins/lucky-clan-bingo
+++ b/plugins/lucky-clan-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/LuckyClanBingo.git
-commit=d4c0cc2f49d9e0df08d70371dba0ca99e30e4179
+commit=13e104894aa00a83dbaff84a806cb627a91772d6

--- a/plugins/lucky-clan-bingo
+++ b/plugins/lucky-clan-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/LuckyClanBingo.git
-commit=0c5b30e3f8865b6da889b188133d74e4e63d5148
+commit=d4c0cc2f49d9e0df08d70371dba0ca99e30e4179

--- a/plugins/lucky-clan-bingo
+++ b/plugins/lucky-clan-bingo
@@ -1,0 +1,2 @@
+repository=https://github.com/EwwItsMike/LuckyClanBingo.git
+commit=561c41e72f5eb9f2c4b7ce86551bf6f891cd916f


### PR DESCRIPTION
A plugin intended for usage in Clan events.

When players receive a drop, it is checked against a list of commonly used items for Bingo-type clan events. 
Plugin sends a screenshot and drop information to a Discord webhook.

The Discord webhook link is the ONLY adjustable setting for this plugin, meaning the items list cannot be altered (at least not easily, some tech-savvy people could find out they can alter it within the .jar file).
This is intentional, and the main point of the plugin, to prevent cheating in certain types of clan events (where people not submitting a drop because it doesn't benefit them is prohibited, for example).

The plugin is originally intended for the Lucky clan, but I hope other clans/communities will find this plugin useful for their events too.