### PR TITLE
Create prices-menu-entry

### DIFF
--- a/plugins/prices-menu-entry
+++ b/plugins/prices-menu-entry
@@ -1,2 +1,2 @@
 repository=https://github.com/TheHeroBrine422/prices-menu-entry.git
-commit=3a838200e2a8afd888c2520d2fb240d10276c774
+commit=433c07c48120318322030c31742145f54d4936f7

--- a/plugins/prices-menu-entry
+++ b/plugins/prices-menu-entry
@@ -1,0 +1,2 @@
+repository=https://github.com/TheHeroBrine422/prices-menu-entry.git
+commit=3a838200e2a8afd888c2520d2fb240d10276c774


### PR DESCRIPTION
Added a plugin that adds a menu entry to tradable items to open a link to prices.runescape.wiki.