### PR TITLE
Add deep-delve-pacer plugin

### DIFF
--- a/plugins/deep-delve-pacer
+++ b/plugins/deep-delve-pacer
@@ -1,0 +1,2 @@
+repository=https://github.com/DustinKieler/deep-delve-pacer.git
+commit=920078180d01035547ea28d45138cfb531cc2ed7


### PR DESCRIPTION
A plugin for the Doom of Mokhaiotl that estimates the delve level you'll reach before being 6-hour logged, and tracks your average and best deep delve completion times for the run.