### PR TITLE
Update clean-chat to v2.2.1

### DIFF
--- a/plugins/clean-chat
+++ b/plugins/clean-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/chat-cleanup.git
-commit=b4b74bbd6ccbea96d299913e2b45df57637ae066
+commit=563b4f2db737cd66a845163032853d026bccb377


### PR DESCRIPTION
- Small fix for long messages dropping down to the 2nd line when indent was enabled