### PR TITLE
Cox mega scale

### DIFF
--- a/plugins/cox-mega-scale
+++ b/plugins/cox-mega-scale
@@ -1,2 +1,2 @@
-repository=https://github.com/Akash9933/cox-mega-scale.git
+repository=https://github.com/FadedAshen/cox-mega-scale.git
 commit=0edd61f949fc8fc87afd32d30ea31641cc37858a


### PR DESCRIPTION
Cox Mega Scale plugin helps with running a mega scale with friends by providing utility and information.

Provides:

Scouting assistance by selecting whitelisted rooms and order.
Points gained and lost.
Drop chance with amount of rolls.
How many overloads/golpar/fish needed.

NOT INTENDED FOR BOOSTING IRONS.