### PR TITLE
Create Group Storage Reminder plugin

### DIFF
--- a/plugins/group-storage-reminder
+++ b/plugins/group-storage-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/RedSparr0w/runelite-plugins.git
+commit=6b1b03faa0c7b71802e5fe718f6571089e96df74


### PR DESCRIPTION
# Group Storage Reminder

A reminder plugin for group ironmen to put items back in to the group storage

![image](https://github.com/user-attachments/assets/ada1cbef-8298-458f-a687-ae9f19d2c14e)

Box showing items in inventory or bank:

![image](https://github.com/user-attachments/assets/698a755a-86e6-4fa7-9e2f-5eca6cd1f7a8)

While you have the logout button visible:

![image](https://github.com/user-attachments/assets/da05eb55-5613-46c1-8750-75b7adbc1b50)

