### PR TITLE
Adds the brimhaven-agility plugin

### DIFF
--- a/plugins/brimhaven-agility
+++ b/plugins/brimhaven-agility
@@ -1,0 +1,2 @@
+repository=https://github.com/kagof/rl-plugin-brimhaven-agility.git
+commit=b164efa5195d926fc7b5d63aaf7089b1b30677b6


### PR DESCRIPTION
# Brimhaven Agility Arena plugin

Adds a new plugin to aid with the Brimhaven agility arena. Specifically, it currently computes the shortest path the the active ticket dispenser, and displays that path on the screen for the user. This takes into account whether the user has the agility level for a given obstacle, and is computed using the A* pathfinding algorithm.

![](https://github.com/kagof/rl-plugin-brimhaven-agility/blob/master/images/example.png?raw=true)

The weightings of obstacles, line colour, and whether or not to actually draw the line are all configurable:

![](https://github.com/kagof/rl-plugin-brimhaven-agility/blob/master/images/config.png?raw=true)

## Future expansions

These are not yet features in this plugin, but I may decide to expand it to include:

* removing the hint arrow when the ticket has been claimed
* highlighting the correct plank to use of the 3 options