### PR TITLE
Update Dry Rate Tracker Plugin

### DIFF
--- a/plugins/dry-rate-tracker
+++ b/plugins/dry-rate-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/georgebunn97/dry-rate.git
-commit=6b40f57bade0b58d05de7024ffb2969fd5d41ea2
+commit=36c11915ff76f50bb8063f62a617c5f349553bed


### PR DESCRIPTION
Update Dry Rate Tracker Plugin

Fixed TOB detector: Added missing chest IDs (33086-33090) that actually spawn in the room, simplified detection logic
Fixed TOA detector: Corrected object IDs to use actual spawning objects (29994 for player chest, 46220 for non-purple sarcophagus, 44787/44788 for vault chests)
Fixed CoX detector: Added GameTick event handling to properly detect raid completion - light object spawns on room entry but only becomes active after Olm dies
Removed POH test detector: Cleaned up test components that were no longer needed