### PR TITLE
Player Health Bars

### DIFF
--- a/plugins/player-health-bars
+++ b/plugins/player-health-bars
@@ -1,2 +1,2 @@
 repository=https://github.com/jedagen/runelite-external-plugins.git
-commit=fca22d714a8a3f17866f930358750e5535b5dbee
+commit=670819cd31bc1ca68b8748c0e7406a22b454fdda


### PR DESCRIPTION
<img width="303" height="306" alt="Capture" src="https://github.com/user-attachments/assets/631ca1c7-6778-464b-95f7-e0a8f7716475" />
<img width="231" height="543" alt="image" src="https://github.com/user-attachments/assets/b262a608-dfdf-407b-9686-a0ccdeff6421" />
<img width="442" height="169" alt="image" src="https://github.com/user-attachments/assets/66a5df3e-bab3-4b74-be8a-ba9e74bfea2d" />


Player Health Bars allows players to track the health of other players. 

The plugin looks up players' health on the high scores and calculates their health based on the ratio that appears when they take or block damage. The values are only estimates and may be off by a couple of hit points.

Players can set the plugin to Auto-Track (All players, Friends, Non-Friends, Disabled) to enable automatic tracking, or they can use the right-click menu to add/remove players' health bars on the overlay.