### PR TITLE
Reskinned nightmare black swirlies with black square

### DIFF
--- a/plugins/NightmareShadowHighlight
+++ b/plugins/NightmareShadowHighlight
@@ -1,0 +1,2 @@
+repository=https://github.com/touchtouch105/NightmareShadowsPlugin.git
+commit=99acc2bd16c8983f7b7434fd4a53fb62f12a20c8

--- a/plugins/nightmareshadowhighlight
+++ b/plugins/nightmareshadowhighlight
@@ -1,2 +1,2 @@
 repository=https://github.com/touchtouch105/NightmareShadowsPlugin.git
-commit=7d388fd4a9b09f1f7fbf84524906f5c4aa970134
+commit=92484f01c791540b2da3f7158450fe39893e9fe2

--- a/plugins/nightmareshadowhighlight
+++ b/plugins/nightmareshadowhighlight
@@ -1,2 +1,2 @@
 repository=https://github.com/touchtouch105/NightmareShadowsPlugin.git
-commit=99acc2bd16c8983f7b7434fd4a53fb62f12a20c8
+commit=fb9b601f0f7d33b4cb18a48e884db5783b2e36ad

--- a/plugins/nightmareshadowhighlight
+++ b/plugins/nightmareshadowhighlight
@@ -1,2 +1,2 @@
 repository=https://github.com/touchtouch105/NightmareShadowsPlugin.git
-commit=fb9b601f0f7d33b4cb18a48e884db5783b2e36ad
+commit=7d388fd4a9b09f1f7fbf84524906f5c4aa970134


### PR DESCRIPTION
Updated revision of last pull request to meet tos, this time met same standards as vardorvis projectiles. Deletes original version of swirly, fully replaces it with solid black tile, no additional information given. Useful for those who have to squint at those dang swirlies to see them in time