### PR TITLE
Upgrade gauntlet-chest-popup to 1.2.0

### DIFF
--- a/plugins/gauntlet-chest-popup
+++ b/plugins/gauntlet-chest-popup
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/gauntlet-loot-popup.git
-commit=ca99e00d37ecce9ed5bbe934a1c2ab14582405f7
+commit=960e61609c1bdcefaf76368e44118954db2a83ea


### PR DESCRIPTION
- Makes the popup moveable
- Use the bounds of the Overlay to draw instead of using absolute coordinates