### PR TITLE
Transfer configurable-slayer-task-overlay to NathanVegetable

### DIFF
--- a/plugins/configurable-slayer-task-overlay
+++ b/plugins/configurable-slayer-task-overlay
@@ -1,2 +1,2 @@
-repository=https://github.com/mathiaslj/configurable-slayer-task-overlay.git
+repository=https://github.com/NathanVegetable/configurable-slayer-task-overlay.git
 commit=1c900ac5c5d37fc060d11acde58b82c21fc0c77f


### PR DESCRIPTION
Takeover request per plugin takeover policy. Original author (mathiaslj) has been unresponsive for 3+ weeks.
See: https://github.com/mathiaslj/configurable-slayer-task-overlay/issues/27

I have a pending PR (https://github.com/mathiaslj/configurable-slayer-task-overlay/pull/25) addressing multiple open issues that has gone unreviewed, as well as additional fixes beyond the PR.
