### PR TITLE
Update phoenix-necklace-jingle

### DIFF
--- a/plugins/phoenix-necklace-jingle
+++ b/plugins/phoenix-necklace-jingle
@@ -1,2 +1,2 @@
 repository=https://github.com/Thedyolf/phoenix-necklace-jingle.git
-commit=b77e18a556b1ea3a3fa5d71368e93286de6342be
+commit=d053ae53da2635f1201925a3e2bf7e7fe30f6767


### PR DESCRIPTION
Updated plugin to support custom sounds and different sound IDs. It makes a placeholder empty .wav file on launch for user to replace if they want to. Sound ID can be edited for it to play a different sound rather than the GE jingle.