### PR TITLE
Add the Soulflame Horn Buff plugin to the plugin hub

### DIFF
--- a/plugins/soulflamehorn
+++ b/plugins/soulflamehorn
@@ -1,0 +1,2 @@
+repository=https://github.com/sim-macdonald/Soulflame-horn.git
+commit=9ccca435948c33850c3e2271b2a9f17b4b89c7f5


### PR DESCRIPTION
I made a plugin which tells me when I have the entice buff from the soulflame horn. It also plays a silly sound when the horn is used or the buff is received, and has characters using the horn say something. The overlay shows the number of ticks remaining to use the buff, and the overlay disappears when the character lands a melee attack (unless they are on defensive stance).