### PR TITLE
Add BA World Scouter

### DIFF
--- a/plugins/ba-world-scouter
+++ b/plugins/ba-world-scouter
@@ -1,3 +1,3 @@
 repository=https://github.com/rsfost/ba-world-scouter.git
-commit=98ce624b2600ebb385f9345e43dcc331b7cd4d3f
+commit=76e19f7e2507901187a035596b91fed0a2ccd317
 warning=This plugin shares your IP, world, and in-game location with a 3rd party server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This plugin helps scout for worlds with good quick-starting conditions for BA speedruns.