### PR TITLE
99 Notifier plugin

### DIFF
--- a/plugins/99-notifier
+++ b/plugins/99-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/neafey/99-notifier.git
-commit=d0d4209dd74e8ae140c71aa3d09fdfc08c404c14
+commit=4e253d9746071848698ebc4540e03b6ac3a0dc47

--- a/plugins/99-notifier
+++ b/plugins/99-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/neafey/99-notifier.git
+commit=d0d4209dd74e8ae140c71aa3d09fdfc08c404c14


### PR DESCRIPTION
A simple RuneLite plugin that notifies you when you're close to reaching level 99 in a skill.
Notifies you when you're within a configurable XP threshold from level 99
Supports all skills, individually toggleable in settings
In-game overlay with number of skills close to 99
Optional system notifications