### PR TITLE
update 117hd

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=14bc83902090eab4afd85c0e194d25443eb829e2
+commit=5cfd9874d655887a91985a08ca8496464ee774e4
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This addresses the main bit of pushback we've been getting:
- Fall back to old lighting implementation if the new tiled lighting fails to compile & warn the user about it.
- Work around an issue where the autumn theme couldn't apply in Varlamore.
- Attempt to fix a shader issue on some AMD GPUs.
- Add a toggle to bring back the old Theatre of Blood look, since people were pretty vocal about it.