### PR TITLE
Update `hunter-rumours` to `1.3.4`

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,3 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=3ddd6564bc7d99d7b20da3bbbde4469d97adb394
+commit=956108025a683e2c94901504697297a1090eba8f
 authors=geel9,DapperMickie


### PR DESCRIPTION
- Fixes issue whereby rumour killcount continued to increment despite the rumour already being completed (thanks @zekyriah)
- Adds fairy ring auto-scroll time window configuration entry (thanks @zekyriah)
- Adds ability to configure whether hunter creature highlight is for hull, tile, or both (thanks @zekyriah)
- Fixes `At First Light` quest dialogue tricking plugin into thinking a Rumour has been assigned when it hasn't
- Fixes infobox not being properly removed when plugin is shut down or uninstalled
- Fixes display of bullet-point character on MacOS