### PR TITLE
Create colo-death-indicator

### DIFF
--- a/plugins/colo-death-indicator
+++ b/plugins/colo-death-indicator
@@ -1,0 +1,2 @@
+repository=https://github.com/JaccodR/colo-death-indicator.git
+commit=616d92d4c08cc444f77551c839da1074583d962c


### PR DESCRIPTION
- Keeps track of the HP of monsters in the Colosseum.
- Indicates if NPCs in the Colosseum are dead.