### PR TITLE
Add RaidParty Plugin

### DIFF
--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,0 +1,2 @@
+repository=https://github.com/Kalsupes/RaidParty.git
+commit=ceee1418ea775281d05e236601b40b9a67ccc34e

--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,2 +1,2 @@
 repository=https://github.com/Kalsupes/RaidParty.git
-commit=04a532579026504dac1b24eed8e2125feab8b320
+commit=b479e113d154565278ac8667bc9f6fe793ef312a

--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,2 +1,2 @@
 repository=https://github.com/Kalsupes/RaidParty.git
-commit=b479e113d154565278ac8667bc9f6fe793ef312a
+commit=bb70f55aa14b26cda95a6e3118da3dba8c55567f

--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,2 +1,2 @@
 repository=https://github.com/Kalsupes/RaidParty.git
-commit=bb70f55aa14b26cda95a6e3118da3dba8c55567f
+commit=34ca28951d3cf484c49f4f6c9601f6e10cbe92d6

--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,2 +1,2 @@
 repository=https://github.com/Kalsupes/RaidParty.git
-commit=ceee1418ea775281d05e236601b40b9a67ccc34e
+commit=e8f39d1a2d18692155d7639716cf4a79410634a2

--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,2 +1,2 @@
 repository=https://github.com/Kalsupes/RaidParty.git
-commit=e8f39d1a2d18692155d7639716cf4a79410634a2
+commit=04a532579026504dac1b24eed8e2125feab8b320

--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,2 +1,2 @@
 repository=https://github.com/Kalsupes/RaidParty.git
-commit=34ca28951d3cf484c49f4f6c9601f6e10cbe92d6
+commit=5fd4428433b0bab8949db3b920bd7429b3fc16f8


### PR DESCRIPTION
RaidParty is a RuneLite party plugin built for raid teams that want more visibility, faster communication, and better in-raid decision support. It expands the standard party experience with a dedicated team panel, shared player-state syncing, ready checks, loot-rule visibility, and a ping system designed for high-tempo PvM.

The plugin is aimed at coordinated groups running content such as Tombs of Amascut, Chambers of Xeric, and Theatre of Blood, while remaining useful anywhere a party wants better shared awareness; such as in the wilderness.