### PR TITLE
Add Mark of Darkness Reminder plugin

### DIFF
--- a/plugins/mark-darkness-reminder
+++ b/plugins/mark-darkness-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/w0411725/mark-darkness-reminder.git
+commit=37265169d13b0b29e91cfdc92167c9b8a3792c72


### PR DESCRIPTION
This plugin reminds players to recast the Mark of Darkness spell from the Arceuus spellbook.

Features:
- Shows a simple overlay reminder when Mark of Darkness has expired
- Configurable notifications when Mark is about to expire
- Customizable reminder text and appearance
- Support for Purging Staff duration boost