### PR TITLE
Update ba-heal-codes to 1.1

### DIFF
--- a/plugins/ba-heal-codes
+++ b/plugins/ba-heal-codes
@@ -1,2 +1,2 @@
 repository=https://github.com/evaan/ba-heal-codes.git
-commit=6324d57124add58586ba6c5509c532aa4391e408
+commit=aac166c60a9c485c04e2e3359c862feee0af08dd


### PR DESCRIPTION
Changes include a minor refactor (including replacing the deprecated `getMapRegions` function), and adding the ability to use custom heal codes per wave