### PR TITLE
Update Creator's Kit to v2.0.8

### DIFF
--- a/plugins/creators-kit
+++ b/plugins/creators-kit
@@ -1,2 +1,2 @@
 repository=https://github.com/ScreteMonge/creators-kit.git
-commit=75ca260a6faa3cb7c811c1aa015cb9a9851aaa1e
+commit=2b8d167552e0939cd4c51c6374afe8bcab10cc3a


### PR DESCRIPTION
v2.0.8
- Reorganized several classes into appropriate folders
- General code cleanup for several classes, removing unused parameters and methods
- Hotkeys for setting Start and End orientation have been moved to the config for modifiability
- Removed ObjectPanel class and replaced its function with JPanels, as they are functionally identical
- createComplexModel() will now send chat messages regarding model stats only when called through the Model Anvil
- Removed orbSpeedListener Hotkey as it's generally been superseded by orbPresetListener

- Bugfix: ToolBoxFrame is now properly disposed on plugin shutdown
- Bugfix: moving folders should now appropriately update the associated nodes of its children
- Bugfix: reseting HitsplatAttributes will now set sprites to default back to Block instead of None
- Bugfix: fixed NPEs occurring when using the CacheSearcherTab to attempt to add Keyframes