### PR TITLE
Update Dink to v1.11.9

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=49691b45ec81b4c248dc8f4e7345665f3143e19e
+commit=83dd03d066bed455dd0347ab2ddae54a275e2304
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.11.9 improves yama/yami support and utilizes the slayer kill log as another kc source

Full release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.11.9
