### PR TITLE
Update ge-filters to new working version 1.13

### DIFF
--- a/plugins/ge-filters
+++ b/plugins/ge-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/GE-Filters.git
-commit=0128abaef76aaa9d12ef7b2e18b67e75fa911a1c
+commit=257106ad6e88ada9154829bbb5db8a989a694264

--- a/plugins/ge-filters
+++ b/plugins/ge-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/GE-Filters.git
-commit=07db329c4cda7411f7a9ed13cd1fdd70c1808f93
+commit=a2a1f66a3343cdafc02bbc83e96c2d63c746baa1

--- a/plugins/ge-filters
+++ b/plugins/ge-filters
@@ -1,2 +1,3 @@
 repository=https://github.com/salverrs/GE-Filters.git
 commit=a2a1f66a3343cdafc02bbc83e96c2d63c746baa1
+author=Nick2bad4u, Salverss

--- a/plugins/ge-filters
+++ b/plugins/ge-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/salverrs/GE-Filters.git
-commit=257106ad6e88ada9154829bbb5db8a989a694264
+commit=07db329c4cda7411f7a9ed13cd1fdd70c1808f93


### PR DESCRIPTION
Update ge-filters to new working version 1.13

Pushing update for @salverrs as I am a contributor on the project. 
_(Have edit permission to merge mine / other changes - Salverss has been offline for a while, so I pushed a new update for him)_

Had to match new IDs for widgets.

Project Repo: [GEFilters Repo](https://github.com/salverrs/GE-Filters/)

Contributors: [GEFilters Contribs](https://github.com/salverrs/GE-Filters/graphs/contributors)

Commits: [https://github.com/salverrs/GE-Filters/commits/master/](https://github.com/salverrs/GE-Filters/commits/master/)

Latest Hash: a2a1f66a3343cdafc02bbc83e96c2d63c746baa1[https://github.com/salverrs/GE-Filters/tree/a2a1f66a3343cdafc02bbc83e96c2d63c746baa1](https://github.com/salverrs/GE-Filters/tree/a2a1f66a3343cdafc02bbc83e96c2d63c746baa1)