### PR TITLE
Add Cannon Damage plugin metadata

### DIFF
--- a/plugins/cannon-damage
+++ b/plugins/cannon-damage
@@ -1,3 +1,3 @@
 repository=https://github.com/DunkingOreos/Cannon-Damage.git
-commit=e17b91e6c73235a2d37e36c7bc5f836caa87b8f0
+commit=1668e512ae4c859a9ee2e5182c70862a1de79b3b
 authors=DunkingOreos,OzanKurt7,cultbaus

--- a/plugins/cannon-damage
+++ b/plugins/cannon-damage
@@ -1,0 +1,3 @@
+repository=https://github.com/DunkingOreos/Cannon-Damage.git
+commit=41546aacc30b04bffc75c3e45a58b04af8bfe36a
+authors=DunkingOreos,OzanKurt7,cultbaus

--- a/plugins/cannon-damage
+++ b/plugins/cannon-damage
@@ -1,3 +1,3 @@
 repository=https://github.com/DunkingOreos/Cannon-Damage.git
-commit=41546aacc30b04bffc75c3e45a58b04af8bfe36a
+commit=e17b91e6c73235a2d37e36c7bc5f836caa87b8f0
 authors=DunkingOreos,OzanKurt7,cultbaus

--- a/plugins/cannon-damage
+++ b/plugins/cannon-damage
@@ -1,3 +1,3 @@
 repository=https://github.com/DunkingOreos/Cannon-Damage.git
-commit=1668e512ae4c859a9ee2e5182c70862a1de79b3b
-authors=DunkingOreos,OzanKurt7,cultbaus
+commit=49143631bcd3ab0067f32604e4b0a9d5fa20ff10
+authors=DunkingOreos,OzanKurt7,cultbaus,Laophy


### PR DESCRIPTION
This plugin is specifically made to get correct cannonball statistics for use when calculating untrimmed slayer.

The plugin will start when it detects the placement of a cannon, including the shattered relics ornament kit cannon, and will stop once the cannon is picked up. The overlay will remain on screen for 60 seconds after the cannon is picked up to allow time for a screenshot or the user to write down the numbers.

ONLY damage from the cannon is supposed tracked, though if you are ranging as your main attack style when using the cannon it will count that xp as well. This is because you should NOT be ranging when going for untrimmed slayer WHILE using a cannon, magic will suffice.