### PR TITLE
Update escape-crystal-notify (v1.13)

### DIFF
--- a/plugins/escape-crystal-notify
+++ b/plugins/escape-crystal-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/Xylot/escape-crystal-notify.git
-commit=6b5322a046ffacba344b68af63611fa48136a683
+commit=809e65ac49246dedea83848b997171179a85beae

--- a/plugins/escape-crystal-notify
+++ b/plugins/escape-crystal-notify
@@ -1,2 +1,2 @@
 repository=https://github.com/Xylot/escape-crystal-notify.git
-commit=809e65ac49246dedea83848b997171179a85beae
+commit=7038395a1c95d0a9ea0b083fd2648f2b90fab510


### PR DESCRIPTION
Bug fixes:
- Ensure manually excluded region IDs take priority over the `Enable Everywhere` option
- Lower entrance deprioritization priority to ensure it's always on top

Add/Change:
- 6-hour log entrance warning overlay for Leviathan and Doom entrances
- Simplify Leviathan and Doom safeguard configuration settings