### PR TITLE
Create scrollboxcounter

### DIFF
--- a/plugins/scrollboxcounter
+++ b/plugins/scrollboxcounter
@@ -1,2 +1,2 @@
 repository=https://github.com/thelaakes/scrollboxcounter.git
-commit=72830b80efef79ae9e2bbd1ed8a323a7ad802bb7
+commit=fa9c40c7ed9df4b8c7f48d63d1320cd533af3878

--- a/plugins/scrollboxcounter
+++ b/plugins/scrollboxcounter
@@ -1,2 +1,2 @@
 repository=https://github.com/thelaakes/scrollboxcounter.git
-commit=fa9c40c7ed9df4b8c7f48d63d1320cd533af3878
+commit=0a12c7b152a7e2ecd0de17b5500a3670d65be76b

--- a/plugins/scrollboxcounter
+++ b/plugins/scrollboxcounter
@@ -1,2 +1,2 @@
 repository=https://github.com/thelaakes/scrollboxcounter.git
-commit=2052d8dada3c004c3dc2250dcc68cbde1aadda26
+commit=fffd422cc3a4b43d64bf812caf620b3d62af3dab

--- a/plugins/scrollboxcounter
+++ b/plugins/scrollboxcounter
@@ -1,2 +1,2 @@
 repository=https://github.com/thelaakes/scrollboxcounter.git
-commit=fffd422cc3a4b43d64bf812caf620b3d62af3dab
+commit=72830b80efef79ae9e2bbd1ed8a323a7ad802bb7

--- a/plugins/scrollboxcounter
+++ b/plugins/scrollboxcounter
@@ -1,0 +1,2 @@
+repository=https://github.com/thelaakes/scrollboxcounter.git
+commit=2052d8dada3c004c3dc2250dcc68cbde1aadda26


### PR DESCRIPTION
A RuneLite plugin that displays the maximum number of clue scroll boxes you can hold for each tier. With options to mark the stack red if the maximum quantity is reached (including banked scroll boxes). Also able to display the number of clue scroll boxes currently banked. 

Interference with clue scrolls and how it behaves if the scroll boxes are in a looting bag/other storage has to be tested.
