### PR TITLE
Upgrade clean-chat to 1.0.12

### DIFF
--- a/plugins/clean-chat
+++ b/plugins/clean-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/chat-cleanup.git
-commit=bc1d878a3049e014ddbee58bfaf631ed7c967cb8
+commit=7b59f8649533fce047abb02ca8eac129aa001be7


### PR DESCRIPTION
- Handles CA broadcasts in clan chat
  - Only added back the View action since that one is handled client side according to Adam
- Don't get icons for unranked clan chat members