### PR TITLE
Update chance-man to v2.4.0

### DIFF
--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=e71cf1fca16b4455a3e5d55d60efe37f7642da63
+commit=d7bfee7b188a3716b40e280dec3329a9e57d4ec9


### PR DESCRIPTION
- DropItem pulls rarity from the wiki
- Added getOneOverRarity to convert fractions like “2/128” to “1/64”
- DropFetcher reads the rarity column when building DropItem objects
- MusicWidgetController maps icons to DropItem instances instead of IDs
- DropsTooltipOverlay draws name and rate in stacked boxes
- Restart drop fetch executor on plugin enable
- Restore widget via ClientThread on plugin disable
- Prune drop caches older than 7 days on account change
- update to v2.4.0