### PR TITLE
Bump dialogue to fix some issues with tbox being recorded when it shouldn't and add gamevals

### DIFF
--- a/plugins/npc-dialogue
+++ b/plugins/npc-dialogue
@@ -1,2 +1,2 @@
 repository=https://github.com/leejt/npc-dialogue.git
-commit=8e9b47f3d338142efb590915c8786bce43f08684
+commit=7d715a3d779f71e31e3ae3c6baede20bc68a42cf


### PR DESCRIPTION
We had some issues where the dialogue recorder would keep outputting blank tboxes.

Also has a refactor to move magic numbers and deprecated IDs to the new gamevals.

I don't think I'm in the maintainers file on this one but cook isn't gonna make a pr to pluginhub. I can attach a picture of him giving me a thumbs up as proof he supports this if necessary.