### PR TITLE
Add fairy-ring-favourites plugin

### DIFF
--- a/plugins/fairy-ring-favourites
+++ b/plugins/fairy-ring-favourites
@@ -1,0 +1,2 @@
+repository=https://github.com/h1pstr/fairy-ring-favourites.git
+commit=1e08d2d0b18ad270c9b339f38f33a829025eb4a0

--- a/plugins/fairy-ring-favourites
+++ b/plugins/fairy-ring-favourites
@@ -1,2 +1,2 @@
 repository=https://github.com/h1pstr/fairy-ring-favourites.git
-commit=1e08d2d0b18ad270c9b339f38f33a829025eb4a0
+commit=36f914cfb5d0841a8e321f4e8bb67f70e9635d22


### PR DESCRIPTION
## Fairy Ring Favourites

  Replaces cryptic 3-letter fairy ring codes with readable destination names in the favourites menu.

  ### What it does

  - Labels favourite fairy ring codes (e.g. `AIQ` → `Mudskipper Point`) in:
    - Favourites submenu
    - Swap left-click / shift-click submenus
    - Top-level swapped menu entries
    - Last-destination entry
  - Built-in short names for all 52 fairy ring destinations
  - Users can set custom labels per code via config (e.g. `BLP,Tzhaar`)
  - Option to show/hide the original code alongside the name

  ### Why

  OSRS recently added fairy ring favourites, but the submenu only shows the 3-letter codes which are hard to remember. This plugin makes them human-readable.

  ### Screenshots

  | Before | After |
  |--------|-------|
  | ![Before](https://raw.githubusercontent.com/h1pstr/fairy-ring-favourites/master/images/before-favorites.png) | ![After](https://raw.githubusercontent.com/h1pstr/fairy-ring-favourites/master/images/after-favorites.png) |
  
  
  ### Configuration

  ![Configuration](https://raw.githubusercontent.com/h1pstr/fairy-ring-favourites/master/images/configurations.png)