### PR TITLE
project-xeric: update plugin version

### DIFF
--- a/plugins/project-xeric
+++ b/plugins/project-xeric
@@ -1,3 +1,3 @@
 repository=https://github.com/Septem151/project-xeric.git
-commit=ed4a108fa05de6035b8d9c2c9bc8aa85ebae1aaa
+commit=af2218a5c88294b8fe036498772c5bb1f6b3d884
 warning=This plugin submits your IP address and player data including username to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Small bugfix for Project Xeric that was added with merge to master branch: https://github.com/runelite/plugin-hub/commit/78b0f952501287b035654aaca2b7d0ef8c455a85 that addresses a _small_ issue when the plugin hub side panel displays the plugin... as seen below (some parts redacted for at least a smudge of privacy):
![Screenshot_20250813_195158](https://github.com/user-attachments/assets/eee3e9b0-657c-4f0d-9731-067637b427be)

Apologies in advance for the rookie mistake, I'll use the plugin-hub repo to sanity check the plugin's listing if possible in the future!