### PR TITLE
Add PVP Entity Hider plugin

### DIFF
--- a/plugins/pvp-entity-hider
+++ b/plugins/pvp-entity-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/zuest/pvp-entity-hider.git
+commit=5c1e9b8ee9d8fc16d5b6457edcf13a1ec13d3393


### PR DESCRIPTION
## PVP Entity Hider

Combat-aware entity hider for PVP — hides other players while keeping combat targets visible.

### Why not Entity Hider?

This plugin automates what's **already achievable manually** with Entity Hider today:
a user can add their opponent as a friend, enable "Hide Others" with "Hide Friends" off,
and Entity Hider shows only that opponent. This plugin removes the manual friend-list
step by detecting combat interactions directly.

Key differences from Entity Hider:
- **Combat linger timer** — keeps opponents visible for configurable seconds after combat
  ends (default 7s), useful in multi-combat so targets don't vanish instantly
- **Health bar validation** — only registers actual combat (requires visible health bar),
  filtering out follows, trade attempts, and safe-zone clicks
- **Filtering options** — show/hide by friends, clan, FC, skull status, team cape,
  combat level range, and tile distance

### No menu modifications

This plugin **only affects visual rendering** (player model visibility via `shouldDraw`).
It does not modify right-click menus, attack options, or the minimenu in any way.

### Features
- Show your combat target
- Show players attacking you
- Show all players in PvP combat (opt-in, off by default)
- Combat linger timer (0–30s, default 7s)
- Filter by: friends, clan, FC, skull, team cape, combat level, distance