### PR TITLE
Update goblin-scape-clan-plugin

### DIFF
--- a/plugins/goblin-scape-clan-plugin
+++ b/plugins/goblin-scape-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/s0lved/goblin-scape-clan-plugin.git
-commit=3a902fea5ec517237feb5d24680641c8e7b2fcf4
+commit=f845c34061c762f02f193e70cc13bc7c4d133eaf


### PR DESCRIPTION
New update to include clan broadcasts which can now be viewed on the website. Also added a redirect for those using the old application link.