### PR TITLE
add runelogs

### DIFF
--- a/plugins/runelogs
+++ b/plugins/runelogs
@@ -1,3 +1,3 @@
 repository=https://github.com/RuneLogs/runelogs-plugin.git
-commit=b2c672421d9ca54bfd4a4a077ceaa6b43cbbc921
+commit=0f40ead297cdb519f2fc73c8528dce839d5db684
 authors=hawolt


### PR DESCRIPTION
this plugin simply writes a tailored log file for a sister project which is still work in progress

its the refactored version of the last PR that I closed due to using a socket and binary logic which I was told will limit the reviewer pool but also overcomplicate everything for everyone

this more minimalistic approach simply just writes a log which can be handled by an external application outside of the RuneLite eco system which makes life easier for both parties, the maintainers and me, easier

additionally this setup should be future proof for the official jagex client as all the logic is outsourced of the plugin
hopefully this is more acceptable than my last iteration