### PR TITLE
add clue-combat-helper

### DIFF
--- a/plugins/clue-combat-helper
+++ b/plugins/clue-combat-helper
@@ -1,0 +1,3 @@
+repository=https://github.com/kitten-lissy/clue-combat-helper.git
+commit=2dc070ed5aa992be4660fbd7993e8b6cc382c856
+authors=kitten-lissy


### PR DESCRIPTION
New plugin that shows combat advice for treasure trail clue scroll encounters — prayer, gear, and item suggestions for each monster type (Saradomin/Zamorak wizards, Double Agents, Brassican Mage, Ancient Wizards, Armadylean/Bandosian guards). Distinguishes between specific enemies and either/or cases based on clue data, and shows wilderness warnings when applicable.