### PR TITLE
Add System Clock plugin

### DIFF
--- a/plugins/systemclock
+++ b/plugins/systemclock
@@ -1,2 +1,2 @@
 repository=https://github.com/soda3x/runelite-system-clock.git
-commit=341e310de028d69c09f7d56e16c83e603769a744
+commit=e7f5b1e8a8c99d4cc54269827ee1b67e981d93b9


### PR DESCRIPTION
My plugin (https://github.com/soda3x/runelite-system-clock) adds a system clock to the game. You can place the clock anywhere and it supports many time formats.