### PR TITLE
Add prevent-minimap-reset plugin repository details

### DIFF
--- a/plugins/prevent-minimap-reset
+++ b/plugins/prevent-minimap-reset
@@ -1,0 +1,2 @@
+repository=https://github.com/Yookiop/PreventMinimapReset.git
+commit=8a37231d4bea2bbe4d2d6dcb6b6f74fd05c058b2

--- a/plugins/prevent-minimap-reset
+++ b/plugins/prevent-minimap-reset
@@ -1,2 +1,2 @@
 repository=https://github.com/Yookiop/PreventMinimapReset.git
-commit=8a37231d4bea2bbe4d2d6dcb6b6f74fd05c058b2
+commit=e2ffa4320f8c748e86cbfd3db05d0e65cbb69837


### PR DESCRIPTION
This plugin allows you to disable the functionality where a right mouse click on the minimap resets the zoom level.