### PR TITLE
Update DropTracker to v5.2.3 (minor bugfix)

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=73788effcda1629b3b9b457f56c17f5d080a5104
+commit=9160b94779e727c91a9ef15b7a4a7467ad589791
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
This is pretty much the same change as v5.2.2, adding better null-handling...

Unfortunately the fixes from yesterday/the previous day's updates to our plugin left it still unable to properly process drop submissions... I was finally able to sit down today and fully run through a test on the client to ensure it was working this time.

Apologies for the troubles.. :)