### PR TITLE
Update steps-per-clue

### DIFF
--- a/plugins/steps-per-clue
+++ b/plugins/steps-per-clue
@@ -1,2 +1,2 @@
 repository=https://github.com/Chubs1/StepsPerClue.git
-commit=7639d435fba68fbdd1dde387b9407ffbfcdff441
+commit=04a87ce1566383668598bb3b22c1b2d0d0c39e7b


### PR DESCRIPTION
Fixed the issue with using methods that not longer exist, also fixed it to only run when you check steps on clue instead of always running on any chat message like it was before.