### PR TITLE
add colosseum hp tracker

### DIFF
--- a/plugins/colosseum-hp-tracker
+++ b/plugins/colosseum-hp-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Supalosa/colo-hp-tracker.git
-commit=326737985261af3cb6b3c7ad6012fb990f245f7e
+commit=4d69bb91a86f25d3d9e80f32070dbaf636b971d5


### PR DESCRIPTION
This is a version of the [Tzhaar HP Tracker plugin](https://github.com/MoreBuchus/buchus-plugins/tree/tzhaar-hp-tracker) but adapted for Colosseum. (I have attempted to contact the author of that plugin since this could be folded into it, but to no avail)

Other than adding details for Colosseum NPCs and regions, this plugin also predicts the target that a Venator bow will hit, and includes an optional indicator to show players which NPCs will be hit.

Some clips of the plugin in action:
https://streamable.com/8fa4q8
https://streamable.com/i1kjal
https://streamable.com/3zjgu1
