### PR TITLE
Update shortest-path to v1.17.6

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=418afc221490b0df36c3f6c787cd630f0ef2b0ba
+commit=14dd98eb9044d794117770eb8875e4e6ae9de9bd


### PR DESCRIPTION
- Added PoH teleportation jewellery boxes
- Added PoH mounted amulets and capes
- Added some PoH teleportation portals  
  - Annakarl
  - Ardougne
  - Barrows
  - Camelot / Seers' Village
  - Falador
  - Kharyrll
  - Lumbridge
  - Varrock / Grand Exchange 
  - Yanille / Watchtower
- Added missing house teleport skill requirements

**PS: the PoH teleportation options will currently be slightly inaccurate and suggested less often than expected as the pathfinder will often take an unnecessarily long path inside the house**