### PR TITLE
Shortest path

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=06ba9c34a18a43af1878d3230d853e8058188042
+commit=a52c69e72b03373b44765b35c8d424213cc57395
 authors=Skretzo,FIrgolitsch,wvanderp

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=594127fd0105802688192cf7b0bed809266c2f50
+commit=06ba9c34a18a43af1878d3230d853e8058188042
 authors=Skretzo,FIrgolitsch,wvanderp


### PR DESCRIPTION
Update shortest path to version 1.18.0.

Sorry for the relatively large update. Some of the internals of the plugin were reworked for ease of development. These internal changes don't change any functionality, just way transports are loaded and integrated into the plugin.

- Added a series of missing transports: https://github.com/Skretzo/shortest-path/pull/379
- Fixed transports/teleports around Ape Atoll: https://github.com/Skretzo/shortest-path/pull/398
- Small fixes for hot air balloos + quetzal check: https://github.com/Skretzo/shortest-path/pull/400
- Internal changes:
    - New TSV parsing method: https://github.com/Skretzo/shortest-path/pull/329 (Some of the changes listed are forthcoming)
    - Centralisation of the transport configuration: https://github.com/Skretzo/shortest-path/pull/401 (easier for us to work with transports, no new functionality, just a refactor)

There's another somewhat sizeable upgrade coming as well, but I didn't want to flood you all with even more review work at once.