### PR TITLE
Add InfoDock (Classic) plugin entry

### DIFF
--- a/plugins/infodock-classic
+++ b/plugins/infodock-classic
@@ -1,0 +1,2 @@
+repository=https://github.com/rdrs333/infodock-classic.git
+commit=https://github.com/rdrs333/plugin-hub/new/master?filename=plugins%2Finfodock-classic

--- a/plugins/infodock-classic
+++ b/plugins/infodock-classic
@@ -1,2 +1,2 @@
 repository=https://github.com/rdrs333/infodock-classic.git
-commit=https://github.com/rdrs333/plugin-hub/new/master?filename=plugins%2Finfodock-classic
+commit=e275f7d27edab7f164a42412c9b495b1db50b44b


### PR DESCRIPTION
Plugin name: InfoDock (Classic)
Author / GitHub: rdrs333 (https://github.com/rdrs333)
Repository: https://github.com/rdrs333/infodock-classic.git
Commit SHA: e275f7d27edab7f164a42412c9b495b1db50b44b

Short description:
A RuneLite plugin that provides a fixed dock above the chatbox for InfoBoxes (Classic resizable layout only). Supports auto-park, adaptive/hard-lock layout, and an optional mask overlay.

How to test locally (for maintainers):
1. Clone plugin repo:
   git clone https://github.com/rdrs333/infodock-classic.git
   cd infodock-classic

2. Build the plugin with Gradle:
   Windows:
     .\gradlew.bat build
   Linux/macOS:
     ./gradlew build

   The built jar is at: build/libs/infodock-classic-1.0.0.jar

3. Copy the jar to RuneLite external plugins folder (developer mode required):
   %USERPROFILE%\.runelite\external-plugins\infodock-classic-1.0.0.jar

4. Start RuneLite in developer mode:
   java -jar RuneLite.jar --developer-mode
   Ensure you have developer mode enabled in Launcher or start with --developer-mode.

Notes / additional info:
- License: BSD-2-Clause (included)
- README.md present in the repo with usage and configuration notes.
- I removed the backup file info/dock properties (if you see infodock-classic.properties.bak in the repo please let me know and I'll remove it) — bak file is not needed.
- If maintainers want any changes to the plugin metadata or tests, please request them here.

Contact:
GitHub: https://github.com/rdrs333
