### PR TITLE
Create crosshair-cursor-plus

### DIFF
--- a/plugins/crosshair-cursor-plus
+++ b/plugins/crosshair-cursor-plus
@@ -1,3 +1,3 @@
 repository=https://github.com/Benjames01/crosshair-cursor-plus.git
-commit=4eda57e7d0050bd05a0c01dc34934d47ff95d459
+commit=ace978904c0dc34821e038c79b1cdc4256ac48c5
 authors=Gashtag,whonan,Kurtiz,Gnomesy

--- a/plugins/crosshair-cursor-plus
+++ b/plugins/crosshair-cursor-plus
@@ -1,0 +1,3 @@
+repository=https://github.com/Benjames01/crosshair-cursor-plus.git
+commit=4eda57e7d0050bd05a0c01dc34934d47ff95d459
+authors=Gashtag,whonan,Kurtiz,Gnomesy


### PR DESCRIPTION
Crosshair Cursor Plus
This plugin works by switching to the "crosshair" system cursor type, called "Precision Select" in Windows. It looks like a gigantic cross by default, but you can easily change it to any cursor you want. This is an easy way of having cursor files instead of pngs, so you can use center-clicking cursors (crosshairs, dots, circles) as well as animated cursors. That being said, though not very common the Precision Select type is sometimes used by other applications (when you take a snipping screenshot, for example), so keep in mind that if you change it you will also see it outside of Runelite in those situations.