### PR TITLE
update guardians-of-the-rift-optimizer to version 1.0.6

### DIFF
--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=9273b51b4ef51a6915641133299d78c878159b25
+commit=9bdee5412d0b5d864ae08934e1000b129c6d124d


### PR DESCRIPTION
the commits of the original PR are feature seperated for a hopefully easier review process
- https://github.com/hawolt/guardian-of-the-rift/pull/18


total git diff +451 −103

a big part of the diff is a new seperate class for the infobox to avoid issues with the overlay layer of the current custom painted overlay