### PR TITLE
Update recommended-equipment

### DIFF
--- a/plugins/recommended-equipment
+++ b/plugins/recommended-equipment
@@ -1,2 +1,2 @@
 repository=https://github.com/t8or/runelite-recommended-equipment.git
-commit=dd45953b8bfd1f67a609eb37acd7177797480550
+commit=e7c64ece0a83c49f98b25cdc57c34f7ee3f641cb


### PR DESCRIPTION
Fixed issue with `execute` being deprecated.  Replaced with `enqueue` callback instead.

Also updated Readme, License year, and minor version number