### PR TITLE
Add plugin: Rune Pouch Redesign

### DIFF
--- a/plugins/rune-pouch-redesign
+++ b/plugins/rune-pouch-redesign
@@ -1,0 +1,2 @@
+repository=https://github.com/trs/runelite-rune-pouch-redesign.git
+commit=8fe79f16a7b99cbaee2163566e3b099df329cda4


### PR DESCRIPTION
Add a new plugin to redesign the rune pouch loadout widget.

<img width="202" height="273" alt="image" src="https://github.com/user-attachments/assets/8a23cbad-1e2f-4222-a267-cc5c85fcb381" />
