### PR TITLE
Add Inferno 2d map plugin

### DIFF
--- a/plugins/inferno-2d-map
+++ b/plugins/inferno-2d-map
@@ -1,0 +1,2 @@
+repository=https://github.com/TheRealGuru/inferno-2d-map.git
+commit=3339a9df61f72f25158b19e89879420d8af77d8d


### PR DESCRIPTION
This plugin simply adds the ability to view your current inferno wave as a 2d map, very similarly to tools such as this one https://ifreedive-osrs.github.io

This is just convieniently in the client. 

This doesn't provide any specific helpers for inferno other than providing a very simple 2d representation of the tiles within inferno.