### PR TITLE
update fish-barrel to v1.3.0

### DIFF
--- a/plugins/fish-barrel
+++ b/plugins/fish-barrel
@@ -1,2 +1,2 @@
 repository=https://github.com/molo-pl/runelite-plugins.git
-commit=4126d7bcc0bf631297eaedec5c8228a87ba361cf
+commit=6db8cd457d3581389e96fc9fbd49234643620845


### PR DESCRIPTION
Allows to configure the color used for the barrel overlay that displays the fish count.