### PR TITLE
Update Chat Widgets plugin

### DIFF
--- a/plugins/chat-widgets
+++ b/plugins/chat-widgets
@@ -1,2 +1,2 @@
-repository=https://github.com/cannnelle/chat-widgets.git
-commit=3a6317feeb44893213315af53fc676ec4678115f
+repository=https://github.com/cnnnr/chat-widgets.git
+commit=21fedcf6a2dae43c2e845b61cf435865d29f6b09


### PR DESCRIPTION
Now supports more than just game- and private-related message types. Allows users to create their own widgets composed of their desired message types.
<img width="274" height="390" alt="image" src="https://github.com/user-attachments/assets/7575fe90-e663-44fd-a23d-b244bec9fed3" />
