### PR TITLE
Update max-hit-calculator to v2.0.2

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=42bb5df7b7d866123ca12d9761aaec9fbe2bd440
+commit=707290be54bd969cc55da700a98febab5c7bf9eb

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=0bed5e42da5494cafd4ac841d1ff1d3ada393cb5
+commit=ccbbca06f50d5d151cfb0920581fd9f3a3dea400

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=ebc9cb50ff75473563373e32c326f8739a5ddaec
+commit=42bb5df7b7d866123ca12d9761aaec9fbe2bd440

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=ccbbca06f50d5d151cfb0920581fd9f3a3dea400
+commit=ebc9cb50ff75473563373e32c326f8739a5ddaec


### PR DESCRIPTION
v2.0.2 Update:
- Added Hueycoatl damage bonus items (Tome of Earth and Dragon Hunter Wand) (j-cob44/max-hit-calc/issues/50)
- Added Twinflame staff bonuses (https://github.com/j-cob44/max-hit-calc/issues/49)
- Added Royal Titans prayers (https://github.com/j-cob44/max-hit-calc/issues/46)
- Added check for correct ranged weapon ammo when calculating
- Fixed Autocasted spells not calculating Max Hit vs Types correctly (https://github.com/j-cob44/max-hit-calc/issues/48)
- Fixed Smokebattle Staff dmg bonus (https://github.com/j-cob44/max-hit-calc/issues/45)
- Updated multiple deprecated API functions
- Increased max prediction range for prayer prediction