### PR TITLE
Create rogue-silencer

### DIFF
--- a/plugins/rogue-silencer
+++ b/plugins/rogue-silencer
@@ -1,0 +1,2 @@
+repository=https://github.com/Jbasilious/SilenceRogues.git
+commit=2424ac25187e57a826f191d77a86b76b95009929


### PR DESCRIPTION
Toggle to hide rogues models or overhead text at the rogues castle to make thieving rogues chests less annoying.