### PR TITLE
Add RuneTrader GE Sync plugin

### DIFF
--- a/plugins/runetrader-ge-sync
+++ b/plugins/runetrader-ge-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/KrazziR1/runetrader-plugin.git
-commit=f3ca1ee1d01d3f0989d30a9fbb10d6046eaba39c
+commit=0ca09c8ceaffd34089be109cefb5c0014f263375
 warning=This plugin submits your Grand Exchange offer data to RuneTrader.gg, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/runetrader-ge-sync
+++ b/plugins/runetrader-ge-sync
@@ -1,0 +1,3 @@
+repository=https://github.com/KrazziR1/runetrader-plugin.git
+commit=f3ca1ee1d01d3f0989d30a9fbb10d6046eaba39c
+warning=This plugin submits your Grand Exchange offer data to RuneTrader.gg, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/runetrader-ge-sync
+++ b/plugins/runetrader-ge-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/KrazziR1/runetrader-plugin.git
-commit=ac29c1fbfddab22086d4ba797430f3d9d178d265
+commit=a1598111978ee9a0f804241a75e1fde943786c40
 warning=This plugin submits your Grand Exchange offer data to RuneTrader.gg, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/runetrader-ge-sync
+++ b/plugins/runetrader-ge-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/KrazziR1/runetrader-plugin.git
-commit=85d84dd5a1b8c9f2e3d4a5b6c7d8e9f0a1b2c3d4
+commit=85d84dd8bbc6de5841c401bef13fd600913fa70d
 warning=This plugin submits your Grand Exchange offer data to RuneTrader.gg, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/runetrader-ge-sync
+++ b/plugins/runetrader-ge-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/KrazziR1/runetrader-plugin.git
-commit=85d84dd8bbc6de5841c401bef13fd600913fa70d
+commit=ac29c1fbfddab22086d4ba797430f3d9d178d265
 warning=This plugin submits your Grand Exchange offer data to RuneTrader.gg, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/runetrader-ge-sync
+++ b/plugins/runetrader-ge-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/KrazziR1/runetrader-plugin.git
-commit=a1598111978ee9a0f804241a75e1fde943786c40
+commit=3a88167335a20e26cb7087a9181b9d9526a775c0
 warning=This plugin submits your Grand Exchange offer data to RuneTrader.gg, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/runetrader-ge-sync
+++ b/plugins/runetrader-ge-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/KrazziR1/runetrader-plugin.git
-commit=0ca09c8ceaffd34089be109cefb5c0014f263375
+commit=85d84dd5a1b8c9f2e3d4a5b6c7d8e9f0a1b2c3d4
 warning=This plugin submits your Grand Exchange offer data to RuneTrader.gg, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/runetrader-ge-sync
+++ b/plugins/runetrader-ge-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/KrazziR1/runetrader-plugin.git
 commit=3a88167335a20e26cb7087a9181b9d9526a775c0
-warning=This plugin submits your Grand Exchange offer data to RuneTrader.gg, a 3rd-party server not controlled or verified by RuneLite developers.
+warning=This plugin submits your IP address and Grand Exchange offer data to RuneTrader.gg, a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Adds the RuneTrader GE Sync plugin which syncs Grand Exchange offers to runetrader.gg for real-time flip tracking and analytics.

## Features

### 1. Live GE sync
Sends GE offer data (item, price, quantity, status) to runetrader.gg in real time so players can track their flips on the website. Uses debouncing to avoid hammering the API on rapid partial-fill ticks.

### 2. Sync pause / resume
A toggle button and configurable keybind (default Shift+P) that completely stops all GE data from being sent. Designed for players who want to buy items for personal use without polluting their flip tracker. When paused, a small "RT PAUSED" reminder is shown on the GE screen. Auto-resumes after a configurable timeout (default 60 min).

### 3. Buy limit countdown overlays
Displays a countdown timer on each active GE slot showing when the 4-hour buy limit resets. Pure display — no automation. Calculated from when the buy offer was placed.

### 4. Drift alert overlays
When an active offer's price has drifted from the current Wiki market price by a configurable threshold (default 3%), a badge is shown on that slot with the drift percentage and a recommended relist price. Pure display — no automation.

### 5. Flip recommendation panel
A side panel showing the top flip recommendations from runetrader.gg based on the player's configured preferences (risk tier, cash stack, membership). Shows item name, margin, ROI, GP per flip, and estimated fill time.

### 6. Click-to-fill (opt-in, off by default)
When enabled in config, clicking a suggested price or quantity in the recommendation panel types that value into the focused GE input field using java.awt.Robot keystrokes. The player clicks the GE slot themselves, clicks the price field themselves, then clicks Confirm themselves. This feature is explicitly opt-in and disabled by default.

### 7. Actual fill price tracking
Uses getSpent() / getQuantitySold() to calculate the true average fill price rather than the offer price, giving more accurate profit calculations.

## Compliance notes

- Every feature is display-only or player-initiated. The plugin never clicks, never auto-confirms, and never opens the GE interface automatically.
- Click-to-fill uses java.awt.Robot keystrokes only — same approach used by other approved plugins. It is off by default and requires explicit opt-in in config.
- The player makes every decision and performs every click. The plugin shows information and suggestions only.
- All assisted features can be disabled individually in the plugin config.