### PR TITLE
disable tictac7x-charges

### DIFF
--- a/plugins/tictac7x-charges
+++ b/plugins/tictac7x-charges
@@ -1,2 +1,3 @@
 repository=https://github.com/TicTac7x/runelite-plugins.git
 commit=8f524b5d02a992d7bc7af6f2b448bf20f0cf2ba0
+disabled=hiding all infoboxes


### PR DESCRIPTION
multiple reports of confused users having all their infoboxes hidden, even ones not created/managed by this plugin.