### PR TITLE
Create petreminder

### DIFF
--- a/plugins/petreminder
+++ b/plugins/petreminder
@@ -1,0 +1,2 @@
+repository=https://github.com/HerbRuns/petreminder.git
+commit=11b10a44be948d7f08bec6e65ad75c88ddc17937


### PR DESCRIPTION
A small plugin that simply reminds the player that they have a follower/pet out. Adds a small UI element when pet is out, and hides when it is not.