### PR TITLE
Update fuzzy-bank-search

### DIFF
--- a/plugins/fuzzy-bank-search
+++ b/plugins/fuzzy-bank-search
@@ -1,2 +1,2 @@
 repository=https://github.com/i/rl-plugins.git
-commit=61bf3de1500c68bc7015f0f727831aba3ff5b819
+commit=ee50dfcc1492df2b3d2dd433df1093b32288217b

--- a/plugins/fuzzy-bank-search
+++ b/plugins/fuzzy-bank-search
@@ -1,2 +1,2 @@
 repository=https://github.com/i/rl-plugins.git
-commit=ee50dfcc1492df2b3d2dd433df1093b32288217b
+commit=9aafd2f67efeccecb4dcc2478d7fea8aaed4e317


### PR DESCRIPTION
Since `client.stringStack `no longer exists, use `client.objectStack` and cast to String. Referenced from bank tags plugin.