### PR TITLE
Add GuthixLive plugin

### DIFF
--- a/plugins/guthix-live
+++ b/plugins/guthix-live
@@ -1,0 +1,2 @@
+repository=https://github.com/zilobol/guthix-live.git
+commit=b4f01b931d0bff8f5a077c6e1c26b53cebf36d2b


### PR DESCRIPTION
[Guthix.Live](https://map.guthix.live) is a plugin designed to make PvP HCIMs' live **even harder**.

With the power of crowdsourcing, players can contribute to being spotters of PvP HCIM, and other players with bounties on their heads.

The plugin fetches a [list of players](https://api.guthix.live/api/tracked-players) to look out for, stores it in cache for a while, and if the player spots one of these tracker players, submits a report of the sighting to the endpoint.

Each player can see their rankings (of how many sightings they've contributed) in game, and the player sightings are plotted on [the map](https://map.guthix.live) for hunters to react to.

No personal information is stored, IP addresses are hashed in storage and only kept for rate-limiting/abuse prevention purposes.