### PR TITLE
Update pvp-performance-tracker to v1.6.3

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=efcaa7a79044b171edbec1bfcb696ce65a9c364c
+commit=3b44f47469b312bfe51f139e9edae649b7caf37c


### PR DESCRIPTION
executor/threading crash hotfix as discussed in discord

I would have included a chat message to say this crash was fixed but I cba cause I already refactored the on-update chat messages in the pending 1.7.0 PR