### PR TITLE
Create overall-tob-timer

### DIFF
--- a/plugins/overall-tob-timer
+++ b/plugins/overall-tob-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/Divine-Dream/overall-timer-tob.git
-commit=55d989dbdb244da9971ec8bc2c782a7b80f35344
+commit=ec70b2d48794b0ecb0b6f240c029b08fdd196a92

--- a/plugins/overall-tob-timer
+++ b/plugins/overall-tob-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/Divine-Dream/overall-timer-tob.git
+commit=55d989dbdb244da9971ec8bc2c782a7b80f35344


### PR DESCRIPTION
displays a realtime timer when the player enters Maiden's room to track current overall raid time. I was asked to recreate this pull request. Hopefully it's right now.