### PR TITLE
Add Venomed NPC Tracker plugin

### DIFF
--- a/plugins/venomed-npc-tracker
+++ b/plugins/venomed-npc-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/HenningSte/venomed-npc-tracker.git
+commit=1e4a50ac70dcaef262f9019a46c1131f4e0a3c44


### PR DESCRIPTION
- Keeps track of venomed NPCs (optionally poisoned ones as well)
- Recolours their menu entries, optionally adds suffix
- Integrates with Monster Menu HP plugin if installed alongside it

<img width="440" height="350" alt="venom_standalone" src="https://github.com/user-attachments/assets/2f06a494-c99d-432e-bd0c-ee684644f3dc" />
