### PR TITLE
Add cooking chance tooltip plugin

### DIFF
--- a/plugins/cooking-chance-tooltip
+++ b/plugins/cooking-chance-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/AshleyThew/runelite-cooking-chance-tooltip.git
-commit=5c92a3d91cca227cf62042a425a35b827c85632f
+commit=ede329ed1b5665b87ffb81bc81083e3c40ed5d72


### PR DESCRIPTION
Create a cooking tooltip plugin to add cooking chance & estimated xp gained to cookable items.

Cooking rates were pulled from wiki.

Was a QoL I thought would be nice

Image from previous attempt to add to the runelite cooking plugin, but tooltip is same
![image](https://github.com/user-attachments/assets/1d2901e2-7988-4205-b721-5384377eb30b)


