### PR TITLE
Adding "Hide Prayer Descriptions" plugin

### DIFF
--- a/plugins/hide-prayer-descriptions
+++ b/plugins/hide-prayer-descriptions
@@ -1,2 +1,2 @@
 repository=https://github.com/SamuelDev/runelite-plugins.git
-commit=2113969bd831b020d720784f86e007bb846829db
+commit=be1dd5d8d89009714d6cbfd3d6792b734c675ba8

--- a/plugins/hide-prayer-descriptions
+++ b/plugins/hide-prayer-descriptions
@@ -1,2 +1,2 @@
-repository=https://github.com/SamuelDev/average-total-level.git
+repository=https://github.com/SamuelDev/runelite-plugins.git
 commit=2113969bd831b020d720784f86e007bb846829db

--- a/plugins/hide-prayer-descriptions
+++ b/plugins/hide-prayer-descriptions
@@ -1,0 +1,2 @@
+repository=https://github.com/SamuelDev/average-total-level.git
+commit=2113969bd831b020d720784f86e007bb846829db


### PR DESCRIPTION
This is a plugin that will hide different parts of the prayer description tooltip on hover (or the entire thing).

### Examples
No tooltip (all config options selected to hide):
<img width="358" height="224" alt="image" src="https://github.com/user-attachments/assets/1d6b73b2-0c22-4afb-b51f-ab11fb276a8f" />

Only show name:
<img width="242" height="211" alt="image" src="https://github.com/user-attachments/assets/17611fba-fb25-410a-a843-0bdd1a2d0450" />

Show level and drain rate:
<img width="315" height="221" alt="image" src="https://github.com/user-attachments/assets/b1c8628c-9d06-4b41-bee3-beac0fc1a510" />
