### PR TITLE
Update DropTracker to v5.0.1

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=2b534dfce71ca5fd44c83e5cf867105eb42d8145
+commit=851a5e73b7793a807a310b9b77ec4810457a1c28
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=a61bc16962695dc2220ade3ef716d1835f448641
+commit=3527c38e70a0d3a08755fd35ddf2f00643888040
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=89a201d349a213903237ef57d13a34ea26234183
+commit=987f2bf92ce70d24758d68f575880570739a15f4
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=3527c38e70a0d3a08755fd35ddf2f00643888040
+commit=772020263aee6ddef0f43ac023e97dd3985ad55c
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=f729f2219b9059ddceaf31a857a999288326e7ab
+commit=b2b2807c84fe9aee672238c8ecd992b06bb7e1b9
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=772020263aee6ddef0f43ac023e97dd3985ad55c
+commit=5aee7e56e4e96ab2266722ef31b171e2bdbf656b
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=b552575c5d959f9ffb946d768fa88903625e213b
+commit=e15f6858214f1157f55d2981da36ca27fab89440
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=5aee7e56e4e96ab2266722ef31b171e2bdbf656b
+commit=20db8b19230a87a12a966118dac32234b1896438
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=00617486830bf3b3cb249fceb0d8a9c7cbd66c7c
+commit=dd729b9bea6db1485fca98678dfde97f87b249c4
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=e15f6858214f1157f55d2981da36ca27fab89440
+commit=a61bc16962695dc2220ade3ef716d1835f448641
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=5abe4bf3f5d3dadae8c511a95c4df7f136caa9a3
+commit=602e9586127a7dd9f7b54a3b79037dbc17695a86
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=987f2bf92ce70d24758d68f575880570739a15f4
+commit=5abe4bf3f5d3dadae8c511a95c4df7f136caa9a3
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=b2b2807c84fe9aee672238c8ecd992b06bb7e1b9
+commit=00617486830bf3b3cb249fceb0d8a9c7cbd66c7c
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=851a5e73b7793a807a310b9b77ec4810457a1c28
+commit=ca1c727dfbfe04bef38cea3588508fb0dea15c72
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=20db8b19230a87a12a966118dac32234b1896438
+commit=2b534dfce71ca5fd44c83e5cf867105eb42d8145
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=dd729b9bea6db1485fca98678dfde97f87b249c4
+commit=89a201d349a213903237ef57d13a34ea26234183
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=ca1c727dfbfe04bef38cea3588508fb0dea15c72
+commit=f729f2219b9059ddceaf31a857a999288326e7ab
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
We've made a large number of changes with this update:

- Added Quest, pet and experience tracking functionality (courtesy to the Dink team for the heavy lifting <3)
- Refactored our event handlers to move them all into their own classes; extending upon a base (another thanks to Dink for the inspiration)
- Fixed KCs being sent alongside drop submissions--which were sending blank.

Most of the codebase has been redesigned to create a more manageable codebase moving forward & to provide players a more intuitive way of viewing leaderboards and player/group stats from directly inside the client.