### PR TITLE
Add Bank Standing XP plugin

### DIFF
--- a/plugins/bank-standing-xp
+++ b/plugins/bank-standing-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/VerifiedError/bank-standing-xp-plugin.git
-commit=22b385b
+commit=ddf153b60a1f8b9dba8bf8aaaa3c9cda44b4c81d

--- a/plugins/bank-standing-xp
+++ b/plugins/bank-standing-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/VerifiedError/bank-standing-xp-plugin.git
-commit=0837c52
+commit=22b385b

--- a/plugins/bank-standing-xp
+++ b/plugins/bank-standing-xp
@@ -1,0 +1,2 @@
+repository=https://github.com/VerifiedError/bank-standing-xp-plugin.git
+commit=0837c52


### PR DESCRIPTION
## Bank Standing XP Plugin

A fun and engaging plugin that allows players to gain experience while socializing in bank areas.

### Features:
- **Tier-based banking system** with Grand Exchange (Tier 1) and major banks (Tier 2)
- **60-second standing requirement** with continuous XP gains every 5 seconds thereafter
- **Random events** with bonus XP and entertaining messages (10% chance)
- **Sound effects** and real-time chat notifications for all interactions
- **Movement detection** with automatic timer reset when player moves
- **Balanced XP rates** with tier-based multipliers (GE: 100%, Major banks: 75%)

### Plugin Benefits:
- Encourages social interaction in popular bank areas like Grand Exchange
- Provides a fun AFK activity for players who want to socialize
- Balanced progression with modest XP rewards
- Engaging random events to keep players interested
- Clear feedback system with chat messages and sound effects

### Bank Locations Supported:
**Tier 1 (100% XP):** Grand Exchange
**Tier 2 (75% XP):** Varrock East/West, Falador, Camelot, Draynor

This plugin promotes the social aspect of Old School RuneScape by encouraging players to spend time in busy bank areas while gaining modest XP rewards. The standing requirement prevents abuse while the tier system balances rewards based on location popularity.

**Repository:** https://github.com/VerifiedError/bank-standing-xp-plugin
**Commit:** 0837c52