### PR TITLE
Update lower-chat-box

### DIFF
--- a/plugins/lower-chat-box
+++ b/plugins/lower-chat-box
@@ -1,2 +1,2 @@
 repository=https://github.com/joseccandido/lower-chat-box.git
-commit=1b0c70566c85b451afa29af6e469937c9d99f064
+commit=2d86002300da3b55af895f1e1ac864fd38b0ea37


### PR DESCRIPTION
Added checks to prevent chat changes in fixed mode.

Plugin now specifies its meant only for resizable mode use.