### PR TITLE
Update nylo-death-indicators to v1.1.0

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=f181129398f99a5803d2570d0ef414e8fd624fb3
+commit=ea273a26f5ec578d8b19cae01fed615d31090172


### PR DESCRIPTION
- Updates the barrage animation ID to use both the old (seen via anim replacer) and the new one introduced during the summer sweep up.
- Refactors some of the XP tracking to simplify the branches.
- Refactors retrieving nylo information on spawn and fixes a bug where certain nylos had the wrong hp or were missing