### PR TITLE
Add totem-minigame plugin

### DIFF
--- a/plugins/totem-minigame
+++ b/plugins/totem-minigame
@@ -1,0 +1,2 @@
+repository=https://github.com/Meantub/totem-minigame-plugin.git
+commit=237253e0b213c3183727babbb9e665085879e69f


### PR DESCRIPTION
This is a plugin for the new totem minigame in Varlamore: The Final Dawn.

Right now it highlights the tile of each totem, it changes the color of the tile to represent how well you've carved the totem.
Red: No base
Orange: Not carved base
Yellow: Carved base
Green: Decorated base

It displays which spirits you need to carve into the totem. And also highlights all spirits and ents and adds text to show their names. There is something that also highlights the Ent Trails for better tracking.

It also contains an overlay that will track how many points you've claimed since starting the session. If you have any questions feel free to let me know, thanks!