### PR TITLE
Add Inventory Restore Values Plugin

### DIFF
--- a/plugins/inventory-restore-values
+++ b/plugins/inventory-restore-values
@@ -1,0 +1,2 @@
+repository=https://github.com/Sintry1/Inventory-Restore-Values
+commit=b4b2e70d09301d6d79838c7871c44265f15abb20

--- a/plugins/inventory-restore-values
+++ b/plugins/inventory-restore-values
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/Inventory-Restore-Values.git
-commit=ee0485560129938fc4c4c8ab95fc53c95d997670
+commit=13876390f08ee53328f2c4c8ef3d0ca50b1ce2d7

--- a/plugins/inventory-restore-values
+++ b/plugins/inventory-restore-values
@@ -1,2 +1,2 @@
-repository=https://github.com/Sintry1/Inventory-Restore-Values
+repository=https://github.com/Sintry1/Inventory-Restore-Values.git
 commit=b4b2e70d09301d6d79838c7871c44265f15abb20

--- a/plugins/inventory-restore-values
+++ b/plugins/inventory-restore-values
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/Inventory-Restore-Values.git
-commit=5d1065a882bb29c2cc80fb62d43c927e0eda0cdd
+commit=43e21c558ac0fac9c0c0814a2240b185ab971a00

--- a/plugins/inventory-restore-values
+++ b/plugins/inventory-restore-values
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/Inventory-Restore-Values.git
-commit=6fb47f949d0cef85545bd2bdb1b8e420a3bca568
+commit=404e84765db2951a19a84a582f2686bafa5d8707

--- a/plugins/inventory-restore-values
+++ b/plugins/inventory-restore-values
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/Inventory-Restore-Values.git
-commit=404e84765db2951a19a84a582f2686bafa5d8707
+commit=ee0485560129938fc4c4c8ab95fc53c95d997670

--- a/plugins/inventory-restore-values
+++ b/plugins/inventory-restore-values
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/Inventory-Restore-Values.git
-commit=13876390f08ee53328f2c4c8ef3d0ca50b1ce2d7
+commit=cd1c8cfc695bbf2f8d0b770de09381f8738787fc

--- a/plugins/inventory-restore-values
+++ b/plugins/inventory-restore-values
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/Inventory-Restore-Values.git
-commit=b4b2e70d09301d6d79838c7871c44265f15abb20
+commit=6fb47f949d0cef85545bd2bdb1b8e420a3bca568

--- a/plugins/inventory-restore-values
+++ b/plugins/inventory-restore-values
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/Inventory-Restore-Values.git
-commit=cd1c8cfc695bbf2f8d0b770de09381f8738787fc
+commit=5d1065a882bb29c2cc80fb62d43c927e0eda0cdd


### PR DESCRIPTION
Adds the Inventory Restore Values plugin, which displays HP and prayer restore amounts as a text overlay on inventory item icons. Prayer restore values are calculated  dynamically from the player's prayer level and accounts for Holy Wrench / Ring of the Gods (i) bonuses. Has options for colour changes of text, and font sizes, as well as choosing whether to display on every item or just the first of each. Also adds an info box for delayed healing food with a timer.