### PR TITLE
Takeover: mistake tracker to allow further development 

### DIFF
--- a/plugins/tob-mistake-tracker
+++ b/plugins/tob-mistake-tracker
@@ -1,2 +1,2 @@
-repository=https://github.com/QuestingPet/TobMistakeTracker.git
+repository=https://github.com/NickSmeding/TobMistakeTracker.git
 commit=67ae34d865f9d89ee2e7523fed5e190f40423529


### PR DESCRIPTION
until now no response next to that plugin wasn't touched for a year. Hopefully someone in plugin hub can get hold on him because I don't like to take over the plugin without getting approval from previous owner. Preferable I will just be added as contributor