### PR TITLE
ToA Invocations plugin

### DIFF
--- a/plugins/toa-invocations
+++ b/plugins/toa-invocations
@@ -1,2 +1,2 @@
 repository=https://github.com/mxO-dev/toa-invocations.git
-commit=9e8c8e812dce4e41b80692f366fed67a5b9d744e
+commit=289337a91a3ebcceee5c9f8b0c56b5985f2fb65e

--- a/plugins/toa-invocations
+++ b/plugins/toa-invocations
@@ -1,2 +1,2 @@
-repository=https://github.com/mxO-dev/toa-invocations
+repository=https://github.com/mxO-dev/toa-invocations.git
 commit=a79cc79e0c2e6c66f72de946fa4da6b83e3ef4c3

--- a/plugins/toa-invocations
+++ b/plugins/toa-invocations
@@ -1,2 +1,2 @@
 repository=https://github.com/mxO-dev/toa-invocations.git
-commit=748f7982abe969530b4807d5f92bcec4055bf77e
+commit=84fa5bcc586a75178b599f307184fb8619787404

--- a/plugins/toa-invocations
+++ b/plugins/toa-invocations
@@ -1,2 +1,2 @@
 repository=https://github.com/mxO-dev/toa-invocations.git
-commit=a79cc79e0c2e6c66f72de946fa4da6b83e3ef4c3
+commit=a79cc79e45596b0ad8f58894311093d8201ffd16

--- a/plugins/toa-invocations
+++ b/plugins/toa-invocations
@@ -1,2 +1,2 @@
 repository=https://github.com/mxO-dev/toa-invocations.git
-commit=d43ad698b93a0b3a02fde7bae14e7a20c7cefd9a
+commit=748f7988a97ea2e86feec29c4e0a2c979e71c862

--- a/plugins/toa-invocations
+++ b/plugins/toa-invocations
@@ -1,0 +1,2 @@
+repository=https://github.com/mxO-dev/toa-invocations
+commit=a79cc79e0c2e6c66f72de946fa4da6b83e3ef4c3

--- a/plugins/toa-invocations
+++ b/plugins/toa-invocations
@@ -1,2 +1,2 @@
 repository=https://github.com/mxO-dev/toa-invocations.git
-commit=a79cc79e45596b0ad8f58894311093d8201ffd16
+commit=9e8c8e812dce4e41b80692f366fed67a5b9d744e

--- a/plugins/toa-invocations
+++ b/plugins/toa-invocations
@@ -1,2 +1,2 @@
 repository=https://github.com/mxO-dev/toa-invocations.git
-commit=289337a91a3ebcceee5c9f8b0c56b5985f2fb65e
+commit=d43ad698b93a0b3a02fde7bae14e7a20c7cefd9a

--- a/plugins/toa-invocations
+++ b/plugins/toa-invocations
@@ -1,2 +1,2 @@
 repository=https://github.com/mxO-dev/toa-invocations.git
-commit=748f7988a97ea2e86feec29c4e0a2c979e71c862
+commit=748f7982abe969530b4807d5f92bcec4055bf77e


### PR DESCRIPTION
Adds the ToA Invocations plugin.

Shows active invocations relevant to the current boss room (Kephri, Zebak, Akkha, Ba-Ba, Wardens) as a HUD overlay when entering a boss room. Two display modes: names list or count only.

Plugin repository: https://github.com/mxO-dev/toa-invocations