### PR TITLE
Update shooting-stars-tracking

### DIFF
--- a/plugins/shooting-stars-tracking
+++ b/plugins/shooting-stars-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/Shooting-Stars-Tracking.git
-commit=7503a4d6a447787c35ecb3dffbef2b7e2d901371
+commit=a20e296be451882b096701b29d60e03506e351aa


### PR DESCRIPTION
- One liner fix for deprecated usage that caused the world hop feature to not work