### PR TITLE
Add salve-reminder plugin

### DIFF
--- a/plugins/salve-reminder
+++ b/plugins/salve-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/Dazuzi/salve-reminder.git
-commit=19e9f79c294d8c7a7906857d08072b9f8b174e02
+commit=79b6fcd98728b3be5fd8b222a738fb89d19a1093


### PR DESCRIPTION
Reminds you to use Salve amulet when appropriate.

![salve-reminder](https://github.com/user-attachments/assets/a4bd9fc9-03bd-483f-b121-589070c2eaa9)
<img width="229" height="382" alt="salve-reminder" src="https://github.com/user-attachments/assets/2c9bf13f-5706-43ee-a985-c22f0e7c41ef" />

I'm aware there's a similar plugin, but it's specific to Chambers of Xeric and Theatre of Blood.