### PR TITLE
Update gauntlet-chest-popup to 1.1.3

### DIFF
--- a/plugins/gauntlet-chest-popup
+++ b/plugins/gauntlet-chest-popup
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/gauntlet-loot-popup.git
-commit=fadef2ecb8c49ca286ce8285cb935ef65527c3a3
+commit=ca99e00d37ecce9ed5bbe934a1c2ab14582405f7


### PR DESCRIPTION
- Remove LootReceived now that gauntlet has been switched fully to ServerNpcLoot
- Adjust overlay positions, now a bit more left and up. Also unified across screen sizes