### PR TITLE
Add menu-stones-hider

### DIFF
--- a/plugins/menu-stones-hider
+++ b/plugins/menu-stones-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/Richardant/menustoneshider.git
-commit=234c60f388fa0ef6c6649aef55ff4eb6dc37f909
+commit=9aacf8f28f1f11a8e7fa6af2a99821da80c09845

--- a/plugins/menu-stones-hider
+++ b/plugins/menu-stones-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/Richardant/menustoneshider.git
+commit=234c60f388fa0ef6c6649aef55ff4eb6dc37f909


### PR DESCRIPTION
This plugin hides the menu stones and their respective icons, the menu background (resizable classic only), and the sidebars in the menu. It also includes a toggle that you can use to unhide them. The default keybind is: CTRL+B.

This plugins attempts to mimic something that the modern resizable layout has by default, but that the classic resizable layout doesn't.