### PR TITLE
Create Surge potion notifier

### DIFF
--- a/plugins/surge-potion-notifier
+++ b/plugins/surge-potion-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/Newbcake/Surge-Potion-Notifier.git
-commit=3f4cd67a65b09af60cee2c4f4349138f27f0ac1d
+commit=3b952703caab9235cc427b2ecbaf8b116cd55d32

--- a/plugins/surge-potion-notifier
+++ b/plugins/surge-potion-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/Newbcake/Surge-Potion-Notifier.git
-commit=3b952703caab9235cc427b2ecbaf8b116cd55d32
+commit=3f4cd67a65b09af60cee2c4f4349138f27f0ac1d

--- a/plugins/surge-potion-notifier
+++ b/plugins/surge-potion-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/Newbcake/Surge-Potion-Notifier.git
-commit=3b952703caab9235cc427b2ecbaf8b116cd55d32
+commit=bbd7986bd83fda93c79482e655e386573bd8586b

--- a/plugins/surge-potion-notifier
+++ b/plugins/surge-potion-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/Newbcake/Surge-Potion-Notifier.git
+commit=3b952703caab9235cc427b2ecbaf8b116cd55d32


### PR DESCRIPTION
The plugin notifies the player when their surge potion can be used again.

It is based on [Heart Notifier by JuliusAF](https://github.com/JuliusAF/imbued-heart-notifier), I have rewritten most of it to suit my usecase and updated it to use gamevals.

This is my first plugin and I'm somewhat new to programming and java so bear with me while I implement feedback if there is any.

Apologies on botching the original PR, I know im not supposed to open multiple. I explicitly tried NOT doing this but I think I messed that one up to a irrecoverable state (probably not true, but is to my current experience, I'll do some reading up to avoid this in the future.)