### PR TITLE
update 117hd

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=b304041d72f6fb7bc1cf1ef41a36664d3ecbf612
+commit=579d52f0f5aee57bb48ee35f36d0027080b5b4be
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
The new demon boss room is too dark with 117 HD. This brightens it up to the same level as vanilla.