### PR TITLE
Update Embargo to 1.4.1

### DIFF
--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=0a2a10e3dc4bcdf98ffe2d518819308fab1a6bc1
+commit=2498e02856a93cbf7f720bf6411b4f1a995e0b66
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=4bfc2cb0349ade278305d553df4ccc4cb194e34b
+commit=0a2a10e3dc4bcdf98ffe2d518819308fab1a6bc1
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github


### PR DESCRIPTION
- Bump version to 1.4.1
- Add timeout to isUserRegistered method in case of API failures
    - If the API was down, the plugin would freeze due to looping requests. Reduce timeout to 2 seconds, add a minute cooldown on the API call
- Populate untradable item icons in the side panel by having the API pass itemIDs for them instead of names
- Change default side panel to match what it used to be (not signed in, log in to send data to Embargo) + reset it on logOut() as intended
- Only add wiki link to items that are found. This prevents "EHB/EHP/| items" from linking to nonsense wikipedia links

--
Sorry for the PR so quickly after the last one, this one was somewhat urgent as it was locking people's clients on login when the API was down. 