### PR TITLE
Add Skwid Games Plugin

### DIFF
--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=1c359e25f9e8b6f86419befd23423cf617020515
+commit=8b0cf984f7bf66d4b6cd3d1d318dc59b0cbdf8c0

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,0 +1,2 @@
+repository=https://github.com/codycrossley/skwid-games-plugin.git
+commit=1317279288879985ef5171c64703ebff2898b1a3

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,3 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
 commit=c05009eb4cd61fd6404b54bf1337e8326f905fe8
+warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=3eea5f378143b91cd63b7c19d8dee907a1c3b5c9
+commit=c6a2cb6081c9bb492303de538eb55953f8c98b76

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=c75d509a1fd4467a7d88238f451ad6bc0cfe2ac3
+commit=3eea5f378143b91cd63b7c19d8dee907a1c3b5c9

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=1317279288879985ef5171c64703ebff2898b1a3
+commit=5f75df094a5f57ea2850f26f50020b1b07369d34

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=33d147a7e10c1d469c8379f2f479d2fc7fe9d1a6
+commit=62b43a88e1c7db1d09f5c03dbd4e3403f4af05c2

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=62b43a88e1c7db1d09f5c03dbd4e3403f4af05c2
+commit=1c359e25f9e8b6f86419befd23423cf617020515

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=557ab42fac883914da5c38fd1acd14a90625299c
+commit=b5d7507a8825ba0071577e7cdbf7d38adc929fe4

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=8b0cf984f7bf66d4b6cd3d1d318dc59b0cbdf8c0
+commit=c05009eb4cd61fd6404b54bf1337e8326f905fe8

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=c6a2cb6081c9bb492303de538eb55953f8c98b76
+commit=557ab42fac883914da5c38fd1acd14a90625299c

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=5f75df094a5f57ea2850f26f50020b1b07369d34
+commit=c75d509a1fd4467a7d88238f451ad6bc0cfe2ac3

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,2 +1,2 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=b5d7507a8825ba0071577e7cdbf7d38adc929fe4
+commit=33d147a7e10c1d469c8379f2f479d2fc7fe9d1a6

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=42d41bb5145c6f71075f5b53535a0b855ab5d5ee
+commit=1573e5c655f3a9b9ca7b5ecfd37bb48826b2e299
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/skwid-games
+++ b/plugins/skwid-games
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/skwid-games-plugin.git
-commit=c05009eb4cd61fd6404b54bf1337e8326f905fe8
+commit=42d41bb5145c6f71075f5b53535a0b855ab5d5ee
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.


### PR DESCRIPTION
  ---                                                                                                                                                                                                      
  Skwid Games — RuneLite Plugin
                                                                                                                                                                                                           
A RuneLite plugin for running elimination-style events in OSRS. Commanders can create and manage custom games, assign roles, mark special tiles, and track a live roster — all synchronized across participants in real time via a relay server: https://skwid.runescape.gay

  ---
  
<img width="1242" height="821" alt="Screenshot 2026-03-07 at 11 39 12 PM" src="https://github.com/user-attachments/assets/7c1cb62f-7421-43f1-b3c1-8e973f165114" />


  ---
  Features

  Game Management
  - Create a game and share a join code with participants
  - Join an existing game
  - End or leave a game from the sidebar panel

  Roster & Roles
  - Assign players as Guards or Contestants via right-click → Enlist
  - Eliminate, revive, or remove players from the sidebar or in-game right-click menu
  - Live roster with color-coded status (alive, eliminated, guard, removed)
  - Player head labels rendered above all visible participants in the game

  Tile Markers
  - Commanders can Shift+right-click any tile to configure it with a label, class, and visibility rules
  - Standard — cosmetic highlight
  - Landmine — auto-eliminates any contestant who steps on it; tile reveals to all players on trigger
  - Stoplight — can toggle between red and green; contestants standing on these tiles are eliminated if the tile is red

  Multiplayer Sync
  - All game state is derived from a sequential event log polled from the relay server
  - Roster and tile state are snapshotted on join for initial load, then kept up to date via incremental polling

  ---
