### PR TITLE
Add DPS Threshold Alerts plugin

### DIFF
--- a/plugins/dpsthresholdalerts
+++ b/plugins/dpsthresholdalerts
@@ -1,0 +1,2 @@
+repository=https://github.com/sonnypb/runelite-plugins.git
+commit=22f8e24e810cd000c3a18d3ee366a5cccddff4f5

--- a/plugins/dpsthresholdalerts
+++ b/plugins/dpsthresholdalerts
@@ -1,2 +1,2 @@
 repository=https://github.com/sonnypb/runelite-plugins.git
-commit=22f8e24e810cd000c3a18d3ee366a5cccddff4f5
+commit=356182eb75c83f0dab8b3837a3721833d4162d5e

--- a/plugins/dpsthresholdalerts
+++ b/plugins/dpsthresholdalerts
@@ -1,2 +1,2 @@
 repository=https://github.com/sonnypb/runelite-plugins.git
-commit=356182eb75c83f0dab8b3837a3721833d4162d5e
+commit=c39d0de1e0b965ce7f7dde3115da98e11595bad2


### PR DESCRIPTION
Adds a plugin that alerts when damage exceeds a configurable threshold. Useful when alting bosses to help to prevent alts from sniping kills.