### PR TITLE
Add Kill Clog plugin

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,0 +1,2 @@
+repository=https://github.com/420kc/kill-clog-plugin.git
+commit=16ddba931dce422e434889a7d669fad08f092593


### PR DESCRIPTION
Streamlined PvM-focused HiScores replacement with Collection Log integration.

- Boss KC grid with clog completion overlays
- One-click collection log sync from in-game widget
- Native OSRS-styled tooltips (hover/click modes)
- Automatic ironman detection across all account types
- Local cache with TempleOSRS fallback for viewing friends' logs
- Configurable progress highlighter with 5 color tiers

https://github.com/420kc/kill-clog-plugin