### PR TITLE
Update ping-grapher to 1.6.1

### DIFF
--- a/plugins/ping-grapher
+++ b/plugins/ping-grapher
@@ -1,2 +1,2 @@
 repository=https://github.com/yuh25/Ping-Grapher.git
-commit=fe351113b0be6b8a2d6e5555f131976673bd257b
+commit=bdb2f6d607d2f73b45b6bf1debc469828c703177

--- a/plugins/ping-grapher
+++ b/plugins/ping-grapher
@@ -1,2 +1,2 @@
 repository=https://github.com/yuh25/Ping-Grapher.git
-commit=bdb2f6d607d2f73b45b6bf1debc469828c703177
+commit=a527ceb71b3b1ca549d025ba97ee6e71a42dd837


### PR DESCRIPTION
Added settings:
-  Enable ping spikes when getting Timed out.
-  Change the ping label when getting Timed out.
-  Graph labels that measure deviation from 600 ms.
-  Simple Label, removes extra text in labels e.g. Ping: and Tick: +/-.

Changed Tick labels back to the previous setting.