### PR TITLE
Create zulrah-loot-locator

### DIFF
--- a/plugins/zulrah-loot-locator
+++ b/plugins/zulrah-loot-locator
@@ -1,0 +1,2 @@
+repository=https://github.com/RonnyTommy548/ZulrahLootLocator.git
+commit=f7fc5bec0833a062497afcebc8a0c20821f57139


### PR DESCRIPTION
My new plugin, ZulrahLootLocator, shows you where your loot will spawn at the end of a Zulrah kill. I made this plugin because there are some very unintuitive and surprising loot spawning locations. Understanding the logic behind where the game places the loot was a fun journey that required the help of multiple individuals including Mod Ash. Demonstration gifs are included in the repo's README. I can't wait for people to get their hands on this!