### PR TITLE
[HOTFIX] Update `odablock-sounds` to play sounds again

### DIFF
--- a/plugins/odablock
+++ b/plugins/odablock
@@ -1,2 +1,2 @@
 repository=https://github.com/DapperMickie/odablock-sounds.git
-commit=668180451b2727bd0931ed7ac57fc5fdb54cbffe
+commit=2935696564e87db763b7e5644fb29901e7c9d0e5


### PR DESCRIPTION
Fixes issue with playing the sounds.
Current version doesn't play sounds at all.