### PR TITLE
Update chance-man to 2.2.0

### DIFF
--- a/package/verification-template/build.gradle
+++ b/package/verification-template/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 		because "discord-rare-drop-notifier, droptracker"
 	}
 	thirdParty("org.jsoup:jsoup:1.13.1") {
-		because "discord-rare-drop-notifier, drop-simulator, fire-beats, loot-table, loot-lookup"
+		because "discord-rare-drop-notifier, drop-simulator, fire-beats, loot-table, loot-lookup, chance-man"
 	}
 	thirdParty("com.miglayout:miglayout-swing:5.2") {
 		because "drop-simulator"

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=d1385679f649363d9c0b44863af86c47f8ddaed4
+commit=6c0cdb92fa2b6d5a48e1b6999d3d412f8e7c5231

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=46aad9438ac0c110ab693c2a76596c33c92ac299
+commit=082168fc12d7b0ca02aa8f5e1a57d295db475a73

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=e394db5dfb179cac7187aa3614d8e7745f1dcfa5
+commit=07ac06415aa28e9189aead12ec77bf746a5cca67

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=6c0cdb92fa2b6d5a48e1b6999d3d412f8e7c5231
+commit=d9d0808f6c103e5e10b0f24de762577d64e0114c

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=082168fc12d7b0ca02aa8f5e1a57d295db475a73
+commit=d1385679f649363d9c0b44863af86c47f8ddaed4

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=3b0a95d0797bd3db2f008ee9b888ee66d78157ff
+commit=e394db5dfb179cac7187aa3614d8e7745f1dcfa5

--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=07ac06415aa28e9189aead12ec77bf746a5cca67
+commit=46aad9438ac0c110ab693c2a76596c33c92ac299


### PR DESCRIPTION
feat: Implement NPC drop table viewer in music tab

This commit introduces a major UI feature that allows players to view NPC drop tables directly in-game by temporarily hijacking the music tab interface.

A "Show Drops" menu option has been added to the right-click menu for NPCs. When selected, the plugin fetches the NPC's drop data and dynamically replaces the content of the music tab with a custom drop viewer UI.

The new UI consists of several components:
- **`DropsTabUI`**: The main class that initializes and manages the lifecycle of this feature.
- **`DropsMenuListener`**: Injects the "Show Drops" option into the NPC context menu.
- **`MusicWidgetController`**: The core of the feature, responsible for:
    - Backing up and hiding the original music widget elements.
    - Drawing a new interface that displays the NPC's name, level, and a progress bar for rolled vs. total drops.
    - Creating a scrollable grid of all possible drop items, with items the player haven't already "rolled" appearing faded.
- **`SpriteOverrideManager`**: Replaces the default music tab icon with a custom "drops" icon to indicate that the drop viewer is active.
- **`TabListener`**: Detects when the player navigates away from the music tab and restores its original content, ensuring the drop viewer is temporary.
- **`WidgetUtils`**: Provides helper functions for creating menu entries and managing widget children.