### PR TITLE
Add ProgressScape plugin

### DIFF
--- a/plugins/progressscape
+++ b/plugins/progressscape
@@ -1,2 +1,2 @@
 repository=https://github.com/whippahh/ProgressScape-plugin.git
-commit=949979814abaa1c649f1003e10c0648743936f22
+commit=34129ac9a51758131c696838a394164b73ef69a6

--- a/plugins/progressscape
+++ b/plugins/progressscape
@@ -1,2 +1,3 @@
 repository=https://github.com/whippahh/ProgressScape-plugin.git
 commit=1b5f34ffc33613dceb17e4600cc43b43a29ce30d
+ 

--- a/plugins/progressscape
+++ b/plugins/progressscape
@@ -1,2 +1,2 @@
 repository=https://github.com/whippahh/ProgressScape-plugin.git
-commit=fd92792edd67fb030217d3249a1a1a4f9a9d5b66
+commit=576f5e99799662dee31fff9300d639c15a7d0b38

--- a/plugins/progressscape
+++ b/plugins/progressscape
@@ -1,0 +1,2 @@
+repository=https://github.com/whippahh/ProgressScape-plugin.git
+commit=fd92792edd67fb030217d3249a1a1a4f9a9d5b66

--- a/plugins/progressscape
+++ b/plugins/progressscape
@@ -1,2 +1,2 @@
 repository=https://github.com/whippahh/ProgressScape-plugin.git
-commit=576f5e99799662dee31fff9300d639c15a7d0b38
+commit=2eeadf9d81a7ef974526dc0b6ad680ba67b1c963

--- a/plugins/progressscape
+++ b/plugins/progressscape
@@ -1,2 +1,2 @@
 repository=https://github.com/whippahh/ProgressScape-plugin.git
-commit=2eeadf9d81a7ef974526dc0b6ad680ba67b1c963
+commit=949979814abaa1c649f1003e10c0648743936f22

--- a/plugins/progressscape
+++ b/plugins/progressscape
@@ -1,2 +1,2 @@
 repository=https://github.com/whippahh/ProgressScape-plugin.git
-commit=34129ac9a51758131c696838a394164b73ef69a6
+commit=1b5f34ffc33613dceb17e4600cc43b43a29ce30d

--- a/plugins/progressscape
+++ b/plugins/progressscape
@@ -1,3 +1,4 @@
 repository=https://github.com/whippahh/ProgressScape-plugin.git
 commit=1b5f34ffc33613dceb17e4600cc43b43a29ce30d
+warning=This plugin submits your IP address, RSN, and numerous account data to a 3rd-party server not controlled or verified by Runelite developers.
  


### PR DESCRIPTION
### Plugin description
Syncs your OSRS quests, achievement diaries, boss kill counts and collection log to the ProgressScape progression tracker. Data syncs automatically on login/logout. Collection log requires a manual sync with the log open.

### Does this plugin collect data remotely?
Yes. The following data is sent to a Supabase-hosted PostgreSQL database (Asia-Pacific, Sydney):
- OSRS username and account type
- Quest completion status
- Achievement Diary completion (Easy/Medium/Hard/Elite)
- Boss kill counts (from in-game chat messages)
- Collection log obtained items (manual sync only)

No bank contents, GE history, or other player data is collected. Data is never sold to third parties.

### Privacy policy
https://whippahh.github.io/ProgressScape/privacy.html

### Support
https://github.com/whippahh/ProgressScape-plugin/issues