### PR TITLE
Global Chat - Hotfix, fix broken navbar (simple change)

### DIFF
--- a/plugins/global-chat
+++ b/plugins/global-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/RusseII/region-chat.git
-commit=02e8df03b1f9cba485a2a6bbcfda973b624bf4c1
+commit=d46ae09b86d1d328785a329e0fb52f8ccb00e0e8
 warning=This plugin submits all sent chat messages and your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
<img width="1072" height="320" alt="GM 000466" src="https://github.com/user-attachments/assets/95053af7-e275-49e8-a76d-24bd5af8e783" />

I was incorrectly loading the navigation sidepannel, causing it to fail to load. I'm now loading it correctly as in done for the other runelite core plugins. 