### PR TITLE
Add raid-spell-checker plugin

### DIFF
--- a/plugins/raid-spell-checker
+++ b/plugins/raid-spell-checker
@@ -1,0 +1,2 @@
+repository=https://github.com/tyler-arnett/raid-spell-checker.git
+commit=4f08b72e5803b07a7c3b92be2a48e63e68fef842

--- a/plugins/raid-spell-checker
+++ b/plugins/raid-spell-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/tyler-arnett/raid-spell-checker.git
-commit=714e95b3bfea4627adccd74945c2fefeeb4ddfa1
+commit=24c245599a47c2152187b10f5bf6c2335f939696

--- a/plugins/raid-spell-checker
+++ b/plugins/raid-spell-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/tyler-arnett/raid-spell-checker.git
-commit=4f08b72e5803b07a7c3b92be2a48e63e68fef842
+commit=1d5953ed26978ca4e44a1d49798a20a33b9ffac8

--- a/plugins/raid-spell-checker
+++ b/plugins/raid-spell-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/tyler-arnett/raid-spell-checker.git
-commit=1d5953ed26978ca4e44a1d49798a20a33b9ffac8
+commit=714e95b3bfea4627adccd74945c2fefeeb4ddfa1

--- a/plugins/raid-spell-checker
+++ b/plugins/raid-spell-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/tyler-arnett/raid-spell-checker.git
-commit=24c245599a47c2152187b10f5bf6c2335f939696
+commit=df24bfd3ee201e84a4dd2ee1378e37fc6abe036a


### PR DESCRIPTION
This plugin checks that you have the correct spellbook and required spells/runes before starting COX, TOB, or TOA.
If you're missing the required spellbook or runes, it alerts you with a configurable popup and sound.

Features:
Custom sound support (.wav files in resources).
Supports rune pouch, divine rune pouch, and staves.
Configurable per-raid and per-spellbook.

NOTE: Plugin must be configured before use. The player selects their preferred spellbook and spells per raid.
