### PR TITLE
Update shooting-stars-tracking

### DIFF
--- a/plugins/shooting-stars-tracking
+++ b/plugins/shooting-stars-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/Shooting-Stars-Tracking.git
-commit=8897230830e07cdaee0e830cc8d5c51b5d3cb806
+commit=7503a4d6a447787c35ecb3dffbef2b7e2d901371


### PR DESCRIPTION
- change child id from 1 to 3 for an interface change that completely broke the plugin