### PR TITLE
DropTracker webhook fixes

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=9fbddd158934fa5e8d91c6e0db7cc1e2db1d3673
+commit=a369415c5492dcba2e9c23ae090d0ede08f74212
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=a369415c5492dcba2e9c23ae090d0ede08f74212
+commit=24819d73b29222eada26cbba4576884bda9b13c6
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
Adds a simple change to the logic for loading our list of webhook URLs, so that it can be performed on plugin startup as opposed to relying on the first submission the player receives to populate the list.