### PR TITLE
Update chance-man to v2.3.1

### DIFF
--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=2c67598aed0c0f5a9571bbd74bb09f182489f94f
+commit=60f85f6ce22a7c84ffb571a551571f6e049720ed


### PR DESCRIPTION
- add `requiresUnlock` flag and lookup map to SkillItem
- register untradeable items with unlock disabled
- bypass unlock checks for those items when evaluating inventory/equipment