### PR TITLE
Update better-npc-highlight

### DIFF
--- a/plugins/better-npc-highlight
+++ b/plugins/better-npc-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/MoreBuchus/buchus-plugins.git
-commit=356eb16d154bfc38b19a7b29b25e74f429025cb0
+commit=2fe1a1424a2d4a7d86c42570a6885b0dad07595e


### PR DESCRIPTION
Fixes issue turning off/on plugin by using Client Thread and updates cached npcs. Updated to version 1.1.0