### PR TITLE
Hotfix - update flipping copilot to 1.6.9

### DIFF
--- a/plugins/flipping-copilot
+++ b/plugins/flipping-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/cbrewitt/flipping-copilot.git
-commit=67868056a63d7b0a95b02607143fb6ebb5c1d92c
+commit=74d1a786b6fd1a8918715460994cb85e1efba98c
 warning=This plugin submits your grand exchange offers, grand exchange transactions, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
ComponentID needed changing due to Runelite v1.11.9 update