### PR TITLE
Update supplies-tracker

### DIFF
--- a/plugins/supplies-tracker
+++ b/plugins/supplies-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/SuppliesTrackerExternal.git
-commit=b2aee9961c2ea1ca4da497189ef03b91fe68224c
+commit=d7bb9d728630c630afd2cf74d4d57f4c58cd8a76


### PR DESCRIPTION
- Fix various mage spells not tracking
- Add elemental tomes tracking
- Fix varrock/cammelot teleport tabs not working with specific city option
- Add eye of ayak tracking
- Fix powered staff tracking