### PR TITLE
Update OldSchoolSnitch to 1.1.3

### DIFF
--- a/plugins/old-school-snitch
+++ b/plugins/old-school-snitch
@@ -1,3 +1,3 @@
 repository=https://github.com/wkpatrick/old-school-snitch.git
-commit=5c20e88f591398daa350e5bf482a4a9846c72d98
+commit=4d35d5537bc0064ea2fbe21cb2538da1576f4d86
 warning=This plugin submits your player name, player model, account hash, xp data, drop data, in-game location, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Switches to ServerNpcLoot, adds Blast Mine support for tracking loot, and updates the README and screenshot.