### PR TITLE
add alternative-click

### DIFF
--- a/plugins/alternative-click
+++ b/plugins/alternative-click
@@ -1,0 +1,2 @@
+repository=https://github.com/ErikOverflow/Alternative-Click.git
+commit=233b0b0a029d7712d29c846097260ed54d43ee79


### PR DESCRIPTION
Introduces the ability to remap a keyboard key to act as a mouse button press, following the 1:1 mapping rule.

Jagex providing confirmation can be found here: https://x.com/JagexSupport/status/1793498663995544037