### PR TITLE
Update tick-counter

### DIFF
--- a/plugins/orb-hider
+++ b/plugins/orb-hider
@@ -1,2 +1,3 @@
-repository=https://github.com/wizguin/runelite-orb-hider.git
+repository=https://github.com/richardant/runelite-orb-hider.git
 commit=84f9f3440401f3a2ad275d9e595a37880a7013f6
+authors=Richardant

--- a/plugins/orb-hider
+++ b/plugins/orb-hider
@@ -1,3 +1,2 @@
-repository=https://github.com/richardant/runelite-orb-hider.git
+repository=https://github.com/wizguin/runelite-orb-hider.git
 commit=84f9f3440401f3a2ad275d9e595a37880a7013f6
-authors=Richardant

--- a/plugins/tick-counter
+++ b/plugins/tick-counter
@@ -1,3 +1,3 @@
 repository=https://github.com/winterdaze/tick-counter.git
-commit=26b7372aed33c35febb338fc7d8bbc972d57e410
+commit=45dedd0670cf9258184e40b28280e787a251b805
 authors=LlemonDuck,Richardant,winterdaze

--- a/plugins/tick-counter
+++ b/plugins/tick-counter
@@ -1,3 +1,3 @@
 repository=https://github.com/winterdaze/tick-counter.git
-commit=45dedd0670cf9258184e40b28280e787a251b805
+commit=26b7372aed33c35febb338fc7d8bbc972d57e410
 authors=LlemonDuck,Richardant,winterdaze


### PR DESCRIPTION
Tridents and some magic animations fixes

* tridents 1167 -> 11430 (now tridents and wave spells with staff has the same animation)
* strike/bolt/blast 711 -> 9144
* wave spells no staff 727 -> 11429
* strike/bolt/blast w/ staff 1162 -> 11423
* surge spells 7855 -> 9145
* rush/blitz 1978 -> 10091
* burst/barrage 1979 -> 10092