### PR TITLE
Add Discord Forwarder plugin

### DIFF
--- a/plugins/discord-forwarder.manifest.json
+++ b/plugins/discord-forwarder.manifest.json
@@ -1,0 +1,9 @@
+{
+  "internalName": "discordforwarder",
+  "displayName": "Discord Forwarder",
+  "description": "Forwards clan chat messages containing 'coffer' to a Discord webhook.",
+  "author": "shpg8642",
+  "tags": ["discord", "clan", "webhook", "chat"],
+  "repo": "https://github.com/spg8642/discord-forwarder",
+  "commit": "b9c6ac741a0b130f0930760626068a80c96e8505"
+}


### PR DESCRIPTION
This plugin forwards clan chat messages containing the word "coffer" to a user-defined Discord webhook.

- Filters only CLAN_CHAT messages
- Allows users to configure their webhook URL via the plugin settings
- Lightweight and useful for clan leadership or community bots

Author: shpg8642  
Repo: https://github.com/spg8642/discord-forwarder
