### PR TITLE
Add Quick Obtain plugin

### DIFF
--- a/plugins/quick-obtain
+++ b/plugins/quick-obtain
@@ -1,0 +1,2 @@
+repository=https://github.com/davebrouwer1/quick-obtain.git
+commit=ef2f48cadcf2c738d619e60943583b3164c8943b


### PR DESCRIPTION
This plugin shows multiple options for obtaining an item when searching for it, for example "Pot" or "Cheese" It pulls data from the wiki, and shows you the different spawn and/or store locations, when you click on an option it uses the "ShortestPath" plugin code (packaged within this plugin) to route it out.