### PR TITLE
Update inferno-stats to v2.1.7

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=260aaa3463d962c23bd8fc2bd991911fcdf1850c
+commit=b3517a2167e2f24f35292da1c88f4b72a644c2dd


### PR DESCRIPTION
The goal of this update is to always have the final recorded time be equivalent to the chat message in game. This was not an issue with inferno, but in fight caves the timer is started on cave entry and wave 1 spawns whenever you break the entry interface. This PR also adds precise timing support.

A lof of this is formatting unfortunately, so for functional changes:

- src/main/java/com/infernostats/InfernoStatsOverlay.java
  - OverlayPriority.MED -> PRIORITY_MED
- src/main/java/com/infernostats/InfernoStatsPlugin.java
  - Use Gamevals for Fire cape and Infernal cape item IDs
  - Create an isInRegion method that isInFightCaves and isInInferno can use
  - In onRunCompletedEvent, manually set the duration of the final wave as "completed duration - start of final wave"
- src/main/java/com/infernostats/InfernoStatsTimer.java
  - Use `formatTicksShort`, a new method in TimeFormatter, to maintain the previous behavior of "MM:SS" in splits
- src/main/java/com/infernostats/controller/ChatHandler.java
  - Use TZHAAR_DURATION_MESSAGE instead of the previous TZHAAR_COMPLETED_MESSAGE to extract the final time of the kill with extractDuration
- src/main/java/com/infernostats/controller/WaveHandler.java
  - Uses gamevals for NPC IDs
- src/main/java/com/infernostats/view/TimeFormatting.java
  - Formatting is now done with formatTicks (clipboard/save files) or formatTicksShort (overlays, infoboxes, chat messages)