### PR TITLE
Bump to include dom crowdsourcing

### DIFF
--- a/plugins/osrs-wiki-crowdsourcing
+++ b/plugins/osrs-wiki-crowdsourcing
@@ -1,3 +1,3 @@
 repository=https://github.com/leejt/osrs-wiki-crowdsourcing.git
-commit=6d1a5d327246d298fbf3680a11c4829cda393a63
+commit=5821ad14e7d313cce71efe06719059314a48fe01
 authors=leejt,andmcadams


### PR DESCRIPTION
Adds crowdsourcing for doom so we can see what each wave's loot was, rather than just the final loot.