### PR TITLE
Update Twitch Live Loadout to v2.3.0

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=588c42c2abb213059b3a00eed42cba5cb445e7e4
+commit=f1f6921f44747f073ca35645b5cd02c226011a4a


### PR DESCRIPTION
## Summary

### 1. Group Ironmen storage
Group storage can now be synced to viewers:
<img width="1353" alt="Screenshot 2025-06-26 at 11 45 09" src="https://github.com/user-attachments/assets/b41a630f-1f4c-48d4-bd99-af4fbb6a5aa2" />

### 2. Game events activating random events
Events such as 'level up', 'boss kill' or 'raid completion' can now also activate random events:
<img width="744" alt="Screenshot 2025-06-26 at 11 46 29" src="https://github.com/user-attachments/assets/2686a073-0c32-4302-b511-c63c5a75645a" />

### 3. Deadman Mode deposit box
For DMM worlds and seasonals the deposit box can now be synced to viewers:
<img width="794" alt="Screenshot 2025-06-26 at 11 47 06" src="https://github.com/user-attachments/assets/e758911d-5d83-46ae-93c9-d3807a5ef9a1" />

### 4. Long term mode support
You can now have certain events active for long periods of time if you want to experiment with some kind of 'mode' as a content creator. If you use this in conjunction with the game event feature (see above) you can have events run indefinitely (e.g. 6 hour duration with the login game event combined).
<img width="401" alt="Screenshot 2025-06-26 at 11 48 08" src="https://github.com/user-attachments/assets/1e463e6d-a639-489f-9112-eef026d0cc6b" />

## Detailed changelog
https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin/blob/master/docs/changelog.md