### PR TITLE
add collection-log-master

### DIFF
--- a/plugins/collection-log-master
+++ b/plugins/collection-log-master
@@ -1,0 +1,4 @@
+repository=https://github.com/OSRS-Taskman/collection-log-master.git
+commit=c9f6d8cfafbf5e4ae56bf6376d0e558002f96fc2
+authors=ImTedious,rmobis
+warning="This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.",


### PR DESCRIPTION
[As discussed in Discord](https://discord.com/channels/301497432909414422/419891709883973642/1406054806467903591), we'll be launching this new plugin `collection-log-master` to replace the deprecated `log-master`.

To help this first review, this PR includes the bare minimum changes form the deprecated `log-master` plugin as possible.

**Reference:**
- https://github.com/runelite/plugin-hub/pull/8949