### PR TITLE
Update prestige plugin repo

### DIFF
--- a/plugins/prestige
+++ b/plugins/prestige
@@ -1,2 +1,2 @@
-repository=https://github.com/ckosidow/prestige-levelling.git
+repository=https://github.com/salvite/prestige-levelling.git
 commit=2c50871318cfa98dbe9c098d7a09d1488c096f0b


### PR DESCRIPTION
The original prestige plugin repo appears to be dead. I've updated the code to work w/ the latest runelite version on my fork.