### PR TITLE
Add GE Helper V1.0.0 - Add latest buy/sell price tracking

### DIFF
--- a/plugins/runelite-ge-helper
+++ b/plugins/runelite-ge-helper
@@ -1,2 +1,2 @@
-repository=https://github.com/ilee2914/runelite_ge_helper
+repository=https://github.com/ilee2914/runelite_ge_helper.git
 commit=4b1b0ac06b9a55218f302a17a91476ff7555a6e3

--- a/plugins/runelite-ge-helper
+++ b/plugins/runelite-ge-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/ilee2914/runelite_ge_helper
+commit=4b1b0ac06b9a55218f302a17a91476ff7555a6e3


### PR DESCRIPTION
Adding the GE Helper plugin which tracks Grand Exchange prices with live wiki data, features interactive price history graphs, and provides active offer monitoring.

### Screenshots

<p align="center">
  <img src="https://raw.githubusercontent.com/ilee2914/runelite_ge_helper/master/docs/ge_overlay.png" width="500" alt="GE Helper Overlay" />
</p>
<p align="center">
  <img src="https://raw.githubusercontent.com/ilee2914/runelite_ge_helper/master/docs/sidebar.png" width="250" alt="GE Helper Sidebar" />
</p>