### PR TITLE
ONE LINE HOTFIX - update flipping-copilot to v1.6.7

### DIFF
--- a/plugins/flipping-copilot
+++ b/plugins/flipping-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/cbrewitt/flipping-copilot.git
-commit=4758ff663bc849e1204c674de762f6d8597215fd
+commit=1593064ecb155dec5b68acda6b0025a48a6ffd60
 warning=This plugin submits your grand exchange offers, grand exchange transactions, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.

--- a/plugins/flipping-copilot
+++ b/plugins/flipping-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/cbrewitt/flipping-copilot.git
-commit=1593064ecb155dec5b68acda6b0025a48a6ffd60
+commit=266ca8160e3833caaa033e7e183af9c2b8bb5398
 warning=This plugin submits your grand exchange offers, grand exchange transactions, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
In the update today, Jagex increased the GE tax to 2%. This has affected the plugin profit calculations, so we've changed the GE_TAX constant from 0.01 to 0.02.

Edit - due to the 5M per item tax cap, the MAX_PRICE_FOR_GE_TAX constant also needed changing.