### PR TITLE
Update escape-crystal-notify (v1.8)

### DIFF
--- a/plugins/escape-crystal-notify
+++ b/plugins/escape-crystal-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/Xylot/escape-crystal-notify.git
-commit=6a72ac78f6a5d93e8338cf24c6e4052205811a7c
+commit=1c00f9c870d370a25d0629bbfb4869b04b4a01d7


### PR DESCRIPTION
- Adds additional handling for removing the highlight from Whisperer's quest variant
- Adds support for additional text overlay message on entrances of bosses that do not allow Escape Crystal use

This includes:
- Fight Caves (Escape Crystal should work there but it currently does not)
- DT2 Mysterious Figure fight