### PR TITLE
Add slayer-cape-reminder plugin

### DIFF
--- a/plugins/slayer-cape-reminder
+++ b/plugins/slayer-cape-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/slayer-cape-reminder.git
-commit=7c8229daccd044f8591ac9e020e26e1975454a4c
+commit=9b8bbe9cbae05c2ee7d527d88e260f063628517d

--- a/plugins/slayer-cape-reminder
+++ b/plugins/slayer-cape-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/idyet/slayer-cape-reminder
+commit=7c8229daccd044f8591ac9e020e26e1975454a4c

--- a/plugins/slayer-cape-reminder
+++ b/plugins/slayer-cape-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/slayer-cape-reminder.git
-commit=9b8bbe9cbae05c2ee7d527d88e260f063628517d
+commit=c6c9449aa5e8659207fdcb029f1d93c06f39f737

--- a/plugins/slayer-cape-reminder
+++ b/plugins/slayer-cape-reminder
@@ -1,2 +1,2 @@
-repository=https://github.com/idyet/slayer-cape-reminder
+repository=https://github.com/idyet/slayer-cape-reminder.git
 commit=7c8229daccd044f8591ac9e020e26e1975454a4c


### PR DESCRIPTION
# Summary

Slayer Cape Reminder is a quality-of-life plugin for players who use the Slayer Cape's perk to request a repeated Slayer task. The cape must be in your inventory or equipped when speaking to a Slayer master — this plugin reminds you to grab it from the bank when it's absent.

## Behavior
Overlay triggers when:
  - Your last Slayer task was completed (detected via the task-complete chat message) and the Slayer Cape is not in your inventory or equipped, or
  - You walk within 16 tiles of a Slayer master without an active task and without your cape — a proximity reminder that fires even if you haven't recently completed a task.

The overlay suppresses itself automatically once you pick up or equip the cape, receive a new task, or after a configurable auto-dismiss delay (default 2 minutes).

## Configuration
  - Only at 99 Slayer, restrict the reminder to players with level 99 (enabled by default, since the cape perk requires 99)
  - Reminder text, customisable overlay message
  - Text color / Background color, overlay appearance
  - Flash background, alternates between two background colors for a more attention-grabbing alert
  - Auto-dismiss delay, how long the overlay stays visible after task completion before hiding on its own (0 = never auto-dismiss)
  - Proximity Alert section, per-master toggles for Duradel, Nieve/Steve, Konar quo Maten, and Krystilia