### PR TITLE
Update & Rename boss-hp-reorder (v2.0)

### DIFF
--- a/plugins/boss-hp-reorder
+++ b/plugins/boss-hp-reorder
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/boss-hp-reorder.git
-commit=d0ad9b15e6a629b5f595678a4963e3e53eabd914
+commit=b2f23cc9cf2acc884d64eefdef6c602e7cc966aa


### PR DESCRIPTION
* Renamed the plugin to `Boss HP Bar Offset`
* Updated the plugin so it no longer uses the Deprecated WidgetID or WidgetInfo enums
* Fixed a bug where the boss HP bar would bounce up and down
* Added the ability for this plugin offset the Tob Progress bar
