### PR TITLE
Update Chest-Kicker

### DIFF
--- a/plugins/chest-kicker
+++ b/plugins/chest-kicker
@@ -1,2 +1,2 @@
 repository=https://github.com/edmeyer8851/chest-kicker.git
-commit=badd61da11e72881f1ceac9e1286363906ea25f9
+commit=8bee13566118dc2796f0e0ade94b396168544b51

--- a/plugins/chest-kicker
+++ b/plugins/chest-kicker
@@ -1,2 +1,2 @@
 repository=https://github.com/edmeyer8851/chest-kicker.git
-commit=e5322e2b9c9b8cdb11b4e276b92cb847cd7b5630
+commit=badd61da11e72881f1ceac9e1286363906ea25f9

--- a/plugins/chest-kicker
+++ b/plugins/chest-kicker
@@ -1,2 +1,2 @@
 repository=https://github.com/edmeyer8851/chest-kicker.git
-commit=8bee13566118dc2796f0e0ade94b396168544b51
+commit=2a981caffdca521e925ef9472f3a68e9f0885ac5


### PR DESCRIPTION
Updates Chest Kicker to use WorldAreas for distance compare instead of overriding the open animation, similar to Boss Kicker. Also adds support for barrows, moons, tob, and toa chests.