### PR TITLE
Update shortest-path to v1.17.16

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=46a0c08a7b016d19a5550507ea17ff3fd6eba9c2
+commit=f9316dd2d8f73682da929be1f5563f9ffafe60b1


### PR DESCRIPTION
- Removed varbit requirement for MTA teleport
- Added some new agility shortcuts and update existing transport paths
- 63 agility Taverley Dungeon Loose Railing should now respect the agility requirement
- Added Climb Rocks in Hailstorm Mountains
- Shilo Village Travel cart is free after Karamja elite diary
- Added coin requirement to Shilo Village travel cart boarding
- Hunter Guild rope, stairs, ladders and cave
- Add Almera's house ladder
- Fremennik sea boots 1, 2 and 3 now have 1, 3 and 5 teleports per day
- Jiggig Crushed barricade and dungeon Stairs
- Added Climb Rocks (Tears of Guthix)
- Added 74 agility Cross Stepping stone (Lava Dragon Isle)
- Added 82 agility Cross Stepping stone (Lava Maze)
- Added Climb-over Stile at Watson's house in Hosidius