### PR TITLE
Takeover Chat Name Colors

### DIFF
--- a/plugins/chat-name-colors
+++ b/plugins/chat-name-colors
@@ -1,2 +1,2 @@
-repository=https://github.com/BagleBreath/beaglebreath-chat-name-colors.git
+repository=https://github.com/rsbfox/beaglebreath-chat-name-colors.git
 commit=efbaa86712e6a50ea174b3a540a9d3f9a92e1026


### PR DESCRIPTION
Plugin has been incompatible for more than 60 days.

Issue and pull request to fix was not responded to.

Last activity from author was Feb 2023.