### PR TITLE
Update loot-filters to v1.10.4.2

### DIFF
--- a/plugins/loot-filters
+++ b/plugins/loot-filters
@@ -1,2 +1,2 @@
 repository=https://github.com/riktenx/loot-filters.git
-commit=95e5f9d5772b4242f0f02bcb3b2749b8f06ead69
+commit=75a8fdd233af7328f44bb5b7af16f8bf152b0ddd


### PR DESCRIPTION
re-gate the --developer-mode debug overlay behind a JVM sysprop since some folks reached out about it