### PR TITLE
Create EventTools-Attendance

### DIFF
--- a/plugins/EventTools-Attendance
+++ b/plugins/EventTools-Attendance
@@ -1,0 +1,2 @@
+repository=https://github.com/jeromkiller/EventTools-AttendanceCounter.git
+commit=f1de5fe8be1b5b609cd595ea78ad667bd27b0ae1

--- a/plugins/EventTools-Attendance
+++ b/plugins/EventTools-Attendance
@@ -1,2 +1,0 @@
-repository=https://github.com/jeromkiller/EventTools-AttendanceCounter.git
-commit=f1de5fe8be1b5b609cd595ea78ad667bd27b0ae1

--- a/plugins/eventtools-attendance
+++ b/plugins/eventtools-attendance
@@ -1,0 +1,2 @@
+repository=https://github.com/jeromkiller/EventTools-AttendanceCounter.git
+commit=f1de5fe8be1b5b609cd595ea78ad667bd27b0ae1


### PR DESCRIPTION
I've heard event hosts on the OSRS discord have been using an emergent feature from the Hide-and-seek-tracker plugin to count general attendance for their events.

I've mentioned this feature in the readme of that plugin.

To make the life of these hosts a little easier I decided to pair this feature off into its own plugin. So its easier for them to find what they're looking for.

Hosts are able to setup a capture area in the world, any new players entering this area will be counted as a participant to the event.
