### PR TITLE
Add Song Mute plugin

### DIFF
--- a/plugins/song-mute
+++ b/plugins/song-mute
@@ -1,2 +1,2 @@
 repository=https://github.com/dorquex-ctrl/osrs-songmute.git
-commit=af4b39cf14554f499289e43671644cd61fd4fc57
+commit=af4b39ce05ba5fb4f9a10ee4b9e60ab8907f223e

--- a/plugins/song-mute
+++ b/plugins/song-mute
@@ -1,2 +1,2 @@
 repository=https://github.com/dorquex-ctrl/osrs-songmute.git
-commit=d7f7375e1be2f8e59d42cb2ef29cb79742995e32
+commit=9e03a9028d77df6b55b23d7a7ede423262773909

--- a/plugins/song-mute
+++ b/plugins/song-mute
@@ -1,2 +1,2 @@
 repository=https://github.com/dorquex-ctrl/osrs-songmute.git
-commit=f3e5fa1721db669e49dcf1459661945ad144a3f1
+commit=d35820906f534e28908c2346e9e73a11afbc0f55

--- a/plugins/song-mute
+++ b/plugins/song-mute
@@ -1,2 +1,2 @@
 repository=https://github.com/dorquex-ctrl/osrs-songmute.git
-commit=d35820906f534e28908c2346e9e73a11afbc0f55
+commit=537ac02929da76152bfa7be99a3f86eee9122327

--- a/plugins/song-mute
+++ b/plugins/song-mute
@@ -1,2 +1,2 @@
 repository=https://github.com/dorquex-ctrl/osrs-songmute.git
-commit=af4b39ce05ba5fb4f9a10ee4b9e60ab8907f223e
+commit=f3e5fa1721db669e49dcf1459661945ad144a3f1

--- a/plugins/song-mute
+++ b/plugins/song-mute
@@ -1,0 +1,2 @@
+repository=https://github.com/dorquex-ctrl/osrs-songmute.git
+commit=d7f7375e1be2f8e59d42cb2ef29cb79742995e32

--- a/plugins/song-mute
+++ b/plugins/song-mute
@@ -1,2 +1,2 @@
 repository=https://github.com/dorquex-ctrl/osrs-songmute.git
-commit=9e03a9028d77df6b55b23d7a7ede423262773909
+commit=af4b39cf14554f499289e43671644cd61fd4fc57


### PR DESCRIPTION
Adds Song Mute, a Plugin Hub plugin that lets users mute specific music tracks without disabling music entirely.

It provides a sidebar list that matches the in-game Music Player, right-click mute/unmute options in the Music tab, and grays out muted songs in the in-game music list.