### PR TITLE
Update scrollboxcounter

### DIFF
--- a/plugins/scrollboxcounter
+++ b/plugins/scrollboxcounter
@@ -1,2 +1,2 @@
 repository=https://github.com/IEarnSolo/scrollboxcounter.git
-commit=14bfc0265f1c012652a125d12a3af0033de3ff7d
+commit=f6ae14a0a825444dc5378177434cd2f900786a36


### PR DESCRIPTION
Fixed bug with clue scrolls miscalculating current total when withdrawing and bank is closed fast

Added logic for considering picking up or dropping clue items if the bank was open last tick, instead of always assuming it's going to or coming from the bank

Added config option for showing or hiding item overlays for clue/challenge scrolls