### PR TITLE
Update phoenix-necklace-jingle

### DIFF
--- a/plugins/phoenix-necklace-jingle
+++ b/plugins/phoenix-necklace-jingle
@@ -1,2 +1,2 @@
 repository=https://github.com/Thedyolf/phoenix-necklace-jingle.git
-commit=b77e18a556b1ea3a3fa5d71368e93286de6342be
+commit=492894fc37cbc640d39e751abf0ab94c8a46723e


### PR DESCRIPTION
Removed creating sound from code, instead shipping empty wav in JAR now. 

From current version in pluginhub: Added option to play any ingame sound in game by sound ID, alternatively play any wav file instead that can be placed in the .Runelite folder by the user.