### PR TITLE
Add player-render-boundary

### DIFF
--- a/plugins/player-render-boundary
+++ b/plugins/player-render-boundary
@@ -1,0 +1,2 @@
+repository=https://github.com/Nick-Yawn/player-render-boundary.git
+commit=1f947abe17817ddca2aaf13182a235a84a701821


### PR DESCRIPTION
This plugin draws a 31-tile square boundary around the player's true tile. The purpose of this boundary is to show where players and NPCs begin to render.

The boundary is configurable for color, alpha, and width.

Future additions may include coloring tiles outside the boundary.