### PR TITLE
Update chance-man to v2.1.5

### DIFF
--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=6780f5e98ba39b4be7ef5996d67805dc5f8fcd02
+commit=1c255ab00b0d34b75093b5ee7c0b5b0b4454ec52

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=e6ef035eda612201df82a57ec269470b6979eddb
+commit=6780f5e98ba39b4be7ef5996d67805dc5f8fcd02


### PR DESCRIPTION
- bypass spell restrictions for Blighted Surge Sack
- add option to disable rolling f2p trade only items
- add FreeToPlayBlockedItems enum for items that cannot be self-sufficiently obtained on f2p
- add option to filter out f2p items that cannot be self-sufficiently obtained on f2p