### PR TITLE
Create pbsync

### DIFF
--- a/plugins/pbsync
+++ b/plugins/pbsync
@@ -1,2 +1,2 @@
 repository=https://github.com/HerbRuns/pbsync.git
-commit=f1aa36ed694e0c6341221b303fabd11cda08ab23
+commit=906e1e4a8dc5898af205eb4fb2da78e8e83856a2


### PR DESCRIPTION
Added new plugin 'pbsync'

ReadMe has a little more info, however it's designed to sync and send all current personal best times to a Discord channel via webhook by a chatcommand (!pbsync). In addition, clan chat is monitored for new PBs and sent to a channel via a second webhook.

Was designed for use by the Mirage clan and Discord but has been written in a way to allow all clans to pick up and use if they wish.