### PR TITLE
[Hotfix] Updates Emote Clue Items to v4.3.3.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=978e59df9b3d3301337cd7e7ee7cf53fb5c52ced
+commit=b8f2e3d290f6a7823e78bb270326dd19fdd19894


### PR DESCRIPTION
This update of Emote Clue Items features the following updates:

- Conforms to breaking changes in the RuneLite API. (see https://github.com/larsvansoest/emote-clue-items/issues/120, https://github.com/larsvansoest/emote-clue-items/pull/121)
- Fixes a typo in the name of STASH unit in Taverley. (see https://github.com/larsvansoest/emote-clue-items/issues/117)
- Fixes pointed blue snelm item listing. (see https://github.com/larsvansoest/emote-clue-items/pull/118)
- Fixes incorrect item requirement description text for sun fire elite clue. (see https://github.com/larsvansoest/emote-clue-items/pull/114)