### PR TITLE
Update shortest-path to v1.17.9

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=b5f4d6821beb6e861f44376f27686b20a568d374
+commit=41925c10b3d91452c6f45ddbf6bcf8bc48a4bd02


### PR DESCRIPTION
- Using a spirit tree to travel from the north to the south side of a spirit tree should no longer be suggested as often
- Added Mos Le'Harmless to Harmony Island transport via Brother Tranquility
- Added support for using items inside the bank (the player needs to open the bank once during each login session)