### PR TITLE
update scrollboxcounter

### DIFF
--- a/plugins/scrollboxcounter
+++ b/plugins/scrollboxcounter
@@ -1,2 +1,2 @@
 repository=https://github.com/thelaakes/scrollboxcounter.git
-commit=0a12c7b152a7e2ecd0de17b5500a3670d65be76b
+commit=02688643cd30b81e52dddd316d30628dd7862264


### PR DESCRIPTION
I fixed two bugs: one where withdrawing from the bank too quickly would cause the amount to increase incorrectly, and another where chat messages wouldn't appear. Also, now the plugin takes clue scrolls, challenge scrolls, and torn clue scrolls into account when checking if your scroll boxes are at the cap. I also refactored the code a bit.