### PR TITLE
Add the Home Assistant Exporter

### DIFF
--- a/plugins/haexporter
+++ b/plugins/haexporter
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/RuneLite-Home-Assistant-Exporter.git
-commit=c2c0955b32e70fe83f48700e7938e1b5c38de846
+commit=14bd28f1d698f368c50f63f8c72909ddc2b7aae1


### PR DESCRIPTION
This plugin allows the player to export/stream their stats live to a local (to their network) Home Assistant instance for home automation purposes.

An example with dummy data just displaying the information in a dashboard:
<img width="1706" height="860" alt="image" src="https://github.com/user-attachments/assets/c9d419e2-fbb0-484b-a49c-880cf0bce1fb" />


Only allowing the webhook without any additional auth as of now since I personally do not want to have to deal with attempting to utilize a webhook remotely. This way if the webhook is local it will work and it will not if the webhook is not local. 