### PR TITLE
Create doom-projectile-replacer

### DIFF
--- a/plugins/doom-projectile-replacer
+++ b/plugins/doom-projectile-replacer
@@ -1,0 +1,2 @@
+repository=https://github.com/RuneAaron/DoomProjectileReplacer
+commit=c134fb72883afb26cef41a66f3ce3e39ff909997


### PR DESCRIPTION
This plugin is to replace the Doom of Mokhaiotl / Osto-Ayak projectiles with alternative projectiles from TOA, TOB or CoX. 

Created to support colourblind players struggling with identifying the default projectiles.
