### PR TITLE
Update wom-utils to 1.4.13

### DIFF
--- a/plugins/wom-utils
+++ b/plugins/wom-utils
@@ -1,4 +1,4 @@
 repository=https://github.com/wise-old-man/wiseoldman-runelite-plugin.git
-commit=38c48475cbcb6b6d438041b8a1a933cebb480d2f
+commit=b8388ffae425ad515f84c6194152b91cf82d4837
 warning=This plugin submits the names of you, your friends and members of your clan chat to wiseoldman.net.
 authors=dekvall,rorro,psikoi


### PR DESCRIPTION
Makes it so importing group members only happens after a proper log out and not world hopping because that is spamming the API a little bit too much.