### PR TITLE
Add trackpad camera plugin repository information

### DIFF
--- a/plugins/trackpadcamera
+++ b/plugins/trackpadcamera
@@ -1,2 +1,2 @@
-repository=https://github.com/crichmond1989/rl-trackpad-camera-plugin
+repository=https://github.com/crichmond1989/rl-trackpad-camera-plugin.git
 commit=aeaae079e7df55a1df098c7c2ea2f7cfdf5c1cf5

--- a/plugins/trackpadcamera
+++ b/plugins/trackpadcamera
@@ -1,2 +1,2 @@
 repository=https://github.com/crichmond1989/rl-trackpad-camera-plugin.git
-commit=aeaae079e7df55a1df098c7c2ea2f7cfdf5c1cf5
+commit=2a127f9b713fa98f8c6da89e58ec37e73626186e

--- a/plugins/trackpadcamera
+++ b/plugins/trackpadcamera
@@ -1,2 +1,2 @@
 repository=https://github.com/crichmond1989/rl-trackpad-camera-plugin.git
-commit=aeff1f914bd6135e8d3030d9f7612e365bed6662
+commit=59ddf7132304b574656717852ecfc881e783fcd5

--- a/plugins/trackpadcamera
+++ b/plugins/trackpadcamera
@@ -1,2 +1,2 @@
 repository=https://github.com/crichmond1989/rl-trackpad-camera-plugin
-commit=c4b9c866f8362c37a455b288c3355796670220bf
+commit=aeaae079e7df55a1df098c7c2ea2f7cfdf5c1cf5

--- a/plugins/trackpadcamera
+++ b/plugins/trackpadcamera
@@ -1,2 +1,2 @@
 repository=https://github.com/crichmond1989/rl-trackpad-camera-plugin.git
-commit=2a127f9b713fa98f8c6da89e58ec37e73626186e
+commit=b60c3ec5e2a83ea57a0e821789cb052388ef7a4c

--- a/plugins/trackpadcamera
+++ b/plugins/trackpadcamera
@@ -1,0 +1,2 @@
+repository=https://github.com/crichmond1989/rl-trackpad-camera-plugin
+commit=c4b9c866f8362c37a455b288c3355796670220bf

--- a/plugins/trackpadcamera
+++ b/plugins/trackpadcamera
@@ -1,2 +1,2 @@
 repository=https://github.com/crichmond1989/rl-trackpad-camera-plugin.git
-commit=b60c3ec5e2a83ea57a0e821789cb052388ef7a4c
+commit=aeff1f914bd6135e8d3030d9f7612e365bed6662


### PR DESCRIPTION
# Trackpad Camera Plugin for RuneLite

Control the Old School RuneScape camera using trackpad gestures. Developed for MacBook trackpads, but compatible with any input device that encodes gestures the same way.

## Gestures

| Gesture | Action |
|---|---|
| Two-finger swipe left/right | Rotate camera (yaw) |
| Ctrl + two-finger scroll up/down | Tilt camera (pitch) |
| Two-finger swipe up/down | Zoom camera (OSRS native) |

## Configuration

Each gesture can be individually enabled, inverted, and tuned:

| Section | Options |
|---|---|
| Zoom | Invert scroll direction |
| Rotation | Enable/disable, invert, sensitivity (1–20) |
| Tilt | Enable/disable, invert, sensitivity (1–20) |

The plugin intercepts scroll events by modifier key — it does not detect the input device. Mouse users who scroll while holding SHIFT or CTRL will also trigger rotation and tilt. Zoom inversion applies to all plain vertical scroll input.

## Requirements

- Java 11
- RuneLite client
- A trackpad that encodes horizontal swipes as `SHIFT+scroll` and ctrl+scroll as `CTRL+scroll` (standard on macOS)

## Development

```bash
./gradlew build    # compile and lint
./gradlew test     # run unit tests
./gradlew run      # launch RuneLite with the plugin loaded
```
