### PR TITLE
Update Dink to v1.11.10

### DIFF
--- a/plugins/dink
+++ b/plugins/dink
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/DinkPlugin.git
-commit=83dd03d066bed455dd0347ab2ddae54a275e2304
+commit=590133f34ee6f268b890a7dfee2004e24762bcaf
 authors=Mm2PL,pajlada,Felanbird,iProdigy


### PR DESCRIPTION
Dink v1.11.10 most notably fixes loot notifications for gauntlet and pharaoh's sceptre

Full release notes: https://github.com/pajlads/DinkPlugin/releases/tag/v1.11.10
