### PR TITLE
Update DropTracker to v3.9

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=07e53ab5420a0ce0d724de2bf7c4430b6f9602cc
+commit=6a959823c54d95e3c5d98de15e3b4b5bb9f72a12
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=e2657f66cf3de48ba91386602f0239d5e1dff2d0
+commit=b552575c5d959f9ffb946d768fa88903625e213b
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=94707eb5163da11dc0c3f4fe94ab11d0198169d6
+commit=07e53ab5420a0ce0d724de2bf7c4430b6f9602cc
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=6a959823c54d95e3c5d98de15e3b4b5bb9f72a12
+commit=e2657f66cf3de48ba91386602f0239d5e1dff2d0
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=f4735c7d6b3626787c4f811260886033c6ab9b4a
+commit=94707eb5163da11dc0c3f4fe94ab11d0198169d6
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
Due to some recent unfortunate events, we've been forced to take a bit of a different approach to ensuring we can accurately track players' drops/achievements; namely:
- No longer embedding the encryption key for our webhooks directly inside the client, and instead "dynamically" loading it on startup so that it can be changed
- Using a different repository name and file naming scheme
We also needed to re-implement the ability for players to send their submissions directly to our server instead of relying on pesky Discord webhooks; which are susceptible to a number of problems when used in the context we've been using them for years.

We also changed a few things to clean up the code structure and add proper tracking functionality to Yama.

All outbound connections from the client are still prefaced with the configuration option for enabling the API; to stay in line with guidelines.