### PR TITLE
[Update] - Varlamore House Thieving - v1.5.5 - Sololegnds

### DIFF
--- a/plugins/varlamore-house-thieving
+++ b/plugins/varlamore-house-thieving
@@ -1,2 +1,2 @@
 repository=https://github.com/sololegends/runelite-varlamore-house-thieving.git
-commit=a27486c63ac5948bbd517fa577f5c99a7c8dbfa3
+commit=65e98db36a8f732408b88d00b4b6f0794e64e338


### PR DESCRIPTION
# Release v1.5.5

Various configuration and usage updates

- Implemented newer Notification spec for configuration options
- Added a high contrast arrow option for distraction icon
- Added stroke to the default distraction icon
- Altered the The distracted citizen flashing in house option to also control alerting
- Lowered the bonus chest red threshold to 45 seconds