### PR TITLE
Adding warmth alert plugin to plugin hub

### DIFF
--- a/plugins/warmth-alert
+++ b/plugins/warmth-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/graceulinski/warmth-alert.git
-commit=22ac638ac016bd10eeafc5b4c007a76fe527ca28
+commit=3d4e6de7d97d1a5cde22a486a1ccb7add047927f

--- a/plugins/warmth-alert
+++ b/plugins/warmth-alert
@@ -1,0 +1,2 @@
+repository=https://github.com/graceulinski/warmth-alert.git
+commit=22ac638ac016bd10eeafc5b4c007a76fe527ca28


### PR DESCRIPTION
Warmth Alert plugin for Wintertodt allows you to set notifications and/or a colored overlay when your warmth falls below a specified level at the skilling boss. 