### PR TITLE
Update player-status-highlight

### DIFF
--- a/plugins/player-status-highlight
+++ b/plugins/player-status-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/Dot145/Player-Status-Highlight.git
-commit=3e920c419ff812b8e99fe2ab7580e17e215eb23d
+commit=1f17c52e4be608d6adbf6e78b7f98b2239dde8fb


### PR DESCRIPTION
Update Mark of Darkness timing to reflect the update changing it to base 300 seconds regardless of magic level