### PR TITLE
Update escape-crystal-notify (v1.9)

### DIFF
--- a/plugins/escape-crystal-notify
+++ b/plugins/escape-crystal-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/Xylot/escape-crystal-notify.git
-commit=bafec74df8397e1faedb27b9694b0ed4cbbd6784
+commit=3af18d97f7d0152e6ebd0cc06fbdbfbc4bca601f

--- a/plugins/escape-crystal-notify
+++ b/plugins/escape-crystal-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/Xylot/escape-crystal-notify.git
-commit=1c00f9c870d370a25d0629bbfb4869b04b4a01d7
+commit=bafec74df8397e1faedb27b9694b0ed4cbbd6784


### PR DESCRIPTION
Adds the following regions to the list of regions that do not allow the use of Escape Crystals

- Making Friends With My Arm Don't Know What Fight
- The Final Dawn's Emissary Enforcer Fight
- Lunar Diplomacy Final Fight
- Dream Mentor Final Fight
- Movario's Base