### PR TITLE
Simple kill statistics / kills per hour plugin

### DIFF
--- a/plugins/simple-kill-stats
+++ b/plugins/simple-kill-stats
@@ -1,0 +1,2 @@
+repository=https://github.com/fabianwesterbeek/simple-kc-stats.git
+commit=c1d80b72e23192981deab5c49a5b8cc357b24631


### PR DESCRIPTION
Adds a simple kills per hour tracker, customisable with NPC IDs/names. Similar to bossing info plugin but simpler, and does not only work for specific bosses/require updates for new bosses. 