### PR TITLE
Create npc-aggro-highlighter

### DIFF
--- a/plugins/npc-aggro-highlighter
+++ b/plugins/npc-aggro-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/HamzehMuaz/npc-aggro-highlighter.git
+commit=db87cc67976c76275307b6116f4022c24e4d5768


### PR DESCRIPTION
Hello all

This is a new plugin that tags and highlights NPC that are targeting you.
This is mainly made for Bursting/Barraging when you need to use darts/knives to tag NPCs then stack them to barrage them easily. It helps to know what NPCs were not tagged yet or lost aggro due to distance or other reason.

This plugin also counts NPC in a stack near you (good for barraging many and counting)

It has many options to toggle or edit.

<img width="243" height="449" alt="image" src="https://github.com/user-attachments/assets/ad27f572-0647-41a9-8b9a-0749684c4e44" />
