### PR TITLE
Update Lucky Clan Bingo

### DIFF
--- a/plugins/lucky-clan-bingo
+++ b/plugins/lucky-clan-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/LuckyClanBingo.git
-commit=13e104894aa00a83dbaff84a806cb627a91772d6
+commit=ef24d495635319b1592a6cd248edc79715362d0b


### PR DESCRIPTION
Several item additions, spelling fixes and bug fixes.

Item additions:
- Oathplate helm, chest, and legs
- Soulflame horn
- Scurrius' spine
- Blood shard

Item name fixes:
- Ice and Fire elemental staff crown
- Revenant weapons
- Black tourmaline core

Bug fixes:
- Plugin no longer sends multiple webhook messages for unnoted item stacks which are in the item list. (dragon platelegs f. ex.)
- Whisperer, Araxxor and Royal Titans now proc plugin, previously did not due to different loot events
- PvP drops no longer proc the plugin when loot contains items from the item list
- Plugin no longer starts a new thread with every received Game message. Should decrease performance issues.

New features:
- PvP loot now only procs the plugin when total loot is over 1m value
- Items list is now ordered, and can differentiate comments (Python style, with # )
- Value numbers are now formatted