### PR TITLE
Update shortest-path to v1.17.3

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=9421a460d60a8be36e359aa72034e3ec83096cf9
+commit=330fbf70783519f5b12c74b8dff3faf6b1e22381


### PR DESCRIPTION
- Add missing stairs and ladders for clue locations in Shayzien, the Lighthouse, the Tree Gnome agility course and the Fortis Colosseum