### PR TITLE
Create compact-orbs

### DIFF
--- a/plugins/compact-orbs
+++ b/plugins/compact-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/its-cue/compact-orbs.git
-commit=21ffb10b79a9f525d5a570b1ec7c70b9efe3b85d
+commit=308b4b720da81e57660ad7a6d8374ef18bbcc03b


### PR DESCRIPTION
Emulate the mobile client's minimap collapsing feature, positioning the orbs to the right-most side of the window in a compact layout

- Minimap can be hidden and shown
- Compass can be hidden and shown, so long as the minimap isn't visible
- Toggle buttons configure whether minimap or compass is visible
- Toggle buttons can be hidden, from the config settings
- Only supported when in ``resizable-modern`` and ``resizable-classic`` display mode

## Preview
![preview](https://imgur.com/rOliKl2.png)

## In-game

![ingame](https://imgur.com/dCSMmWZ.png)
