### PR TITLE
Update pickpocket-helper to v1.0.6

### DIFF
--- a/plugins/pickpocket-helper
+++ b/plugins/pickpocket-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/runelite-pickpocket-helper.git
-commit=9ead9bf4e501f274e5d77d93979da799af439821
+commit=fbfa50ddc4f45c46b465bbfda7319857d637c15b
 authors=iProdigy

--- a/plugins/pickpocket-helper
+++ b/plugins/pickpocket-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/runelite-pickpocket-helper.git
-commit=fbfa50ddc4f45c46b465bbfda7319857d637c15b
+commit=727ecae02e2791f1f65ce449fe5eb3f6534ced38
 authors=iProdigy


### PR DESCRIPTION
https://github.com/pajlads/runelite-pickpocket-helper/releases/tag/v1.0.5

https://github.com/pajlads/runelite-pickpocket-helper/releases/tag/v1.0.6

Includes build fix thanks to felan

also migrates `Clip` usage to `AudioPlayer`