### PR TITLE
Update ca-export to 1.2.1

### DIFF
--- a/plugins/ca-export
+++ b/plugins/ca-export
@@ -1,2 +1,2 @@
 repository=https://github.com/cdfisher/ca-export.git
-commit=e45bf1eb6eb979fad3412c4417323083bb53230b
+commit=23bbb1c51bd95787160ff1fd2ad86c22cebf1217


### PR DESCRIPTION
Fixes the plugin not working due to a new varplayer being added for Yama combat achievements (cdfisher/ca-export#1).

Two line change, one of which is a version number bump.