### PR TITLE
Fix typo in clickertraining logic breaking functionality

### DIFF
--- a/plugins/clickertraining
+++ b/plugins/clickertraining
@@ -1,2 +1,2 @@
 repository=https://github.com/pyonium/clicker-training-osrs.git
-commit=aa906e38b6787077528732e38ba602c7db717fa4
+commit=2edbc8d280840f43fd0bd9f45e7bbdaabe982057


### PR DESCRIPTION
I'm so sorry to have to ask y'all to review a PR of mine again, but due to a single comparator being the wrong way around an entire feature is broken.