### PR TITLE
Update hide-chat

### DIFF
--- a/plugins/hide-chat
+++ b/plugins/hide-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/Jordanza21/hide-chat.git
-commit=3949c0ee6131decbd4bc663019c18fd246b7faaf
+commit=e2b71e021a2dce2787eb7b4acb60b6fa8e158707


### PR DESCRIPTION
Fixed startup method to account for config settings

When I added PVM & PVP automatic hiding, I didn't update startup to check config flags on client start. So it resulted in default behavior until a config change event occurred in the hide-chat group.