### PR TITLE
Update cox-special-loot-hider

### DIFF
--- a/plugins/cox-special-loot-hider
+++ b/plugins/cox-special-loot-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/riktenx/cox-special-loot-hider.git
-commit=36941df4b49b06511e35b44f43f157eaef73d900
+commit=41048e142a286f880efc770090c62d39a7a56af5

--- a/plugins/cox-special-loot-hider
+++ b/plugins/cox-special-loot-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/riktenx/cox-special-loot-hider.git
-commit=41048e142a286f880efc770090c62d39a7a56af5
+commit=c95c07a52737f555affe139d3f9bf76565c096d5


### PR DESCRIPTION
API fixes for removal of getStringStack() / deprecation of WidgetID