### PR TITLE
Add demonic-larva-tracker

### DIFF
--- a/plugins/demonic-larva-tracker
+++ b/plugins/demonic-larva-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/marknewan/newan-plugins.git
+commit=3ea1bca491a932f34d1ca3b3a9217e0f1f93a49c


### PR DESCRIPTION
This plugin essentially replicates the tzhaar hp tracker plugin, but for larva npcs instead of nibblers.

- Death prediction on stat change
- Hide overheads for color-coded larva (mage/range/melee)
- Convenience features that other generic plugins provide
  - Menu recolor
  - Outline/tile/hull highlights