### PR TITLE
Update godbook to v1.0.3

### DIFF
--- a/plugins/godbook
+++ b/plugins/godbook
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/godbook.git
-commit=62e4b93ad66705c4d900cef1dab85b64aa608914
+commit=95d73dcc41b10367a39761e1c4fd8030cdf3b105


### PR DESCRIPTION
Adds support for specific emotes to start the timer instead of just godbook preaches as well as a config option to restrict the overlay to instances instead of just ToB.