### PR TITLE
update brimhaven-agility

### DIFF
--- a/plugins/brimhaven-agility
+++ b/plugins/brimhaven-agility
@@ -1,2 +1,2 @@
 repository=https://github.com/kagof/rl-plugin-brimhaven-agility.git
-commit=7df024e389b0f2780b01b2becbbb1614e9252977
+commit=e9dc6e58be4cd0c46cf1cee358bb8ca99144fce6


### PR DESCRIPTION
Adds a couple new features to the Brimhaven agility arena plugin, all togglable:

1. A panel when near the entrance indicating whether the player can enter the arena (fee paid & cooldown)
2. A warning when not wearing the Karamja gloves 2. 3, or 4 if the player has obtained them and is near the entrance of the Brimhaven agility arena, or is in the arena

diff with previous release https://github.com/kagof/rl-plugin-brimhaven-agility/compare/7df024e389b0f2780b01b2becbbb1614e9252977..e9dc6e58be4cd0c46cf1cee358bb8ca99144fce6