### PR TITLE
add PvP Anti-oops v1

### DIFF
--- a/plugins/anti-oops
+++ b/plugins/anti-oops
@@ -1,0 +1,2 @@
+repository=https://github.com/mads-jm/rl-anti-oops.git
+commit=c36e231e63181db2885ea07d231942c8aa1e1ca3

--- a/plugins/anti-oops
+++ b/plugins/anti-oops
@@ -1,0 +1,2 @@
+repository=https://github.com/mads-jm/rl-anti-oops
+commit=c36e231e63181db2885ea07d231942c8aa1e1ca3


### PR DESCRIPTION
## Summary

Adds **PvP Anti-Oops** — a click-to-confirm safety gate for teleports on PvP and High Risk worlds.

Ironmen use PvP worlds for blighted supplies, often grinding bosses in safe instances. One autopilot teleport means you're dropped into Edgeville pvp with your full Titans tri-bridding gear at risk. This plugin intercepts teleport actions while in a safe zone and requires a second click to confirm.

On regular worlds, or when already in a dangerous area, the plugin does nothing.

## What it protects

- Teleport jewelry (ring of dueling, glory, games necklace, etc.), including mounted in poh
- Spellbook teleports (all 4 books, standard + group variants)
- Teleport tablets (redirected house tabs, etc.)
- POH portals and exit portal
- Charged items (enchanted lyre, skull sceptre, teleport crystal, diary rewards, etc.)

"Teleport to House" is never blocked — it takes you *to* safety.

## How it works

1. Checks if the player is on a PvP/High Risk world (cached on login/hop)
2. Checks if the player is in a safe zone via `PVP_AREA_CLIENT` varbit
3. Classifies the menu action as a teleport type
4. Blocks the first click with a chat warning; the second click within the timeout window confirms

Each teleport type can be toggled independently. Confirmation timeout is configurable (1–10s)

## Repository

https://github.com/mads-jm/rl-anti-oops