### PR TITLE
add in catracker plugin info

### DIFF
--- a/plugins/combat-achievements-tracker
+++ b/plugins/combat-achievements-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/ehubbartt/combat-achievements-tracker.git
-commit=7f79264b84c1bff35f88524ec6cfef5164418e8e
+commit=96ff78772490dcac9f5df54a8d6c0efd807cd573


### PR DESCRIPTION
This plugin is an all-in-one tracker for Combat Achievements. This plugin allows you to view all the current CA's in the game and syncs with your account progress automatically when you log in. It also allows you to choose certain CA's to track in order to manage progress on your goals. Another great feature is a searchable boss tab that quickly shows you the list of all bosses that have CA's and gives easy access to the CA's for those bosses. This all syncs with your client, so you don't have to redo all your tracking on each load. You can also hover on a task for more info and right-click to pull up the wiki page for that task.
The readme at https://github.com/ehubbartt/combat-achievements-tracker provides some more detailed info and images!