### PR TITLE
Add Elemental Weakness

### DIFF
--- a/plugins/elemental-weakness
+++ b/plugins/elemental-weakness
@@ -1,0 +1,2 @@
+repository=https://github.com/jonathanvanduppen/runelite-elemental-weakness.git
+commit=59be70feddfdae60bd656a0ef8bb5579d94cffe3


### PR DESCRIPTION
The first time a monster is spawned it looks up the elemental weakness. This is then cached in memory until the client is shut down utilizing https://vanduppenllc.com/runelite/api/elemental-weakness 
IE
https://vanduppenllc.com/runelite/api/elemental-weakness/imp 

<img width="1529" height="937" alt="image" src="https://github.com/user-attachments/assets/1c26aedb-e4e8-4a07-8cc3-ec0d453ebb4a" />
