### PR TITLE
Update shortest-path to v1.17.12

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=a4fa44f38a9b63c81949a36a980d4ba70762c1e0
+commit=a32bee4caba9dc024d181fefbd20db6284646f3a

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=5003673cde6ed441e16bc2492d6fe65d896d14e8
+commit=a4fa44f38a9b63c81949a36a980d4ba70762c1e0


### PR DESCRIPTION
- Added the Tree Gnome Village Elkoy maze guide
- Added a partial Land of the Goblins quest requirement for the BLQ fairy ring
- Added magic carpets
- Fixed the Shayzien to Hosidius stepping stone
- Fixed the Sandicrahb boat
- Moved the Varrock rat pits minigame teleport
- Added Brimhaven dungeon entrance and vines
- Added 76 agility stepping stones to Zul-Andra
- Added new Slayer Tower shortcuts and Fossil Island zip line
- Moved the Fossil Island rowboat
- Fixed an incorrect wilderness level check for upstairs areas above 20 and 30 wilderness
- Added 79 agility Kharazi Jungle vine shortcut
- Added Karamja gloves 4 teleport to Duradel
- Added Shilo Village ladders
- Fixed a bug where teleports would overwrite existing transports on the same tile
- Added Yanille Dungeon obstacle pipe
- Added Watchtower trellis
- Added Forthos Dungeon strange floor shortcut
- Added Cairn Isle rocks
- Added Yanille Dungeon staircases
- Added Yanille Wizard's Guild staircases
- Added Watchtower ladders
- Added Forthos Dungeon ladders and staircases
- Added Catacombs of Kourend vines and entrances/exits
- Added Giants' Den entrances/exits
- Added Barbarian Outpost agility course obstacle pipe
- Added Kharazi Jungle entrances/exits via jungle bushes and trees with machete and axe
- Added support for communicating the transportations used in the current path to other plugins
- Added checks for daily achievement diary item teleports
- Added 29 and 62 agility climbing rocks to Mount Karuulm