### PR TITLE
Create royal-titans-damage-tracker-plugin

### DIFF
--- a/plugins/royal-titans-damage-tracker-plugin
+++ b/plugins/royal-titans-damage-tracker-plugin
@@ -1,0 +1,3 @@
+repository=https://github.com/Mojac/royal-titans-damage-tracker-plugin.git
+commit=4638e7540ff47481b313bd121cdd61b294756157
+authors=Mojac


### PR DESCRIPTION
A RuneLite plugin that tracks your damage contribution during Royal Titans encounters (Branda and Eldric) and calculates your drop rate based on damage dealt.

I'm so sorry for spamming these pull requests. Hopefully this time everything is good.

1) I moved my repo out of an organization. I also added my name to the authors key in the manifest, just in case. 
2) Very much appreciated on the Gameval.RT_FIRE_QUEEN and RT_ICE_KING constants suggestion. I've updated from hard values to the constants. 
3) I've added several methods to ensure NPC references are always properly cleaned up. In the process of cleaning up loose ends, I also added logic for when the player exits and re-enters the arena that I didn't consider before. 