### PR TITLE
update no-bad-alchs 1.2.1

### DIFF
--- a/plugins/no-bad-alchs
+++ b/plugins/no-bad-alchs
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/no-bad-alchs.git
-commit=6da8f46d1742f9e8a73b999ea537c3e208b6c11a
+commit=5f1add8bfd549586ef0fbd243848b9b0d88a0338


### PR DESCRIPTION
Fix due to a bug in RuneLite where noted items are marked as not tradeable.