### PR TITLE
Added PvP Zone Warning plugin

### DIFF
--- a/plugins/pvp-zone-warning
+++ b/plugins/pvp-zone-warning
@@ -1,2 +1,2 @@
 repository=https://github.com/XirevGH/pvp-zone-warning.git
-commit=ac12d40c7f61de7ce22e4aaea3ed025a32496450
+commit=0588223179454369f504aec16f5f989324193d34

--- a/plugins/pvp-zone-warning
+++ b/plugins/pvp-zone-warning
@@ -1,0 +1,2 @@
+repository=https://github.com/XirevGH/pvp-zone-warning.git
+commit=ac12d40c7f61de7ce22e4aaea3ed025a32496450


### PR DESCRIPTION
This plugin enhances the visibility of the skull icon that tells the player that they are in a PvP enabled area by triggering a notification when the state of the icon changes. This is intended to remind players that are not paying attention to the skull icon that they can now be attacked. For example if the player logged out in a PvP world, forgot and didn't notice the skull icon, then went on to do something without the intent of PKing, this would give a clear reminder that they are about to do something dangerous. (Totally not what happened to me and the reason I made this plugin)