### PR TITLE
Add TrapEdge plugin

### DIFF
--- a/plugins/trapedge
+++ b/plugins/trapedge
@@ -1,2 +1,2 @@
 repository=https://github.com/Onechan/trapedge-runelite-plugin.git
-commit=9e16899489b251b0acfbcdfed33fad084e232e36
+commit=03d0afaa5b05ea5ec8331d66c67f878db568e8b4

--- a/plugins/trapedge
+++ b/plugins/trapedge
@@ -1,0 +1,2 @@
+repository=https://github.com/Onechan/trapedge-runelite-plugin.git
+commit=9e16899489b251b0acfbcdfed33fad084e232e36


### PR DESCRIPTION
## What this plugin does
TrapEdge is a read-only RuneLite sidebar for OSRS flips. It focuses on trap warnings and next action rather than generic market tracking.

## Current behavior
- shows watched-item triage
- shows next action
- shows compact supporting context and replay/memory context
- no automation, no in-game actions, no client writeback
- default config now uses a public hosted read-only snapshot feed instead of localhost

## Notes
The plugin source repository is public here: https://github.com/Onechan/trapedge-runelite-plugin
Hosted default feed: https://onechan.github.io/trapedge-runelite-plugin/hosted-api/bootstrap.json
