### PR TITLE
addded zulrah-wrist-saver

### DIFF
--- a/plugins/zulrah-wrist-saver
+++ b/plugins/zulrah-wrist-saver
@@ -1,0 +1,2 @@
+repository=https://github.com/GarrettBlackmon/zulrah-wrist-saver.git
+commit=43aeafc0f58241bdb9ae5332bebb37574e5d5382


### PR DESCRIPTION
This plugin simply outlines Zulrah on the tick it becomes attackable with the goal of reducing RSI. Instead of spam clicking upon zulrah's emerge you can simply click once when it becomes outlined, saving your wrist.

This is not achievable with other plugins as the id does not change and there is always a "Attack" option for Zulrah even when it is doing its emerge animation and is not yet attackable. This plugin simply waits the minimum 4 ticks it takes before the boss becomes attackable before outlining.

Please see my repos readme for a demo video.