### PR TITLE
Complete overhaul of clean-chat

### DIFF
--- a/plugins/clean-chat
+++ b/plugins/clean-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/chat-cleanup.git
-commit=7b59f8649533fce047abb02ca8eac129aa001be7
+commit=42cd64db187b837d4114f1fbb0b30e4a9ff5cbd7


### PR DESCRIPTION
- Totally refactor channel name removal
  - It now edits the chat widgets instead of re-sending chat messages as different types
- Chat message blocking has mostly stayed the same
- All user-facing functionality should remain the same

Sorry for the huge PR but this needed to be done, the old method was not looking very sustainable. I kept having to fix small bugs with not scalable methods.