### PR TITLE
Add Burner Alarm Plugin

### DIFF
--- a/plugins/burner-alarm
+++ b/plugins/burner-alarm
@@ -1,0 +1,2 @@
+repository=https://github.com/AltarOSRS/BurnerAlarmPlugin.git
+commit=0ed4fadf26c7a6b6b84f8add2aad4a47e3ba9b2a


### PR DESCRIPTION
**Plugin Description:**
Sends a notification and plays a sound when your POH burners are about to go out.

**Features:**
- Provides a configurable pre-notification alert when burners are close to reaching their random burnout timer
- Plays an audible alarm sound when burners fully reach their random burnout timer
- Designed to notify only once per type for a "batch" of burners lit together
- Timer scales with firemaking level
- Automatically clears active burner timers when leaving a Player-Owned House (POH) or other game state transitions
- Toggle alerts, change volume, or adjust stage 1 alert lead time in config