### PR TITLE
Add Gymlocked Tracker plugin

### DIFF
--- a/plugins/gymlocked-tracker
+++ b/plugins/gymlocked-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/pdewit/gymlocked-tracker.git
-commit=f4a4cbd79d12bda1b77d8bdd825046c2eec26e25
+commit=26964e5f6203ef789574fe03ce76ec45e032b955

--- a/plugins/gymlocked-tracker
+++ b/plugins/gymlocked-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/pdewit/gymlocked-tracker.git
-commit=26964e5f6203ef789574fe03ce76ec45e032b955
+commit=da0b67cf8011a525e50e32108803be2828bce603

--- a/plugins/gymlocked-tracker
+++ b/plugins/gymlocked-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/pdewit/gymlocked-tracker.git
+commit=f4a4cbd79d12bda1b77d8bdd825046c2eec26e25


### PR DESCRIPTION
This PR adds a plugin called Gymlocked Tracker. This is a plugin made for an XP locked account by Zidria with the following rules:

You can only gain XP in game if you unlock them IRL by getting fit. For example:

(Body)Weight training (per rep) = 2,000xp  
Running (per 1km) = 15,000xp  
Walking (per step) = 5xp  
Eating protein (per gram) = 1,000xp  
Calories (per calorie overage) = -25xp  
Sleeping & waking on time = 50,000xp  
Meditate (per session) = 25,000xp  

Once you've built up XP IRL you can add them via the plugin and start playing. When the counter hits 0 you'll be Gymlocked.

Game your way towards a healthy life!