### PR TITLE
Initiate better-npc-highlight takeover

### DIFF
--- a/plugins/better-npc-highlight
+++ b/plugins/better-npc-highlight
@@ -1,2 +1,2 @@
-repository=https://github.com/MoreBuchus/buchus-plugins.git
+repository=https://github.com/SamuelDev/buchus-plugins.git
 commit=356eb16d154bfc38b19a7b29b25e74f429025cb0


### PR DESCRIPTION
After making [this post](https://github.com/MoreBuchus/buchus-plugins/issues/124) in the better npc highlight plugin repo I have not received a reply within 1 week.

I am initiating step 2 of [the plugin takeover policy](https://github.com/runelite/runelite/wiki/Plugin-takeover-policy) by changing the plugin repo to one that I forked from the original owner.

Note: The original repo contains a number of branches for different plugins. I deleted those branches from the fork as I am only initiating this takeover for the `better npc highlight` plugin, not all plugins from that repo.