### PR TITLE
Update chance-man to v2.3.4

### DIFF
--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=32051c76bc885b6143c92d986874ac3bbc6e2801
+commit=e71cf1fca16b4455a3e5d55d60efe37f7642da63


### PR DESCRIPTION
- Allow untradeable runeprovider items to pass checks
- Fix typo
- update to v2.3.4