### PR TITLE
Adding PvM Analytics

### DIFF
--- a/plugins/pvm-analytics
+++ b/plugins/pvm-analytics
@@ -1,2 +1,2 @@
 repository=https://github.com/glukt/runelite-plugin-pvm-analytics.git
-commit=324d726713852d329d09b7c078cf73c5dfab3128
+commit=84363bfad080c9d9d96788f007f1057c3c4181d0


### PR DESCRIPTION
First iteration... testing functionality !!!

This pull request introduces the initial version of the PvM Analytics plugin, a tool designed to help players track and analyze their performance during instanced PvM encounters.

The primary goal of this plugin is to act as a personal, retrospective logbook. It passively records data during a bossing or raiding "trip" and presents it in a clear, summarized format. This allows players, especially Ironmen who are highly dependent on resource management, to get actionable insights into their efficiency, supply consumption, and profitability over time.

Core Features:

    Automatic Trip Detection: The plugin automatically detects when a player enters and leaves supported instanced areas (starting with The Gauntlet) to log sessions.

    Detailed Kill Logging: For each kill within a trip, the plugin is designed to track:

        Precise kill times.

        Loot received and its GE value.

        Supplies consumed (e.g., potion doses, food, ammo).

    Data History & Review: All completed trips will be saved to a history panel, allowing players to review past performance, compare kill times, and track long-term profitability.

This initial submission establishes the foundational trip-detection logic. Future updates will build upon this to implement detailed loot/supply tracking and the UI for the history panel. All features are designed to be purely informational and fully compliant with Jagex/RuneLite guidelines.