### PR TITLE
Add Cough Syrup Plugin

### DIFF
--- a/plugins/cough-syrup
+++ b/plugins/cough-syrup
@@ -1,0 +1,2 @@
+repository=https://github.com/edmeyer8851/cough-syrup.git
+commit=0c0820227f59a4bf77dec45a501b1423b754e0f6


### PR DESCRIPTION
This plugin removes player cough spam in public chat during Nex's Choke attack.