### PR TITLE
Add slayer-boosting plugin repository information

### DIFF
--- a/plugins/slayer-boosting
+++ b/plugins/slayer-boosting
@@ -1,0 +1,2 @@
+repository=https://github.com/TheInsomnolent/slayer-boosting.git
+commit=f34e5a253dde2bd26a7f5b532a0a5d8cf9146b08


### PR DESCRIPTION
A RuneLite plugin that helps you maximise slayer points by reminding you which slayer master to use at each milestone task.

- **Configurable rules** – define up to 5 rules of the form *"every X tasks, use master Y"*; the highest-interval match wins.
- **NPC highlighting** – correct master is highlighted **green**, wrong masters are highlighted **red** (uses the built-in NPC overlay service).
- **Info overlay** –  panel showing your next task number, which master to visit, current streak, points, and projected points for the next task.
- **Achievement diary support** – toggle Elite Western Provinces (+25 % for Nieve/Steve) and Elite Kourend & Kebos (boosted Konar points) for accurate projections.