### PR TITLE
Add bingosrs plugin

### DIFF
--- a/plugins/bingosrs
+++ b/plugins/bingosrs
@@ -1,0 +1,4 @@
+repository=https://github.com/mistereman22/bingosrs-runelite-plugin.git
+commit=728f3184c6bc8924c13760bf0794bb53d4d6a83c
+authors=mistereman22
+warning=This plugin sends player data, including usernames, screenshots, and IP address to a third-party server not controlled or verified by the RuneLite Developers, for tile verification.


### PR DESCRIPTION
This plugin is for use alongside the BingOSRS website: https://bingosrs.com/.

It will grab data on required drops from the server based on user configuration (bingo ID), and then listen for drops and submit a screenshot along with drop data when the player receives one of the required drops.