### PR TITLE
Adding overhead-notifications to pluginhub

### DIFF
--- a/plugins/overhead-notifications
+++ b/plugins/overhead-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/Shuddie/overhead-notifications.git
+commit=7cb6673318d2bd71e9a521b5fc9396d0e79cf49c

--- a/plugins/overhead-notifications
+++ b/plugins/overhead-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/Shuddie/overhead-notifications.git
-commit=7cb6673318d2bd71e9a521b5fc9396d0e79cf49c
+commit=e768890b382b9a0f26ea28c6ed7f7315856367f5

--- a/plugins/overhead-notifications
+++ b/plugins/overhead-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/Shuddie/overhead-notifications.git
-commit=599fc523989d4e5d52c6d5553414297b45e48c74
+commit=24622739696980c1fef3d920534dbae858f784d4

--- a/plugins/overhead-notifications
+++ b/plugins/overhead-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/Shuddie/overhead-notifications.git
-commit=ee341d5bad996cc317ccebbf657b2538ca72b73f
+commit=a6ba21b971a9c47ea2bab4fbae6ad5253c578bc8

--- a/plugins/overhead-notifications
+++ b/plugins/overhead-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/Shuddie/overhead-notifications.git
-commit=e768890b382b9a0f26ea28c6ed7f7315856367f5
+commit=ee341d5bad996cc317ccebbf657b2538ca72b73f

--- a/plugins/overhead-notifications
+++ b/plugins/overhead-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/Shuddie/overhead-notifications.git
-commit=a6ba21b971a9c47ea2bab4fbae6ad5253c578bc8
+commit=0f9916efe080573447c2c22b98cf1c12137b266f

--- a/plugins/overhead-notifications
+++ b/plugins/overhead-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/Shuddie/overhead-notifications.git
-commit=0f9916efe080573447c2c22b98cf1c12137b266f
+commit=599fc523989d4e5d52c6d5553414297b45e48c74


### PR DESCRIPTION
Notification plugin that lets you do overhead text for stuff such as thralls, saturated heart, overloads and divine potions.

This is similar to the overhead option in Watchdog, but as Watchdog is restricted in most endgame pvm locations it's hard to benefit from it. this plugin uses hardcoded checks to avoid misuse for game message checks.

This restricts the overhead option to only be used with things that doesn't go against the game integrity and isn't limited to watchdog's limited areas.