### PR TITLE
Create keybind-button-overlay

### DIFF
--- a/plugins/keybind-button-overlay
+++ b/plugins/keybind-button-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/LeeT96/keybind-button-overlay.git
+commit=e66746d586818aaae0e67cbdbd02bf7a80c18e4f


### PR DESCRIPTION
This is different to a similarly-named plugin, whereby this plugin displays hotkey/keybinds on the icons/tabs themselves, whereas the other plugin shows them in an infobox.