### PR TITLE
update guardian-of-the-rift-optimizer to version 1.0.5

### DIFF
--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=09c708832fabc489633572740947541cf692800c
+commit=9273b51b4ef51a6915641133299d78c878159b25


### PR DESCRIPTION
- adds new config that allows what to optimize for either experience or point distribution before it was defaulting to XP
- added quest checking, obelisks that cant be entered are no longer suggested

total git diff +328/-82

- majority of the diff is moving point tracking out from the overlay slice to a seperate new class

- commit https://github.com/hawolt/guardian-of-the-rift/commit/9273b51b4ef51a6915641133299d78c878159b25