### PR TITLE
update clue-teleport-helper

### DIFF
--- a/plugins/clue-teleport-helper
+++ b/plugins/clue-teleport-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/kitten-lissy/clue-teleport-helper.git
-commit=3857864272d2dc3f5752777c54442cc440bfa36e
+commit=3b1a7dab6a35f6d17daec08f1361902336e5bae1

--- a/plugins/clue-teleport-helper
+++ b/plugins/clue-teleport-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/kitten-lissy/clue-teleport-helper.git
-commit=09448b3258370a41db9c49ceb45a4260b32e62c6
+commit=dabcc311d2514f4a4011b37d93e69ca72efd9c88

--- a/plugins/clue-teleport-helper
+++ b/plugins/clue-teleport-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/kitten-lissy/clue-teleport-helper.git
-commit=3b1a7dab6a35f6d17daec08f1361902336e5bae1
+commit=09448b3258370a41db9c49ceb45a4260b32e62c6


### PR DESCRIPTION
Adds house teleport tabs, minigame teleports, Arceuus tablets, and Quetzal whistle destinations. Adds kill-for-key clue system with inventory-based phase switching. Adds multi-step three-step cryptic support. Plane normalization fix for upper floor clues. New location overrides for Rimmington, Emir's Arena, Paterdomus, Pyramid Plunder, Fairy Queen hideout, Iorwerth Camp, Kharazi Jungle, Wilderness Resource Area, and several dungeons.