### PR TITLE
Unicode Compatibility for osrs-archipelago

### DIFF
--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=f8c3c4af44502495099f6a4673d03b588d88723b
+commit=c209dcf53773f99fa73dda355b7871ea5c97cef4


### PR DESCRIPTION
Changes ASCII-only FileWriters for Output Streams capable of writing out UTF-8 encoded Json files.