### PR TITLE
Update Image Bankai README

### DIFF
--- a/plugins/image-bankai
+++ b/plugins/image-bankai
@@ -1,2 +1,2 @@
 repository=https://github.com/DeadRobotDev/ImageBankai.git
-commit=ad6c210884e2bc1c553df9e117a813511a3f6719
+commit=39a2df07db9613c34cd94adcf47877e4b8d2b71f


### PR DESCRIPTION
Fixes the missing \ in the README.

`%userprofile%.runelite\` to `%userprofile%\.runelite\`