### PR TITLE
Update royal-titans-damage-tracker-plugin

### DIFF
--- a/plugins/royal-titans-damage-tracker-plugin
+++ b/plugins/royal-titans-damage-tracker-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Mojac/royal-titans-damage-tracker-plugin.git
-commit=d5175683d8232f1b13919eb8ba0fe2065c31568d
+commit=175b228aeaacf020d18ef5a3c4be0ae782b03e5b
 authors=Mojac


### PR DESCRIPTION
Added a flag to know when the titan IDs are null from being killed versus the player leaving the area. 

There was a bug where the damage tracker was resetting as soon as the titans were killed (both titans IDs become null when killed because of the onNpcDespawn() method). With this flag, the reset scheduler should work now for when the titans are despawned (killed) and the reset timer is active. 