### PR TITLE
Create mage-animation-replacer

### DIFF
--- a/plugins/mage-animation-replacer
+++ b/plugins/mage-animation-replacer
@@ -1,0 +1,2 @@
+repository=https://github.com/washer83/mage-animation-replacer.git
+commit=ed5915bec6387ea21c52d7aadcb345d2a6eadbe1


### PR DESCRIPTION
Add mage-animation-replacer -- a plugin designed to swap the trident/barrage animations back to their old animations, which have a visual animation stall.