### PR TITLE
Create tangletracker

### DIFF
--- a/plugins/tangletracker
+++ b/plugins/tangletracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Cwallis-Dev/tangle-tracker
+commit=50154932f8b0abc41bb32c1c48a7a05fad97ab9d


### PR DESCRIPTION
Creating tangletracker plugin which is a plugin I created to track farming actions and add them to a side panel so you can know how dry you may be for obtaining tangleroot.