### PR TITLE
Update Spell Reminder

### DIFF
--- a/plugins/thrall-helper
+++ b/plugins/thrall-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/PortAGuy/thrall-helper.git
-commit=13cea91a97d4487088a0546138febc271cc5925b
+commit=ab2efb61b3033b9c2212923933dcc8825cc18a3d


### PR DESCRIPTION
The latest OSRS update broke the thrall reminder timing if the master combat achievements were completed. Quick fixes to that and some bug fixes.