### PR TITLE
Update chance-man to v2.2.2

### DIFF
--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=6e6ba58f3ee4b2bf7bd45f1ebb05ced274765423
+commit=03f6aba05528f01a61bf5b0f9d5e736282ccb33a


### PR DESCRIPTION
- fix: nullify music widget children to prevent NPEs on Profile Switch
- fix false positives by skipping non-item entries in getItemId and ground-item handling
- add "fire" to SkillOp
- add Unfired pottery to SkillItem