### PR TITLE
Update/revert wintertodt-scouter

### DIFF
--- a/plugins/wintertodt-scouter
+++ b/plugins/wintertodt-scouter
@@ -1,3 +1,3 @@
 repository=https://github.com/Nouser/wintertodt-scouter.git
-commit=1d8e55390da22210d6b4db5784552e1214cabece
+commit=d2d2386c19ae6b37267dc8a07f6c4abbdae9dfa5
 warning=This plugin shares your IP with a 3rd party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
This just reverts the last set of changes, and bumps the version up. The UI and data have a desync that makes the plugin non-functional at the moment.

I'm also open to reverting the plugin-hub commit that updated to the latest version of `wintertodt-scouter` if that is more idiomatic.