### PR TITLE
rename repo for log-master

### DIFF
--- a/plugins/log-master
+++ b/plugins/log-master
@@ -1,3 +1,3 @@
-repository=https://github.com/OSRS-Taskman/generate-task.git
+repository=https://github.com/OSRS-Taskman/collection-log-master.git
 commit=4430b602f5c242dc0f6a39696a61946357a121e1
 authors=ImTedious,rmobis


### PR DESCRIPTION
Just renaming the repo so it matches the plugin actual name.