### PR TITLE
Add plugin: TickSync Music

### DIFF
--- a/plugins/ticksync-music
+++ b/plugins/ticksync-music
@@ -1,2 +1,2 @@
 repository=https://github.com/theOranguzang/osrs-ticksync-music.git
-commit=099f6d5014e9f2087d282a03c7da384ccdb517c1
+commit=da651c1e2ffc7ba2ed975005a34324e30695681d

--- a/plugins/ticksync-music
+++ b/plugins/ticksync-music
@@ -1,2 +1,2 @@
 repository=https://github.com/theOranguzang/osrs-ticksync-music.git
-commit=c1bdfb070bd9ff62f94f4a9baaa08be17a7713e1
+commit=099f6d5014e9f2087d282a03c7da384ccdb517c1

--- a/plugins/ticksync-music
+++ b/plugins/ticksync-music
@@ -1,2 +1,2 @@
 repository=https://github.com/theOranguzang/osrs-ticksync-music.git
-commit=da651c1e2ffc7ba2ed975005a34324e30695681d
+commit=3923481579904f8a1c4c58c3db96ed3d5173e37f

--- a/plugins/ticksync-music
+++ b/plugins/ticksync-music
@@ -1,0 +1,2 @@
+repository=https://github.com/theOranguzang/osrs-ticksync-music.git
+commit=be3569ebd03d72bbe35cb3344019f715e49e28fa

--- a/plugins/ticksync-music
+++ b/plugins/ticksync-music
@@ -1,2 +1,2 @@
 repository=https://github.com/theOranguzang/osrs-ticksync-music.git
-commit=be3569ebd03d72bbe35cb3344019f715e49e28fa
+commit=c1bdfb070bd9ff62f94f4a9baaa08be17a7713e1


### PR DESCRIPTION
Tempo-syncs OSRS music to the 600ms game tick grid so beats land on tick boundaries. Reads MIDI from the local game cache, quantizes tempo to tick-aligned BPMs (25, 50, 100, 200), and plays back synced to GameTick events with drift correction.
MIDI-only — zero external dependencies beyond RuneLite's cache library.