### PR TITLE
Update demonic-larva-tracker to v1.2.1

### DIFF
--- a/plugins/demonic-larva-tracker
+++ b/plugins/demonic-larva-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/marknewan/newan-plugins.git
-commit=3ea1bca491a932f34d1ca3b3a9217e0f1f93a49c
+commit=204a7323c580f80a46add41f9e33b78682be7750


### PR DESCRIPTION
Fixes a small bug, not likely to be encountered/noticed, due to a typo.