### PR TITLE
Update Loot Logger v4.3.2

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=aff886ee36e795e3c61446585a28775dfef715eb
+commit=63847a0138dcbe9b51cdb995fb5a6e4a978b2463


### PR DESCRIPTION
Fixes forgotten lockbox not showing in Yama boss tab