### PR TITLE
update mahogany-homes (v1.8.2)

### DIFF
--- a/plugins/mahogany-homes
+++ b/plugins/mahogany-homes
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Mahogany-Homes.git
-commit=e42259c814db7031ab0b76fddbf75c62defe9302
+commit=461771d82df419cc6dc73569f13f872887995a42


### PR DESCRIPTION
* Add a config option to integrate with the `Shortest Path` plugin (defaults to off) Thanks @DeveloperMikey