### PR TITLE
Soulflame Horn Buff - Fix default sound

### DIFF
--- a/plugins/soulflamehorn
+++ b/plugins/soulflamehorn
@@ -1,2 +1,2 @@
 repository=https://github.com/sim-macdonald/Soulflame-horn.git
-commit=f8928748aee67373556a6e8fc0c7256a02f62b43
+commit=6031ca107dbc3c7cb3f3633309c8d521b19f0efe


### PR DESCRIPTION
The default sound (only the default and not custom sounds) is not playing on the user client. It was working fine on the dev client, but didn't work on the user client.

The change will hopefully fix this issue.

Also made a small update to readme and description.