### PR TITLE
Add OSRS Conquest plugin

### DIFF
--- a/plugins/osrs-conquest
+++ b/plugins/osrs-conquest
@@ -1,2 +1,2 @@
 repository=https://github.com/teamprojectonyx/OSRSConquest.git
-commit=2a66719c432e497aa26d835f47efeac36b69f435
+commit=11a254bccb6f8ba9c3329bf57cb7aa247342acf2

--- a/plugins/osrs-conquest
+++ b/plugins/osrs-conquest
@@ -1,0 +1,2 @@
+repository=https://github.com/teamprojectonyx/OSRSConquest.git
+commit=7989f2274ce2ae71eef1bf94353bfb064b65a0ea

--- a/plugins/osrs-conquest
+++ b/plugins/osrs-conquest
@@ -1,2 +1,2 @@
 repository=https://github.com/teamprojectonyx/OSRSConquest.git
-commit=f29995fce9d99e9e19c61dcb616423f1706da389
+commit=2a66719c432e497aa26d835f47efeac36b69f435

--- a/plugins/osrs-conquest
+++ b/plugins/osrs-conquest
@@ -1,2 +1,2 @@
 repository=https://github.com/teamprojectonyx/OSRSConquest.git
-commit=7989f2274ce2ae71eef1bf94353bfb064b65a0ea
+commit=f29995fce9d99e9e19c61dcb616423f1706da389

--- a/plugins/osrs-conquest
+++ b/plugins/osrs-conquest
@@ -1,2 +1,3 @@
 repository=https://github.com/teamprojectonyx/OSRSConquest.git
 commit=11a254bccb6f8ba9c3329bf57cb7aa247342acf2
+warning=This plugin submits your IP address, RSN, and account progress information to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## OSRS Conquest

Clan activity tracking plugin that syncs events, XP gains, sessions, and member status to a shared web dashboard.

**Features:**
- Tracks 12 clan broadcast event types (joins, drops, pets, level-ups, quests, etc.)
- Periodic XP/stat snapshots for all 23 skills
- Session tracking (login/logout with world and duration)
- Member online status sync
- Built-in sidebar panel with event feed, member list, and clan stats
- Web dashboard access for clan admins
- Discord webhook integration with per-event-type filtering

**Repository:** https://github.com/teamprojectonyx/OSRSConquest
**License:** BSD 2-Clause