### PR TITLE
Add LeaguesAdvisor Sync plugin

### DIFF
--- a/plugins/leagues-advisor-sync
+++ b/plugins/leagues-advisor-sync
@@ -1,0 +1,3 @@
+repository=https://github.com/laurenprete/leagues-advisor-sync.git
+commit=8a9e0ff86cc496c18b48dca10f52983c91bae539
+warning=This plugin syncs your league character data (skills, quests, tasks, collection log, owned items) to leagues-advisor.com.<br>Only activates on league (seasonal) worlds. No main game data is transmitted.


### PR DESCRIPTION
Syncs player league progress (skills, quests, achievement diaries, tasks, collection log, combat achievements, owned items) to LeaguesAdvisor (https://leagues-advisor.com) for task planning and route optimization. This companion webapp is still in development.

- Only activates on league (seasonal) worlds. No main game data is transmitted
- Fork of WikiSync (BSD-2-Clause) pointed at a different server
- Coexists with WikiSync, users can have both installed
- Real-time collection log detection adapted from Collection Log plugin by evansloan

