### PR TITLE
Create Royal Titans Damage Tracker Plugin

### DIFF
--- a/plugins/Royal Titans Damage Tracker Plugin
+++ b/plugins/Royal Titans Damage Tracker Plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/Mojac-RS/royal-titans-damage-tracker-plugin.git
+commit=ec348b4b55b21fe6210b714bf61f6cadc310a2c6


### PR DESCRIPTION
A plugin to track the players damage on each of the titans Branda and Eldric in the Royal Titans fight. Also calculates drop rate chance of scrolls and staff pieces based on their damage contribution. Damage tracker resets after every fight. 