### PR TITLE
Update Line of Sight plug-in to version 2025.07.1

### DIFF
--- a/plugins/line-of-sight
+++ b/plugins/line-of-sight
@@ -1,2 +1,2 @@
 repository=https://github.com/Krazune/LineOfSight.git
-commit=fe213bbb24e854e6d9d0114513b9452664c31ead
+commit=0e4ab190af663a81e7a7113478bcbc6aac968f34


### PR DESCRIPTION
This adds a new toggle to include the player's own tile.