### PR TITLE
Add Big Goblins plugin entry

### DIFF
--- a/plugins/big-goblins
+++ b/plugins/big-goblins
@@ -1,0 +1,2 @@
+repository=https://github.com/c1e2007/big-goblins-plugin
+commit=efdce5b88301fbdda50bf111941b47292139f1d


### PR DESCRIPTION
Adds the Big Goblins plugin to the RuneLite Plugin Hub. This entry points to the Big Goblins plugin repository and commit.