### PR TITLE
Update godbook to v1.0.4

### DIFF
--- a/plugins/godbook
+++ b/plugins/godbook
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/godbook.git
-commit=95d73dcc41b10367a39761e1c4fd8030cdf3b105
+commit=5601da9eee1aa408edb8e952bee0640d8db689de


### PR DESCRIPTION
Bugfix: The default config does not constrain the overlay to instances only and `Bob Barter (herbs)` likes to Think emote at the GE, so we'll need to filter all NPC's.