### PR TITLE
Add player-stats-sync plugin

### DIFF
--- a/plugins/player-stats-sync
+++ b/plugins/player-stats-sync
@@ -1,0 +1,3 @@
+repository=https://github.com/mexetys/osrs-duels.git
+commit=f2271dfc88c13c9e80824c87c2750976bb11eba9
+warning=This plugin submits your player data to a third-party server not controlled or verified by RuneLite developers.

--- a/plugins/player-stats-sync
+++ b/plugins/player-stats-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/mexetys/osrs-duels.git
 commit=f2271dfc88c13c9e80824c87c2750976bb11eba9
-warning=This plugin submits your player data to a third-party server not controlled or verified by RuneLite developers.
+warning=This plugin submits your IP address and player data to a third-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary

- Adds the **Player Stats Sync** plugin, which syncs the logged-in player's skill levels, XP, and combat level to a web dashboard
- This is a renamed and updated version of the previously submitted osrs-duels plugin (PR #11213, closed)
- Only skill data is sent — no bank, inventory, or equipment information

## Plugin Details

- **Repository:** https://github.com/mexetys/osrs-duels
- **Author:** oSeikkalia
- **Display Name:** Player Stats Sync
- **External server:** User-configurable API URL (warning field included in manifest)
- **Data sent:** RSN, combat level, skill levels and XP only

## Changes from previous submission (#11213)

- Renamed from OSRS Duels to Player Stats Sync
- Removed all item tracking (bank, inventory, equipment, looting bag)
- Payload now only contains player stats
- API URL is now user-configurable