### PR TITLE
Add auto party plugin

### DIFF
--- a/plugins/auto-party
+++ b/plugins/auto-party
@@ -1,0 +1,2 @@
+repository=https://github.com/neilrush/Auto-Party.git
+commit=563283a3a09f9bae0e3fcb39d1f0f2972bcfb7b4


### PR DESCRIPTION
A simple plugin that rejoins the last party on login. Requires the party plugin to be enabled.

Enable the plugin and then join a party. The plugin will rejoin your last used party at login until you leave the party or disable the plugin.

Upon joining a party at login, a chat message is displayed to notify the user.