### PR TITLE
Add slayer-master plugin

### DIFF
--- a/plugins/slayer-master
+++ b/plugins/slayer-master
@@ -1,0 +1,2 @@
+repository=https://github.com/QualitySushi/slayer-master.git
+commit=3c69950aa4fc8025011bb875957abd1bd404b812


### PR DESCRIPTION
A RuneLite plugin that reminds you to visit the correct Slayer Master at task milestones to maximize your slayer point rewards.