### PR TITLE
Bump shooting stars plugin

### DIFF
--- a/plugins/shooting-stars
+++ b/plugins/shooting-stars
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/plugin-repo.git
-commit=c190373a4baa76fd115c1c5fedd328317afc0592
+commit=986071af9651ce1df8f18ad45932ee750501100a
 warning=This plugin submits the location and time of shooting stars along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Looks like the old way of getting the message box broke with today's update. This change uses the gameval to specify the correct messagebox so that star locations can be read properly from ingame.