### PR TITLE
takeover bank-tag-generation

### DIFF
--- a/plugins/bank-tag-generation
+++ b/plugins/bank-tag-generation
@@ -1,2 +1,2 @@
-repository=https://github.com/MitchBarnett/wiki-bank-tag-integration.git
+repository=https://github.com/Sacr3d/wiki-bank-tag-integration.git
 commit=59809ed15c2ded00fb578272439fdb62a6638d0e


### PR DESCRIPTION
Here is a request to takeover the plugin [bank-tag-integration](https://github.com/MitchBarnett/wiki-bank-tag-integration) owned by [@MitchBarnett](https://github.com/MitchBarnett).

This request is motivated by the plugin currently being non-functional due to an upstream change to the osrs Wiki API raised and documented here https://github.com/MitchBarnett/wiki-bank-tag-integration/issues/31 raised 21/08/2025 and there was no attempt to remedy/action this issue.

A pr to restore functionality to the the plugin is currently raised https://github.com/MitchBarnett/wiki-bank-tag-integration/pull/32 but no one with permissions is available to review and approve these changes.

There have previously been 2 instances of discussions for takeover to no avail due to the Author appearing again or lack of communications from op:
- https://github.com/runelite/plugin-hub/pull/6171#issuecomment-2185605176
- https://github.com/runelite/plugin-hub/pull/6780

Following guidelines from [Plugin-takeover-policy](https://github.com/runelite/runelite/wiki/Plugin-takeover-policy) I have raised an issue to request collaborator access https://github.com/MitchBarnett/wiki-bank-tag-integration/issues/34.

reopened from https://github.com/runelite/plugin-hub/pull/9182 for visibility as previous started in draft.