### PR TITLE
Update tob-predicted-hit

### DIFF
--- a/plugins/tob-predicted-hit
+++ b/plugins/tob-predicted-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/JaccodR/party-hits.git
-commit=cf9da776c9c2df3125f7ab1de6312191bda97eb6
+commit=634af80ed3c3f80cab843619c4f04f5fe1dbb9d3


### PR DESCRIPTION
- getHealthScale is now called on the clientThread
- Add support for verzik JaccodR/party-hits#2