### PR TITLE
Update ca-export

### DIFF
--- a/plugins/ca-export
+++ b/plugins/ca-export
@@ -1,2 +1,2 @@
 repository=https://github.com/cdfisher/ca-export.git
-commit=66f609e04e4946102554976cb4363e3e356b08c9
+commit=fb8b8c56da12f504a6e8e8fd79619ecd96b86324


### PR DESCRIPTION
Updates Combat Achievement Exporter to 1.1.0:
- Adds a config option to print the file path for the CA JSON as a game message
- Adds an icon
- Removes extraneous quotes in the plugin properties so it won't display as `"Combat Achievement Exporter"` with quotes on the Plugin Hub site
- Renames a few stray references to "example"