### PR TITLE
Update loot-filters to v1.9.2

### DIFF
--- a/plugins/loot-filters
+++ b/plugins/loot-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/riktenx/loot-filters.git
-commit=61c23297ff3e6c3cb700e09134d5ef19b533674d
+commit=643b2ddf0f79405e9786b115d65fdeecfbc6e95d


### PR DESCRIPTION
1-line fix for major FPS drops when hovering over a large item pile