### PR TITLE
Creating a plugin to display your total level and the maximum total level in the skill tab 

### DIFF
--- a/plugins/total-total-level
+++ b/plugins/total-total-level
@@ -1,2 +1,2 @@
 repository=https://github.com/psikoo/total-total-level-osrs.git
-commit=1f3a0f067af03edb6b1713a921575f822c864088
+commit=0a182d35dbb9dea64c0ac3553a17c95943ef2375

--- a/plugins/total-total-level
+++ b/plugins/total-total-level
@@ -1,2 +1,2 @@
 repository=https://github.com/psikoo/total-total-level-osrs.git
-commit=c04bedbb9db86c95cdef413a195948e745889522
+commit=88cc8ad9a88832bcb554700a9b4012b8ba912271

--- a/plugins/total-total-level
+++ b/plugins/total-total-level
@@ -1,2 +1,2 @@
 repository=https://github.com/psikoo/total-total-level-osrs.git
-commit=0a182d35dbb9dea64c0ac3553a17c95943ef2375
+commit=c04bedbb9db86c95cdef413a195948e745889522

--- a/plugins/total-total-level
+++ b/plugins/total-total-level
@@ -1,0 +1,2 @@
+repository=https://github.com/psikoo/total-total-level-osrs.git
+commit=1f3a0f067af03edb6b1713a921575f822c864088


### PR DESCRIPTION
I made a plugin to display your total level out of the max amount of total levels.

Default view:
<img width="199" height="32" alt="image" src="https://github.com/user-attachments/assets/e055efc8-f0a2-4d96-a799-fe4c2cd85df7" />

Plugin enabled:
<img width="200" height="29" alt="image" src="https://github.com/user-attachments/assets/9acb31af-e184-4079-b758-80f039413765" />

Compatible with virtual levels:
<img width="200" height="27" alt="image" src="https://github.com/user-attachments/assets/aec16dd8-e548-4352-aae8-be9c8eda8afe" />

I dont own an account with levels over 99 to test the compatibility with virtual levels (and the "Fake Stats" plugin is completely broken since sailing released), but it should be compatible with virtual levels as I set the priority on the @Subscribe to -1. 🐈