### PR TITLE
Add Looting Bag Loot Tracker plugin

### DIFF
--- a/plugins/looting-bag-tracker
+++ b/plugins/looting-bag-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/austincbaker/looting-bag-tracker
+commit=8f4d3a85cae4e047c26eeab436169d77af28f806

--- a/plugins/looting-bag-tracker
+++ b/plugins/looting-bag-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/austincbaker/looting-bag-tracker
-commit=8f4d3a85cae4e047c26eeab436169d77af28f806
+commit=f958a497eb98e8b672f232c76e478ce089005319

--- a/plugins/looting-bag-tracker
+++ b/plugins/looting-bag-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/austincbaker/looting-bag-tracker.git
-commit=f958a497eb98e8b672f232c76e478ce089005319
+commit=b7618b03c13ec77b75e481598bdc83d6b7bf2532

--- a/plugins/looting-bag-tracker
+++ b/plugins/looting-bag-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/austincbaker/looting-bag-tracker.git
-commit=b7618b03c13ec77b75e481598bdc83d6b7bf2532
+commit=881363cb9d881dd2328567c94c0165f7af13d06f

--- a/plugins/looting-bag-tracker
+++ b/plugins/looting-bag-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/austincbaker/looting-bag-tracker.git
-commit=881363cb9d881dd2328567c94c0165f7af13d06f
+commit=f52aad0abc3bd676bb24b847f3535d9916c8deaf

--- a/plugins/looting-bag-tracker
+++ b/plugins/looting-bag-tracker
@@ -1,2 +1,2 @@
-repository=https://github.com/austincbaker/looting-bag-tracker
+repository=https://github.com/austincbaker/looting-bag-tracker.git
 commit=f958a497eb98e8b672f232c76e478ce089005319


### PR DESCRIPTION
Adds a plugin that tracks loot received into an open looting bag during chest and container interactions (e.g. Rogues' Den chests, thieving chests).

The standard Loot Tracker misses loot that goes directly into the looting bag instead of the player's inventory. This plugin listens for chest/container menu interactions, snapshots the looting bag contents, and fires a `PluginLootReceived` event when the bag gains new items — which the Loot Tracker then picks up and records normally.

Supported interactions: Open, Unlock, Search, Search for traps, Steal, Loot