### PR TITLE
Revert "Watchdog v3.14.0"

### DIFF
--- a/plugins/watchdog
+++ b/plugins/watchdog
@@ -1,2 +1,2 @@
 repository=https://github.com/adamk33n3r/runelite-watchdog.git
-commit=1550f5c4ccf0cbaf54ed0c8deed4339a04e3b7b5
+commit=aff18aaa1ed434ffdfa304bc10495878e48cfbda


### PR DESCRIPTION
Reverts runelite/plugin-hub#9035

this is almost certainly leaking, of the 6 plugins updated earlier, only 3 of which have an actual userbase, easy blast furnace, max hit, and watchdog, and suddenly a bunch of people are heap OOMing and all have this plugin