### PR TITLE
Add Yama reminder plugin

### DIFF
--- a/plugins/yama-reminder
+++ b/plugins/yama-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/jdockerty/yama-reminder.git
+commit=bca9a3216ccdfa98a7f832b1fa52975425fcd447


### PR DESCRIPTION
Adds a simple panel which acts as a reminder for what prayer to use on the phases between Yama.

This is deterministic only after user input (clicking the button). This plugin is entirely for removing the need to write reminders to duo partners, instead we can click a button and save spamming chat.
