### PR TITLE
Add GE Offer Timer plugin

### DIFF
--- a/plugins/ge-offer-timer
+++ b/plugins/ge-offer-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/MRiJax/ge-offer-timer.git
-commit=7207f1b7dac6bb9291c248541cc511077a3117e6
+commit=8d7315598653ac813b9cfd888919dc4f5a5d5611

--- a/plugins/ge-offer-timer
+++ b/plugins/ge-offer-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/MRiJax/ge-offer-timer.git
+commit=7207f1b7dac6bb9291c248541cc511077a3117e6


### PR DESCRIPTION
Displays how long each Grand Exchange offer has been active, including buy/sell status and fill progress. Useful for flippers and merchers who want to track stale offers and reprice accordingly.