### PR TITLE
Add BossBank Sync plugin

### DIFF
--- a/plugins/bossbank-sync
+++ b/plugins/bossbank-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/bornthiswayttv-cpu/bossbank-sync.git
-commit=23ab5b86bc26234c662e9115091d8ed41eb4b5f3
+commit=9d8bb2a9bc3e88eb38ebbcb5f04aea666914214c

--- a/plugins/bossbank-sync
+++ b/plugins/bossbank-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/bornthiswayttv-cpu/bossbank-sync.git
-commit=44c95edaeb84495d0352fdac103f8af6104bd050
+commit=23ab5b86bc26234c662e9115091d8ed41eb4b5f3

--- a/plugins/bossbank-sync
+++ b/plugins/bossbank-sync
@@ -1,14 +1,2 @@
-{
-  "id": "bossbank-sync",
-  "name": "BossBank Sync",
-  "author": "BossBank",
-  "support": "https://github.com/bornthiswayttv-cpu/bossbank-sync",
-  "description": "Sync your bank, inventory, equipment, and stats to BossBank for gear optimization",
-  "tags": ["bank", "gear", "boss", "optimizer", "sync"],
-  "plugins": [
-    {
-      "class": "com.bossbank.sync.BossBankSyncPlugin",
-      "jar": "https://github.com/bornthiswayttv-cpu/bossbank-sync/raw/main/bossbank-sync-1.0.0.jar"
-    }
-  ]
-}
+repository=https://github.com/bornthiswayttv-cpu/bossbank-sync.git
+commit=2ee31d5b25b3e497bfd9a8b8e9814a4130631c49

--- a/plugins/bossbank-sync
+++ b/plugins/bossbank-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/bornthiswayttv-cpu/bossbank-sync.git
-commit=2ee31d5b25b3e497bfd9a8b8e9814a4130631c49
+commit=44c95edaeb84495d0352fdac103f8af6104bd050

--- a/plugins/bossbank-sync
+++ b/plugins/bossbank-sync
@@ -1,0 +1,14 @@
+{
+  "id": "bossbank-sync",
+  "name": "BossBank Sync",
+  "author": "BossBank",
+  "support": "https://github.com/bornthiswayttv-cpu/bossbank-sync",
+  "description": "Sync your bank, inventory, equipment, and stats to BossBank for gear optimization",
+  "tags": ["bank", "gear", "boss", "optimizer", "sync"],
+  "plugins": [
+    {
+      "class": "com.bossbank.sync.BossBankSyncPlugin",
+      "jar": "https://github.com/bornthiswayttv-cpu/bossbank-sync/raw/main/bossbank-sync-1.0.0.jar"
+    }
+  ]
+}


### PR DESCRIPTION
Adds BossBank Sync plugin which allows users to sync their bank, inventory, equipment, and stats to an external service for gear optimization and boss recommendations.