### PR TITLE
Updating dry-rate-tracker plugin

### DIFF
--- a/plugins/dry-rate-tracker
+++ b/plugins/dry-rate-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/georgebunn97/dry-rate.git
+commit=fff8b4697c7600135cf99c865b1f067496cf08d2

--- a/plugins/dry-rate-tracker
+++ b/plugins/dry-rate-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/georgebunn97/dry-rate.git
-commit=7e6b3eaa9639018cc0de333593f4a3501b49915c
+commit=9bac49a6261571645cded712d82a8ee9f76007c9

--- a/plugins/dry-rate-tracker
+++ b/plugins/dry-rate-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/georgebunn97/dry-rate.git
-commit=128b8778d93135fb83a7c1f17a213b022b247b22
+commit=7e6b3eaa9639018cc0de333593f4a3501b49915c

--- a/plugins/dry-rate-tracker
+++ b/plugins/dry-rate-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/georgebunn97/dry-rate.git
-commit=fff8b4697c7600135cf99c865b1f067496cf08d2
+commit=128b8778d93135fb83a7c1f17a213b022b247b22

--- a/plugins/dry-rate-tracker
+++ b/plugins/dry-rate-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/georgebunn97/dry-rate.git
-commit=9bac49a6261571645cded712d82a8ee9f76007c9
+commit=7e1696566d3558a6a9302b0c7d2ebaf58815a04a


### PR DESCRIPTION
- Adjusted the logic for how the dry streaks are detected. 
- It now detects dry streak based on the loot chest
- This is different logic for all three raids
- Updated the UI to make it more uniform 