### PR TITLE
Update quest-helper to 4.9.2

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=1f56630051ea7d82fe75bb3a8b0d751f010ee116
+commit=9fd0a5ac056bde5c476923b282aba651a9a33edc

--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=9fd0a5ac056bde5c476923b282aba651a9a33edc
+commit=cd03a745e3849eb30df4ae388c4ed7d075b5214b


### PR DESCRIPTION
- Adds support for the NER plugin. This is using PluginMessage to open up info on items in addition to the existing wiki link on items, should you have the NER plugin installed
- Bunch of fixes for IDs and general improvements of older helpers