### PR TITLE
Add Morrog Speak

### DIFF
--- a/plugins/morrog-speak
+++ b/plugins/morrog-speak
@@ -1,0 +1,2 @@
+repository=https://github.com/MGDproductions/morrog-speak.git
+commit=4b1690f9a6ab537473379b0f8fcc1f985497743c


### PR DESCRIPTION
A plugin which voiceovers all quests with random Dutch voices.
The player is being voiced by a popular Dutch livestreamer called Morrog.

I have obtained full authorization from Morrog to use his branding and voice in this plugin.
Morrog wanted to create this plugin for his big Twitch/Runescape community and tasked me to create it.

If there is anything which needs to be changed because this is a dutch only plugin, do let me know. (For example plugin name or description in dutch)

The plugin is made for this streamer, however it is also applicable to be used by any dutch speaker who doesn't have any relation to his livestreams or his community.