### PR TITLE
Add boss-respawn-notifier plugin repository info

### DIFF
--- a/plugins/boss-respawn-notifier
+++ b/plugins/boss-respawn-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/ASong5/boss-respawn-notifier.git
-commit=308d606ce7523aa1958045c2d445c049bf256955
+commit=30a76a18baebc408108cfdf03635750bb2cda9bb

--- a/plugins/boss-respawn-notifier
+++ b/plugins/boss-respawn-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/ASong5/boss-respawn-notifier.git
+commit=308d606ce7523aa1958045c2d445c049bf256955

--- a/plugins/boss-respawn-notifier
+++ b/plugins/boss-respawn-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/ASong5/boss-respawn-notifier.git
-commit=30a76a18baebc408108cfdf03635750bb2cda9bb
+commit=52bef5e251efb28acf38f8b13d2d0aecb1d6d676


### PR DESCRIPTION
Sends a notification when a boss is about to respawn. Configure which bosses should send notifications and specify a global and/or per-boss lead time that dictates how many seconds before the boss respawns to send the notification