### PR TITLE
Create quest-eat

### DIFF
--- a/plugins/quest-eat
+++ b/plugins/quest-eat
@@ -1,0 +1,2 @@
+repository=https://github.com/Steviefp/quest-eat.git
+commit=6e1c0629eaaf3fe370dfa7000213ebfaa609fa8e


### PR DESCRIPTION
QuestEat is a RuneLite plugin designed to prevent players from accidentally eating specific food items that are required for quests.  For example like chocolatey milk, orange slices, and some basic foods you'd typically never eat. Plugin simply removes the eat option from those food. This is my first plugin 