### PR TITLE
Add dont-telegrab-npcs

### DIFF
--- a/plugins/dont-telegrab-npcs
+++ b/plugins/dont-telegrab-npcs
@@ -1,0 +1,2 @@
+repository=https://github.com/ldavid432/dont-telekinetic-grab-npcs.git
+commit=21e9b9b09c4e7b36d0938bef4a56e6215f59bc7c


### PR DESCRIPTION
Makes it so you can't cast telegrab on any NPCs except those in the whitelist