### PR TITLE
Add projectile-override v1.0.0

### DIFF
--- a/plugins/projectile-override
+++ b/plugins/projectile-override
@@ -1,2 +1,2 @@
 repository=https://github.com/Loze-Put/projectile-override.git
-commit=0a34d42f3f66e7d83749cbd221cc8e88eadfdc0d
+commit=2ddf793140997940bd3ec71a315056fb9634aae3

--- a/plugins/projectile-override
+++ b/plugins/projectile-override
@@ -1,0 +1,2 @@
+repository=https://github.com/Loze-Put/projectile-override.git
+commit=0a34d42f3f66e7d83749cbd221cc8e88eadfdc0d


### PR DESCRIPTION
This plugin replaces boss projectiles with alternatives that are easier to distinguish in color, shape, or contrast. It aims to improve accessibility for colorblind and visually impaired players by reducing ambiguity in high-pressure PvM encounters. All projectiles are only replaced by the projectiles of other bosses to comply with the Jagex third party plugin statement. Some other similar plugins exist and I don't want to create a new plugin for each boss.