### PR TITLE
Add House Hosting plugin and remove Burner Alarm

### DIFF
--- a/plugins/burner-alarm
+++ b/plugins/burner-alarm
@@ -1,2 +1,0 @@
-repository=https://github.com/AltarOSRS/BurnerAlarmPlugin.git
-commit=0ed4fadf26c7a6b6b84f8add2aad4a47e3ba9b2a

--- a/plugins/house-hosting
+++ b/plugins/house-hosting
@@ -1,0 +1,2 @@
+repository=https://github.com/AltarOSRS/HouseHostingPlugin.git
+commit=bfd12654d720f8ba2948dca9c7db57a8ae51dfc7


### PR DESCRIPTION
### Title: Add: House Hosting Plugin & Remove: Burner Alarm Plugin

Scope of my Burner Alarm outgrew itself. Looking to add the House Hosting plugin and Remove the Burner Alarm plugin.

**Features:**
* **Burner Alarm:** Two-stage notifications for incense burners.
* **Unlit Burner Highlight:** Visual outlines for unlit burners.
* **Tip Jar Notifications:** Tiered notifications and chat recoloring for tips.
* **Player Level-Up Notifications:** Alerts for generic, Level 99, and Combat Level 126 achievements by guests.
* **Marrentill Tracker:** Monitors Marrentill supply with low-stock warnings.
* **POH Guest Tracker:** Overlay displaying current guest count.

Notifications are fully customizable now and also allow for customizable chat message colors.