### PR TITLE
Update Wildy QoL to 1.2.0

### DIFF
--- a/plugins/pet-spell-blocker
+++ b/plugins/pet-spell-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/Sacca-1/Wildy-QoL.git
-commit=f9956cc022a4e6c93b83eab421c0e2d851f9b76a
+commit=22e089208a091aec418b6b593523bafee2a7afcc


### PR DESCRIPTION
Added a new feature that caches friends chat members to prevent them from showing up as enemies on player indicators while the friends chat loads on world hops.