### PR TITLE
Update shortest-path to v1.17.5

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=c59b6f067e688d9e96966e82f9117c18910e52ea
+commit=418afc221490b0df36c3f6c787cd630f0ef2b0ba


### PR DESCRIPTION
- Fixed incorrect requirement check for the Watchtower teleport
- Fixed incorrect requirement check for the Hajedy Shilo Village travel cart
- Fixed incorrect requirement check for Dragon Slayer 1 wall under Crandor
- Added level 84 agility rocks climb shortcut on Crandor
- Updated the collision map to 2025-07-23 for the Varlamore: The Final Dawn release
- Fixed incomplete staff of air, earth, fire and water checks to also consider the standard battlestaves
- Added the Giantsoul amulet teleports