### PR TITLE
Create loot-ledger (USES AN ALREADY APPROVED DEPENDENCY)

### DIFF
--- a/package/verification-template/build.gradle
+++ b/package/verification-template/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 		because "discord-rare-drop-notifier, droptracker"
 	}
 	thirdParty("org.jsoup:jsoup:1.13.1") {
-		because "discord-rare-drop-notifier, drop-simulator, fire-beats, loot-table, loot-lookup, chance-man"
+		because "discord-rare-drop-notifier, drop-simulator, fire-beats, loot-table, loot-lookup, chance-man, loot-ledger"
 	}
 	thirdParty("com.miglayout:miglayout-swing:5.2") {
 		because "drop-simulator"

--- a/plugins/loot-ledger
+++ b/plugins/loot-ledger
@@ -1,0 +1,2 @@
+repository=https://github.com/ChunkyAtlas/loot-ledger.git
+commit=98f63e3f958d4f64da680ba3b14236153a8c795d

--- a/plugins/loot-ledger
+++ b/plugins/loot-ledger
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/loot-ledger.git
-commit=12d46f3a48527475a59c0e798d1e63fcbe10a636
+commit=2d78ede733f8890654c83b569407cfbe3630a0d6

--- a/plugins/loot-ledger
+++ b/plugins/loot-ledger
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/loot-ledger.git
-commit=98f63e3f958d4f64da680ba3b14236153a8c795d
+commit=10043e0d3532742c9b8cd95aa0be82c279b729e4

--- a/plugins/loot-ledger
+++ b/plugins/loot-ledger
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/loot-ledger.git
-commit=2d78ede733f8890654c83b569407cfbe3630a0d6
+commit=a502c783fad55d889ceca21197e99eacadbe8a8c

--- a/plugins/loot-ledger
+++ b/plugins/loot-ledger
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/loot-ledger.git
-commit=10043e0d3532742c9b8cd95aa0be82c279b729e4
+commit=12d46f3a48527475a59c0e798d1e63fcbe10a636


### PR DESCRIPTION
USES AN ALREADY APPROVED DEPENDENCY
- Hover an icon to see the item name. Click the eye to hide or show obtained items
- Click the search icon to find NPCs by name or ID from inside the Music tab
- Tracks obtained items per account or per NPC and saves them to disk with rotating backups
- Caches fetched drop tables for 7 days under ~/.runelite/lootledger/<player>/drops
- Lets you sort by rarity and toggle rare drop table and gem drop table
- Restores the original Music UI cleanly when you leave
- Uses RuneLite services: injected OkHttpClient for HTTP and ItemManager for item IDs

Main Files:
- DropFetcher: pulls wiki pages and resolves item and NPC IDs
- DropCache: JSON cache with atomic writes and pruning
- ItemIdIndex: name to id lookup using a bundled index
- AccountManager: keeps the current display name in sync
- ObtainedItemsManager: async JSON persistence and backups
- MusicWidgetController: renders the Music tab overlay and controls
- DropsMenuListener: adds the "Show Drops" entry to NPC menus
- DropsTooltipOverlay: simple hover tooltip for item names