### PR TITLE
Update identificator to 1.8.4

### DIFF
--- a/plugins/identificator
+++ b/plugins/identificator
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/runelite-plugins.git
-commit=0d9db8ebb7986f0d4de483bcbd2a71251548bf47
+commit=476ac7c57cfd7f743a4ce49b8d74c67e6d9a4b34


### PR DESCRIPTION
- Use the correct bitfield for tile object type and game object