### PR TITLE
Add hunllef-prayer-helper plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/hunllef-helper"]
+	path = plugins/hunllef-helper
+	url = https://github.com/Carjul05/hunllef-helper

--- a/plugins/hunllef-helper
+++ b/plugins/hunllef-helper
@@ -1,2 +1,0 @@
-repository=https://github.com/Loze-Put/hunllef-helper.git
-commit=44a4246383cc727551fa45fb7a62b1ca77ee1c54


### PR DESCRIPTION
Plugin that draws an outline over Hunllef based on its attack style and flashes red if the player is not protected correctly.

Renamed from `hunllef-helper` to `hunllef-prayer-helper` to avoid conflict with existing plugin.

Includes:
- Updated `plugin.xml`, `plugin.properties`, `pom.xml`
- Compiled `.jar` aligned with new internalName