### PR TITLE
Create F2P Join Warnings

### DIFF
--- a/plugins/f2p-join-warnings
+++ b/plugins/f2p-join-warnings
@@ -1,0 +1,2 @@
+repository=https://github.com/rsbfox/f2p-join-warnings.git
+commit=daea1521b6076c9f4780240dadabbbea9d805cbc


### PR DESCRIPTION
This plugin helps friends chat ranks quickly react to spam accounts joining from F2P servers.

See readme for full description.

Forestry CC has been getting heavily spammed recently by throwaway accounts and bots. I was asked yesterday if a plugin could help.

This is my first time making a RuneLite plugin. I looked at how other plugins worked and kept tweaking it till I was happy with behavior and what I think is no bugs remaining.

🦊 