### PR TITLE
Add TOA Invocation Display Plugin

### DIFF
--- a/plugins/toa-invocation-display
+++ b/plugins/toa-invocation-display
@@ -1,2 +1,2 @@
 repository=https://github.com/noahnoah711/toa-invocation-display.git
-commit=2de7b525d165f58503826fff81f3b36d5624a079
+commit=4bfdcd9d7548c035c46b96e01847a2135720c633

--- a/plugins/toa-invocation-display
+++ b/plugins/toa-invocation-display
@@ -1,2 +1,2 @@
 repository=https://github.com/noahnoah711/toa-invocation-display.git
-commit=4bfdcd9d7548c035c46b96e01847a2135720c633
+commit=1e41726962df6ea8654f34779064cbb2de781f80

--- a/plugins/toa-invocation-display
+++ b/plugins/toa-invocation-display
@@ -1,0 +1,2 @@
+repository=https://github.com/noahnoah711/toa-invocation-display.git
+commit=2de7b525d165f58503826fff81f3b36d5624a079


### PR DESCRIPTION
Description:

Adds a new plugin, ToA Invocation Display, which shows the active Tombs of Amascut invocations for the room you are currently in. During a raid, the invocation screen is not easily accessible, making it difficult to quickly remind yourself which invocations are active for the boss you're about to fight. This plugin adds a small overlay that automatically updates as you move through the raid, showing boss-specific invocations at the top and global invocations (attempts, time limit, path level, and prayer) below a divider. Works for both raid leaders and players who joined someone else's raid.

Screenshots:
<img width="2278" height="1074" alt="image" src="https://github.com/user-attachments/assets/38720897-5a25-4026-bf8c-40e570eec0ca" />
<img width="2233" height="1086" alt="image" src="https://github.com/user-attachments/assets/b5ca3e55-e717-4095-9bdc-7f406d7d4b09" />
