### PR TITLE
Add 'No Run Hotkey' plugin

### DIFF
--- a/plugins/no-run-hotkey
+++ b/plugins/no-run-hotkey
@@ -1,0 +1,2 @@
+repository=https://github.com/willediger/No-Run-Hotkey.git
+commit=6ef0ae54e194debefaa3df5eddbd2a7e246f4c84


### PR DESCRIPTION
## No Run Hotkey plugin

A RuneLite plugin that lets you temporarily disable "Walk here" by holding a hotkey.

Useful to avoid yellow clicks when attacking NPCs with tricky clickboxes or when they die just before you click.

Repo: https://github.com/willediger/No-Run-Hotkey