### PR TITLE
log-master: hotfix for plugin not starting

### DIFF
--- a/plugins/log-master
+++ b/plugins/log-master
@@ -1,3 +1,3 @@
 repository=https://github.com/OSRS-Taskman/collection-log-master.git
-commit=4430b602f5c242dc0f6a39696a61946357a121e1
+commit=f2dd0ff09385a63c9b93ed60b2e179db200b9056
 authors=ImTedious,rmobis


### PR DESCRIPTION
A very small fix for an issue affecting some of our users who had been inactive for a while.