### PR TITLE
blast-mine-tracker

### DIFF
--- a/plugins/blast-mine-tracker
+++ b/plugins/blast-mine-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/samkovaly/blast-mine-tracker.git
-commit=76b3725856726e5e7873232f6efb98c5d4f0f754
+commit=a23cbf5da77d87a85f00080d15552f6bc0dfd60a

--- a/plugins/blast-mine-tracker
+++ b/plugins/blast-mine-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/samkovaly/blast-mine-tracker.git
+commit=76b3725856726e5e7873232f6efb98c5d4f0f754


### PR DESCRIPTION
This plugin lets you track all XP and Profit related statistics of your Blast Mine Runs while you blast, and keeps track of XP waiting to be collected.