### PR TITLE
Update nylo-death-indicators to v1.1.2

### DIFF
--- a/plugins/nylo-death-indicators
+++ b/plugins/nylo-death-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/Nylo-Death-Indicators.git
-commit=853b8098e95b924c15b79f99492160c4b3d78434
+commit=1b29a76e1799cf813299bfdc75e12251028643ae


### PR DESCRIPTION
Set the nylos to dead at the end of the client tick so that other plugins (like blert) can check if the targeted nylo is alive for data tracking.