### PR TITLE
Create hide-ground-item-examine

### DIFF
--- a/plugins/hide-ground-item-examine
+++ b/plugins/hide-ground-item-examine
@@ -1,0 +1,2 @@
+repository=https://github.com/tegsrf/hide-ground-item-examine.git
+commit=bd994cc599be26a6366407ea9c6aef07f48b20d5

--- a/plugins/hide-ground-item-examine
+++ b/plugins/hide-ground-item-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/tegsrf/hide-ground-item-examine.git
-commit=bd994cc599be26a6366407ea9c6aef07f48b20d5
+commit=89cd87a6b55e130076a74412fc804256c040af1c

--- a/plugins/hide-ground-item-examine
+++ b/plugins/hide-ground-item-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/tegsrf/hide-ground-item-examine.git
-commit=89cd87a6b55e130076a74412fc804256c040af1c
+commit=7e2fa43b32ce72b42f3be8a4a24336fc3d305cbf

--- a/plugins/hide-ground-item-examine
+++ b/plugins/hide-ground-item-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/tegsrf/hide-ground-item-examine.git
-commit=7e2fa43b32ce72b42f3be8a4a24336fc3d305cbf
+commit=f1a088d7cdfb77c0c8c9caea10c49cce5c4a3cb3

--- a/plugins/hide-ground-item-examine
+++ b/plugins/hide-ground-item-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/tegsrf/hide-ground-item-examine.git
-commit=f1a088d7cdfb77c0c8c9caea10c49cce5c4a3cb3
+commit=c616da3ef6bbb1f4d8a4a8dcc6b0ed9f5fa05645

--- a/plugins/hide-ground-item-examine
+++ b/plugins/hide-ground-item-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/tegsrf/hide-ground-item-examine.git
-commit=55f360920a34b9bd1388fb095b8e78f8c8bcb42f
+commit=aabc62f41899292ceb20e230334311f9a6906ff3

--- a/plugins/hide-ground-item-examine
+++ b/plugins/hide-ground-item-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/tegsrf/hide-ground-item-examine.git
-commit=c616da3ef6bbb1f4d8a4a8dcc6b0ed9f5fa05645
+commit=55f360920a34b9bd1388fb095b8e78f8c8bcb42f


### PR DESCRIPTION
Adds a plugin that removes the Examine option from ground items to reduce right-click menu clutter.