### PR TITLE
Add pvp leaderboard

### DIFF
--- a/plugins/pvp-leaderboard
+++ b/plugins/pvp-leaderboard
@@ -1,3 +1,3 @@
 repository=https://github.com/findarian/pvp-leaderboard.git
 commit=f60d732babfea7b9353e558e961ca61d24f928cf
-warning=This plugin connects to external servers by default to fetch and submit PvP data. Your IP address and in-game username may be transmitted to the external service.
+warning=This submits your IP address, in-game username, and PvP fight statistics to a 3rd-party service not controlled or verified by RuneLite developers.


### PR DESCRIPTION
PvP Leaderboard plugin.

Overall it sends POST request after you fight someone to my AWS API gateway. Backend does logic and keeps this data in a dynamoDB to process matches and be able to get this information to my website and back to the plugin.

The plugin pulls ranks of people around them in game, this information is gotten from my website https://devsecopsautomated.com/ and the API gateway endpoints depending on which information is requested. Then that information is pushed back into client to display people's ranks. 

It loads ranks of people around you that are also on the leaderboard and works with different styles of combat (multi/dmm/nh/pvp/veng). 

I appreciate all of your time in reviewing this, you guys keep this community great <3