### PR TITLE
Create gemstallhelper plugin

### DIFF
--- a/plugins/gemstallhelper
+++ b/plugins/gemstallhelper
@@ -1,3 +1,3 @@
 repository=https://github.com/Pepijn-V/Ardy-Gem-Stall.git
-commit=709b8e009afc23a69d05b104a3b5e1c5632557f2
+commit=e640352a2d61a3b82e23c80d7860594876a70ab4
 authors=PepijnV


### PR DESCRIPTION
Added gemstallhelper plugin to the plugin hub.
Plugin does the following:
- Checks what gemstall is closest to the player
- Checks if it is safe to steal from (no guards in range or LOS)
- Highlight the gemstall green or red if it is safe or not respectively