### PR TITLE
Update chance-man to v2.3.3

### DIFF
--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=d43bd0957b3bb98fc3d8fbf8bb80d3083ca7d5d2
+commit=32051c76bc885b6143c92d986874ac3bbc6e2801


### PR DESCRIPTION
add config option "requireRolledUnlockedForGe", requiring the item to be both UNLOCKED AND ROLLED.

update README with new config option

update to v2.3.3