### PR TITLE
Add Clue Path Finder to the Plugin Hub

### DIFF
--- a/plugins/clue-path-finder
+++ b/plugins/clue-path-finder
@@ -1,0 +1,2 @@
+repository=https://github.com/Infinitay/clue-path-finder-plugin.git
+commit=6243c4e842b13776d8522fa77f27c4772469ad05


### PR DESCRIPTION
This plugin helps automatically path to an active clue scrolls destination(s) by utilizing the [Shortest Path plugin](https://github.com/Skretzo/shortest-path).

_Shameless request for an `onClueScrollUpdated` event either to be subscribed to or hooked onto via it's service if possible_