### PR TITLE
Update clue-details to 2.6.2.1

### DIFF
--- a/plugins/clue-details
+++ b/plugins/clue-details
@@ -1,3 +1,3 @@
 repository=https://github.com/Zoinkwiz/clue-details.git
-commit=d892a6fddd488e40bd3d94451e40cb24363e9b41
+commit=8ec26ba459ca7c3d481e8d89c85bb6bb2f037564
 authors=Zoinkwiz,TheLope


### PR DESCRIPTION
One line removal change to fix a break with clue removal.