### PR TITLE
Update chance-man to v2.1.2

### DIFF
--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=b0305c18c7f77135d2b81feeaa380442a40b0bac
+commit=eefcba690e71bc18cbfed5e6d34cc76ae4e1256d

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=c034fec6b6d53d221308fe99f8d349baaf97644d
+commit=b0305c18c7f77135d2b81feeaa380442a40b0bac


### PR DESCRIPTION
Normalize item ID handling, fix Clean/Rub, and add rune pouch & fountain support

- Introduce `getItemId(...)` in ActionHandler to unify raw, inventory, and ground item ID lookup, and canonicalize for all checks
- Special‑case “Clean” and “Rub” menu options so they always appear (greyed out when locked), and remove ground‑item actions from the global disabled list
- Extend `RuneProvider` with blighted‑sack entries (Surge, Entangle, Teleblock, Vengeance, Ice Barrage) so unlocked spell‑sacks supply the correct runes
- In `Restrictions`, define a Fountain of Rune `WorldArea` and short‑circuit `isSpellOpEnabled()` there for free casting
- Integrate rune pouch contents into `availableRunes` by reading explicit type/amount varbits and decoding with the pouch enum