### PR TITLE
Update npc-max-hit to v1.3

### DIFF
--- a/plugins/npc-max-hit
+++ b/plugins/npc-max-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/npc-max-hit.git
-commit=a3529e7f1f12515b965441d642e43bd447fe0da8
+commit=4993e6cd3e6b40aa7c71ee1776331b78a9724db4


### PR DESCRIPTION
refactor wiki data fetching

- move away from deprecated api to new one
- preload and cache all npc max hits on startup, avoid background asyncs
- cache request at cdn level