### PR TITLE
Add Clan Feed Plugin

### DIFF
--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,0 +1,2 @@
+repository=https://github.com/porcupine-fish/clan-feed-plugin.git
+commit=bfb2b3f0b43b9eef3875c074238b6fa79bc40ff4

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=fe51a65478349ae81729408295358a7f334e1dc0
+commit=349cf98803985c188f8403135e053fd212398530

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=111343c087bd375bdab1a05b2f0a410417a61855
+commit=fe51a65478349ae81729408295358a7f334e1dc0

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=6db24d2d25fc8334f7d60910a6f396ffbcd14e6b
+commit=dde5b8bcda8f09cd0904a6cdbfd2fe73426db564

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=63adf9933ad2db2aa8cb1e0b350946cb52269e88
+commit=f63c0c2476bf59eaef06cb1a42eff6dec5f01508

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=59217d24982adf3ccd28b7115cf6a93c930a16f7
+commit=150e58d3f2b0017e22a32de7a559a56bfbf0e8de

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=150e58d3f2b0017e22a32de7a559a56bfbf0e8de
+commit=6db24d2d25fc8334f7d60910a6f396ffbcd14e6b

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=349cf98803985c188f8403135e053fd212398530
+commit=d64a3c710b1eab45431b1cec10e06e54073b5e94

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=9dda60188ab05d46a67c7deab989840fa937c0aa
+commit=f322070f68820538603a4d93598c1528e706e14f

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=1d2860ba9b81d4651d2a61bc29a05d4e29e0a6da
+commit=9dda60188ab05d46a67c7deab989840fa937c0aa

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=dde5b8bcda8f09cd0904a6cdbfd2fe73426db564
+commit=111343c087bd375bdab1a05b2f0a410417a61855

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=f322070f68820538603a4d93598c1528e706e14f
+commit=59217d24982adf3ccd28b7115cf6a93c930a16f7

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=bfb2b3f0b43b9eef3875c074238b6fa79bc40ff4
+commit=63adf9933ad2db2aa8cb1e0b350946cb52269e88

--- a/plugins/clan-feed
+++ b/plugins/clan-feed
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-feed-plugin.git
-commit=f63c0c2476bf59eaef06cb1a42eff6dec5f01508
+commit=1d2860ba9b81d4651d2a61bc29a05d4e29e0a6da


### PR DESCRIPTION
 - Subscribe to clan feed for clan events via clan websockets url
 - Display clan events information in the clan chat in game
 - One way: plugin does not send anything to the server and only receives clan related messages. 
 
<img width="238" height="240" alt="Screenshot from 2026-04-03 15-15-43" src="https://github.com/user-attachments/assets/2d421819-772b-4753-ae88-e2312e099986" />

JSON payload shape for websocket subscriber is:
 ```
 { 
    message: string
 }
```
The websockets secret key must be configured in the payload header, on the server-side, using the key `X-WS-Key`.

## Examples of clan messages
- "Drop party will be at 11pm BST 6pm EDT. 20mill. W301 Clan hall"
- "The boss of the week is Royal Titans, all you need to do is get kc! Crush weapon (zombie axe) + Twinflame staff."
- "The skill of the week is Magic, all you need to do is get magic xp!"
- "Hide and seek clan event W321. Host: some-username"
- "LMS clan event! Last man standing, ferox enclave, no risk PVP, don't bring items, W326, come practice for wilderness content"

## Testing
- Tested with the clan websockets url with secret key and can see the published messages come through into clan chat.
- Tested reconnect
- Tested disconnect
- Tested logout to login screen disconnects and logging back in reconnects
- Tested plugin config changes triggers reconnect

## PR
- Can't trigger the PR build step so I need help with that if changes are requested.
- Can't see the output of `RuneLite Plugin Hub Checks` PR action or the `#reviewer-scanner` channel.