### PR TITLE
update action-logger to v0.1.5

### DIFF
--- a/plugins/action-logger
+++ b/plugins/action-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/ActionLogger.git
-commit=12b7f773bc89e9bf68e8a225fa624f5f71d3b81c
+commit=17cf7339612edf8e02c05b75636d97b1eb9d1f84
 authors=pajlada

--- a/plugins/action-logger
+++ b/plugins/action-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/pajlads/ActionLogger.git
-commit=e9efd023c29b3ecb11dbaee5cff64379cdacfa7f
+commit=12b7f773bc89e9bf68e8a225fa624f5f71d3b81c
 authors=pajlada


### PR DESCRIPTION
This version adds two commands to the action logger plugin:

`::ActionLogger restart` - closes the current file and starts writing to a new file. Useful if you're wanting to separate logs from multiple activities in the same session

`::ActionLogger dump` - dumps information (NPCs, ground items, and objects) about your surrounding to the current file. Lots of data, useful for scenarios where you run into a quest where it doesn't highlight an item due to the ID or coordinates being wrong.