### PR TITLE
Create bank-price-tracker

### DIFF
--- a/plugins/bank-price-tracker
+++ b/plugins/bank-price-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/EvachiOSRS/runelite-bank-price-tracker.git
+commit=3bb60665332912de58dfd46efd1810644dd974ad


### PR DESCRIPTION
Bank Price Tracker tracks the GE changes to tradeable items within your bank and displays them in a table format showing profitable/loss changes ranging from 30 minutes to a month using the in game GE pricing. To help alleviate the concerns when seeing the total bank value increasing/decreasing over time and pinpointing what has changed. Uses a side panel, with clickable sorting.