### PR TITLE
Trollflame Horn plugin

### DIFF
--- a/plugins/trollflame-horn
+++ b/plugins/trollflame-horn
@@ -1,0 +1,2 @@
+repository=https://github.com/Tybo24/trollflame-horn.git
+commit=d11cf73958d4909915bb900941ff3377a80a00ac


### PR DESCRIPTION
Plugin that changes the sound effect the Soulflame Horn plays to a random list of creators. Allows users to add a custom sound if they so wish which will hopefully help avoid constant changes because of individual opinions.