### PR TITLE
Added Idle Fishing Notifications plugin

### DIFF
--- a/plugins/idle-fishing-notifications
+++ b/plugins/idle-fishing-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/Salcrainia/Idle-Fishing-Notfications.git
+commit=3dfc6cceca996769e847d8b9b7508663db95c4e9


### PR DESCRIPTION
### Description
Enables better idle notifications when fishing.
Covers all cases encountered so far - primarily tested at Tempoross.

