### PR TITLE
Create ore-highlighter

### DIFF
--- a/plugins/ore-highlighter
+++ b/plugins/ore-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/BuzzfeedBlue/ore-highlighter.git
-commit=469fd44e4e2da9b78e0659e2270c3ac4cd2031a4
+commit=6fea73b6794dcba3ad1934c414fcca2c024fb3b4

--- a/plugins/ore-highlighter
+++ b/plugins/ore-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/BuzzfeedBlue/ore-highlighter.git
-commit=6fea73b6794dcba3ad1934c414fcca2c024fb3b4
+commit=0364d4400689cdeb3f4d38d36c57fedaf1bad533

--- a/plugins/ore-highlighter
+++ b/plugins/ore-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/BuzzfeedBlue/ore-highlighter.git
-commit=b3c4dfd97682442edd2b33674406d3acd659ed6b
+commit=902e022d9a8663149a873082af1e30c6a936e6ca

--- a/plugins/ore-highlighter
+++ b/plugins/ore-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/BuzzfeedBlue/ore-highlighter.git
+commit=b3c4dfd97682442edd2b33674406d3acd659ed6b

--- a/plugins/ore-highlighter
+++ b/plugins/ore-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/BuzzfeedBlue/ore-highlighter.git
-commit=e793cd755f76a0a654db16b41812ca3f81fecb0c
+commit=469fd44e4e2da9b78e0659e2270c3ac4cd2031a4

--- a/plugins/ore-highlighter
+++ b/plugins/ore-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/BuzzfeedBlue/ore-highlighter.git
-commit=902e022d9a8663149a873082af1e30c6a936e6ca
+commit=eb2652848221146225a5260e32f1cb988aa833b8

--- a/plugins/ore-highlighter
+++ b/plugins/ore-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/BuzzfeedBlue/ore-highlighter.git
-commit=eb2652848221146225a5260e32f1cb988aa833b8
+commit=e793cd755f76a0a654db16b41812ca3f81fecb0c


### PR DESCRIPTION
Creation of ore-highlighter plugin. Adds image to interactable paydirt in motherlode mine and amethyst crystals. Image can be changed locally, default is the map mining area circle with pickaxe,