### PR TITLE
Update Ge-Filters Support Link

### DIFF
--- a/plugins/ge-filters
+++ b/plugins/ge-filters
@@ -1,3 +1,3 @@
 repository=https://github.com/nick2bad4u/GE-Filters.git
-commit=5851376b18e91a65a942eb221b739c643902ab9b
+commit=54c7886eceef69724608a988f95cc8175d50cfe7
 authors=nick2bad4u, Salverrs


### PR DESCRIPTION
Support link for the old repo was never changed, this commit only changed the support url to the correct URL:

Commit in GE-Filter Repo: https://github.com/Nick2bad4u/GE-Filters/commit/54c7886eceef69724608a988f95cc8175d50cfe7

```support=https://github.com/salverrs/GE-Filters```
Changed to:
```support=https://github.com/Nick2bad4u/GE-Filters```

No other changes made.