### PR TITLE
Update identificator to v1.8.3

### DIFF
--- a/plugins/identificator
+++ b/plugins/identificator
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=cb2890a68e84d06b8f80096654d07f3e6efe5051
+commit=0d9db8ebb7986f0d4de483bcbd2a71251548bf47


### PR DESCRIPTION
- Added config option to show interface item id, model id and sprite id. Only supports skill guide for now.