### PR TITLE
Update Twitch Live Loadout to v2.2.4

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=58c8b1a2013756308c9c1666553c4c0751c6624a
+commit=588c42c2abb213059b3a00eed42cba5cb445e7e4


### PR DESCRIPTION
Fixed two minor breaking changes with the RL update last week along with the resolution of some other (future) deprecation issues.

Commits are cherry picked from another branch to not include any of the new features currently in development:
- chore: updated the version number to reflect the latest changes.
- fix: fixed minor issue when checking for a valid item in the menu entries.
- fix: fixed a deprecation issue where the creation of a custom projectile API has been removed from the WorldView instance.
- fix: fixed an issue where sometimes the data payload to Twitch is too large (exceeding the 5Kb limit) with certain combat achievements and other data. Syncing combat achieve ments simply takes longer now.
- fix: resolved issue with various deprecations due to the newly introduced gamevals.
- fix: fixed an issue where the previous player location is now known upon login when you have not moved yet. Now it searches for the first nearby tile and selects that as the 'fake' previous location. This ensures products that make use of this (e.g. 'you are on fire') work immediately without moving first.
- fix: fixed a bug causing it to not fetch preview transactions properly when there are no products added to any slots. You should be able to preview them without having configured any of them.