### PR TITLE
Fixed "Clan Spam Filter" to work with ObjectStack instead of StringStack

### DIFF
--- a/plugins/guild-spam-filter
+++ b/plugins/guild-spam-filter
@@ -1,3 +1,3 @@
 repository=https://github.com/andreasx23/GuildSpamFilter.git
-commit=a2383bcff57080c0247ac37a02f26563e4fc039d
+commit=4b9c63141a7add748af9d3d70edb3ea8a074049d
 authors=andreasx23


### PR DESCRIPTION
Fixed "Clan Spam Filter" to work with ObjectStack instead of StringStack