### PR TITLE
added alch warning plugin

### DIFF
--- a/plugins/alchemy-warning-filter
+++ b/plugins/alchemy-warning-filter
@@ -1,0 +1,2 @@
+repository=https://github.com/SugoiAF/Alch-Warning-Filter.git
+commit=41e70540ed58235854249ce07c6511e2c3bbd875


### PR DESCRIPTION
This plugin allows players to block or allow casting alchemy on items based on configurable item lists and the items GE value. 

Blacklist / Whitelist: Prevent or always allow alchemy on specific items.

Max Alch Value Filter: Blocks items with a GE value above a configurable limit.

Chat Warnings: Alerts the player when an alch is blocked.

The plugin does not change the default OSRS alchemy warning settings and does not work with the explorers ring yet.

This is also my first plugin so apologies in advance for beginner mistakes...