### PR TITLE
Add Mettle Sync plugin

### DIFF
--- a/plugins/mettle-runelite-sync
+++ b/plugins/mettle-runelite-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/ryanpgoldberg-osrs/mettle-runelite-sync.git
-commit=4ea1361de28832d4a165d3f3466f71f9a92dc3a0
+commit=9100c1adc63c809a26b005e789ac74cc0affee42

--- a/plugins/mettle-runelite-sync
+++ b/plugins/mettle-runelite-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/ryanpgoldberg-osrs/mettle-runelite-sync.git
+commit=4ea1361de28832d4a165d3f3466f71f9a92dc3a0

--- a/plugins/mettle-runelite-sync
+++ b/plugins/mettle-runelite-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/ryanpgoldberg-osrs/mettle-runelite-sync.git
-commit=9100c1adc63c809a26b005e789ac74cc0affee42
+commit=5027e03b2e76cec6e8c0dba655166f1d25ec752c


### PR DESCRIPTION
## Summary
Adds the Mettle Sync plugin to Plugin Hub.

This plugin exports a Mettle account sync snapshot for use in the Mettle web app. The current export covers player identity, skills, quests, and achievement diaries. Boss killcounts are enriched separately in the web app via Wise Old Man after import.

## Testing
- Built locally with the Gradle wrapper
- Launched in the RuneLite development client with the plugin enabled
- Verified the plugin can turn on and export a snapshot JSON file