### PR TITLE
Create hide-spellbook-tooltip

### DIFF
--- a/plugins/hide-spellbook-tooltip
+++ b/plugins/hide-spellbook-tooltip
@@ -1,0 +1,2 @@
+repository=https://github.com/umer-rs/hide-spell-overlay.git
+commit=ae3b6c3eb95e4c593adc40549f07e877aa96fd85


### PR DESCRIPTION
Simple plugin that hides the spellbook tooltip. Also open to suggestions for a different plugin to add this simple functionality to.