### PR TITLE
Update wom-utils to 1.4.8

### DIFF
--- a/plugins/wom-utils
+++ b/plugins/wom-utils
@@ -1,4 +1,4 @@
 repository=https://github.com/wise-old-man/wiseoldman-runelite-plugin.git
-commit=5d76406ad387af55c097a58f01802c3a8797cb49
+commit=994b7c6ae4ca22015ed7dee32ef38e6501622c44
 warning=This plugin submits the names of you, your friends and members of your clan chat to wiseoldman.net.
 authors=dekvall,rorro,psikoi

--- a/plugins/wom-utils
+++ b/plugins/wom-utils
@@ -1,4 +1,4 @@
 repository=https://github.com/wise-old-man/wiseoldman-runelite-plugin.git
-commit=2109cdc394f7a233b82c96abb739c0d09ccd13e7
+commit=5d76406ad387af55c097a58f01802c3a8797cb49
 warning=This plugin submits the names of you, your friends and members of your clan chat to wiseoldman.net.
 authors=dekvall,rorro,psikoi


### PR DESCRIPTION
Many changes in this update. Many are just deletions.

- Adds a chat notification for when a group is out of sync.
- Adds a warning if the group being synced is a different clan. One more layer of agreement before accidentally overriding a group.
- Removes the small party hats. They served the purpose of showing the group admins if a clan member was not synced to the group, but now we have a notification instead. This also removes some visual clutter from the plugin.
- Removes the Add/Remove member menu options. These were very underused and unnecessary since most people just use the sync button. 
- Resends a group sync attempt if players that have been opted out of being added to groups are invloved.

Most changes are from this list of concerns: https://github.com/wise-old-man/wiseoldman-runelite-plugin/issues/25