### PR TITLE
update 117hd

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=5cfd9874d655887a91985a08ca8496464ee774e4
+commit=7586eb3dd4dbe9e5ea41d0dfb05fae9306d2a25a
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
Another set of fixes for v1.4.0, sorry! Should be the last of the important stuff:
- Fix an issue with light flickering in certain cases with tiled lighting.
- Fix an area hiding mistake in Karuulm dungeon.
- Readjust the lighting in Nightmare of Ashihama's arena.
- Potentially fix tiled lighting for old AMD cards.