### PR TITLE
Update quest-helper to 4.8.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=d3c0c9e6bffe6e484c8e12e46a5ba04082a7ee9f
+commit=285503a0ebc7d60d98e86fec4ff0b0adbd57208d


### PR DESCRIPTION
Crash fix in CoA and fixed minimap arrow not appearing at a distance.