### PR TITLE
Update clogman-mode to v1.2.0

### DIFF
--- a/plugins/clogman-mode
+++ b/plugins/clogman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/mozjay/clogman-mode.git
-commit=e269f39da09adfa77ed3080b320cc0fba34bcb85
+commit=db76dc7c54173386e944ee474768530839770a31


### PR DESCRIPTION
- Added support for alternative recipe sources. Items with multiple recipe paths (e.g. Armadylean plate -> Masori fortified variants) now unlock correctly.
- Updated clog_restrictions.json to support alternative recipes + added some alternatives for problematic items
- Updated chat message on restricted item check to find closest recipe to unlock

Release: https://github.com/mozjay/clogman-mode/releases/tag/v1.2.0