### PR TITLE
Odablock Sound Plugin Update

### DIFF
--- a/plugins/odablock
+++ b/plugins/odablock
@@ -1,2 +1,2 @@
 repository=https://github.com/DapperMickie/odablock-sounds.git
-commit=2935696564e87db763b7e5644fb29901e7c9d0e5
+commit=77e3b66914dc6c6725378887aa6f6b9e6898d226

--- a/plugins/shop-block
+++ b/plugins/shop-block
@@ -1,2 +1,0 @@
-repository=https://github.com/LogicalSoIutions/Shop-Block.git
-commit=be97e3102e3cba107902ff34087cc2fb7fd906db

--- a/plugins/shop-block
+++ b/plugins/shop-block
@@ -1,0 +1,2 @@
+repository=https://github.com/LogicalSoIutions/Shop-Block.git
+commit=be97e3102e3cba107902ff34087cc2fb7fd906db


### PR DESCRIPTION
<img width="670" height="133" alt="image" src="https://github.com/user-attachments/assets/1874dac1-8347-45e8-971b-86725a86fdbc" />

Making this PR on behalf of @DapperMickie as he is unable to do it via mobile and is unable to get to a PC to handle the update

Removed my Shop-Block plugin from this PR so it is solely just an update for the sound plugin.

He will also be commenting below to confirm - commit hash is tied to his repo as per usual. 
