### PR TITLE
Move from deprecated ids to gamevals

### DIFF
--- a/plugins/wikisync
+++ b/plugins/wikisync
@@ -1,4 +1,4 @@
 repository=https://github.com/weirdgloop/WikiSync.git
-commit=2c2d047ba55da9f0feed0413395c80cbe157c92a
+commit=4d9ebe27be9104ec9f80aeb733a7a4e72579a52b
 warning=Similar to the official HiScores, this plugin pushes up data about your character that can be viewed by anyone.<br>We don't suggest using this if you are (for example) a PvP-locked hardcore ironman, where broadcasting your<br>quest status could be detrimental to your account by giving away information about what you're currently doing.
 authors=andmcadams,leejt,lezed1,jayktaylor


### PR DESCRIPTION
Just moves from raw ids and deprecated VarbitID-like defs to the new gameval values