### PR TITLE
add ardougne-cooldown-timer

### DIFF
--- a/plugins/ardougne-cooldown-timer
+++ b/plugins/ardougne-cooldown-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/coopermor/ardougne-cooldown-timer.git
+commit=d415dac3610a9a699af5ecc315fbe4bb7a9dc6af

--- a/plugins/ardougne-cooldown-timer
+++ b/plugins/ardougne-cooldown-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/coopermor/ardougne-cooldown-timer.git
-commit=d415dac3610a9a699af5ecc315fbe4bb7a9dc6af
+commit=2acdc416965a148d6f734da48e4b31356dcb9890


### PR DESCRIPTION
This plugin adds an infobox when completing Ardougne rooftop agility for the purposes of force spawning marks of grace while skilling at a bank.