### PR TITLE
Add Slayer Notes plugin

### DIFF
--- a/plugins/slayer-notes
+++ b/plugins/slayer-notes
@@ -1,2 +1,2 @@
-repository=https://github.com/MotorMan333/slayer-notes
+repository=https://github.com/MotorMan333/slayer-notes.git
 commit=39c927696e7498946a5e82d703b9e44af3a3607f

--- a/plugins/slayer-notes
+++ b/plugins/slayer-notes
@@ -1,0 +1,2 @@
+repository=https://github.com/MotorMan333/slayer-notes
+commit=39c927696e7498946a5e82d703b9e44af3a3607f


### PR DESCRIPTION
Adds a notepad that saves personal notes per slayer task monster.
Notes are saved via RuneLite's config system and displayed as an
in-game tooltip when hovering the notepad overlay icon.