### PR TITLE
Create perryventory plugin

### DIFF
--- a/plugins/perryventory
+++ b/plugins/perryventory
@@ -1,0 +1,2 @@
+repository=https://github.com/Lunitar8/Perry.git
+commit=c3958324b3226ba32c131f70ab8f6729a6689a1a


### PR DESCRIPTION
Creating perryventory plugin for Permanent Inventory Mode. Whenever an item is dropped, consumed, equipped etc., the plugin leaves behind a placeholder shadow of that item, which limits your total inventory space to 28 over the course of the account.