### PR TITLE
Hide Minimap Hotkey Plugin

### DIFF
--- a/plugins/hide-minimap-hotkey
+++ b/plugins/hide-minimap-hotkey
@@ -1,2 +1,2 @@
 repository=https://github.com/jarromie/hide-minimap-hotkey.git
-commit=8f0d8e9e8b4b0d2a7f0f2dc7817dca6d6eb3b3a7
+commit=6e0186b20fe28c47bfa9b6e90dd7f66cd543902d

--- a/plugins/hide-minimap-hotkey
+++ b/plugins/hide-minimap-hotkey
@@ -1,0 +1,2 @@
+repository=https://github.com/jarromie/hide-minimap-hotkey.git
+commit=8f0d8e9e8b4b0d2a7f0f2dc7817dca6d6eb3b3a7

--- a/plugins/hide-minimap-hotkey
+++ b/plugins/hide-minimap-hotkey
@@ -1,2 +1,2 @@
 repository=https://github.com/jarromie/hide-minimap-hotkey.git
-commit=6e0186b20fe28c47bfa9b6e90dd7f66cd543902d
+commit=19f9fa5b4bdeebb82e7adff37080fa72fffd03f4


### PR DESCRIPTION
Plugin allows you to hide the minimap widgets using a hotkey; depends on the default `Minimap` plugin being enabled. 

Short, simple and sweet; a nice QoL upgrade for those who use that function of the `Minimap` plugin.