### PR TITLE
Update quest-helper to 4.9.0

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=285503a0ebc7d60d98e86fec4ff0b0adbd57208d
+commit=ce6f12a3d60b684d2dc972d4717b86e0aed3020d


### PR DESCRIPTION
Adds a tree run helper, along with a fix for druid pouch IDs and missing huasca detection for patches.