### PR TITLE
add prayer-markers

### DIFF
--- a/plugins/prayer-markers
+++ b/plugins/prayer-markers
@@ -1,0 +1,2 @@
+repository=https://github.com/coopermor/prayer-markers.git
+commit=a431340fa308fd320066d182f16214f0830b1f08


### PR DESCRIPTION
Prayer markers allows you to add dynamic screen markers to the prayer interface. This plugin does **NOT** indicate what prayers to use.

Colored prayed markers can be added for any prayer with a configurable stroke thickness and color.