### PR TITLE
Request to adopt cox analytics

### DIFF
--- a/plugins/cox-analytics
+++ b/plugins/cox-analytics
@@ -1,2 +1,2 @@
-repository=https://github.com/MoreBuchus/buchus-plugins.git
+repository=https://github.com/DangItOSRS/cox-analytics.git
 commit=f7bc06f16ee81ae91f7482dbf582a0bb85560200


### PR DESCRIPTION
Attempted to contact the author for collaborator access via: https://github.com/MoreBuchus/buchus-plugins/issues/172

I would like to add functionality for an optional date export for improved analytics, and party support so that players who re-log during the raid still get accurate splits