### PR TITLE
Create Loot Chance plugin

### DIFF
--- a/plugins/lootchance
+++ b/plugins/lootchance
@@ -1,2 +1,2 @@
 repository=https://github.com/Sloshedd/Loot-Chance.git
-commit=63b3a32141fe601ac28584d50ef0c06f58fe0e54
+commit=95b65dc5328d5fcc57ae8858edd131fdda4f883c

--- a/plugins/lootchance
+++ b/plugins/lootchance
@@ -1,0 +1,2 @@
+repository=https://github.com/Sloshedd/Loot-Chance.git
+commit=63b3a32141fe601ac28584d50ef0c06f58fe0e54

--- a/plugins/lootchance
+++ b/plugins/lootchance
@@ -1,2 +1,2 @@
 repository=https://github.com/Sloshedd/Loot-Chance.git
-commit=95b65dc5328d5fcc57ae8858edd131fdda4f883c
+commit=646686aabca6a56bd93550ee5ea3297838500c23


### PR DESCRIPTION
Loot Chance is a plugin that helps you track base drop rates and calculate your odds of receiving unique items based on your current kill or loot count while factoring in table chance. Additionally, features a probability calculator with inputs for base chance, table chance, and kill count. It supports data from the OSRS Wiki and presents it in a clean, OSRS-themed panel. Data is pulled from a local Json and png icons for offline use and less-frequent updates. Locally re-running a scraper for new content (loot sources/data and icons) and committing on major updates is all that is required. Using local custom scrapers, it gathers not just monsters but anything that might give you loot including scenery (minigames and clues in an update).