### PR TITLE
Update escape-crystal-notify (v1.7)

### DIFF
--- a/plugins/escape-crystal-notify
+++ b/plugins/escape-crystal-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/Xylot/escape-crystal-notify.git
-commit=f977b237177a27674632a296e36b25d2a8b982ba
+commit=6a72ac78f6a5d93e8338cf24c6e4052205811a7c


### PR DESCRIPTION
Add:
- Configurable boss entrance overlay and left-click entry deprioritization when the player does not have an active Escape Crystal
- Left-click logout safeguards for Doom's logout bug
- Minimal Inventory overlays for Non-HC accounts
- Getting revived at Zulrah with the Western Province Diary reward will mark the boss as dangerous until the reward resets
- Add option to only send notifications when the player is, or has recently been, in combat
- Support for new bosses (Amoxiatl, Artio, Bryophyta, Calvar'ion, Crazy Archaeologist, Deranged Archaeologist, Doom of Mokhaiotl, Hueycoatl, King Black Dragon, Mimic, Obor, Royal Titans, Scurrius, Spindel, Yama)