### PR TITLE
Add overhead-alarm plugin repository information

### DIFF
--- a/plugins/overhead-alarm
+++ b/plugins/overhead-alarm
@@ -1,0 +1,2 @@
+repository=https://github.com/TomLangdon/RuneliteOverheadAlarm.git
+commit=7f04ff9ddd3e1604c6eeda9d9e63414bc950885f


### PR DESCRIPTION
A very lightweight plugin that just sends a notification every time you are attacked/ hit without an active overhead prayer