### PR TITLE
update 117hd

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=7586eb3dd4dbe9e5ea41d0dfb05fae9306d2a25a
+commit=ba3df0259d2a76fce4f1321bbe7ee2f73b99d393
 authors=RS117,sosodev,ahooder


### PR DESCRIPTION
This should be our last fixes for 1.4.0. The main thing is automatically disabling the broken variant of tiled lighting on AMD cards, since it'll take more time to properly fix it, and the fallback method works very well anyway. Other than that, this fixes some light flickering issues, and adds two small features that it'd be a shame to postpone.