### PR TITLE
Add TileLite Plugin

### DIFF
--- a/plugins/tilelite
+++ b/plugins/tilelite
@@ -1,2 +1,2 @@
 repository=https://github.com/jackperry2015/tilelite-runelite-plugin.git
-commit=0d3962d585b8a7f843ea6213285d2a1477363b9a
+commit=30688e15e5746b8af48dd0c9ae96ac834fa87c1c

--- a/plugins/tilelite
+++ b/plugins/tilelite
@@ -1,2 +1,2 @@
 repository=https://github.com/jackperry2015/tilelite-runelite-plugin.git
-commit=ccf042e4cf4cfde00c0293ada11201b4fa2437e4
+commit=e4b558db920cde2105071a9c07509b9ad7ff41c1

--- a/plugins/tilelite
+++ b/plugins/tilelite
@@ -1,2 +1,2 @@
 repository=https://github.com/jackperry2015/tilelite-runelite-plugin.git
-commit=0a8815fd052cd4fe80700f884b3aec51a46f7b37
+commit=e33098febce2eb36d8a6220c7c3d0ab0e4d4cf27

--- a/plugins/tilelite
+++ b/plugins/tilelite
@@ -1,2 +1,2 @@
 repository=https://github.com/jackperry2015/tilelite-runelite-plugin.git
-commit=30688e15e5746b8af48dd0c9ae96ac834fa87c1c
+commit=0a8815fd052cd4fe80700f884b3aec51a46f7b37

--- a/plugins/tilelite
+++ b/plugins/tilelite
@@ -1,2 +1,2 @@
 repository=https://github.com/jackperry2015/tilelite-runelite-plugin.git
-commit=59644ee1a9bf4b2cf3a7d254d96ce3b35a12ab98
+commit=ccf042e4cf4cfde00c0293ada11201b4fa2437e4

--- a/plugins/tilelite
+++ b/plugins/tilelite
@@ -1,2 +1,2 @@
 repository=https://github.com/jackperry2015/tilelite-runelite-plugin.git
-commit=e4b558db920cde2105071a9c07509b9ad7ff41c1
+commit=0d3962d585b8a7f843ea6213285d2a1477363b9a

--- a/plugins/tilelite
+++ b/plugins/tilelite
@@ -1,0 +1,2 @@
+repository=https://github.com/jackperry2015/tilelite-runelite-plugin.git
+commit=59644ee1a9bf4b2cf3a7d254d96ce3b35a12ab98

--- a/plugins/tilelite
+++ b/plugins/tilelite
@@ -1,2 +1,3 @@
 repository=https://github.com/jackperry2015/tilelite-runelite-plugin.git
 commit=e33098febce2eb36d8a6220c7c3d0ab0e4d4cf27
+warning=This plugin submits your IP address, RSN, and various account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds the TileLite plugin — automatic tile verification for OSRS bingo competitions.

The plugin sends game events (drops, XP gains, boss KC, heartbeat) to the TileLite 
backend (https://tilelite.app) for automatic bingo tile verification.

Events sent:
- Heartbeat with RSN + world (every 5 min + on login) for account verification
- Monster drops (NPC name, item, quantity)
- XP gains (skill, amount)
- Boss kill counts (from chat messages)

All requests are authenticated via a user-generated API key (X-Runelite-Key header).
No sensitive data is collected. No game client modifications.