### PR TITLE
Bug fix temple-osrs

### DIFF
--- a/plugins/temple-osrs
+++ b/plugins/temple-osrs
@@ -1,4 +1,4 @@
 repository=https://github.com/SMaloney2017/Temple-OSRS-Plugin.git
-commit=fb87d5443130671304b427bb9898d508f6b85d91
+commit=e0abe8099560147dbadc2b71aadcfb98ffb7a8b1
 authors=SMaloney2017,44Mikael,joemckie
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Fixed a bug where warning was displayed when logging in even if required in-game setting was on. Warnings are now only displayed when toggling any settings that require or depend on them, in-game and in RL settings.