### PR TITLE
Update orb-hider repository

### DIFF
--- a/plugins/orb-hider
+++ b/plugins/orb-hider
@@ -1,2 +1,3 @@
-repository=https://github.com/wizguin/runelite-orb-hider.git
+repository=https://github.com/richardant/runelite-orb-hider.git
 commit=84f9f3440401f3a2ad275d9e595a37880a7013f6
+authors=Richardant

--- a/plugins/tick-counter
+++ b/plugins/tick-counter
@@ -1,3 +1,3 @@
 repository=https://github.com/winterdaze/tick-counter.git
-commit=26b7372aed33c35febb338fc7d8bbc972d57e410
+commit=45dedd0670cf9258184e40b28280e787a251b805
 authors=LlemonDuck,Richardant,winterdaze

--- a/plugins/tick-counter
+++ b/plugins/tick-counter
@@ -1,3 +1,3 @@
 repository=https://github.com/winterdaze/tick-counter.git
-commit=45dedd0670cf9258184e40b28280e787a251b805
+commit=26b7372aed33c35febb338fc7d8bbc972d57e410
 authors=LlemonDuck,Richardant,winterdaze


### PR DESCRIPTION
Hello,

I am looking to takeover the Orb hider plugin. There has been no activity on the main repository for over 4 years, and i have waited over a month for a PR + a week for collaborator access.

* Initial PR:  [API Updated + New option (Hide Worldmap) wizguin/runelite-orb-hider#4](https://github.com/wizguin/runelite-orb-hider/pull/4)

* Request for Collaboration issue: [Collaborator access wizguin/runelite-orb-hider#5](https://github.com/wizguin/runelite-orb-hider/issues/5)

* Extra context: [Add Minimap hider Plugin runelite/plugin-hub#8263](https://github.com/runelite/plugin-hub/pull/8263)

Thanks to @pajlada and @Felanbird for the information on how to start this process.