### PR TITLE
Add F Keys Only plugin

### DIFF
--- a/plugins/fkeysonly
+++ b/plugins/fkeysonly
@@ -1,2 +1,2 @@
 repository=https://github.com/akash2013/Fkeysonly.git
-commit=911a3df133b76b7b946b1cd8e512aaece07c07b8
+commit=32caf181f604a1b2e800f538161f816439bab516


### PR DESCRIPTION
F Keys Only is a RuneLite plugin that forces players to use F-keys for abilities.  
The goal is to train muscle memory and improve speed by making F-key usage mandatory.  
