### PR TITLE
Update shortest-path to v1.17.14

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=70a264174b0f28ecba6f86cc191e99b81af62424
+commit=1992a14e76ac1706874dd00c75e58591e5cec04f


### PR DESCRIPTION
- Added Lumbridge Swamp Caves entrances
- Added 66 magic level requirement for the Yanille Magic Guild entrance door
- The magic carpet display info should now respect quest progress
- Added more teleportation item unlock checks
- Teleportation items now have a new option `Unlocked` for disregarding item requirements and only considering unlock skill and quest requirements. The `All` option now also disregards skill requirements
- Skill capes with teleports now have a 99 skill level requirement
- Max cape, quest cape and achievement diary cape now have unlock requirements
- The Pest Control Minigame teleport now has a 40 combat requirement