### PR TITLE
Create special-attack-orb-hider

### DIFF
--- a/plugins/special-attack-orb-hider
+++ b/plugins/special-attack-orb-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/adnapPanda/special-attack-orb-hider.git
+commit=345f96bf2fd60f9b5301ab4bf48ec102143e4b2f

--- a/plugins/special-attack-orb-hider
+++ b/plugins/special-attack-orb-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/adnapPanda/special-attack-orb-hider.git
-commit=345f96bf2fd60f9b5301ab4bf48ec102143e4b2f
+commit=331c3e21232e510c4b83ec60ca9f7987a8703105


### PR DESCRIPTION
Added a new plugin that hides the special attack orb for specified weapons. This will allow players to not accidentally spec with undesired weapons like the abyssal whip.

Alternatively there's also an option to hide the orb for all weapons if desired