### PR TITLE
Fix bug with prevent misclicks

### DIFF
--- a/plugins/preventsgm
+++ b/plugins/preventsgm
@@ -1,2 +1,2 @@
 repository=https://github.com/Zippilipy/prevent-sgm.git
-commit=670741eae7bcd393c7b25fc6f2b1ba96cbff900c
+commit=3c691f2f4975fcc84cd9bb0462a6ee36711c451f


### PR DESCRIPTION
I accidentally broke the plugin and didn't notice. Fixed now