### PR TITLE
GIM Tracker Sync

### DIFF
--- a/plugins/gim-tracker-sync
+++ b/plugins/gim-tracker-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/JoshuaALawrence/GIM-Tracker-Sync.git
-commit=9506e74af295c3c030eb8a44464845d53dbb5e9c
+commit=2b543a16157415ab084faf113877723c9b50898f


### PR DESCRIPTION
Hello, this plugin checks your items in your inventory/bank/collection logs/drops and will add/remove that item from your party on my self-hosted (self-made) 'Group Ironman Tracker'. This helps my team keep track of who already owns which items. I've attached images of the website.

The settings require the user to add the host, api key and check which boxes they want to sync; nothing goes to a server unless they directly add the location.

<img width="1559" height="766" alt="481329059-aae84ba3-ab34-432c-a686-ca1bfd5a561a" src="https://github.com/user-attachments/assets/a8b8fc2b-1865-468f-b53f-b15ad0f75304" />
<img width="1808" height="780" alt="481329053-bc9bb9da-eefd-4618-b082-cbab456f868b" src="https://github.com/user-attachments/assets/774ba81a-7ae5-4e45-8aad-74b7b8ab9347" />
<img width="1869" height="889" alt="481329036-5febc5ac-78bc-45a5-95e3-ce9a0ed4aae6" src="https://github.com/user-attachments/assets/284901f7-020d-4c16-9821-4f6bccb3af62" />
<img width="1530" height="874" alt="481329063-e8ecb6f4-420d-4e5f-ae06-5d1fbd3bd359" src="https://github.com/user-attachments/assets/cde5920a-113d-495b-8f8d-f05d7485c750" />
