### PR TITLE
update time-to-max to v1.1.1

### DIFF
--- a/plugins/time-to-max
+++ b/plugins/time-to-max
@@ -1,2 +1,2 @@
 repository=https://github.com/Hamelot/time-to-max.git
-commit=88d809dfb70305af04f10f4490bae0500ad4a30e
+commit=d62edfbe7f767e8e025727b0dfe69121a7c27db2


### PR DESCRIPTION
Utilize state to determine start date for interval reset.

previously the reset would only trigger if you were online crossing an interval threshold.
I unfortunately was only testing in goblin mode and would always have my testing client open across midnight...