### PR TITLE
Add Bank Standscape plugin

### DIFF
--- a/plugins/bank-standscape
+++ b/plugins/bank-standscape
@@ -1,0 +1,2 @@
+repository=https://github.com/VerifiedError/bank-standing-xp-plugin.git
+commit=ddf153b60a1f8b9dba8bf8aaaa3c9cda44b4c81d


### PR DESCRIPTION
## Bank Standscape Plugin

A fun cosmetic skill plugin that allows players to gain XP while standing idle at bank areas.

### Plugin Details:
- Repository: https://github.com/VerifiedError/bank-standing-xp-plugin
- Commit: ddf153b60a1f8b9dba8bf8aaaa3c9cda44b4c81d
- Structure: Follows RuneLite example plugin format exactly

### Features:
- Idle Detection: Precise tracking of player movement, animations, and interactions
- Grand Exchange Focus: Primary location with full XP rates  
- Multi-Bank Support: Optional XP at other major banks
- XP Scaling: Increased XP rates as player level increases
- Real-time UI: Overlay showing current level and total XP
- Chat Integration: Enable messages and XP gain notifications

This plugin promotes social gameplay by giving players a reason to spend time in busy bank areas while providing an entertaining progression system.