### PR TITLE
Create Turael slayer

### DIFF
--- a/plugins/turael-slayer
+++ b/plugins/turael-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/wesley-221/Turael-Slayer.git
-commit=63e60f6ea865ab4164418ade3f9d1dd29265c75c
+commit=f411a7c3357cd9545b4420db8984fb0bc79cb836


### PR DESCRIPTION
Adds a new plugin to help with Turael/Aya slayer tasks. Similar to the `Turael skipping` plugin, but with more features and customisations. 

Also added future proofing for alternative tasks which I plan to implement at a later time, to for example show the monkeys near Shilo Village instead of in Kruk's dungeon, or cows near Ectofuntus instead of lumbridge, etc.

I created this as a separate plugin rather than modifying `Turael skipping` plugin to avoid having to rewrite the data structures and other logic, so I could implement my features more easily.