### PR TITLE
Update shortest-path to v1.17.4

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=330fbf70783519f5b12c74b8dff3faf6b1e22381
+commit=c59b6f067e688d9e96966e82f9117c18910e52ea


### PR DESCRIPTION
- Using the Ardougne Teleport spell now requires having read the Ardougne teleport scroll
- Added missing agility climbing rocks north of Eagles' Peak
- Added missing agility balancing ledge in Yanille Dungeon
- Added missing agility monkeybars in Yanille Dungeon
- Added missing staircase to Salarin the Twisted in Yanille Dungeon
- Added missing agility pile of rubble to Salarin the Twisted in Yanille Dungeon
- Added missing thieving lockpick door in Yanille Dungeon
- Using non-wilderness teleports such as minigame teleports from upstairs inside the wilderness is now correctly prevented