### PR TITLE
Update clean-chat to v2.3.2

### DIFF
--- a/plugins/clean-chat
+++ b/plugins/clean-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/chat-cleanup.git
-commit=2549bc17fec9e8b01ba17e0c0ce5a345bc1db529
+commit=a40a83e01955231e2a230b59b5fb5934b96b4a52


### PR DESCRIPTION
Tiny fix to handle underscores when calculating the length of text