### PR TITLE
fix exception during install/startup preventing proper plugin start

### DIFF
--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=875eb456bd2211ae5b65fbfe186dc08a97142df8
+commit=3d0b53fdb4b8091b8099052c383d3602d07fd4be


### PR DESCRIPTION
see title, plugin does not properly start due to a config issue because i used char[] to create labels rather than void
- https://github.com/hawolt/guardian-of-the-rift/pull/24


total git diff +4 −7 
