### PR TITLE
Add Maniacal Hunter plugin

### DIFF
--- a/plugins/maniacal-hunter
+++ b/plugins/maniacal-hunter
@@ -1,0 +1,2 @@
+repository=https://github.com/IanMcNelly/maniacal-hunter.git
+commit=0e0bd62629b71015ea218c7998cf3e90debdc44a


### PR DESCRIPTION
A plugin to track stats while griding maniacal monkeys in kruks dungeon. Includes a compact mode with just an infobox, and a full panel with customizable metrics, session, and aggregate tracking