### PR TITLE
update banked-experience to v2.7.2

### DIFF
--- a/plugins/banked-experience
+++ b/plugins/banked-experience
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/banked-experience.git
-commit=f25280007689d9c53674a1645595067f1a2d469b
+commit=81664259b320c717a9e216175c323f91981cb82f


### PR DESCRIPTION
* Fixes a bug with cascading item quantities where any item in the chain produced an output with more than 1 item