### PR TITLE
Update ping-grapher to 1.6.0

### DIFF
--- a/plugins/ping-grapher
+++ b/plugins/ping-grapher
@@ -1,2 +1,2 @@
 repository=https://github.com/yuh25/Ping-Grapher.git
-commit=fe351113b0be6b8a2d6e5555f131976673bd257b
+commit=bdb2f6d607d2f73b45b6bf1debc469828c703177


### PR DESCRIPTION
- Added setting for labels under the graph
- Removed "Timed out" message, replaced with "-" after getting no response 3 times.
- Removed the ping spikes when getting no response, instead the result doesn't get added
- Changed Tick labels to measure deviation from 600 ms
- Fixed graph not drawing properly