### PR TITLE
NpcLevelOverlay Plugin

### DIFF
--- a/plugins/npcleveloverlay
+++ b/plugins/npcleveloverlay
@@ -1,0 +1,2 @@
+repository=https://github.com/DexHonsa/NpcLevelOverlay
+commit=a587ebefa4ab2dbbbe60db9af442059ab2807c19


### PR DESCRIPTION
NPC Combat Level Display
-Shows NPC combat levels above their heads
-Shows the maximum damage an NPC can deal in brackets (e.g., [0-23])
-Helps ironmen and hardcore players avoid potentially deadly encounters
-Displays icons indicating what the NPC is weak to