### PR TITLE
Update faux-bingo plugin

### DIFF
--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/ThatOhio/faux-bingo.git
-commit=ffb55dce52139c41d1f028786c69d19d4a89e02e
+commit=012f37352906f81f4a5e5e3debf9dae3e2f73849


### PR DESCRIPTION
Small post bingo update

- Disables some of the setting overrides so people can continue using the plugin post bingo without being forced to have the team overlay.
- Race condition fix for the global icon collection.