### PR TITLE
Add Nearby Player Logger plugin

### DIFF
--- a/plugins/nearbyplayerlogger.properties
+++ b/plugins/nearbyplayerlogger.properties
@@ -1,0 +1,2 @@
+repository=https://github.com/rickandreae/nearbyplayerlogger.git
+commit=58613d27dda9ccc10aaa50de4df4075c4ca3581e


### PR DESCRIPTION
Small plug-in to show names of players currently visible.