### PR TITLE
Add Gemstone Trainer plugin

### DIFF
--- a/plugins/gemstone-trainer
+++ b/plugins/gemstone-trainer
@@ -1,0 +1,2 @@
+repository=https://github.com/johnstoermer/osrs-boss-trainer.git
+commit=8f431ccb090ab45975929589f72f486c75443f2e

--- a/plugins/gemstone-trainer
+++ b/plugins/gemstone-trainer
@@ -1,2 +1,2 @@
 repository=https://github.com/johnstoermer/osrs-boss-trainer.git
-commit=8f431ccb090ab45975929589f72f486c75443f2e
+commit=efb9743880a994925542f8916f6ed6252416cf55

--- a/plugins/gemstone-trainer
+++ b/plugins/gemstone-trainer
@@ -1,2 +1,2 @@
 repository=https://github.com/johnstoermer/osrs-boss-trainer.git
-commit=efb9743880a994925542f8916f6ed6252416cf55
+commit=554d70e67d9387564dc4052d70548c6f893af278


### PR DESCRIPTION
## Summary
- Overlays boss models and attack patterns on the Gemstone Crab for PvM training
- Supports Verzik P2 and Sol Heredit with precise tick timing
- Hit detection, configurable sounds, ghostly transparent boss models, hazard tile indicators

## Test plan
- [x] Plugin loads via sideloaded-plugins with --developer-mode
- [x] Verzik P2 overlay: attack cycle, projectiles, explosions, sounds
- [x] Sol Heredit overlay: spear lines, shield rectangles, ground slams, attack sequencing
- [x] Boss switching via config dropdown
- [x] Hit detection with "Ouch!" overhead text
- [x] Sound configuration

Repository: https://github.com/johnstoermer/osrs-boss-trainer