### PR TITLE
Bump instant inventory to v1.3.1

### DIFF
--- a/plugins/instant-inventory
+++ b/plugins/instant-inventory
@@ -1,2 +1,2 @@
 repository=https://github.com/elgbar/instant-inventory.git
-commit=cab3b2537ea7ac402600fc76cc7de457813e955c
+commit=7491f09377b82c6dee8abb0f048f0297ca84a5bd


### PR DESCRIPTION
## 1.3.1 - 2025-09-20

### Fixed

* [#33](https://github.com/elgbar/instant-inventory/issues/33) Disallow all interaction with modified inventory widgets
