### PR TITLE
Add monster-lookup plugin

### DIFF
--- a/plugins/monster-lookup
+++ b/plugins/monster-lookup
@@ -1,0 +1,2 @@
+repository=https://github.com/robertjnic/monster-lookup.git
+commit=702c233e61cbeadc6119ee6201cc586a1886c60d


### PR DESCRIPTION
Adds Monster Lookup to the Plugin Hub. 

Search monsters in RuneLite from the in‑game menu or a simple search panel to see basic stats. Uses OSRS Reboxed DB, cached locally (gzipped) with a ~30‑day refresh