### PR TITLE
Update frozen-icon-me 

### DIFF
--- a/plugins/frozen-icon-me
+++ b/plugins/frozen-icon-me
@@ -1,2 +1,2 @@
 repository=https://github.com/HamzehAdawi/FrozenIcon.git
-commit=6ee7d81372858756b2ada388466b922c1f96ba3c
+commit=b555e9cd9835928b6ae6c9297dea41954286ad3e


### PR DESCRIPTION
Fixes the freeze icon from triggering during the immunity period to prevent incorrect displays. Also corrects the Ice Rush spell handling by using the proper spell ID. Adds a new icon.png.