### PR TITLE
Update dry rate tracker plugin

### DIFF
--- a/plugins/dry-rate-tracker
+++ b/plugins/dry-rate-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/georgebunn97/dry-rate.git
-commit=250a7f99ccdbaae26c3b072ade1fd75f2661f89e
+commit=6b40f57bade0b58d05de7024ffb2969fd5d41ea2


### PR DESCRIPTION
Update dry rate tracker plugin

Updated the detection logic for each raid so it's now based on chests rather than chat messages
- This is because the chat messages were reliant on other plugins. This new logic is more robust and will work for everyone no matter what plugins they use.

Updated the UI 

Updated dry streak save logic