### PR TITLE
Add item-locker plugin

### DIFF
--- a/plugins/item-locker
+++ b/plugins/item-locker
@@ -1,0 +1,2 @@
+repository=https://github.com/Dari-K/item-locker.git
+commit=afbf86f13797ca63d67fb14f427e5ba5a7f4f650


### PR DESCRIPTION
Item locker plugin I'm used for my quest locked ironman. I've had a few people request it, so I thought I'd upload it.

Plugin adds a red overlay to all items in various UI locations (bank, inventory, etc) to indicate locked status. Default left click option is change to drop/destroy. Items are unlocked by holding shift and right clicking, which will add a lock/unlock option to the right click menu.