### PR TITLE
update fortis-colosseum to v1.6.1

### DIFF
--- a/plugins/fortis-colosseum
+++ b/plugins/fortis-colosseum
@@ -1,2 +1,2 @@
 repository=https://github.com/LlemonDuck/fortis-colosseum.git
-commit=df34d8c9d0fa0ef6e4278fcc4820de29da73d9e7
+commit=1f73e5ab8d6579ea4811d299d506e7a820260d70


### PR DESCRIPTION
adds the ability to load your wave spawns into los.colosim.com for practice and review