### PR TITLE
Update royal-titans-damage-tracker-plugin

### DIFF
--- a/plugins/royal-titans-damage-tracker-plugin
+++ b/plugins/royal-titans-damage-tracker-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Mojac/royal-titans-damage-tracker-plugin.git
-commit=b7e10a1b76c604fb3bb2828ec1a6f7b954d7c5bd
+commit=939a901ec20242031a7a662d9f047b612fd63168
 authors=Mojac


### PR DESCRIPTION
Added the option for players to include burn damage into the damage trackers contribution and drop rate calculation. 

It is off by default but can be toggled on if the player wants to include burn in the tracker. Seeing as burn is a damage over time effect with the hitsplats isMine() and isOther() both being false, it would be difficult to attribute the damage to the correct player in the event both players are applying burn. But with this, the player has options to play around with.