### PR TITLE
DropTracker - Adventure Log support

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=98d36df63e8c48dd981c6837b03c15d815e49c02
+commit=5afb3776f77b242dd704725e377afad9569fbd88
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=a991f7c1a96e02cc2929864c3e0ae4ff50e8547b
+commit=9fbddd158934fa5e8d91c6e0db7cc1e2db1d3673
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=5afb3776f77b242dd704725e377afad9569fbd88
+commit=01f4f5c534222cdca83bbfeac4b7c2f3c7593183
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=3e3d3b6ec6e3b8b5b9aaf330be0c8db9f49ba36e
+commit=98d36df63e8c48dd981c6837b03c15d815e49c02
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=01f4f5c534222cdca83bbfeac4b7c2f3c7593183
+commit=a991f7c1a96e02cc2929864c3e0ae4ff50e8547b
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
Added support to the plugin for tracking Adventure Log entries when a player opens the log in their own POH, allowing us to grab all existing stored PBs for use in our clans' "hall of fames" instantly, without requiring a re-submission of boss kills.

Alongside this, we're also able to parse players' acquired pets and send this data with the gathered PBs.