### PR TITLE
Add Group Ironman Tracker

### DIFF
--- a/plugins/gim-tracker-sync
+++ b/plugins/gim-tracker-sync
@@ -1,2 +1,2 @@
-repository=https://github.com/JoshuaALawrence/GIM-Tracker-Sync
+repository=https://github.com/JoshuaALawrence/GIM-Tracker-Sync.git
 commit=555bfab9cb2b170e8a64ef79cb94f4615bb53e86


### PR DESCRIPTION
Hello, this plugin checks your items in your inventory/bank/collection logs/drops and will add/remove that item from your party on my self-hosted (self-made) 'Group Ironman Tracker'. This helps my team keep track of who already owns which items. I've attached images of the website.

The settings require the user to add the host, api key and check which boxes they want to sync; nothing goes to a server unless they directly add the location.

<img width="1869" height="889" alt="image" src="https://github.com/user-attachments/assets/5febc5ac-78bc-45a5-95e3-ce9a0ed4aae6" />
<img width="1808" height="780" alt="image" src="https://github.com/user-attachments/assets/bc9bb9da-eefd-4618-b082-cbab456f868b" />
<img width="1559" height="766" alt="image" src="https://github.com/user-attachments/assets/aae84ba3-ab34-432c-a686-ca1bfd5a561a" />
<img width="1530" height="874" alt="image" src="https://github.com/user-attachments/assets/e8ecb6f4-420d-4e5f-ae06-5d1fbd3bd359" />
