### PR TITLE
 Update 1.1 Collection-Tracker

### DIFF
--- a/plugins/collection-tracker
+++ b/plugins/collection-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/voltmaister/collection-tracker.git
-commit=8e22d93eabb571122dcf8f528b2c0ace728a71b0
+commit=28b588492c14a91f3e0361aa7e6e7c241d848aab
 warning=This plugin submits your username and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/collection-tracker
+++ b/plugins/collection-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/voltmaister/collection-tracker.git
-commit=28b588492c14a91f3e0361aa7e6e7c241d848aab
+commit=882aaa81f70914a69ff76a887ae722bea838d3f1
 warning=This plugin submits your username and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/collection-tracker
+++ b/plugins/collection-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/voltmaister/collection-tracker.git
-commit=882aaa81f70914a69ff76a887ae722bea838d3f1
+commit=0591fd8e18c597e0a300b9af26da587550f66cb9
 warning=This plugin submits your username and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Fixed names with multiple spaces in the name (this time for sure) changed normalize function to replace non-breaking spaces with regular spaces and added more aliases
Apologies for the frequent PRs — I discovered that the bug had been fixed in the test environment but not in production, so I needed to push a quick fix to address it.