### PR TITLE
Update schboop

### DIFF
--- a/plugins/schboop
+++ b/plugins/schboop
@@ -1,2 +1,2 @@
 repository=https://github.com/katlande/kat-RL-plugins.git
-commit=2150333496c126dfc1d3a991db10d035a9c1f174
+commit=080e0c2f38f90de7746fc303b7071d95e92acadf


### PR DESCRIPTION
Apologies for updating again so immediately. I have to replace the newest .wav files with 16-bit ones as the plugin cannot handle the 32-bit version I had uploaded last commit.

I also removed a niche joke from the plugin that I didn't think anyone knew about, but the community noticed within an hour and is now requesting I restore it lol.