### PR TITLE
Update npc-max-hit to 1.2.0

### DIFF
--- a/plugins/npc-max-hit
+++ b/plugins/npc-max-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/npc-max-hit.git
-commit=9cd8e00fce5f05590d703b754481099d6fc5350b
+commit=aca6c2c914cb314fb43f2697d6d10c40691609a1

--- a/plugins/npc-max-hit
+++ b/plugins/npc-max-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/npc-max-hit.git
-commit=aca6c2c914cb314fb43f2697d6d10c40691609a1
+commit=d71773d3b4f248c03b3de53201b802d271232a99


### PR DESCRIPTION
fixes couple issues and adds a new config
- fix: truncate displayed max hits when exceeding 25 chars
- fix: handle computing max hits with "x" such as `12x2` when displaying highest max hit and fallback to "?"
- add lookup command for testing
- add ability to show max hit value in npc right-click menus