### PR TITLE
Transform Thrall Helper into Spell Reminder

### DIFF
--- a/plugins/thrall-helper
+++ b/plugins/thrall-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/PortAGuy/thrall-helper.git
-commit=91efaee9926efc5dd47a30a6e8ab8c9287c0ddd2
+commit=ffa27d26f0e9bf48a1cc08d3682425b42302dc9c


### PR DESCRIPTION
Massive change turning the Thrall Helper plugin into a general Spell Reminder plugin with support for Charge, Corruption, Death Charge, Mark of Darkness, Shadow Veil, Vengeance, Vile Vigour, Ward of Arceuus, and Thralls.

Huge thanks to the people in the RuneLite discord (Mainly Nick Ints/InfernoStats, you are amazing) that assisted with this rework.