### PR TITLE
Add placeholder-prices

### DIFF
--- a/plugins/placeholder-prices
+++ b/plugins/placeholder-prices
@@ -1,0 +1,3 @@
+repository=https://github.com/Maximuis94/runelite-plugins.git
+commit=850d550838e787b553e4c8f84189d90cd433fb5e
+authors=maximuis94

--- a/plugins/placeholder-prices
+++ b/plugins/placeholder-prices
@@ -1,3 +1,3 @@
 repository=https://github.com/Maximuis94/runelite-plugins.git
-commit=850d550838e787b553e4c8f84189d90cd433fb5e
+commit=4a3b594c766420361ac1a7595ba53868e2fde605
 authors=maximuis94

--- a/plugins/placeholder-prices
+++ b/plugins/placeholder-prices
@@ -1,3 +1,3 @@
 repository=https://github.com/Maximuis94/runelite-plugins.git
-commit=4a3b594c766420361ac1a7595ba53868e2fde605
+commit=3978f7d61358451d60b173efd68852b4e931c8bd
 authors=maximuis94


### PR DESCRIPTION
Adds a tooltip to unowned bank placeholders that shows the item name, GE- and HA prices.
The plugin uses the same configurations as the item prices plugin, effectively extending it to unowned placeholders.
<img width="378" height="278" alt="tooltip-example" src="https://github.com/user-attachments/assets/b0488a6d-e8f5-4ff7-9faa-1af006499d14" />
