### PR TITLE
Take-over phoenix-necklace-jingle

### DIFF
--- a/plugins/phoenix-necklace-jingle
+++ b/plugins/phoenix-necklace-jingle
@@ -1,2 +1,2 @@
-repository=https://github.com/Nope1252/phoenix-necklace-jingle.git
+repository=https://github.com/Thedyolf/phoenix-necklace-jingle.git
 commit=b77e18a556b1ea3a3fa5d71368e93286de6342be


### PR DESCRIPTION
I have updated to Phoenix Necklace Jingle to support custom sounds (.wav) files and to support different sound IDs. The owner is non-responsive and I would like to take over the plugin.