### PR TITLE
Create royal-titans-damage-tracker-plugin

### DIFF
--- a/plugins/royal-titans-damage-tracker-plugin
+++ b/plugins/royal-titans-damage-tracker-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/Mojac-RS/royal-titans-damage-tracker-plugin.git
+commit=ec348b4b55b21fe6210b714bf61f6cadc310a2c6


### PR DESCRIPTION
OSRS plugin to track player damage to the Royal Titans duo boss. Also calculates drop rate of scrolls and staff pieces based on damage contribution. 