### PR TITLE
RuneProfile v2.1.1

### DIFF
--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,3 +1,3 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=3fced102e49ec2b35b156aae773cd5244c9d24bf
+commit=7fba4f61db084011d49bf17784c32a4f8a88f7bb
 warning=This plugin submits your player data and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Bugfix: Manual sync button didn't work when player had 0 collection log items.
Now executes update directly, when VarPlayerID.COLLECTION_COUNT = 0.