### PR TITLE
Update Prestige

### DIFF
--- a/plugins/imadrum-money
+++ b/plugins/imadrum-money
@@ -1,2 +1,2 @@
 repository=https://github.com/EwwItsMike/ImaDrum-Money.git
-commit=fdd47662c21d0986195cd82fbedc48800dec5e16
+commit=7bf854c90d15cfdfd3d1a51a6dadba79742ecebf

--- a/plugins/prestige
+++ b/plugins/prestige
@@ -1,2 +1,2 @@
 repository=https://github.com/salvite/prestige-levelling.git
-commit=2c50871318cfa98dbe9c098d7a09d1488c096f0b
+commit=39c228900db3feb1539d7c27b8f45851826970e9

--- a/plugins/prestige
+++ b/plugins/prestige
@@ -1,2 +1,2 @@
 repository=https://github.com/salvite/prestige-levelling.git
-commit=39c228900db3feb1539d7c27b8f45851826970e9
+commit=2ad6d6fd2f2055dcff4807a4c155ae76ae6068eb

--- a/plugins/prestige
+++ b/plugins/prestige
@@ -1,2 +1,2 @@
 repository=https://github.com/salvite/prestige-levelling.git
-commit=2ad6d6fd2f2055dcff4807a4c155ae76ae6068eb
+commit=d5bceccea709707f62fcf326ff6abb46b6d247b6


### PR DESCRIPTION
Updates prestige to the latest build which removes the use of WidgetID.