### PR TITLE
Add Sote Ball Highlighter

### DIFF
--- a/plugins/sote-ball-highlighter
+++ b/plugins/sote-ball-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/1jz/sote-ball-highlighter.git
+commit=f0c47a6e20344c558d08f3e9c60349c151a64f65

--- a/plugins/sote-ball-highlighter
+++ b/plugins/sote-ball-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/1jz/sote-ball-highlighter.git
-commit=f0c47a6e20344c558d08f3e9c60349c151a64f65
+commit=5abe6cf9595429366f5dbe42c1ba3dd4d2dbe6ed


### PR DESCRIPTION
This allows players to add an outline highlight to Sotetseg projectiles so they can see them under the boss which can be hidden due to render order. The plugin highlights default sote balls along with the ToA and Inferno themes from the TOB QoL plugin. The plugin only highlights these projectiles within the Sotetseg instance.