### PR TITLE
chore(emote-clue-items): updates emote-clue-items to version 4.3.4.

### DIFF
--- a/plugins/emote-clue-items
+++ b/plugins/emote-clue-items
@@ -1,2 +1,2 @@
 repository=https://github.com/larsvansoest/emote-clue-items.git
-commit=b8f2e3d290f6a7823e78bb270326dd19fdd19894
+commit=78249a715bc4caf8fce9387c48779078948e3ad0


### PR DESCRIPTION
This update of Emote Clue Items features the following updates:

* Adds missing medium, hard and master STASH units from the Varlamore update. (see https://github.com/larsvansoest/emote-clue-items/issues/115, https://github.com/larsvansoest/emote-clue-items/issues/116, https://github.com/larsvansoest/emote-clue-items/issues/119, https://github.com/larsvansoest/emote-clue-items/issues/123) 
* Removes rendering items while potion storage is opened. (see https://github.com/larsvansoest/emote-clue-items/issues/122)
* Refactors deprecated imports, using `net.runelite.api.gameval` instead.

🚀  Special thanks to @coopermor for implementing the changes above. (see [emote-clue-items/pull124](https://github.com/larsvansoest/emote-clue-items/pull/124))