### PR TITLE
update guardians-of-the-rift-optimizer to v1.0.6.4

### DIFF
--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=aecaad57e3d94fefd2a3f320f700d510dadda9d7
+commit=875eb456bd2211ae5b65fbfe186dc08a97142df8


### PR DESCRIPTION
the commits of the original PR are feature seperated for a hopefully easier review process
- https://github.com/hawolt/guardian-of-the-rift/pull/23


total git diff +125 −70

a big part of the diff is moving stuff around in the config to make the plugin less overwhelming