### PR TITLE
Update fog-of-war

### DIFF
--- a/plugins/entity-render-distance
+++ b/plugins/entity-render-distance
@@ -1,2 +1,2 @@
 repository=https://github.com/Dazuzi/fog-of-war.git
-commit=106b1d27bacff915a0d81306484c2f8f452fea7a
+commit=a3608a6513a10bba51d7b176c0e132063767939b


### PR DESCRIPTION
Added exclusions for:

- Tombs of Amascut
- Theatre of Blood
- Hallowed Sepulchre
- Chambers of Xeric

Also, added "Current plane" info box option in the tweaks to make it easier to figure out which planes to exclude in the future.