### PR TITLE
Create mokhaiotl-rock-highlighter

### DIFF
--- a/plugins/mokhaiotl-rock-highlighter
+++ b/plugins/mokhaiotl-rock-highlighter
@@ -1,2 +1,2 @@
-repository=https://github.com/vatsake/mokhaiotl-rock-highlighter
+repository=https://github.com/vatsake/mokhaiotl-rock-highlighter.git
 commit=3ff8443a4f46d41c3c5e795df41a51a94c29d856


### PR DESCRIPTION
In later waves when Mokha does the racecar mechanic, it's sometimes hard to find rocks to stand behind.
This plugin highlights the rock tiles.