### PR TITLE
Add blackjack glance alert plugin

### DIFF
--- a/plugins/blackjack-glance-alert
+++ b/plugins/blackjack-glance-alert
@@ -1,0 +1,2 @@
+repository=https://github.com/haneri98/BlackjackAlert.git
+commit=ba591ea38169ee1e1243192c7a977368ca80ad8c


### PR DESCRIPTION
Plays a sound when the player fails to put a bandit to sleep while blackjacking.