### PR TITLE
Update clogged-me to v1.1.1

### DIFF
--- a/plugins/clogged-me
+++ b/plugins/clogged-me
@@ -1,3 +1,3 @@
 repository=https://github.com/Advistane/clogged.git
-commit=bd652eac1af0d41ebe859c6c1553d5f579fe289c
+commit=5ad132c6aed2579a6c3b25b00d01f936a9a87ed3
 warning=This plugin submits your IP address, username, and collection log data to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Removed parenthesis in response for quantities.

Added option to view missing items in clog.

Added option to show total items in clog.

Removed ToB entry mode from KC count because you can't get uniques from entry mode.

Fixed issue where "!clog sync" would trigger syncing even if the player wasn't the author.