### PR TITLE
Update c-engineer-completed to v1.2.6

### DIFF
--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=2ff5e25369a397373325c87a73b19789eb291e13
+commit=18eea780e47a134cb8d5307ab731f9d441bc0be1

--- a/plugins/c-engineer-completed
+++ b/plugins/c-engineer-completed
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/c-engineer-completed.git
-commit=0f113dc03d0ec4f37d51975677afa3ee473d5f20
+commit=2ff5e25369a397373325c87a73b19789eb291e13


### PR DESCRIPTION
Closes https://github.com/m0bilebtw/c-engineer-completed/issues/33 

Adds the inventory full hunter rumour chat message for the normal hunter rumour completed sound

Adds a new hunter rumour _not_ completed sound for the rare inventory full hunter rumour chat message whereby instead of dropping to the ground, the hunter rumour item is simply destroyed (e.g. at dashing kebbits)