### PR TITLE
Update max-hit-calculator to v2.1.2

### DIFF
--- a/plugins/max-hit-calculator
+++ b/plugins/max-hit-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/j-cob44/max-hit-calc.git
-commit=ad2da04f6b562cf2037b98bfbd72521e54c25ceb
+commit=1d77c0d5b8ddd062d762bfefcf69efdf82aa2bd4


### PR DESCRIPTION
v2.1.2:
- Fixed Eclipse Atlatl calculations to use Strength level and strength bonus instead of ranged (https://github.com/j-cob44/max-hit-calc/issues/58)
- Fixed Barrows Brothers type weakness not recognizing partial name in lookup (https://github.com/j-cob44/max-hit-calc/issues/59)
- Add Skeletal Hellhound spell weakness bonus