### PR TITLE
Update aqp-finder

### DIFF
--- a/plugins/aqp-finder
+++ b/plugins/aqp-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/JamesShelton140/aqp-finder.git
-commit=78e6d31925658cfaf8e2092cd1280e9ccc86b827
+commit=a56d80209856403e97930340b06ebf72b4c3a800


### PR DESCRIPTION
- Correctly strip known chat prefixes.
- Fix inconsistent recommendations when using < or > characters in messages containing QP patterns.