### PR TITLE
Update named-pets

### DIFF
--- a/plugins/named-pets
+++ b/plugins/named-pets
@@ -1,3 +1,3 @@
 repository=https://github.com/Sacca-1/named-pets-runelite.git
-commit=dbad3f8df7af8e2ea930784e903b2375938026d2
+commit=7960579cbb88525069da327766f36321445ff6ba
 authors=Sacca-1, pappymint


### PR DESCRIPTION
Fixes a bug that left POH pet names rendered indefinitely when logging out or otherwise disconnecting while in the POH.