### PR TITLE
update demonic-larva-tracker to v1.3.1

### DIFF
--- a/plugins/demonic-larva-tracker
+++ b/plugins/demonic-larva-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/marknewan/newan-plugins.git
-commit=204a7323c580f80a46add41f9e33b78682be7750
+commit=b94d970a9c14093431b2a4e283785f4022b84b0b


### PR DESCRIPTION
- fix bug where damage was calculated twice
- add name label highlight config
- add clickbox highlight config
- add antialias config