### PR TITLE
Add the plugin file for ge-trade-tracker

### DIFF
--- a/plugins/ge-trade-tracker
+++ b/plugins/ge-trade-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/megarares/ge-trade-tracker.git
+commit=86d92b21a066b8e1a2a9dfc6c9f2f135bf035dc6
+warning=This plugin submits your GE trade data and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/ge-trade-tracker
+++ b/plugins/ge-trade-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/megarares/ge-trade-tracker.git
-commit=86d92b21a066b8e1a2a9dfc6c9f2f135bf035dc6
+commit=d1504612397b3b03d66583659de9c6366d92ba79
 warning=This plugin submits your GE trade data and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/ge-trade-tracker
+++ b/plugins/ge-trade-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/megarares/ge-trade-tracker.git
-commit=d1504612397b3b03d66583659de9c6366d92ba79
-warning=This plugin submits your GE trade data and IP address to a server not controlled or verified by the RuneLite developers.
+commit=5a687c6944db0b9651d3be4191b6ba21305299b6
+warning=This plugin submits your display name, GE trade data, and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/ge-trade-tracker
+++ b/plugins/ge-trade-tracker
@@ -1,3 +1,4 @@
 repository=https://github.com/megarares/ge-trade-tracker.git
 commit=c12d37e12d4f70a66268ff20194e10393281c34e
 warning=This plugin submits your display name, GE trade data, and IP address to a server not controlled or verified by the RuneLite developers.
+authors=matjuu

--- a/plugins/ge-trade-tracker
+++ b/plugins/ge-trade-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/megarares/ge-trade-tracker.git
-commit=5a687c6944db0b9651d3be4191b6ba21305299b6
+commit=c12d37e12d4f70a66268ff20194e10393281c34e
 warning=This plugin submits your display name, GE trade data, and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This is a plugin that automatically tracks your GE trades and sends them to a third party repository (api.megarares.com).
These trades can then be viewed and observed at https://www.megarares.com on the Trade Tracker page.

The plugin requires an API key to be provided, which is used to authenticate and attribute the GE trades to the correct authenticated discord user on the website.

See attached screenshots for the Trade Tracker screen and the API key settings page.

<img width="1788" height="1790" alt="www megarares com_ge_trade-tracker (2)" src="https://github.com/user-attachments/assets/8d685584-bf0f-45a4-8440-24a13fce94d8" />
<img width="1788" height="3150" alt="www megarares com_ge_trade-tracker (1)" src="https://github.com/user-attachments/assets/03a12161-d8c3-4ab7-9b29-3cd4be74be7f" />
