### PR TITLE
Add crab-crowd-counter plugin repository info

### DIFF
--- a/plugins/crab-crowd-counter
+++ b/plugins/crab-crowd-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/IanMcNelly/crab-crowd-counter.git
+commit=69dd86029803c478647bb5db77b89293600efe21


### PR DESCRIPTION
Minimal plugin to place the number of attacking players the gemstone crab ontop of the gemstone crab, with customizable colors and height. Inspired by [Tree Count Plugin](https://github.com/Infinitay/tree-count-plugin/)