### PR TITLE
Add High Alchemy Profit Calculator plugin

### DIFF
--- a/plugins/high-alchemy-calculator.json
+++ b/plugins/high-alchemy-calculator.json
@@ -1,0 +1,8 @@
+{
+  "name": "High Alchemy Profit Calculator",
+  "description": "Shows the most profitable items to high alch based on current GE prices",
+  "tags": ["alchemy", "profit", "money", "ge", "calculator"],
+  "enabledByDefault": false,
+  "repository": "https://github.com/justindbrown07-dev/high-alchemy-calculator",
+  "commit": "main"
+}

--- a/plugins/high-alchemy-calculator/plugin-hub.json
+++ b/plugins/high-alchemy-calculator/plugin-hub.json
@@ -1,8 +1,0 @@
-{
-  "name": "High Alchemy Profit Calculator",
-  "description": "Shows the most profitable items to high alch based on current GE prices",
-  "tags": ["alchemy", "profit", "money", "ge", "calculator"],
-  "enabledByDefault": false,
-  "repository": "https://github.com/justindbrown07-dev/high-alchemy-calculator",
-  "commit": "main"
-}

--- a/plugins/high-alchemy-calculator/plugin-hub.json
+++ b/plugins/high-alchemy-calculator/plugin-hub.json
@@ -1,0 +1,8 @@
+{
+  "name": "High Alchemy Profit Calculator",
+  "description": "Shows the most profitable items to high alch based on current GE prices",
+  "tags": ["alchemy", "profit", "money", "ge", "calculator"],
+  "enabledByDefault": false,
+  "repository": "https://github.com/justindbrown07-dev/high-alchemy-calculator",
+  "commit": "main"
+}


### PR DESCRIPTION
## High Alchemy Profit Calculator

A RuneLite plugin that shows the most profitable items to high alch based on current Grand Exchange prices.

### Features:
- **Real-time GE Prices**: Fetches current Grand Exchange prices using the official OSRS Wiki API
- **Profit Calculation**: Calculates profit per item including nature rune costs
- **Configurable Display**: Customizable overlay showing different levels of detail
- **Sorting Options**: Sort by profit, item name, GE price, alch value, buy limit, or profit margin
- **Membership Support**: Automatically detects player membership and filters items accordingly
- **Item Sprites**: Displays item pictures next to names in the overlay
- **Nature Rune Pricing**: Use current GE price or set a fixed price for nature runes

### Repository:
https://github.com/justindbrown07-dev/high-alchemy-calculator

### Compliance:
-  Follows RuneLite plugin architecture
-  Complies with Jagex's 3rd Party Statement
-  Uses official OSRS Wiki API
-  No unfair advantages provided
-  Proper error handling and rate limiting