### PR TITLE
Upgrade clean-chat to 1.0.9

### DIFF
--- a/plugins/clean-chat
+++ b/plugins/clean-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/chat-cleanup.git
-commit=c56ddedadc5c522f4a959a7653d4cd60d226c367
+commit=de72c9051dca1eeee0455c0df2de6908afc99bff


### PR DESCRIPTION
- read MessageNode message instead of event message
  - Fixes ldavid432/chat-cleanup#3
- Switch to singleThreadScheduledExecutor