### PR TITLE
update fish-barrel to v1.2

### DIFF
--- a/plugins/fish-barrel
+++ b/plugins/fish-barrel
@@ -1,2 +1,2 @@
 repository=https://github.com/molo-pl/runelite-plugins.git
-commit=b1b4c975599e33a0f90aa7ff2dd6387c945208d4
+commit=594ac3659d97de30e0d0d57513899590a7ccbea9


### PR DESCRIPTION
Updating the Fish Barrel plugin to properly register catches in Shilo.

Also moving away from some of the deprecated RuneLite APIs.