### PR TITLE
Update aqp-finder

### DIFF
--- a/plugins/aqp-finder
+++ b/plugins/aqp-finder
@@ -1,2 +1,2 @@
 repository=https://github.com/JamesShelton140/aqp-finder.git
-commit=a56d80209856403e97930340b06ebf72b4c3a800
+commit=484c4c94d379b7c84c4e0b16bc4cde68abb3edbe


### PR DESCRIPTION
- Limit plugin to handle specific chat types only.
- Prevent overlay from being cleared by messages from other chat types.
- Add some missing characters to the size dictionary.