### PR TITLE
Update Untrimmed Slayer Cape Helper

### DIFF
--- a/plugins/untrimmed-slayer-cape-helper
+++ b/plugins/untrimmed-slayer-cape-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/clairemira/untrimmed-slayer-cape-helper.git
-commit=ded55d7bf51eee48cc674f7cffc3242fbee484f7
+commit=1a274c620c04b3f9fc8b66e12dcbe89ca6157e0c

--- a/plugins/untrimmed-slayer-cape-helper
+++ b/plugins/untrimmed-slayer-cape-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/clairemira/untrimmed-slayer-cape-helper.git
-commit=1a274c620c04b3f9fc8b66e12dcbe89ca6157e0c
+commit=96021ba3ee2de2408f8f93e43cc8f4e0c8b5639d


### PR DESCRIPTION
- Fix HP combat exp calculation to refer to 1.33 as per Wiki, instead of previously 1.3
- Added projected HP XP, which shows the player's expected HP XP after obtaining 99 slayer from standard combat
- Also added Slayer exp to 99 info text
- All above options can be toggled on/off in the config panel