### PR TITLE
Create lockedchunkoverlay

### DIFF
--- a/plugins/lockedchunkoverlay
+++ b/plugins/lockedchunkoverlay
@@ -1,0 +1,2 @@
+repository=https://github.com/rauvagol/lockedchunkoverlay.git
+commit=65843e2794b4a35a2069c8a41b038632bdf1513c


### PR DESCRIPTION
Overlay that works with the region-locker plugin to display locked chunks on the world map with any gpu.

Includes optional warnings and penalties for time spent in a locked chunk (disabled by default except for increasing (non-opaque) darkness)

First plugin, so I apologize in advance if I messed up any steps, and I will correct any issues ASAP