### PR TITLE
Add plugin: Gauntlet Crafting

### DIFF
--- a/plugins/gauntlet-crafting
+++ b/plugins/gauntlet-crafting
@@ -1,0 +1,2 @@
+repository=https://github.com/trs/runelite-gauntlet-crafting.git
+commit=e7f99e818d9eff1221c9c657de4674a042cb743f


### PR DESCRIPTION
Add a plugin to highlight craftable items in The Gauntlet based on a set of configs

<img width="638" height="294" alt="cover" src="https://github.com/user-attachments/assets/9f1853e6-a994-43e3-a5c4-97b3f7b9e77e" />
