### PR TITLE
Update quest-helper to 4.9.3.1

### DIFF
--- a/plugins/quest-helper
+++ b/plugins/quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Zoinkwiz/quest-helper.git
-commit=de54afd40a63393aa5bc83023b7ea796436ffff0
+commit=9b83c46eb000ea3ee8ec5e5514ccf4a0c267e0c3


### PR DESCRIPTION
Fix for rune pouch checks to avoid dev mode freeze.