### PR TITLE
Create NewGamePlus

### DIFF
--- a/plugins/newgameplus
+++ b/plugins/newgameplus
@@ -1,2 +1,2 @@
 repository=https://github.com/jdpriest/new-game-plus.git
-commit=698a1a992dd8fb32a2d509bde31337badbf03b15
+commit=fe25110e73149009eb750c80d99213ad87adc324


### PR DESCRIPTION
New Game Plus lets you replay PvM progression without creating a new account, so you can re-earn items in the game without redoing quests, skilling, and supply grinds. It locks boss, raids, and slayer items by default and prevents using/withdrawing locked items while dimming them in your inventory/bank. Items are automatically unlocked when you receive them as NPC drops, from chest/raid rewards, or when they first appear in your inventory on ground pick up or crafting. Each unlock is confirmed via chat and can show a popup and optional sound. A sidebar panel lets you add/remove unlocks and view your collection and unlocks persist between sessions.

The intention of this plugin is for a player who has a well progressed bank to be able to redo the PvM progression without starting a new account, dropping any items, or destroying their bank layout to move all previously earned items out of the way. A player can toggle NG+ on to continue their "redo" playthrough, and then toggle it off to resume normal progression.