### PR TITLE
Update c-engineer-completed to v1.2.5

### DIFF
--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=e5a8843c2e5f5069a21e4b372c6603642e53e788
+commit=0f113dc03d0ec4f37d51975677afa3ee473d5f20


### PR DESCRIPTION
Workaround for linux audio bug that appears to be specific to the combination of
- Pipewire
- Sound files that are somewhere between 1.5 and 2 seconds long

Fixes issue https://github.com/m0bilebtw/c-engineer-completed/issues/26