### PR TITLE
Add Chat Overlay plugin

### DIFF
--- a/plugins/chat-overlay
+++ b/plugins/chat-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/devrat0/chat-overlay-plugin.git
-commit=fade52b92933a836029cb7c26aa9060875922e0d
+commit=6dd0efa3abd604cc7ab3587dbfe306974e993f12

--- a/plugins/chat-overlay
+++ b/plugins/chat-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/devrat0/chat-overlay-plugin.git
-commit=6dd0efa3abd604cc7ab3587dbfe306974e993f12
+commit=a3bbf3102c426a9969d626a236fda5568540161a

--- a/plugins/chat-overlay
+++ b/plugins/chat-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/devrat0/chat-overlay-plugin.git
-commit=f5ebab2f490bec8f286d04990b48a43cf8e6db32
+commit=38eb7091553723c189f658156fd32f0159d132b3

--- a/plugins/chat-overlay
+++ b/plugins/chat-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/devrat0/chat-overlay-plugin.git
-commit=a3bbf3102c426a9969d626a236fda5568540161a
+commit=3266a3773e9dff82eabc1766e858c000b5082341

--- a/plugins/chat-overlay
+++ b/plugins/chat-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/devrat0/chat-overlay-plugin.git
-commit=abb2e0246d829e03e568f502670ddd5a70e207b5
+commit=fade52b92933a836029cb7c26aa9060875922e0d

--- a/plugins/chat-overlay
+++ b/plugins/chat-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/devrat0/chat-overlay-plugin.git
-commit=38eb7091553723c189f658156fd32f0159d132b3
+commit=abb2e0246d829e03e568f502670ddd5a70e207b5

--- a/plugins/chat-overlay
+++ b/plugins/chat-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/devrat0/chat-overlay-plugin.git
+commit=f5ebab2f490bec8f286d04990b48a43cf8e6db32


### PR DESCRIPTION
Creating PR to submit a new plugin. The Chat Overlay plugin aims to create a helpful overlay for the OSRS chat. There are three separate overlays:

1. "Main Chat" - shows all chats, with the exception of game chats, in the overlay
2. "Private Chat" - shows a separate overlay for private chats only
3. "Game Chat" - shows an overlay for game messages. Very helpful in PVM situations! 

My main goal was to create a tool to allow me to see messages at glance, and then having them disappear. I typically collapse my chat when PVMing, and always found myself missing important messages.

Main chat overlay
![chat overlay example gif](https://github.com/user-attachments/assets/a8ea71a1-1094-4ad1-b0a5-d9bd0be78df0)

Active chat preview / peek mode 
![active chat bubble and peek mode](https://github.com/user-attachments/assets/237a7abd-95d1-4173-b64e-2c60d185eb9a)

Game chat message overlay
![game messages example](https://github.com/user-attachments/assets/fad4133a-7c4a-44d6-a90c-b10f21d7e545)

