### PR TITLE
Add osrs-prayer-helpper (minimal low-prayer warning overlay)

### DIFF
--- a/plugins/osrs-prayer-helpper
+++ b/plugins/osrs-prayer-helpper
@@ -1,0 +1,2 @@
+repository=https://github.com/jehkis/osrs-prayer-helpper.git
+commit=51967bb25ba693daa46f101000953296b25c0591


### PR DESCRIPTION
This submission is intentionally minimal and narrow in scope.

Feature set:
- Shows a warning overlay when Prayer points are at or below a configurable threshold.

Out of scope by design:
- no boss-specific logic
- no NPC animation parsing
- no prayer switching recommendations
- no input automation or click simulation

Repository: https://github.com/jehkis/osrs-prayer-helpper.git
Commit: 51967bb25ba693daa46f101000953296b25c0591