### PR TITLE
Add Polygon limiter

### DIFF
--- a/plugins/polygon-limiter
+++ b/plugins/polygon-limiter
@@ -1,0 +1,2 @@
+repository=https://github.com/Skretzo/runelite-plugins.git
+commit=91c300af565a68d1ba6df33ef916d0f9b1f312d6


### PR DESCRIPTION
A plugin that removes objects with a user-defined too many polygons to improve performance. Also useful as a green screen plugin in combination with the skybox plugin.