### PR TITLE
Add UIM Herb XP plugin

### DIFF
--- a/plugins/uim-herb-xp
+++ b/plugins/uim-herb-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/SaneX8/uim-herb-xp.git
-commit=4d3428afbd785f41a92049c95f26dfa5e718e060
+commit=6321544d4c1054516fa3abc455a58f4358fefc8f
 authors=Santeri

--- a/plugins/uim-herb-xp
+++ b/plugins/uim-herb-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/SaneX8/uim-herb-xp.git
-commit=c70dc9628b77a7bbc27d2255b6d918fde6543d6e
+commit=4d3428afbd785f41a92049c95f26dfa5e718e060
 authors=Santeri

--- a/plugins/uim-herb-xp
+++ b/plugins/uim-herb-xp
@@ -1,0 +1,3 @@
+repository=https://github.com/SaneX8/uim-herb-xp.git
+commit=c70dc9628b77a7bbc27d2255b6d918fde6543d6e
+authors=Santeri

--- a/plugins/uim-herb-xp
+++ b/plugins/uim-herb-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/SaneX8/uim-herb-xp.git
-commit=6321544d4c1054516fa3abc455a58f4358fefc8f
+commit=4620bfb0e502b8c8ce624d302a63ba924f1125b6
 authors=Santeri


### PR DESCRIPTION
Plugin that calculates banked Herblore XP for Ultimate Ironman players by scanning herbs in the inventory and looting bag.

Displays possible potions and total Herblore XP obtainable from the herbs.