### PR TITLE
Add Bank Standscape plugin

### DIFF
--- a/plugins/bank-standscape
+++ b/plugins/bank-standscape
@@ -1,0 +1,2 @@
+repository=https://github.com/VerifiedError/bank-standing-xp-plugin.git
+commit=ddf153b60a1f8b9dba8bf8aaaa3c9cda44b4c81d

--- a/plugins/bank-standscape
+++ b/plugins/bank-standscape
@@ -1,2 +1,2 @@
 repository=https://github.com/VerifiedError/bank-standing-xp-plugin.git
-commit=ddf153b60a1f8b9dba8bf8aaaa3c9cda44b4c81d
+commit=1978e92e6f1e90bef5b8e5847c5b7442f6b00fac


### PR DESCRIPTION
Adds Bank Standscape plugin - a fun idle skill for standing at banks.

**Features:**
- Gain XP for standing idle at bank areas  
- Level progression with RuneScape-style XP formula
- Configurable XP scaling and multi-bank support
- Overlay display showing current level and total XP
- Chat notifications for XP gains and level ups

**Plugin Details:**
- Repository: https://github.com/VerifiedError/bank-standing-xp-plugin
- Java 11 compatible with Gradle 7.6
- Follows RuneLite example plugin structure
- No external dependencies beyond RuneLite client

🤖 Generated with [Claude Code](https://claude.ai/code)