### PR TITLE
Create alch-copilot

### DIFF
--- a/plugins/alch-copilot
+++ b/plugins/alch-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/rcnoob/alch-copilot.git
-commit=eb12912db2f312ad2cd24efa0672f3f538562f46
+commit=7cfdcc9dcb63f1736e5c812c7c8e69616b998574


### PR DESCRIPTION
Alch Copilot: a more profit-driven fork of ABC Alchemy

The plugin will recommend the player items to purchase and HA based on multiple variables set in the configuration