### PR TITLE
Add shield-timers plugin

### DIFF
--- a/plugins/shield-timers
+++ b/plugins/shield-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/FigmentsOSRS/Shield-Timers-Plugin.git
-commit=df4ad01fb7eeef46327ee971a0e833e3f85f6a0b
+commit=0fe8eaf8a69a7a48ce9e57a2b55f1518fe48db80

--- a/plugins/shield-timers
+++ b/plugins/shield-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/FigmentsOSRS/Shield-Timers-Plugin.git
-commit=a247f09453a30bd7261fba766a3362d83b4467a7
+commit=2f6ace9a5c47d27093eb061d44d954640ade67c6

--- a/plugins/shield-timers
+++ b/plugins/shield-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/FigmentsOSRS/Shield-Timers-Plugin.git
-commit=2f6ace9a5c47d27093eb061d44d954640ade67c6
+commit=01dc57e1a5189a8491d24eaa696bbc7e84eb99a4

--- a/plugins/shield-timers
+++ b/plugins/shield-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/FigmentsOSRS/Shield-Timers-Plugin.git
-commit=01dc57e1a5189a8491d24eaa696bbc7e84eb99a4
+commit=6a5f711fdc5a2d1dd1f024a8e680713feda8bac2

--- a/plugins/shield-timers
+++ b/plugins/shield-timers
@@ -1,0 +1,2 @@
+repository=https://github.com/FigmentsOSRS/Shield-Timers-Plugin
+commit=a247f09453a30bd7261fba766a3362d83b4467a7

--- a/plugins/shield-timers
+++ b/plugins/shield-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/FigmentsOSRS/Shield-Timers-Plugin.git
-commit=6a5f711fdc5a2d1dd1f024a8e680713feda8bac2
+commit=aeb1981210cf92cbad60904a7b636bc054e01021

--- a/plugins/shield-timers
+++ b/plugins/shield-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/FigmentsOSRS/Shield-Timers-Plugin.git
-commit=aeb1981210cf92cbad60904a7b636bc054e01021
+commit=df4ad01fb7eeef46327ee971a0e833e3f85f6a0b

--- a/plugins/shield-timers
+++ b/plugins/shield-timers
@@ -1,2 +1,2 @@
-repository=https://github.com/FigmentsOSRS/Shield-Timers-Plugin
+repository=https://github.com/FigmentsOSRS/Shield-Timers-Plugin.git
 commit=a247f09453a30bd7261fba766a3362d83b4467a7


### PR DESCRIPTION
Shield Timers tracks independent 2-minute activation cooldowns for the Dragonfire Shield, Dragonfire Ward, and Ancient Wyvern Shield.

Detection method per shield:
Dragonfire Shield — varbit 6539 (DRAGONFIRE_SHIELD_COOLDOWN)
Dragonfire Ward — varbit 6540
Ancient Wyvern Shield — projectile 500 originating from the local player

An InfoBox is shown for each shield whenever it is equipped or in your inventory. When off cooldown the box displays "Ready" in green, or the current charge count if charges have been checked. While on cooldown it counts down in M:SS format, turning yellow below 30 seconds and red below 10. Charges below 5 always show red regardless of cooldown state.

Charges are tracked by listening for the game message produced by right-clicking Inspect (DFS/Ward) or Check (AWS).
Per-shield config options: Track, Charges shown, Tray notification
Projectile Swaps: cosmetic replacement of the dragonfire or freeze blast projectile with 69 alternative visuals sourced from the Projectile Override plugin by Loze-Put and the RuneMonk entity viewer. Options include Default, Random (picks a different one each activation), and Rainbow Cycle (steps through a spectrum-ordered sequence of 9 colours on successive activations).
Cooldown state persists across logout and world hops via ConfigManager.