### PR TITLE
Add Loot Origin plugin

### DIFF
--- a/plugins/loot-origin
+++ b/plugins/loot-origin
@@ -1,0 +1,2 @@
+repository=https://github.com/DegoDani/Loot-Origin.git
+commit=12868efd6ca792bc58ced2fb1462e2a3113e4269

--- a/plugins/loot-origin
+++ b/plugins/loot-origin
@@ -1,2 +1,2 @@
 repository=https://github.com/DegoDani/Loot-Origin.git
-commit=12868efd6ca792bc58ced2fb1462e2a3113e4269
+commit=616256dd66c78cc5cf70d74ddec2d7a86a8098bc


### PR DESCRIPTION
A plugin that parses local and official tracker data to show the exact origin of items in your bank/inventory. Users need to import Loot Tracker .json file obtained directly from the official runelite website.