### PR TITLE
Clan Broadcasts plugin

### DIFF
--- a/plugins/clan-broadcasts
+++ b/plugins/clan-broadcasts
@@ -1,0 +1,2 @@
+repository=https://github.com/2Lica/Clan-Broadcasts.git
+commit=825bb84fa9f8b974c8779c82718ce6448f355257


### PR DESCRIPTION
Adds Clan Broadcasts plugin to track and send embed Discord messages via Webhooks for all in-game clan broadcasts.