### PR TITLE
Create no-prayer-fight-cave-guide

### DIFF
--- a/plugins/no-prayer-fight-cave-guide
+++ b/plugins/no-prayer-fight-cave-guide
@@ -1,2 +1,2 @@
 repository=https://github.com/DylanGroenewoud/no-prayer-fight-cave-guide.git
-commit=fa7a0fff03935ee18e51317d9d789b3bb8c6ee2f
+commit=20c7dd5ba4d68e71214b105806e1e7b1bc9b0889


### PR DESCRIPTION
The plugin I've developed is to help during NO PRAYER fight cave runs. Currently I (and probably very few other people who do no prayer fight cave runs, i mean.. who even does this.. but anyway) always have to check the Wiki rotations page on where to run and when to request a log out. This plugin shows the somewhat optimal path to run so checking the Wiki isn't needed anymore. For certain waves it also shows helpful information, like preferred amount of hitpoints for the upcoming wave and some other info.