### PR TITLE
Update loot-filters to v1.9.5

### DIFF
--- a/plugins/loot-filters
+++ b/plugins/loot-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/riktenx/loot-filters.git
-commit=11d8ff4491fa544dd0aafcc0c974f225ba92dff6
+commit=75dbd8b2b4bbe7836764f786c04759cde452bd10


### PR DESCRIPTION
hotfix for confusing `???` shown in menu quantities