### PR TITLE
Add Colosseum Waves plugin

### DIFF
--- a/plugins/colosseum-waves
+++ b/plugins/colosseum-waves
@@ -1,0 +1,2 @@
+repository=https://github.com/willediger/Colosseum-Waves.git
+commit=94376dd66413bca4aaae39011eccd130d5cc124e


### PR DESCRIPTION
This plugin captures player & NPC locations for wave spawns & reinforcements in Fortis Colosseum. It generates shareable links to [https://los.colosim.com/](https://los.colosim.com/) for planning and analysis, including support for "Current LoS" snapshots of the current pillar stack.

Supports uncharged manticores & Mantimayhem 3.

The plugin has been tested extensively in the Fortis Colosseum with various wave compositions and reinforcement patterns. All generated links have been verified to work correctly with los.colosim.com.