### PR TITLE
Slayer Task Sorter

### DIFF
--- a/plugins/slayer-task-sorter
+++ b/plugins/slayer-task-sorter
@@ -1,3 +1,3 @@
 repository=https://github.com/MJHylkema/slayer-task-sorter.git
-commit=21a338a48441c48a856d84651508597fc3dd5174
+commit=485110c20203671a4efaa5b1611b25e628bf32fb
 authors=mjhylkema

--- a/plugins/slayer-task-sorter
+++ b/plugins/slayer-task-sorter
@@ -1,0 +1,3 @@
+repository=https://github.com/MJHylkema/slayer-task-sorter.git
+commit=4c4e5e0ffe9ee4b4d9be46353fbf55a61629177c
+authors=mjhylkema

--- a/plugins/slayer-task-sorter
+++ b/plugins/slayer-task-sorter
@@ -1,3 +1,3 @@
 repository=https://github.com/MJHylkema/slayer-task-sorter.git
-commit=346ec5f5f3a36b2ebe09c42931a86fb02c5a8b50
+commit=d8f7e2e0c11d6fdba6f4e26713544fe5b6863551
 authors=mjhylkema

--- a/plugins/slayer-task-sorter
+++ b/plugins/slayer-task-sorter
@@ -1,3 +1,3 @@
 repository=https://github.com/MJHylkema/slayer-task-sorter.git
-commit=aa77d3a1bee716741fca5334215c711d96e12f72
+commit=21a338a48441c48a856d84651508597fc3dd5174
 authors=mjhylkema

--- a/plugins/slayer-task-sorter
+++ b/plugins/slayer-task-sorter
@@ -1,3 +1,3 @@
 repository=https://github.com/MJHylkema/slayer-task-sorter.git
-commit=4c4e5e0ffe9ee4b4d9be46353fbf55a61629177c
+commit=aa77d3a1bee716741fca5334215c711d96e12f72
 authors=mjhylkema

--- a/plugins/slayer-task-sorter
+++ b/plugins/slayer-task-sorter
@@ -1,3 +1,3 @@
 repository=https://github.com/MJHylkema/slayer-task-sorter.git
-commit=485110c20203671a4efaa5b1611b25e628bf32fb
+commit=346ec5f5f3a36b2ebe09c42931a86fb02c5a8b50
 authors=mjhylkema


### PR DESCRIPTION
Add plugin to sort Slayer task lists by weight. Allows you to also reverse the order and revert back to alphabetical.

<img width="305" height="256" alt="image" src="https://github.com/user-attachments/assets/e00e74e3-4312-4a53-8f3c-9c11b93564ab" />

<img width="313" height="110" alt="image" src="https://github.com/user-attachments/assets/6a184147-1b9a-4a6b-8824-192d04d43fed" />
