### PR TITLE
Create hide-chat

### DIFF
--- a/plugins/hide-chat
+++ b/plugins/hide-chat
@@ -1,0 +1,2 @@
+repository=https://github.com/Jordanza21/hide-chat.git
+commit=f3d4d76e57f192907d58261b7fc59045b9cb5623


### PR DESCRIPTION
A plugin to hide the Chatbox widget from the user interface via a toggle option in the configuration of the plugin.