### PR TITLE
Custom Menu Swaps 2.5.15 - Munging fix.

### DIFF
--- a/plugins/hotkeyable-menu-swaps
+++ b/plugins/hotkeyable-menu-swaps
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/More-menu-entry-swaps.git
-commit=3640a13d7a30459026c380b3a295a11742894daf
+commit=15026c69c137228bf9f548404e5e23446d4c2caf


### PR DESCRIPTION
Jagex's munging was changed and the plugin had to have its munging updated.