### PR TITLE
Update DropTracker to v5.2.2 - Fix creation of Color object

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=8382552303bd6d1b38b7b694ff8b41d549ac7b1e
+commit=8fc54c3c8d7a54d757a240b830983354e2a4021b
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=0431aad43abb7946e519b0008a0ab24b9ae98557
+commit=8382552303bd6d1b38b7b694ff8b41d549ac7b1e
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
Sorry for the quick succession updates today.. just got home a bit ago, and the plugin was still creating (non-breaking) NullPointer errors inside our new warning methods. Fixed this by using fromHex instead of fromString to create red.

I will do my best to be better about testing changes myself prior to publishing from here on, apologies for the troubles :'(