### PR TITLE
feat: Add disable cancel plugin

### DIFF
--- a/plugins/disable-cancel
+++ b/plugins/disable-cancel
@@ -1,3 +1,3 @@
 repository=https://github.com/AmeliaXT/disable-cancel.git
-commit=299cc2d90437aa9159832b08e48692fe7d6e40d6
+commit=99012b912c7f4c2081c6dc81d89399a841b8dfde
 authors=AmeliaXT

--- a/plugins/disable-cancel
+++ b/plugins/disable-cancel
@@ -1,3 +1,3 @@
 repository=https://github.com/AmeliaXT/disable-cancel.git
-commit=99012b912c7f4c2081c6dc81d89399a841b8dfde
+commit=f82063d78f282507fb5192b26d2c0ede95a4c6bf
 authors=AmeliaXT

--- a/plugins/disable-cancel
+++ b/plugins/disable-cancel
@@ -1,3 +1,3 @@
 repository=https://github.com/AmeliaXT/disable-cancel.git
-commit=a0033a20d00ceabaa4884e8c284d50d51f78dc18
+commit=64ae9f7fcfc03bfaceb2837b434b1415d04efbf7
 authors=AmeliaXT

--- a/plugins/disable-cancel
+++ b/plugins/disable-cancel
@@ -1,0 +1,3 @@
+repository=https://github.com/AmeliaXT/disable-cancel.git
+commit=3a62aca6a4b6ec5610d19d85f5234cd01a503013
+authors=AmeliaXT

--- a/plugins/disable-cancel
+++ b/plugins/disable-cancel
@@ -1,3 +1,3 @@
 repository=https://github.com/AmeliaXT/disable-cancel.git
-commit=64ae9f7fcfc03bfaceb2837b434b1415d04efbf7
+commit=daf5eeaad7eba9fb381b61cc4770568153e40133
 authors=AmeliaXT

--- a/plugins/disable-cancel
+++ b/plugins/disable-cancel
@@ -1,3 +1,3 @@
 repository=https://github.com/AmeliaXT/disable-cancel.git
-commit=d39b1b00f8d0c5d5cadef9d55d415c3113f90f5c
+commit=a0033a20d00ceabaa4884e8c284d50d51f78dc18
 authors=AmeliaXT

--- a/plugins/disable-cancel
+++ b/plugins/disable-cancel
@@ -1,3 +1,3 @@
 repository=https://github.com/AmeliaXT/disable-cancel.git
-commit=3a62aca6a4b6ec5610d19d85f5234cd01a503013
+commit=d39b1b00f8d0c5d5cadef9d55d415c3113f90f5c
 authors=AmeliaXT

--- a/plugins/disable-cancel
+++ b/plugins/disable-cancel
@@ -1,3 +1,3 @@
 repository=https://github.com/AmeliaXT/disable-cancel.git
-commit=daf5eeaad7eba9fb381b61cc4770568153e40133
+commit=299cc2d90437aa9159832b08e48692fe7d6e40d6
 authors=AmeliaXT


### PR DESCRIPTION
RuneLite plugin that effectively allows the user to prevent usable action from being cancelled based on configuration. E.g., casting telekinetic grab requires a target, preventing you from cancelling by miss clicking in the world somewhere.

Available configuration values:

- Ignore all items and / or spells
- Comma separated list of Items to ignore, if not ignoring all
- Comma separated list of Spells to ignore, if not ignoring all
- Apply only for left clicks, so users can cancel with the right click menu if desired (Default value)

