### PR TITLE
Add Accidental Teleport Blocker

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,17 @@
 BSD 2-Clause License
 
-Copyright (c) 2025, bielie993-ui
+Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,16 @@
 BSD 2-Clause License
 
-Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
-All rights reserved.
+Copyright (c) 2025, bielie993-ui
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/plugins/accidental-teleport-blocker
+++ b/plugins/accidental-teleport-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/bielie993-ui/accidental-teleport-blocker.git
-commit=d1d4b5f030528a278adb70437f721fd7c3003199
+commit=bf44556c9fbc15501ff812ed10d405eb99d6db48

--- a/plugins/accidental-teleport-blocker
+++ b/plugins/accidental-teleport-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/bielie993-ui/accidental-teleport-blocker.git
-commit=484d99ed678ede35dd50c088c60ac8f3954c5288
+commit=d1d4b5f030528a278adb70437f721fd7c3003199

--- a/plugins/accidental-teleport-blocker
+++ b/plugins/accidental-teleport-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/bielie993-ui/accidental-teleport-blocker.git
-commit=ced506214e79af82f881c528ea178ec11c4d2148
+commit=484d99ed678ede35dd50c088c60ac8f3954c5288

--- a/plugins/accidental-teleport-blocker
+++ b/plugins/accidental-teleport-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/bielie993-ui/accidental-teleport-blocker.git
-commit=bf44556c9fbc15501ff812ed10d405eb99d6db48
+commit=4e43dbfe4679085c9f9e58f8ad7d0dec14ef4955

--- a/plugins/accidental-teleport-blocker
+++ b/plugins/accidental-teleport-blocker
@@ -1,0 +1,2 @@
+repository=https://github.com/bielie993-ui/accidental-teleport-blocker.git
+commit=aa3c132c7effcd1d7e1a1c12a9935e0f07b784d4

--- a/plugins/accidental-teleport-blocker
+++ b/plugins/accidental-teleport-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/bielie993-ui/accidental-teleport-blocker.git
-commit=aa3c132c7effcd1d7e1a1c12a9935e0f07b784d4
+commit=ced506214e79af82f881c528ea178ec11c4d2148

--- a/plugins/accidental-teleport-blocker
+++ b/plugins/accidental-teleport-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/bielie993-ui/accidental-teleport-blocker.git
-commit=4e43dbfe4679085c9f9e58f8ad7d0dec14ef4955
+commit=82d49be88dde1a330131d92a3e60bfcbc288561a

--- a/plugins/accidental-teleport-blocker
+++ b/plugins/accidental-teleport-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/bielie993-ui/accidental-teleport-blocker.git
-commit=82d49be88dde1a330131d92a3e60bfcbc288561a
+commit=1299d86f16eb7b9bbea69b70c8a120e3cc8d8333


### PR DESCRIPTION
# Accidental Teleport Blocker
A simple plugin which blocks teleports to prevent accidental teleports while casting other spells in any spellbook. The block can be overruled by pressing a modifier key.

This idea came from the frustration of accidentally teleporting while trying to cast high alchemy or manually casting other spells.
- - -
### Features
- Blocks any teleports you configured.
  - Use the shift right click menu to add/remove teleports from the block list.
- Supports all spellbooks (normal, ancient, lunar and arceuus).
- Configurable modifier key to overrule the block.
- Only activate block after a spell on your configurable spell list was cast.
  - Configurable timeout to reset the block after a certain time.
  - Use the shift right click menu to add/remove spells from the spell list.
  - Share your spell list with others using the comma-separated text box.

### Printscreens

![screenshot](https://i.imgur.com/oSGuDuB.png)

![screenshot](https://i.imgur.com/Orm13Nf.png)

![screenshot](https://i.imgur.com/40Vq6Hc.png)

![screenshot](https://i.imgur.com/Aw627Lf.png)


This is a reworked and improved version of: https://github.com/runelite/plugin-hub/pull/8909
