### PR TITLE
Update clean-chat to 1.0.11

### DIFF
--- a/plugins/clean-chat
+++ b/plugins/clean-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/chat-cleanup.git
-commit=9126eda96e36be1ac00974fd3699ca5f07a4361a
+commit=bc1d878a3049e014ddbee58bfaf631ed7c967cb8


### PR DESCRIPTION
- Don't try and get an icon for unranked friends chat members
- Replace friends chat messages to friends challenge messages instead of friends notifications so the menu options remain