### PR TITLE
Update Lucky Clan Bingo

### DIFF
--- a/plugins/lucky-clan-bingo
+++ b/plugins/lucky-clan-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/LuckyClanBingo.git
-commit=d6c209449760de0038cd21df9849bf62e4c0827b
+commit=b120908835e256634b9576473b1755dda553c5b4


### PR DESCRIPTION
Small item list fixes;

- Warrior ring spelling corrected
- Removed tzhaar-ket-em as it does not drop from PvM
- Dragon knife spelling corrected
- Elemental tome spelling corrected
- Added Venator vestige to list
- Added Elven signet to list