### PR TITLE
Add Frozen Icon Me plugin metadata

### DIFF
--- a/plugins/frozen-icon-me
+++ b/plugins/frozen-icon-me
@@ -1,0 +1,2 @@
+repository=https://github.com/HamzehAdawi/FrozenIcon.git
+commit=d7c79340fbd915d5c8c02734cf6eda780c0a0b9d


### PR DESCRIPTION
Adds a visual indicator of the spell your player is frozen with icon next the HP bar. Ex. when you are frozen or entangled by spells like Ice Barrage or Entangle. Helps track what kind of freeze with matching icon for a quick reference during combat (your own character only).