### PR TITLE
Add scaper plugin repository information

### DIFF
--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,0 +1,2 @@
+repository=https://github.com/Deafpie/scaper.git
+commit=8acac8bf29433caf38bad7af23cce749069df9d0

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=8acac8bf29433caf38bad7af23cce749069df9d0
+commit=237cd080aa277740465a519ce7dca35a9bad952e

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=237cd080aa277740465a519ce7dca35a9bad952e
+commit=52360b541ea473267a364adf1f24c9da8dbd97cf

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=52360b541ea473267a364adf1f24c9da8dbd97cf
+commit=d3864202ae2667e209150a7250b8ab0ce6834f8a

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=8a38f02b3dd2e0cae045a67ca3e36d80e0f78fd5
+commit=56d2888ac4b292b4faace125668b02b4e6c07d13

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=d3864202ae2667e209150a7250b8ab0ce6834f8a
+commit=335ec4dacd5ba33856dec541d3695b83704ad948

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=bd83223cbaec6dd3299333531a33c7ef70ac922d
+commit=566b73d71d236b3897820be8fba1a822a5d22817

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=b62a785a6de3fc232c8c5143319cffb58f979448
+commit=5f22056cc73b6ee4e6749258058f215bbcfa7b27

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=335ec4dacd5ba33856dec541d3695b83704ad948
+commit=aadc1d7d614c6a3a29d3d34b5617a69e897d71cd

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,3 @@
 repository=https://github.com/Deafpie/scaper.git
 commit=56d2888ac4b292b4faace125668b02b4e6c07d13
+warning=This plugin submits your IP address, RSN, in-game location, clan chat messages, and numerous account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=aadc1d7d614c6a3a29d3d34b5617a69e897d71cd
+commit=b62a785a6de3fc232c8c5143319cffb58f979448

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=152b3cf37678f5b80ac4382448239463191de9e0
+commit=8a38f02b3dd2e0cae045a67ca3e36d80e0f78fd5

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=f4f1a2337cb2e68bc7d0ec804348362c85504f07
+commit=152b3cf37678f5b80ac4382448239463191de9e0

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=7c6de2cd65635cba1ec072b62e56ddd290c89542
+commit=f4f1a2337cb2e68bc7d0ec804348362c85504f07

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=5f22056cc73b6ee4e6749258058f215bbcfa7b27
+commit=bd83223cbaec6dd3299333531a33c7ef70ac922d

--- a/plugins/scaper
+++ b/plugins/scaper
@@ -1,2 +1,2 @@
 repository=https://github.com/Deafpie/scaper.git
-commit=566b73d71d236b3897820be8fba1a822a5d22817
+commit=7c6de2cd65635cba1ec072b62e56ddd290c89542


### PR DESCRIPTION
Scaper links OSRS accounts to Discord for clan management.

Players generate a short-lived verification code in-game via the RuneLite sidebar panel, then use a /link command in Discord to confirm their identity. This lets clan servers verify members and assign roles automatically.

Repository: https://github.com/Deafpie/scaper