### PR TITLE
Update Spell Reminder

### DIFF
--- a/plugins/thrall-helper
+++ b/plugins/thrall-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/PortAGuy/thrall-helper.git
-commit=ab2efb61b3033b9c2212923933dcc8825cc18a3d
+commit=c04e3d6d4e2be4c79d24e5c4c34cc33b844b3bbb


### PR DESCRIPTION
The latest OSRS update tripled the Mark of Darkness duration, quick-fix to support that.