### PR TITLE
Create alch-tp-blocker

### DIFF
--- a/plugins/alch-tp-blocker
+++ b/plugins/alch-tp-blocker
@@ -1,0 +1,2 @@
+repository=https://github.com/bielie993-ui/runelite-alch-tp-blocker.git
+commit=f3b9bd10431ca2b643baf54fe4be06d778ef4c47


### PR DESCRIPTION
# Alch Teleport Block
A simple plugin which blocks teleports in your regular spellbook to prevent accidental teleports while alching. The block can be overruled by pressing a modifier key.
- - -
### Features
- Choose from all regular spellbook teleports (default: Kourend Castle, Falador).
- Enable a block window which only adds the modifier for x seconds after alching. 
  - Detects high and low alchs.
  - Change block duration (default is 30s).
  - Change the modifier key (default is CTRL).
- Right click casting is still instant (can be disabled in config).

