### PR TITLE
Update npc-max-hit to 1.2.1

### DIFF
--- a/plugins/npc-max-hit
+++ b/plugins/npc-max-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/npc-max-hit.git
-commit=b083a8d09811cf58dd0ea902c06d5fdf7e6937db
+commit=5ebffe8c01e7d8fd7e4005de07528758a242fb5f

--- a/plugins/npc-max-hit
+++ b/plugins/npc-max-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/npc-max-hit.git
-commit=5ebffe8c01e7d8fd7e4005de07528758a242fb5f
+commit=0871682bb1468d9c0bc30ae724104576ef2bd8aa

--- a/plugins/npc-max-hit
+++ b/plugins/npc-max-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/npc-max-hit.git
-commit=0871682bb1468d9c0bc30ae724104576ef2bd8aa
+commit=21d245194ec2188b929ea85112d888a3f945f18c

--- a/plugins/npc-max-hit
+++ b/plugins/npc-max-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/npc-max-hit.git
-commit=d71773d3b4f248c03b3de53201b802d271232a99
+commit=b083a8d09811cf58dd0ea902c06d5fdf7e6937db


### PR DESCRIPTION
- fixes a nasty lag when synchronously attempting to use cached data first but falls back to an http request that fails. changed to only use cached values and do nothing if not found
- checks for inflight requests before making them to ensure no duplicate requests are made simultaneously
- minor change to use `onMenuOptionClicked` instead of attaching `onClick` within `onMenuEntryAdded`
