### PR TITLE
Create tob-party-sync

### DIFF
--- a/plugins/tob-party-sync
+++ b/plugins/tob-party-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/LeonidasTech/ToBPartySync.git
+commit=843def562e84eddbd4026f41a8f3b647dcd33f15


### PR DESCRIPTION
Using runelite's Party function is very important when doing ToB. It is quite hard to get people from the free for all world, w416, to join a party hub. This way, instead of having to manually join / have people not join, they will join automatically which will be benefitial to all raid participants.

This is also useful for we do raids, and raiding in general. It cuts out the effort of creating a party, as all you have to do is join the raid team and one is created for you.