### PR TITLE
Update IRC to v1.1.2 (f956734)

### DIFF
--- a/plugins/irc
+++ b/plugins/irc
@@ -1,4 +1,4 @@
 repository=https://github.com/ryanwohara/irc-plugin.git
-commit=dcbe061ba251af31d32f2cbaafe1f2d322f4d5c2
+commit=f956734fcecd47222d6b76806c17fff21d438da3
 warning=This plugin submits your IP address and applicable IRC messages to a third-party server not controlled by the RuneLite developers.
 authors=ryanwohara


### PR DESCRIPTION
* Changes the full plugin name within the hub to be more descriptive (turns out folks don't know what IRC is)
* Add `:` to URLs to support wikis