### PR TITLE
update guardians-of-the-rift-optimizer to v1.0.6.6

### DIFF
--- a/plugins/guardians-of-the-rift-optimizer
+++ b/plugins/guardians-of-the-rift-optimizer
@@ -1,2 +1,2 @@
 repository=https://github.com/hawolt/guardian-of-the-rift.git
-commit=3d0b53fdb4b8091b8099052c383d3602d07fd4be
+commit=f247eb310e15c1f099acdbe8ec9738af597d7233


### PR DESCRIPTION
fixes some "issues" that I noticed within the plugin