### PR TITLE
bump guardian-of-the-rift-optimizer to v1.0.6.3

### DIFF
--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=bcf4e8ca4552b2152236fd2a579d01c6abb28b8f
+commit=aecaad57e3d94fefd2a3f320f700d510dadda9d7


### PR DESCRIPTION
update a widget ID that for some reason has changed

https://github.com/hawolt/guardian-of-the-rift/commit/aecaad57e3d94fefd2a3f320f700d510dadda9d7

total git diff +2/-2