### PR TITLE
Add Block Teleport While Alching plugin

### DIFF
--- a/plugins/alch-tp-blocker
+++ b/plugins/alch-tp-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/bielie993-ui/runelite-alch-tp-blocker.git
-commit=e7c8b28335595f44af22fb8010b0f31918eb8415
+commit=e72a3d609000872961a1d6491dfed403692f973a

--- a/plugins/alch-tp-blocker
+++ b/plugins/alch-tp-blocker
@@ -1,0 +1,2 @@
+repository=https://github.com/bielie993-ui/runelite-alch-tp-blocker.git
+commit=f3b9bd10431ca2b643baf54fe4be06d778ef4c47

--- a/plugins/alch-tp-blocker
+++ b/plugins/alch-tp-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/bielie993-ui/runelite-alch-tp-blocker.git
-commit=e72a3d609000872961a1d6491dfed403692f973a
+commit=47369287731f3f982bd1a3533021fca788e41733

--- a/plugins/alch-tp-blocker
+++ b/plugins/alch-tp-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/bielie993-ui/runelite-alch-tp-blocker.git
-commit=f3b9bd10431ca2b643baf54fe4be06d778ef4c47
+commit=e7c8b28335595f44af22fb8010b0f31918eb8415

--- a/plugins/alch-tp-blocker
+++ b/plugins/alch-tp-blocker
@@ -1,2 +1,2 @@
-repository=https://github.com/bielie993-ui/runelite-alch-tp-blocker.git
-commit=47369287731f3f982bd1a3533021fca788e41733
+repository=https://github.com/bielie993-ui/runelite-alch-teleport-blocker.git
+commit=197a1b3470866c3ce28ee32081ec8edc7af0e39a


### PR DESCRIPTION
# Alch Teleport Block
A simple plugin which blocks teleports in your regular spellbook to prevent accidental teleports while alching. The block can be overruled by pressing a modifier key. If the user wants it to only be activated if an alch was cast x seconds ago thats also possible, to make it more dynamic.
- - -
### Features
- Choose from all regular spellbook teleports (default: Kourend Castle, Falador).
- Enable a "block window" which only adds the modifier for x seconds after alching. 
  - Detects high and low alchs.
  - Change block duration (default is 30s).
- Change the modifier key (default is CTRL).
- Right click casting is still instant (can be disabled in config).

<img width="241" height="681" alt="image" src="https://github.com/user-attachments/assets/ec669433-2224-49f9-8482-eb79a5246f9f" />

---

<img width="370" height="27" alt="image" src="https://github.com/user-attachments/assets/254dd37a-98b2-4633-a1c2-cd5906d42cff" />

