### PR TITLE
Update Forestry Spawn Helper

### DIFF
--- a/plugins/forestry-spawn-helper
+++ b/plugins/forestry-spawn-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Oelderoth/forestry-force-spawn-plugin.git
-commit=3a98efbe2f920d157d42ccade4aa342474025234
+commit=7e3308e81b4b886d63682db7d1697b545a1adad7


### PR DESCRIPTION
Updating Forestry Spawn Helper to 1.0.1

Changes:
- Fix the toggle-able tracking for specific tree types not being utilized properly when starting tracking timers ([Commit](https://github.com/Oelderoth/forestry-force-spawn-plugin/commit/c6da168375a5b45a5c540f9775fb742baacc8329))
- Get rid of the hard-coded map of ObjectID to TreeTypes, and instead attempt to derive it based on the name of the ObjectComposition and cache the result ([Commit](https://github.com/Oelderoth/forestry-force-spawn-plugin/commit/feab947e4c67a29903b89afeeceedbaa0249bfb3))
 
The tree detection change should mean that the plugin no longer fails to track assorted trees around the world that use unique or unusual ObjectIDs that had been missed in my initial search (like magic trees in the Gnome Stronghold), and should be more robust about handling any new ObjectIDs that are added for trees in future updates.

Comparison page for all changes between previous and new version's commits: https://github.com/Oelderoth/forestry-force-spawn-plugin/compare/3a98efbe2f920d157d42ccade4aa342474025234..7e3308e81b4b886d63682db7d1697b545a1adad7