### PR TITLE
update fortis-colosseum to v1.6.0

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=b84947c73f458c7b87a812b93241f0c0e8fcd867
+commit=13d59c9422c3f5fa957f4a213a021eae4c273c5c


### PR DESCRIPTION
adds a volatility reminder on npc death

does not indicate radius to remain within guidelines