### PR TITLE
Upgrade gauntlet-chest-popup to 1.2.0

### DIFF
--- a/plugins/gauntlet-chest-popup
+++ b/plugins/gauntlet-chest-popup
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/gauntlet-loot-popup.git
-commit=42e5a5c41f6bfb5cfc88923d1984eed67b9d7870
+commit=fadef2ecb8c49ca286ce8285cb935ef65527c3a3


### PR DESCRIPTION
- Use ServerNpcLoot
  - Also still using LootReceived since ServerNpcLoot isn't totally ironed out, will remove it next week
- Add an option to auto-detect chest title and color since ServerNpcLoot contains which hunllef was killed