### PR TITLE
Add Tyrs Guard Clan plugin

### DIFF
--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/YOURUSERNAME/TyrsGuardClan-Plugin
-commit=7e64ac9c7732c8b6a425526a48121d39529f5648
+commit=321a0abd13bbb9612e3cf27dbccf8beda01eff81

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
-commit=321a0abd13bbb9612e3cf27dbccf8beda01eff81
+commit=7acca27d4c44f51fb6cb080efbe71132e54d8fc1

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,0 +1,2 @@
+repository=https://github.com/YOURUSERNAME/TyrsGuardClan-Plugin
+commit=7e64ac9c7732c8b6a425526a48121d39529f5648

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
-repository=https://github.com/YOURUSERNAME/TyrsGuardClan-Plugin
+repository=repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
 commit=321a0abd13bbb9612e3cf27dbccf8beda01eff81

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
-repository=repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
+repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
 commit=321a0abd13bbb9612e3cf27dbccf8beda01eff81

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
-commit=7acca27d4c44f51fb6cb080efbe71132e54d8fc1
+commit=03bc343a7fd0204f9e20daea4e8e4ab3f69508bc

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
-commit=56a87a199a5b752b45298aa27ac67b500ddc4c03
+commit=6143a7896c9b2e7093cc3d60c832d99a63529489

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
-commit=6143a7896c9b2e7093cc3d60c832d99a63529489
+commit=751a8976e5c491453292c4af35479175a4a3405f

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
-commit=03bc343a7fd0204f9e20daea4e8e4ab3f69508bc
+commit=56a87a199a5b752b45298aa27ac67b500ddc4c03

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
-commit=751a8976e5c491453292c4af35479175a4a3405f
+commit=commit=80c8f399fc79640a55065fd53190b9f761a8e611

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,3 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
 commit=7c19224bc6d88d375c79988bb041d5fd24a50aee
+warning=This plugin submits your IP address, RSN, game screenshots, and clan chat messages to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
-commit=commit=80c8f399fc79640a55065fd53190b9f761a8e611
+commit=80c8f399fc79640a55065fd53190b9f761a8e611

--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
-commit=80c8f399fc79640a55065fd53190b9f761a8e611
+commit=7c19224bc6d88d375c79988bb041d5fd24a50aee


### PR DESCRIPTION
Adding the Tyrs Guard Clan plugin for the Tyr's Guard OSRS clan.

This plugin provides:
- Screenshot submissions to the clan's Discord bot
- XP and rank tracking via the plugin panel
- Optional clan chat ↔ Discord bridge (opt-in, can be disabled in settings)

The plugin communicates with a private clan bot hosted by the clan. All features require explicit configuration by the user and nothing is sent anywhere without the user providing their own Discord ID and the clan bot URL. The chat bridge is completely optional and off by default.