### PR TITLE
Update clear-unsent-messages

### DIFF
--- a/plugins/clear-unsent-messages
+++ b/plugins/clear-unsent-messages
@@ -1,2 +1,2 @@
 repository=https://github.com/lightningboltemoji/clear-unsent-messages.git
-commit=2e9d94b80055168e11367f3c8ed65083623ddeaf
+commit=3673fd35ae47f8bd6563c6645776acff8c2f93a6


### PR DESCRIPTION
- Fixes a small bug: https://github.com/lightningboltemoji/clear-unsent-messages/issues/6
- Removes logic for patching the chatbox -- `CHAT_PROMPT_INIT` seems to do the same thing