### PR TITLE
Add Unbonded Log plugin

### DIFF
--- a/unbonded-log/UnbondedLogPlugin.java
+++ b/unbonded-log/UnbondedLogPlugin.java
@@ -1,0 +1,65 @@
+package com.unbondedlog;
+
+import com.google.inject.Provides;
+import net.runelite.api.Client;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+import javax.inject.Inject;
+import java.util.List;
+
+@PluginDescriptor(
+        name = "Unbonded Log",
+        description = "Hides members-only Collection Log sections",
+        tags = {"f2p", "collection log", "pure"}
+)
+public class UnbondedLogPlugin extends Plugin
+{
+    @Inject
+    private Client client;
+
+    private final List<String> f2pCategories = List.of(
+            "Bosses", "Clues", "Other", "Minigames"
+    );
+
+    private final List<String> f2pSubTabs = List.of(
+            "Obor", "Bryophyta",
+            "Beginner Clue", "Easy Clue",
+            "Castle Wars", "Fist of Guthix", "Barbarian Village"
+    );
+
+    @Subscribe
+    public void onGameTick(GameTick tick)
+    {
+        Widget root = client.getWidget(WidgetInfo.COLLECTION_LOG_TABS);
+
+        if (root == null || root.getStaticChildren() == null)
+        {
+            return;
+        }
+
+        for (Widget widget : root.getStaticChildren())
+        {
+            String name = widget.getText();
+
+            if (name == null)
+                continue;
+
+            boolean isCategory = f2pCategories.stream().anyMatch(name::equalsIgnoreCase);
+            boolean isF2PSubTab = f2pSubTabs.stream().anyMatch(name::equalsIgnoreCase);
+
+            if (!isCategory && !isF2PSubTab)
+            {
+                widget.setHidden(true);
+            }
+            else
+            {
+                widget.setHidden(false);
+            }
+        }
+    }
+}

--- a/unbonded-log/plugin.json
+++ b/unbonded-log/plugin.json
@@ -1,0 +1,8 @@
+{
+  "internalName": "unbondedlog",
+  "displayName": "Unbonded Log",
+  "description": "Hides members-only Collection Log tabs for pure F2P play.",
+  "author": "Xi2ediviist",
+  "tags": ["f2p", "collection log", "pure", "utility"],
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Adds a plugin that hides members-only Collection Log sections for pure F2P players.
