### PR TITLE
update membership-alert

### DIFF
--- a/plugins/membership-alert
+++ b/plugins/membership-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/tbloody/osrs-membership-alert.git
-commit=953d9cad520a6ef5dfeb9777bb23bf43eea02949
+commit=05ca10a36f3878d1b3f64fe0f837d2884dcdc9d1


### PR DESCRIPTION
added option to not show overlay when not in warning or danger zone as
proposed by riktenx + attempt to load properly after install without
need to login