### PR TITLE
Update escape-crystal-notify (v1.10)

### DIFF
--- a/plugins/escape-crystal-notify
+++ b/plugins/escape-crystal-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/Xylot/escape-crystal-notify.git
-commit=3af18d97f7d0152e6ebd0cc06fbdbfbc4bca601f
+commit=73324d4e5fa203c8912e21121d426d6fc1b4130a


### PR DESCRIPTION
Bug fix:
- Last combat time calculation
- Entrance definitions are now separated into NPC/Objects to avoid incorrect entrances from being detected

Add:
- Disable entrance deprioritization on PVP worlds
- Improve clarity of the Doom and Leviathan logout prevention settings
- Simplify config section names