### PR TITLE
deprecate log-master

### DIFF
--- a/plugins/log-master
+++ b/plugins/log-master
@@ -1,4 +1,4 @@
 repository=https://github.com/OSRS-Taskman/collection-log-master.git
-commit=4fc474de0ac8ce7c33bdab770a7de03abaa0e7fa
+commit=091e7f0e8e6885ec09baa27069a3f492e2325a13
 authors=ImTedious,rmobis
 warning=This plugin is deprecated, you should not install it. Look for 'Collection Log Master' in the plugin hub for the newest version.

--- a/plugins/log-master
+++ b/plugins/log-master
@@ -1,3 +1,4 @@
 repository=https://github.com/OSRS-Taskman/collection-log-master.git
-commit=f2dd0ff09385a63c9b93ed60b2e179db200b9056
+commit=4fc474de0ac8ce7c33bdab770a7de03abaa0e7fa
 authors=ImTedious,rmobis
+warning=This plugin is deprecated, you should not install it. Look for 'Collection Log Master' in the plugin hub for the newest version.


### PR DESCRIPTION
> [!IMPORTANT]
>  Please merge https://github.com/runelite/plugin-hub/pull/8950 first.
>  ~~Please merge #9029 first.~~


[As discussed in Discord](https://discord.com/channels/301497432909414422/419891709883973642/1406054806467903591), we'll be deprecating the `log-master` plugin in favor of the newly created `collection-log-master`.

All this PR does for now is:
- Renames plugin from `Collection Log Master` to `[DEPRECATED] Collection Log Master`
- Setups conflict with its replacing plugin
- Adds a warning every time you open the task dashboard about the deprecation
- Adds a warning on install that this plugin should no longer be installed

The plan is to eventually completely remove this deprecated version from the hub, but for now it would help migrate users to keep both up, even if a bit confusing.

**Reference:**

- https://github.com/runelite/plugin-hub/pull/8950