### PR TITLE
Add Wildy Slayer World Picker plugin

### DIFF
--- a/plugins/wildy-slayer-world
+++ b/plugins/wildy-slayer-world
@@ -1,0 +1,2 @@
+repository=https://github.com/samjhill/Wildy-Slayer-World-Picker.git
+commit=dce3ebdac7ca595691bb1121cb3a70568879b745

--- a/plugins/wildy-slayer-world
+++ b/plugins/wildy-slayer-world
@@ -1,2 +1,2 @@
 repository=https://github.com/samjhill/Wildy-Slayer-World-Picker.git
-commit=dce3ebdac7ca595691bb1121cb3a70568879b745
+commit=d597aaf88b5bb872941d3c520b5aba79c1f1ebf2


### PR DESCRIPTION
Ranks OSRS worlds by estimated revenant cave risk for Wilderness Slayer. Heuristic recommendation only; no auto-hop or menu injection. Users can report empty/players/PKers and see a best world plus backups.