### PR TITLE
Add clean-chat

### DIFF
--- a/plugins/clean-chat
+++ b/plugins/clean-chat
@@ -1,0 +1,2 @@
+repository=https://github.com/ldavid432/chat-cleanup.git
+commit=b3285e18d7588e598b12e14940a7f63a7865cce2


### PR DESCRIPTION
Adds options to clean up chat channels
- Blocks startup messages (i.e. "to talk in this channel type //////" etc.)
- Remove channel names (friends,clan, guest clan, GIM)
- Remove GIM broadcasts from the clan channel (only show in group channel)

The name removal is accomplished by removing the existing message and sending a new one with a different ChatMessageType (one which does not require a sender but shows up in the same tab)

In the case of clan chats the only viable type to map to was the clan challenge so we also have to disable the menu entries for that.

It's a bit hacky but it works... I did make the subscribe priority on the chat messages lower (-1) so that it should hopefully interfere with other plugins as little as possible.