### PR TITLE
Add Untrimmed Slayer Cape Helper Plugin

### DIFF
--- a/plugins/untrimmed-slayer-cape-helper
+++ b/plugins/untrimmed-slayer-cape-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/clairemira/untrimmed-slayer-cape-helper.git
+commit=ded55d7bf51eee48cc674f7cffc3242fbee484f7


### PR DESCRIPTION
- A clan member asked if I could create a RuneLite plugin which provides helpful information to obtain an untrimmed 99 slayer cape. There are a few members in our clan that are after this kind of plugin, as they currently use an excel sheet to obtain the calculation but the data has to inputted manually.
- The plugin displays an overlay panel indicator for how much "Cannon Slayer XP" is required to reach 99 Slayer at the same time as 99 Hitpoints
- As per RuneLite's plugin guidelines to not bloat the plugin database; I first checked to see if a plugin like this existed but didn't come across anything similar. I have given a generic name to this plugin so that further functionality can be added to this plugin either by myself or other contributors. As the repository owner I will be willing to implement any feature requests that get submitted by anyone, and am fully willing to work with other contributors.