### PR TITLE
seed vault memory plugin

### DIFF
--- a/plugins/seed-vault-memory
+++ b/plugins/seed-vault-memory
@@ -1,0 +1,2 @@
+repository=https://github.com/matt-finney/runelite-seed-vault-memory-plugin.git
+commit=a267c65e60aed7bac71df01141966e5f86bbd5e2


### PR DESCRIPTION
A plugin for [RuneLite] (https://github.com/runelite/runelite) which remembers the contents of your seed vault and displays that in a searchable interface. Based on LazyFaith's "Bank Memory plugin" (https://runelite.net/plugin-hub/LazyFaith)