### PR TITLE
add dutch-mayhem-clan-plugin

### DIFF
--- a/plugins/dutch-mayhem-clan-plugin
+++ b/plugins/dutch-mayhem-clan-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/nekomana-project/dutch-mayhem-clan-plugin.git
+commit=6d4fc8f581fa488fda874995534a0d5ca0659598


### PR DESCRIPTION
Adds the Dutch Mayhem Clan plugin which relays OSRS clan chat to a Discord bot and tracks wilderness loot splits for the Dutch Mayhem Clan community.