### PR TITLE
Update skill-data-exporter readme

### DIFF
--- a/plugins/skill-data-exporter
+++ b/plugins/skill-data-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/cmhainesii/skill_data_exporter.git
-commit=73c50227add1e58a26f9ad4723d0cdfc112984b7
+commit=c2ed3de7731338b99d00e1f703e59ccdbab9ffd1


### PR DESCRIPTION
fixed documented default output directory from ~ to runelite_dir/skill_data_exporter