### PR TITLE
Update skills-tab-progress-bars to v1.5.0

### DIFF
--- a/plugins/skills-tab-progress-bars
+++ b/plugins/skills-tab-progress-bars
@@ -1,2 +1,2 @@
 repository=https://github.com/m0bilebtw/skills-tab-progress-bars.git
-commit=4271ac3235112704785155a39560635152629603
+commit=e4be9eed49c5072fa8c4677ca32557e2643cab78


### PR DESCRIPTION
Closes https://github.com/m0bilebtw/skills-tab-progress-bars/issues/21

Adds option to darken members skills (disabled by default) regardless of xp/level