### PR TITLE
Create scorching-bow-freeze-timer

### DIFF
--- a/plugins/scorching-bow-freeze-timer
+++ b/plugins/scorching-bow-freeze-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/adnapPanda/scorching-bow-freeze-timer.git
-commit=636353cfeba12383faa62ec50c17a90cb0bfc3e4
+commit=7061b209661ee8cab91bb6c1342983c4858dbc81

--- a/plugins/scorching-bow-freeze-timer
+++ b/plugins/scorching-bow-freeze-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/adnapPanda/scorching-bow-freeze-timer.git
+commit=7d4b67bf671c0d1ff417ed697f91e38f65514143

--- a/plugins/scorching-bow-freeze-timer
+++ b/plugins/scorching-bow-freeze-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/adnapPanda/scorching-bow-freeze-timer.git
-commit=7d4b67bf671c0d1ff417ed697f91e38f65514143
+commit=636353cfeba12383faa62ec50c17a90cb0bfc3e4


### PR DESCRIPTION
Created a plugin that shows the time until the scorching bow freeze ends. Useful at bosses like Kril where you want to keep it immobilized at all times without wasting special attack energy