### PR TITLE
Bump crowdsourcing to revert sailing alpha and just add a more lax check on id for sightings to help with the beta

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=ef394a6d774e51964d4d01aa55c608551f0ee8a1
+commit=5b571e9adef264cf629c67f9c5d638899fcce3ad
 authors=leejt,andmcadams


### PR DESCRIPTION
This diff is pretty awful because of the giant list changes. They are just lists of npc/item ids to always report to crowdsourcing. We just decided to be more permissive this time around and do anything above a certain id, so I reverted the additions to the list from the sailing alpha.

We aren't checking for beta world here, but don't anticipate that being a problem on our end.