### PR TITLE
Update pet-info - Fix critical bug

### DIFF
--- a/plugins/pet-info
+++ b/plugins/pet-info
@@ -1,2 +1,2 @@
 repository=https://github.com/microtavor5/PetInfoPlugin.git
-commit=785250358dec82e93fe8fdcc5bace369844b5fe7
+commit=d4782d23bc5c6ed6a6aef36e4b120875b6c2e971


### PR DESCRIPTION
Fix bug preventing the loading of the pet data from github, meaning that new installs could not use the plugin at all, and existing installs only used cached versions of the info.