### PR TITLE
Add 420 kc plugin

### DIFF
--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420-kc-plugin.git
-commit=b3b2d97ab93fec78c52c74130ce43542153dff1e
+commit=bda619fb96e2a00993bb89925954f4a0ab58cae9

--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420-kc-plugin.git
-commit=bda619fb96e2a00993bb89925954f4a0ab58cae9
+commit=2b8d8ecfe90469dd903378d9c5d681b8534ad8fb

--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,0 +1,2 @@
+repository=https://github.com/420kc/420-kc-plugin.git
+commit=50f4b48c40896efc1b5af9a6fa569929b665f139

--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420-kc-plugin.git
-commit=b5f99ec8e82606f6f9081ca4a1017e294ba9c3ba
+commit=b3b2d97ab93fec78c52c74130ce43542153dff1e

--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420-kc-plugin.git
-commit=50f4b48c40896efc1b5af9a6fa569929b665f139
+commit=b5f99ec8e82606f6f9081ca4a1017e294ba9c3ba

--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420-kc-plugin.git
-commit=2b8d8ecfe90469dd903378d9c5d681b8534ad8fb
+commit=724af584b03df43ec369dca7cff4843194cf3676

--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420-kc-plugin.git
-commit=724af584b03df43ec369dca7cff4843194cf3676
+commit=256b460283d56a00f99d5280fcc990ea4090fcc1

--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420-kc-plugin.git
-commit=256b460283d56a00f99d5280fcc990ea4090fcc1
+commit=f4dfaa9c5a92dd6fe9e8cdf942c3ba2eeac5c723


### PR DESCRIPTION
## Summary
- Boss kill count tracker with collection log tooltips
- Parallelized account type detection (Regular, Ironman, HCIM, UIM, De-Ironed)
- TempleOSRS collection log integration showing obtained/missing items per boss
- Item names from OSRS Wiki mapping API
- 420 KC celebrations (green chat message when hitting a 420 milestone)
- Right-click player lookup

## APIs Used
- Jagex hiscores (secure.runescape.com) — boss KC and account type detection
- TempleOSRS collection log API — obtained items per boss category
- OSRS Wiki prices API — item ID to name mapping

## Technical
- Uses RuneLite's injected OkHttpClient for all HTTP requests
- CompletableFuture for parallel async lookups
- Collection log categories and item names cached in memory
- BSD 2-Clause license

Repository: https://github.com/420kc/420-kc-plugin