### PR TITLE
Update clean-chat to 1.0.10

### DIFF
--- a/plugins/clean-chat
+++ b/plugins/clean-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/chat-cleanup.git
-commit=de72c9051dca1eeee0455c0df2de6908afc99bff
+commit=9126eda96e36be1ac00974fd3699ca5f07a4361a


### PR DESCRIPTION
Fix for chat command messages which set RuneLiteFormatMessage before this plugin can process them

Fixes ldavid432/chat-cleanup#5