### PR TITLE
Death Shamer Improved

### DIFF
--- a/plugins/death-shamer-improved
+++ b/plugins/death-shamer-improved
@@ -1,0 +1,2 @@
+repository=https://github.com/MylesAdams/deathshamerimproved.git
+commit=e4362525186eeaf206e7acdf75173e3a1585aa15

--- a/plugins/death-shamer-improved
+++ b/plugins/death-shamer-improved
@@ -1,2 +1,2 @@
 repository=https://github.com/MylesAdams/deathshamerimproved.git
-commit=e4362525186eeaf206e7acdf75173e3a1585aa15
+commit=275bf8ff7beb018d5352e17fc8f90190ffb5a259


### PR DESCRIPTION
This is a fork of the Death Shamer plugin (https://github.com/jack0lantern/raidshamer). It wasn't being updated and many people I know were asking for a feature that allows you the option to filter other players deaths even if they are on your friends list.

This plugin simply takes pictures when you or another player (if you have it enabled) die and saves it to the .runelite folder. Also have the ability to have it post the image to discord through a discord webhook.