### PR TITLE
Update clean-chat to 2.0.2

### DIFF
--- a/plugins/clean-chat
+++ b/plugins/clean-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/chat-cleanup.git
-commit=05227715db5dd52c146ab1a7822d5bf4da3a8b7f
+commit=f211c6f546a025ee666682ab0377cd3dece98e8b


### PR DESCRIPTION
- Actually hide the lastSeenVersion
- Fix the channel name regex also matching the chat timestamp if it had brackets

Fixes https://github.com/ldavid432/chat-cleanup/issues/8