### PR TITLE
add guardians-of-the-rift-optimizer

### DIFF
--- a/plugins/guardians-of-the-rift
+++ b/plugins/guardians-of-the-rift
@@ -1,0 +1,2 @@
+repository=https://github.com/hawolt/guardian-of-the-rift.git
+commit=cf15e39ca62fe40ad9a7e7d761391ba183b1c485

--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=5e141f7be16b0933b94f339a171e5e2292d2d594
+commit=cb8ae213191b3031a9e31e319d9361ffe2ba9992

--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=6bff502d685248d956dbd0947e5bf206a0890fd0
+commit=f73229c621af2f3c8a31eb8362cd1334e8e0671e

--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=f73229c621af2f3c8a31eb8362cd1334e8e0671e
+commit=0de8f5472347e2819af39db48c2ca1face201398

--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=14b2d577884ec5dd79cf117560860ca592850b2e
+commit=61b61a48d6e392dcd34861b98a8f474649e599a6

--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=97e9cc193f0675fcf386e36359dbe67f6e94c672
+commit=14b2d577884ec5dd79cf117560860ca592850b2e

--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=bc2a83bedc52c9a9c2cc8e3e8ce707f02e617a82
+commit=213983547e4cd7f245d5ed9111fba9c76d8a8ff1

--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=0de8f5472347e2819af39db48c2ca1face201398
+commit=bc2a83bedc52c9a9c2cc8e3e8ce707f02e617a82

--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=61b61a48d6e392dcd34861b98a8f474649e599a6
+commit=6bff502d685248d956dbd0947e5bf206a0890fd0

--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=cf15e39ca62fe40ad9a7e7d761391ba183b1c485
+commit=97e9cc193f0675fcf386e36359dbe67f6e94c672

--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=213983547e4cd7f245d5ed9111fba9c76d8a8ff1
+commit=5e141f7be16b0933b94f339a171e5e2292d2d594


### PR DESCRIPTION
this plugin is both a quality of life plugin as a minmax plugin to optimize experience gained during the minigame.

it provides various options for additional information display, highlighting and menu swapping in addition to calculating the best guardian to take by using the total tiles you have to walk and the experience you will get in the end.