### PR TITLE
Update rich-text-notes

### DIFF
--- a/plugins/rich-text-notes
+++ b/plugins/rich-text-notes
@@ -1,2 +1,2 @@
 repository=https://github.com/lgwood/rich-text-notes.git
-commit=0b72704444e832a9231dfe7031c198fd85f81263
+commit=7f51686dff7f440133d9301f83430b2eca9b29dc


### PR DESCRIPTION
fixed an error with the Transferable MIME type in built jar