### PR TITLE
Update royal-titans-damage-tracker-plugin

### DIFF
--- a/plugins/royal-titans-damage-tracker-plugin
+++ b/plugins/royal-titans-damage-tracker-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Mojac/royal-titans-damage-tracker-plugin.git
-commit=175b228aeaacf020d18ef5a3c4be0ae782b03e5b
+commit=b7e10a1b76c604fb3bb2828ec1a6f7b954d7c5bd
 authors=Mojac


### PR DESCRIPTION
Added flags and logic to properly handle resetting of the damage tracker.

The previous bug of the tracker resetting after the titans were killed still persisted. The issue was the checkAreaExit() method would assume the player left the titans area. Since the reset delay only activated when the player looted the titan, the time between the titans dying (NPC IDs becoming null) and the player looting the titans (triggering the chat message to reset the tracker) was treated as a player leaving the titans area (encounter ended without needed to activate the reset timer).