### PR TITLE
Update clue-details to 2.3.5.1

### DIFF
--- a/plugins/clue-details
+++ b/plugins/clue-details
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/clue-details.git
-commit=1aa14ece8154959f11dff0a13b441d84e3d0fe8b
+commit=a6353063f6d9803fcc6061521366e47fab411e3a
 authors=Zoinkwiz,TheLope


### PR DESCRIPTION
Small fix to ensure pre-existing ground clues which 'spawn' without a LOADING state don't get duplicated in tracking.