### PR TITLE
Add Ground Marker Profiles plugin

### DIFF
--- a/plugins/ground-marker-profiles
+++ b/plugins/ground-marker-profiles
@@ -1,0 +1,2 @@
+repository=https://github.com/DangItOSRS/ground-marker-roles.git
+commit=ec274f97cc684e90a1461d3b691faf51b52ece85


### PR DESCRIPTION
- Expected use case is for thieving room in cox, switching between sets of tiles based on team size and whether or not telegrab is used
- Based off of tile packs/nyloer
- Sidebar for switching between sets of tiles with the click of a button
- Up to 10 sets of tiles, able to name buttons via the config
- Only one set of tiles is selected at a time