### PR TITLE
Update escape-crystal-notify (v1.12)

### DIFF
--- a/plugins/escape-crystal-notify
+++ b/plugins/escape-crystal-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/Xylot/escape-crystal-notify.git
-commit=dc8e2bb8145d57f86e5d8f73d80fddf27903cf20
+commit=6b5322a046ffacba344b68af63611fa48136a683

--- a/plugins/escape-crystal-notify
+++ b/plugins/escape-crystal-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/Xylot/escape-crystal-notify.git
-commit=9e0db754df3b3eac9a77c10fd1a6f2740f92be7b
+commit=dc8e2bb8145d57f86e5d8f73d80fddf27903cf20


### PR DESCRIPTION
Add option to disable the widget, infobox, and notifications at regions that are explicitly safe for regular hardcores