### PR TITLE
Update pyramid-plunder-counter

### DIFF
--- a/plugins/pyramid-plunder-counter
+++ b/plugins/pyramid-plunder-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/adnapPanda/pyramid-plunder-counter.git
-commit=d007bb28cc3684e439afdbb9293b40ddccdf17d9
+commit=0c455cfe28e7f3237126eefe8fef30d2ae782708


### PR DESCRIPTION
Small change to config to be able to hide the tool-tip. Hidden by default