### PR TITLE
Fix Teleport Maps compatibility issue v1.0.09

### DIFF
--- a/plugins/spirit-tree-map
+++ b/plugins/spirit-tree-map
@@ -1,2 +1,2 @@
 repository=https://github.com/MJHylkema/spirit-tree-map.git
-commit=489e5de17beeeb77a5200cf4aa6c8b4488364521
+commit=5a363e7c11244f94767d388f8ccd530c4947c639


### PR DESCRIPTION
Replaced usage of Client getStringStack / getStringStackSize with getObjectStack / getObjectStackSize.
A type was also fixed. 