### PR TITLE
Add Quetzal Keybinds

### DIFF
--- a/plugins/quetzal-keybinds
+++ b/plugins/quetzal-keybinds
@@ -1,2 +1,2 @@
 repository=https://github.com/ctrlcam/quetzal-keybinds.git
-commit=c53ea0724da6ca7556706903fe6aa56e26d14d68
+commit=c19c52878fc83c1b1b468575bde83effc7686cea

--- a/plugins/quetzal-keybinds
+++ b/plugins/quetzal-keybinds
@@ -1,0 +1,2 @@
+repository=https://github.com/ctrlcam/quetzal-keybinds.git
+commit=c53ea0724da6ca7556706903fe6aa56e26d14d68

--- a/plugins/quetzal-keybinds
+++ b/plugins/quetzal-keybinds
@@ -1,2 +1,2 @@
 repository=https://github.com/ctrlcam/quetzal-keybinds.git
-commit=c19c52878fc83c1b1b468575bde83effc7686cea
+commit=1f98afe04cfbbff2abba47f4a014458f1ec52998


### PR DESCRIPTION
Adds custom keybinds to the Quetzal transport menu with configurable map overlays to display assigned hotkeys.