### PR TITLE
Update target true tile to 1.3.2

### DIFF
--- a/plugins/target-true-tile
+++ b/plugins/target-true-tile
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/runelite-target-true-tile.git
-commit=08adbb77009f8fb2dbe3956f63e3cee1749e39a3
+commit=efe38d1089ed318bdf75d94b695494ac62f6a4c3
 authors=Notloc


### PR DESCRIPTION
Fixes this visual bug with the actor cutout where the cutout height is offset 

<img width="1060" height="1137" alt="image" src="https://github.com/user-attachments/assets/2f2359b6-7141-4091-8870-129794c662e7" />
