### PR TITLE
Update Port Roberts Thieving Helper (error fix)

### DIFF
--- a/plugins/portrobertsthievinghelper
+++ b/plugins/portrobertsthievinghelper
@@ -1,2 +1,2 @@
 repository=https://github.com/mkwozniak/OSRSPortRobertsThievingHelper.git
-commit=37eaef92fa596f8315645c5118ff64c76e131ec6
+commit=69b863cb5eae2011b245e154605aaaeb6164ff45


### PR DESCRIPTION
Fixed an error mentioned [here](https://github.com/mkwozniak/OSRSPortRobertsThievingHelper/issues/5) which occurred outside Port Roberts and you had stall highlighting on. Just needed to add a null check which I overlooked somehow.

Sorry bout all that.