### PR TITLE
Update ca-export to 1.2.0

### DIFF
--- a/plugins/ca-export
+++ b/plugins/ca-export
@@ -1,2 +1,2 @@
 repository=https://github.com/cdfisher/ca-export.git
-commit=302a6106a7c49c7630a0072474b588ef20058f37
+commit=e45bf1eb6eb979fad3412c4417323083bb53230b

--- a/plugins/ca-export
+++ b/plugins/ca-export
@@ -1,2 +1,2 @@
 repository=https://github.com/cdfisher/ca-export.git
-commit=fb8b8c56da12f504a6e8e8fd79619ecd96b86324
+commit=302a6106a7c49c7630a0072474b588ef20058f37


### PR DESCRIPTION
- Migrates to using gamevals
- Cleans up CAFileWriter a little
- Adds an identifier to the exported filename to denote what sort of game profile it came from (Main game, DMM, Leagues, etc)