### PR TITLE
Update shortest-path to v1.17.8

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=252b1b01b30515a5f4ec2794eb3b2845021e6159
+commit=b5f4d6821beb6e861f44376f27686b20a568d374


### PR DESCRIPTION
- Added Varlamore: Auburn Valley A-I-S fairy ring
- Fix transport info text on tiles not showing up inside instances
- Display transport info text for PoH transports on the player character when inside the PoH as a workaround for not knowing where the transports are built inside the PoH.
- Added more PoH teleportation portals
  - West Ardougne
  - Arceuus
  - Battlefront
  - Carrallanger
  - Catherby
  - Civitas illa Fortis
  - Cemetery
  - Draynor Manor
  - Fenkenstrain's Castle
  - Fishing Guild
  - Ghorrock
  - Harmony
  - Kourend
  - Lunar Isle
  - Marim
  - Mind Altar
  - Salve Graveyard
  - Senntisten
  - Troll Stronghold
  - Waterbirth Island
  - Weiss