### PR TITLE
Update turael-skipping to v1.1

### DIFF
--- a/plugins/turael-skipping
+++ b/plugins/turael-skipping
@@ -1,3 +1,3 @@
 repository=https://github.com/BrastaSauce/turael-skipping.git
-commit=617317fd718c7f876399244ec18d2c4b77ff93ca
+commit=fdd4ac897c9f394ce9962b32e2a296683cb35fb3
 authors=wesley-221


### PR DESCRIPTION
Update Turael Skipping to version 1.1

Contacted the owner of Turael Skipping and got permission to update the plugin to what I created as shown in this pull request: https://github.com/runelite/plugin-hub/pull/9028

Conversations can be found here: 
https://github.com/BrastaSauce/turael-skipping/issues/16
https://github.com/BrastaSauce/turael-skipping/pull/17