### PR TITLE
Update Embargo to 1.4.6

### DIFF
--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=b9434a87cf6d3afb664525aa790018452b3ef770
+commit=bfb2084cb10ebbb853f0b4c3f8bf75b05d65ea3f
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=cb77970702c63e99dc1809e89d5c044a4ae11832
+commit=af78dfcf2302c27e37dbf94bd30974573e0e0d22
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=af78dfcf2302c27e37dbf94bd30974573e0e0d22
+commit=1374e231e927724896ae58127d0818f1a4206cc0
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=1374e231e927724896ae58127d0818f1a4206cc0
+commit=0146251c53c9f9e101e70b97a436eba9e8441022
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Sharpienero/Embargo-Plugin.git
-commit=0146251c53c9f9e101e70b97a436eba9e8441022
+commit=b9434a87cf6d3afb664525aa790018452b3ef770
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github


### PR DESCRIPTION
- Adds a command to display clan rank inside of the text chat.
    - There is a cache server side that caches the original request for n seconds to allow the command to be processed by all clients running 1.4.6

![image](https://github.com/user-attachments/assets/341f0145-4df6-466b-82af-80acf2e3f362)

Configurable in the plugin settings: 
![image](https://github.com/user-attachments/assets/5905be10-f876-48e7-b6e6-2394d891c3f2)
