### PR TITLE
add pushcut

### DIFF
--- a/plugins/pushcut
+++ b/plugins/pushcut
@@ -1,0 +1,2 @@
+repository=https://github.com/usa-usa-usa-usa/usas-plugins.git
+commit=ce047df826691a8105b080ef5f67a243d067c3f4


### PR DESCRIPTION
A plugin that sends push notifications to iOS using PushCut. It’s way more flexible for iPhone than other options like ntfy or pushbullet—letting you trigger shortcuts or open URLs just by tapping the notification.

Main reason I built it: I AFK gemstone crabs on OSRS using a remote desktop app. OSRS Mobile disconnects when it’s not in the foreground on iOS (like 30 seconds max), but with RDP I can keep it going even when the app’s closed. So now, when a crab burrows and triggers a chat message, the plugin sends me a PushCut notification. I’ve set it so tapping the alert launches my RDP app right away.