### PR TITLE
Add Revenant Gear Checker plugin

### DIFF
--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,2 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=58531524076f92978476677eadd6e3b5f5b4e7c3
+commit=a339c4d988e8c1465947b870baa6835a45a34f99
+

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,2 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=498034cfaafc3a81e6db7719041a6d53f6a0804b
+commit=d1ceafd8a84fc9b842f43abb6d7326e5a3dc0c49
+

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,3 +1,2 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=5d37c78c7af104ec7d4a7020d9e66c70a54860e6
-
+commit=498034cfaafc3a81e6db7719041a6d53f6a0804b

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,2 +1,2 @@
-repository=https://github.com/Spiderkill93/Revenant-gear-checker
+repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
 commit=1ce9e14aa8333e29f2974b445089ed739d088a31

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=1ce9e14aa8333e29f2974b445089ed739d088a31
+commit=58531524076f92978476677eadd6e3b5f5b4e7c3

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,0 +1,2 @@
+repository=https://github.com/Spiderkill93/Revenant-gear-checker
+commit=1ce9e14aa8333e29f2974b445089ed739d088a31

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,3 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=a339c4d988e8c1465947b870baa6835a45a34f99
+commit=5d37c78c7af104ec7d4a7020d9e66c70a54860e6
 


### PR DESCRIPTION
Adds the Revenant Gear Checker plugin.

Checks whether your gear setup is correct to safespot Revenants in the Revenant Caves. 
Reads your defence bonuses and effective magic defence to determine if the Revenant is forced into meleeing you.
