### PR TITLE
Quest Eat Plugin

### DIFF
--- a/plugins/quest-eat
+++ b/plugins/quest-eat
@@ -1,0 +1,2 @@
+repository=https://github.com/Steviefp/quest-eat.git
+commit=6e1c0629eaaf3fe370dfa7000213ebfaa609fa8e

--- a/plugins/quest-eat
+++ b/plugins/quest-eat
@@ -1,2 +1,2 @@
 repository=https://github.com/Steviefp/quest-eat.git
-commit=6e1c0629eaaf3fe370dfa7000213ebfaa609fa8e
+commit=df04f2826fdf3923b38d117cf0e97af97a9deb20


### PR DESCRIPTION
First plugin, This plugin prevents accidental eating of quest-related food items. It blocks the ability to eat specific foods required for quests via removing the eat option of certain foods like: Chocolaty Milk, cheese, tomato, orange slices and more.