### PR TITLE
Add Forestry-Spawn-Helper plugin

### DIFF
--- a/plugins/forestry-spawn-helper
+++ b/plugins/forestry-spawn-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Oelderoth/forestry-force-spawn-plugin.git
-commit=4120c27f162b62c9f07b2c74f3b63911558599a5
+commit=3a98efbe2f920d157d42ccade4aa342474025234

--- a/plugins/forestry-spawn-helper
+++ b/plugins/forestry-spawn-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Oelderoth/forestry-force-spawn-plugin.git
+commit=65879b25c3f8dcd17aba401c9b7e6153b5fd6acc

--- a/plugins/forestry-spawn-helper
+++ b/plugins/forestry-spawn-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Oelderoth/forestry-force-spawn-plugin.git
-commit=65879b25c3f8dcd17aba401c9b7e6153b5fd6acc
+commit=4120c27f162b62c9f07b2c74f3b63911558599a5


### PR DESCRIPTION
A plugin to assist with force spawning Forestry events by:
- Highlighting trees that are eligible to spawn an event after one skilling roll has occurred, to let the player know they can safely log out/hop worlds
- Detecting when a player logs out or hops worlds while cutting an eligible tree and tracking the tree, world, and time until despawn. Tracked trees on the current world are highlighted, based on whether they're ready to be harvested or not
- Allowing a player to quickly see how much time is remaining on all tracked trees
- Allowing a player to quickly hop to worlds where tracked trees are ready to be harvested
- Letting the player configure what trees are tracked, highlight styles for in-progress and ready-to-harvest trees, and the order that tracked trees are displayed in the side panel

Plugin Repo: https://github.com/Oelderoth/forestry-force-spawn-plugin/commits/master

