### PR TITLE
Update clean-chat to 1.0.7

### DIFF
--- a/plugins/clean-chat
+++ b/plugins/clean-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/chat-cleanup.git
-commit=ad1c185b8ac89a34b7765b498d86cab65489e152
+commit=c56ddedadc5c522f4a959a7653d4cd60d226c367


### PR DESCRIPTION
Wouldn't let me reopen cause I force pushed, oops

- Add icon
- Some readme updates
- Fix chat commands breaking
  - Fixes ldavid432/chat-cleanup#2
- Fix timestamps
- Fix right-click username being wrong
  - Fixes ldavid432/chat-cleanup#4