### PR TITLE
Update droptracker to v3.83

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=24819d73b29222eada26cbba4576884bda9b13c6
+commit=f4735c7d6b3626787c4f811260886033c6ab9b4a
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
Improvements to our webhook handling
Fixed PB tracking for Grotesque Guardians, Inferno and Fight Caves
