### PR TITLE
update ba-tiles

### DIFF
--- a/plugins/ba-tiles
+++ b/plugins/ba-tiles
@@ -1,2 +1,2 @@
 repository=https://github.com/96jonesa/ba-tiles.git
-commit=62e3f073537a35c07122caf06a0b8ad7e9af8840
+commit=3adfd99f0734c9492ed87130db9ee1ea2dc39884


### PR DESCRIPTION
removes usage of soon-to-be deprecated `java.applet` by using a different
version of `ColorPickerManager::create`