### PR TITLE
Add Golden Skill Outline plugin

### DIFF
--- a/plugins/goldenskilloutline/plugin.json
+++ b/plugins/goldenskilloutline/plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "goldenskilloutline",
+  "name": "Golden Skill Outline",
+  "description": "Adds a golden trim around any skill that is at level 99.",
+  "author": "Murab",
+  "tags": ["overlay", "outline", "99", "skills", "highlight", "overlay"],
+  "plugins": [
+    {
+      "classname": "net.runelite.client.plugins.goldenoutlines.GoldenOutlinesPlugin"
+    }
+  ]
+}


### PR DESCRIPTION
This plugin highlights all skills at level 99 with a golden outline.
