### PR TITLE
Add mark of darkness helper plugin

### DIFF
--- a/plugins/mark-of-darkness-helper
+++ b/plugins/mark-of-darkness-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/elertan/mark-of-darkness-helper.git
-commit=c34e4c7122c8b7189bb8a133fa7f6e4cf3645ef9
+commit=3246fc338e017792acf743ba7e15c4935db9875d

--- a/plugins/mark-of-darkness-helper
+++ b/plugins/mark-of-darkness-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/elertan/mark-of-darkness-helper.git
+commit=42d34b68a39ae61414d16eaec03ecd626abd765d

--- a/plugins/mark-of-darkness-helper
+++ b/plugins/mark-of-darkness-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/elertan/mark-of-darkness-helper.git
-commit=42d34b68a39ae61414d16eaec03ecd626abd765d
+commit=c34e4c7122c8b7189bb8a133fa7f6e4cf3645ef9


### PR DESCRIPTION
A helper plugin similar to Thrall Helper that notifies the user when Mark of Darkness expires or is able to be cast again.