### PR TITLE
[Update] - Varlamore House Thieving - v1.5.3 - Sololegnds

### DIFF
--- a/plugins/varlamore-house-thieving
+++ b/plugins/varlamore-house-thieving
@@ -1,2 +1,2 @@
 repository=https://github.com/sololegends/runelite-varlamore-house-thieving.git
-commit=7289a44c6c2dbf6031be1206f75683c3f2d7547e
+commit=f40f85af28860bdb909f19e28496456dcd46a3a3


### PR DESCRIPTION
# Release v1.5.3

Minor fixes and updates 

- Resolved [Guthub Issue #17](https://github.com/sololegends/runelite-varlamore-house-thieving/issues/17)
  - Return home notification not triggered if return home overlay off
- Updated to most recent Runelite API Changes 
- Updated to newer valuable price with more human readable formatting