### PR TITLE
ironman-ground-items Initial Review

### DIFF
--- a/plugins/ironman-ground-items
+++ b/plugins/ironman-ground-items
@@ -1,2 +1,2 @@
 repository=https://github.com/justin-mercer/ironman-ground-items-plugin.git
-commit=ea111ede736b8fc75e3475d2096118012ce38bfa
+commit=208f46d2b2f52d8f2e727c2d2ce514becd2a62db

--- a/plugins/ironman-ground-items
+++ b/plugins/ironman-ground-items
@@ -1,0 +1,2 @@
+repository=https://github.com/justin-mercer/ironman-ground-items-plugin.git
+commit=ea111ede736b8fc75e3475d2096118012ce38bfa


### PR DESCRIPTION
A RuneLite plugin that removes items you don't own from right-click menus. Perfect for Ironman accounts to avoid clicking on other players' drops that can't be taken.