### PR TITLE
Create inferno-scouter

### DIFF
--- a/plugins/inferno-scouter
+++ b/plugins/inferno-scouter
@@ -1,2 +1,2 @@
 repository=https://github.com/jeremiah855/inferno-scouter.git
-commit=2c491b51f949bc413547dbc9451edbeddeeed7dc
+commit=7f2c4df759ff1743a8f94cd029bf5b380da9f8b0

--- a/plugins/inferno-scouter
+++ b/plugins/inferno-scouter
@@ -1,2 +1,2 @@
 repository=https://github.com/jeremiah855/inferno-scouter.git
-commit=592112384f56f05142d06e8882c4da8b1c212527
+commit=e3bd9f2d0a7c8328e36b9d31344177d203e842bb

--- a/plugins/inferno-scouter
+++ b/plugins/inferno-scouter
@@ -1,2 +1,2 @@
 repository=https://github.com/jeremiah855/inferno-scouter.git
-commit=71b5593188e4ff79999c9fdaf2a71f7a5a4c8bd4
+commit=462db68db01c07b211fc84d58bc3ff0baeebdf38

--- a/plugins/inferno-scouter
+++ b/plugins/inferno-scouter
@@ -1,0 +1,2 @@
+repository=https://github.com/jeremiah855/inferno-scouter.git
+commit=e950b1b3eb49fce49a4fffeae3d8ae24d8e443fe

--- a/plugins/inferno-scouter
+++ b/plugins/inferno-scouter
@@ -1,2 +1,2 @@
 repository=https://github.com/jeremiah855/inferno-scouter.git
-commit=598c049870b4040e862ffc8b50e3d6467a48b9ac
+commit=1b05c4ce57e593b34f0dfe190edd6917be78690b

--- a/plugins/inferno-scouter
+++ b/plugins/inferno-scouter
@@ -1,2 +1,2 @@
 repository=https://github.com/jeremiah855/inferno-scouter.git
-commit=e950b1b3eb49fce49a4fffeae3d8ae24d8e443fe
+commit=2c491b51f949bc413547dbc9451edbeddeeed7dc

--- a/plugins/inferno-scouter
+++ b/plugins/inferno-scouter
@@ -1,2 +1,2 @@
 repository=https://github.com/jeremiah855/inferno-scouter.git
-commit=e3bd9f2d0a7c8328e36b9d31344177d203e842bb
+commit=71b5593188e4ff79999c9fdaf2a71f7a5a4c8bd4

--- a/plugins/inferno-scouter
+++ b/plugins/inferno-scouter
@@ -1,2 +1,2 @@
 repository=https://github.com/jeremiah855/inferno-scouter.git
-commit=1b05c4ce57e593b34f0dfe190edd6917be78690b
+commit=d9f172c6c67f42113e4765841fbec6a54f1252c1

--- a/plugins/inferno-scouter
+++ b/plugins/inferno-scouter
@@ -1,2 +1,2 @@
 repository=https://github.com/jeremiah855/inferno-scouter.git
-commit=462db68db01c07b211fc84d58bc3ff0baeebdf38
+commit=598c049870b4040e862ffc8b50e3d6467a48b9ac

--- a/plugins/inferno-scouter
+++ b/plugins/inferno-scouter
@@ -1,2 +1,2 @@
 repository=https://github.com/jeremiah855/inferno-scouter.git
-commit=7f2c4df759ff1743a8f94cd029bf5b380da9f8b0
+commit=592112384f56f05142d06e8882c4da8b1c212527


### PR DESCRIPTION
Inferno Scouter, a plugin that records the initial spawn position of the monsters in the inferno, making scouting easier. It records it as a 9 digit code, representing the 9 possible spawn locations.