### PR TITLE
Update shortest-path to v1.17.11

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=aeec130657b69ba2a409b922f3b9d3d2dad8d6b7
+commit=5003673cde6ed441e16bc2492d6fe65d896d14e8


### PR DESCRIPTION
- Added missing cave entrance for Eadgar's Cave
- Added Miazrqa tower Rupert the Beard Grim Tales thieving crumbling wall
- Added Rat Pits minigame teleport chat option numbers
- Added Custodia's lake rowboat
- Added Mountain guides for Mount Quidamortem and Auburn Valley
- Added Custodia Mountain cave passage
- Allow 5 coins as item requirement alternative to the Shantay Pass
- Added Dorgesh-Kaan stairs and ladders
- Added Barbarian Assault minigame teleport unlock requirement