### PR TITLE
Update escape-crystal-notify (v1.11)

### DIFF
--- a/plugins/escape-crystal-notify
+++ b/plugins/escape-crystal-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/Xylot/escape-crystal-notify.git
-commit=73324d4e5fa203c8912e21121d426d6fc1b4130a
+commit=9e0db754df3b3eac9a77c10fd1a6f2740f92be7b


### PR DESCRIPTION
Fix bug where safe entrances were being incorrectly being highlighted for regular HCs (ex: Regular HC COX)