### PR TITLE
Update cannon-damage

### DIFF
--- a/plugins/cannon-damage
+++ b/plugins/cannon-damage
@@ -1,3 +1,3 @@
 repository=https://github.com/DunkingOreos/Cannon-Damage.git
-commit=49143631bcd3ab0067f32604e4b0a9d5fa20ff10
+commit=b3c5fe74e9ca44157de7996823889e2b092be391
 authors=DunkingOreos,OzanKurt7,cultbaus,Laophy


### PR DESCRIPTION
Patch 1 - Updated plugin behavior to continue tracking even after cannon has been repaired.

Patch 2 - Updated overlay based on the changes made in patch 1.

Patch 3 - Updated README section for clarity on how the tracking starts/resets.