### PR TITLE
Update time-to-max to v1.0.4

### DIFF
--- a/plugins/time-to-max
+++ b/plugins/time-to-max
@@ -1,2 +1,2 @@
 repository=https://github.com/Hamelot/time-to-max.git
-commit=8e6d98194dc4191b3c3f3102f6052dfeeded5f61
+commit=2c11d82617e3a8c4452207c251e6067b797791f8


### PR DESCRIPTION
Added tracking for users who want to calculate for 200m