### PR TITLE
Add Plugin Stats Plugin

### DIFF
--- a/plugins/plugin-stats
+++ b/plugins/plugin-stats
@@ -1,0 +1,2 @@
+repository=https://github.com/bhatch96/pluginstats-plugin-runelite.git
+commit=a95a590bcec542f095142ac8956bdd116d11f5f0


### PR DESCRIPTION
Displays an overlay with the number of Plugins Installed and Plugins Active for the user.

Updates when a plugin is activated/deactivated or installed/uninstalled
<img width="153" height="62" alt="image" src="https://github.com/user-attachments/assets/8815cc50-1761-4f35-8532-8b9e595d96ae" />

Able to toggle parts of the overlay on/off
<img width="241" height="218" alt="image" src="https://github.com/user-attachments/assets/7f8d2538-68d6-4188-883c-fabea9e52f89" />

Repository:
https://github.com/bhatch96/pluginstats-plugin-runelite

Idea from this comment:
https://github.com/runelite/runelite/discussions/19278