### PR TITLE
Create world-map-runes 0.1.3

### DIFF
--- a/plugins/world-map-runes
+++ b/plugins/world-map-runes
@@ -1,0 +1,2 @@
+repository=https://github.com/weiss-e/world-map-runes.git
+commit=82f7516f1497df6be74682034ec698a9dd8c8838


### PR DESCRIPTION
Creation of World Map Runes 0.1.3 (fixed package naming and deleted previous 2 commits)

This is a very simple plugin that shows the runes required for all spellbook teleport destinations in a human-friendly readable format within the existing tooltip generated by the World Map RuneLite plugin. It's compatible with the default World Map plugin as well as all other plugins. It should be helpful to those who jump around the map a lot and are not always immediately aware of what runes are needed for a specific teleport - now you can just hover your mouse over any teleport icon on the map and see exactly what you need!