### PR TITLE
update 117hd

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=49649af435e0247781c07c598a26493727b15440
+commit=14bc83902090eab4afd85c0e194d25443eb829e2
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Primarily fixes an issue with low dynamic light limits, where the tiled lighting was producing some artifacting. Also fixes a couple of small area hiding issues, and removes a call to `getModel` which was causing crashes.