### PR TITLE
feat: Update Burner Alarm plugin with House Hosting features

### DIFF
--- a/plugins/burner-alarm
+++ b/plugins/burner-alarm
@@ -1,2 +1,2 @@
 repository=https://github.com/AltarOSRS/house-hosting-plugin.git
-commit=ae45fea842425fd0d95e0f35f6c7682ab572028a
+commit=2e9f7c0036088f14ac3f6796ff82f490189c772f


### PR DESCRIPTION
I'm updating the existing Burner Alarm plugin to a new version called "House Hosting". The scope of my plugin outgrew itself so a name change is necessary.

### Features

* Burner Alarm: Two-stage notifications for incense burners.
* Unlit Burner Highlight: Visual outlines for unlit burners.
* Tip Jar Notifications: Tiered notifications and chat recoloring for tips.
* Player Level-Up Notifications: Alerts for generic, Level 99, and Combat Level 126 by guests.
* Marrentill Tracker: Monitors Marrentill supply with low-stock warnings.
* POH Guest Tracker: Overlay displaying current guest count.

Notifications are fully customizable now and also allow for customizable chat message colors.