### PR TITLE
disable rs3-music

### DIFF
--- a/plugins/rs3-music
+++ b/plugins/rs3-music
@@ -1,3 +1,4 @@
 repository=https://github.com/Frunkh/rl-rs3-music.git
 commit=9da74ef4a53d94f575e9a004e699e209991dfee1
 warning=This plugin retrieves the RS3 music from rs3.frunk.ovh, a 3rd party website not controlled or verified by the RuneLite Developers.
+disabled=rs3.frunk.ovh is gone, the plugin is now non-functional and stalls the client when you enable it.


### PR DESCRIPTION
The site that the plugin downloads music from is gone, so this basically no longer works.