### PR TITLE
Create giants-foundry-total-metals

### DIFF
--- a/plugins/giants-foundry-total-metals
+++ b/plugins/giants-foundry-total-metals
@@ -1,0 +1,2 @@
+repository=https://github.com/Aiadan/giants-foundry-total-metals.git
+commit=8e2458798c0614e9bce7728e3e17dacb1bed35a9


### PR DESCRIPTION
Shows a textbox with the sum of all metals you have for the purpose of Giants' Foundry