### PR TITLE
Add Mercenary PvM plugin

### DIFF
--- a/plugins/mercenary-pvm
+++ b/plugins/mercenary-pvm
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/mercenary-pvm-plugin.git
-commit=944a8a08ba391e871b5a42b7a2bffa858561d984
+commit=e48a69aa09018b29abc5eee11bcf4a930dfbd5a4

--- a/plugins/mercenary-pvm
+++ b/plugins/mercenary-pvm
@@ -1,0 +1,2 @@
+repository=https://github.com/randytkrx/mercenary-pvm-plugin.git
+commit=eb93e7ecd28dad77ef5954bf8dd57ebd03003e61

--- a/plugins/mercenary-pvm
+++ b/plugins/mercenary-pvm
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/mercenary-pvm-plugin.git
-commit=d006fea42f9c21f3b6e7dab38da585c2232abd56
+commit=765ccf374f1b5f313b9c243c01c80fbe47e05639

--- a/plugins/mercenary-pvm
+++ b/plugins/mercenary-pvm
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/mercenary-pvm-plugin.git
-commit=605181eaadb88fd90e9373248f7d9983fb0b5aa7
+commit=d006fea42f9c21f3b6e7dab38da585c2232abd56

--- a/plugins/mercenary-pvm
+++ b/plugins/mercenary-pvm
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/mercenary-pvm-plugin.git
-commit=e48a69aa09018b29abc5eee11bcf4a930dfbd5a4
+commit=605181eaadb88fd90e9373248f7d9983fb0b5aa7

--- a/plugins/mercenary-pvm
+++ b/plugins/mercenary-pvm
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/mercenary-pvm-plugin.git
-commit=765ccf374f1b5f313b9c243c01c80fbe47e05639
+commit=83d1e56b153981a174173ff219d8fc78c0582d8d

--- a/plugins/mercenary-pvm
+++ b/plugins/mercenary-pvm
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/mercenary-pvm-plugin.git
-commit=eb93e7ecd28dad77ef5954bf8dd57ebd03003e61
+commit=944a8a08ba391e871b5a42b7a2bffa858561d984


### PR DESCRIPTION
## Summary
- Clan event hub plugin for tracking events, bingo boards, split loot, and drop proofs
- All server URLs are user-configurable via the plugin settings (no hardcoded endpoints)
- Features: event tracker, bingo tile proof submission, split tracker with Discord approval, Hall of Fame drop uploads
- Auto-detects clan membership when user configures their clan name

## Technical details
- Uses OkHttp (from RuneLite's injected client) for all HTTP requests
- All external communication is opt-in via user-configured URLs
- No data is sent anywhere until the user explicitly configures their server URLs
- BSD 2-Clause License