### PR TITLE
New plugin "Simplifying Mixology"

### DIFF
--- a/plugins/simplifying-mixology
+++ b/plugins/simplifying-mixology
@@ -1,0 +1,2 @@
+repository=https://github.com/Thource/simplifying-mixology.git
+commit=9f219575b28bc28835702f96501d2e598ba9eb97


### PR DESCRIPTION
Simplifying Mixology is a RuneLite plugin designed to simplify Mastering Mixology by making it harder to deposit wrong orders by de-prioritizing the Fulfil-order menu entry if no potions in the inventory fulfil any active order.