### PR TITLE
Update combat-logger to v1.3.5

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=d3fcb744a028816da9bfa83b03043855e14952d9
+commit=f5b3bfc4b677db61fc7e49ce19829e2048f5be86


### PR DESCRIPTION
- Use boss ids instead of names