### PR TITLE
Create fishing-spot-timer

### DIFF
--- a/plugins/fishing-spot-timer
+++ b/plugins/fishing-spot-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/ArnautS/FishingSpotTimer.git
+commit=c7387b7357318133cd78d6b2960fa24120ef4a36


### PR DESCRIPTION
This plugin shows a timer above each fishing spot, starting when it last moved. Since fishing spots don't have a set move time, the length of the timer is configurable in the settings. The intended use for this plugin is when afk fishing and your spot just moved, you want to start fishing on the spot that moved last, allowing maximum afk time.