### PR TITLE
Update tile-grid to 1.2

### DIFF
--- a/plugins/tile-grid
+++ b/plugins/tile-grid
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/runelite-tile-grid.git
-commit=c64a66cc80a9635516e53b9cbdd95d99bf0bac82
+commit=0e8e4c31bd41bd92c5d051062b7de4f304554bda
 authors=Notloc


### PR DESCRIPTION
Features:
Ability to only render walkable tiles in the grid
Different grid color settings for the overworld and underground
Line thickness setting

Also:
Sorry for the back to back PRs, I hadn't planned on doing more work on this plugin, it just kinda happened.