### PR TITLE
Add 'Book of the Dead Renamer' plugin

### DIFF
--- a/plugins/book-of-the-dead-renamer
+++ b/plugins/book-of-the-dead-renamer
@@ -1,0 +1,2 @@
+repository=https://github.com/Robadob/rl_botd.git
+commit=7077197e04c16039196c6a6562444dec99408c85


### PR DESCRIPTION
This plugin renames the 5 teleport options within Book of the Dead/Kharedst's Memoirs to their in-game locations to avoid wasting charges.

First attempt at a RuneLite plugin, so keeping it super simple.