### PR TITLE
Update max-hit-calculator to v2.1.0

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=06572456b5e0b3f5c3f587bec93328d7e3cd7413
+commit=cae53129f83c55aad69d7b380c964154a054d382

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=cae53129f83c55aad69d7b380c964154a054d382
+commit=b747687c65f2ce63f046193ddd58367c6bd3d2d4

--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=2b0b281684315c297a82133024f96ba63a9e2cf1
+commit=06572456b5e0b3f5c3f587bec93328d7e3cd7413


### PR DESCRIPTION
v2.1.0:
- Add 600+ new npc type weaknesses from the Summer Sweep Up
- Reworked plugin panel
- Removed NPC Icons (impossible to maintain 750+ npc icon's for type weaknesses)
- Update Dragon Hunter wand to Summer Sweep Up change