### PR TITLE
Update wom-utils to 1.4.6

### DIFF
--- a/plugins/wom-utils
+++ b/plugins/wom-utils
@@ -1,4 +1,4 @@
 repository=https://github.com/wise-old-man/wiseoldman-runelite-plugin.git
-commit=4897d5e908b4029e4338f7d4bf3ee4a4506eb3a7
+commit=22a8977fb602ba132d3a161f96ffb8b960a63f39
 warning=This plugin submits the names of you, your friends and members of your clan chat to wiseoldman.net.
 authors=dekvall,rorro,psikoi


### PR DESCRIPTION
Fixes yet another name discrepancy, this time for clue scrolls. This fix makes it so that clue scroll competitions show up properly in the side panel.