### PR TITLE
add cheapest-food

### DIFF
--- a/plugins/cheapest-food
+++ b/plugins/cheapest-food
@@ -1,0 +1,2 @@
+repository=https://github.com/Luc-Harding/CheapestFood.git
+commit=e12d7e652c2dbb856d2e00e45c84fcd147c85198


### PR DESCRIPTION
Plugin that pulls latest prices for max healing foods (22hp), and displays to user the cheapest option for either a single 22hp healing food, and a 2 bite (pies/pizza) 22hp healing food.