### PR TITLE
Added No-Stalactites

### DIFF
--- a/plugins/No-Stalactites
+++ b/plugins/No-Stalactites
@@ -1,0 +1,3 @@
+repository=https://github.com/TripStank/NoStalactites.git
+commit=1d4e33f7ec083ece8184e297c3075b47d88e43a7
+author=Stank


### PR DESCRIPTION
 A Simple plugin to show scenery object IDs and hide them in the game world, Stalactites added by default.