### PR TITLE
update 117hd

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=b2c2510ccb58a73e3ce729a86c5dc58058135d95
+commit=606b6f235b248ccc90567376642a4f763f5b2e89
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Fixes unpacking of TileObject hashes which broke after https://github.com/runelite/runelite/commit/06bef897aab950678d8ab337fa1dc1533c344df7.