### PR TITLE
Update afk-crab-helper

### DIFF
--- a/plugins/afk-crab-helper
+++ b/plugins/afk-crab-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/1504681/afk-crab-helper.git
-commit=9063497b37d994e02865c02d698f28fc7a29c4e3
+commit=234d35a3d44e44ed2cee833a98f767be95f6ed10

--- a/plugins/afk-crab-helper
+++ b/plugins/afk-crab-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/1504681/afk-crab-helper.git
-commit=20b245c9e5c3f4d3410f0969fe0da43df1f8be1e
+commit=9063497b37d994e02865c02d698f28fc7a29c4e3


### PR DESCRIPTION
Improve plugin description for better searchability - now leads with "Gemstone Crab AFK timer" so players searching for Gemstone Crab plugins can find it more easily.