### PR TITLE
Mark darkness reminder

### DIFF
--- a/plugins/mark-darkness-reminder
+++ b/plugins/mark-darkness-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/w0411725/mark-darkness-reminder.git
+commit=37265169d13b0b29e91cfdc92167c9b8a3792c72

--- a/plugins/mark-darkness-reminder
+++ b/plugins/mark-darkness-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/w0411725/mark-darkness-reminder.git
-commit=37265169d13b0b29e91cfdc92167c9b8a3792c72
+commit=3dc2dabf43388e7e390248f2ef39b5264f7b1918


### PR DESCRIPTION
This plugin reminds players to recast the Mark of Darkness spell from the Arceuus spellbook.

Features:
- Shows a simple overlay reminder when Mark of Darkness has expired
- Configurable notifications when Mark is about to expire
- Customizable reminder text and appearance
- Support for Purging Staff duration boost