### PR TITLE
Create Yama Colorblind Helper

### DIFF
--- a/plugins/Yama Colorblind Helper
+++ b/plugins/Yama Colorblind Helper
@@ -1,0 +1,2 @@
+repoistory=https://github.com/OSRSenbt/Yama-Colorblind-Helper.git
+commit=4fb81f60971822f47ca6c2bb737802d5dd48eb85


### PR DESCRIPTION
Yama Colorblind Helper
Very straight forward cosmetic plugin that helps to read Yama's attack better for those who struggle to see the shadow/flames on his autos, or the shadow from the rockfalls.


For his autos, the plugin reads Yama's arm animation and displays a color beneath him to reflect which style he is actively attacking with.  
The color of the highlight is togglable with presets for deuteranopia, protanopia, tritanopia, and high contrast- as well as a custom color selector.


For the Rockfalls, the plugin reads the ground GFX for the shadow of the falling rocks, and displays a colored tile on that square.
The plugin does <b>NOT</b> predict where the next rocks will fall, show which tile you should stand on, or offer any assistance in avoiding the shadow waves that follow the rocks- only visual aid in highlighting the existing graphic showing where it will fall. 


This is my first plugin and was developed with AI assistance, so please let me know if there are any bugs or issues and I'll try to polish it up!