### PR TITLE
Add Shared Boss Uniques plugin

### DIFF
--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=631b70a83a038d1598245c48a85890c548bbabd5
+commit=cd8baf6ad30c68f7077d866a7d64c39e2c18db8f

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=eda13ad032465f7da50f857d1f9bc2d7dfc34578
+commit=3105707a27ee013e37cc083c615fba991244b494

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=a49f6764508fca185561557a771c5b6d68ba815a
+commit=6f423e3d374d2d33e0495f18668bae69f68a2ca6

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=cd8baf6ad30c68f7077d866a7d64c39e2c18db8f
+commit=eda13ad82ffe4a8e48f3d4bdca9e2a059da2fa2c

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=6f423e3d374d2d33e0495f18668bae69f68a2ca6
+commit=631b70a83a038d1598245c48a85890c548bbabd5

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,0 +1,2 @@
+repository=https://github.com/Totalchi/groupItems.git
+commit=9e905ab30f044ccf9c46799aa300bc57b056e9fa

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=9e905ab30f044ccf9c46799aa300bc57b056e9fa
+commit=5d09dac27a0ef6dd09c4362d6f4f0e9c1a797703

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=eda13ad82ffe4a8e48f3d4bdca9e2a059da2fa2c
+commit=eda13ad032465f7da50f857d1f9bc2d7dfc34578

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=5d09dac27a0ef6dd09c4362d6f4f0e9c1a797703
+commit=a49f6764508fca185561557a771c5b6d68ba815a

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=a820de8930bd1fb83940d70aaf9bd158924c5b99
+commit=917f0493171dddd771b0fb6b097fd57f74dc5bfb

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=917f0493171dddd771b0fb6b097fd57f74dc5bfb
+commit=d163647d250bedc977634daabc8976dc6f24bdc2

--- a/plugins/shared-boss-uniques
+++ b/plugins/shared-boss-uniques
@@ -1,2 +1,2 @@
 repository=https://github.com/Totalchi/groupItems.git
-commit=3105707a27ee013e37cc083c615fba991244b494
+commit=a820de8930bd1fb83940d70aaf9bd158924c5b99


### PR DESCRIPTION
## Summary
Adds the Shared Boss Uniques RuneLite plugin to Plugin Hub.

This plugin uploads boss collection-log data and shows shared unique progress for participating group members.