### PR TITLE
Add Sith Clan plugin repository information

### DIFF
--- a/plugins/sith-clan-plugin
+++ b/plugins/sith-clan-plugin
@@ -1,2 +1,3 @@
 repository=https://github.com/psenk/SithClanPlugin.git
 commit=e145738b7d647c2d0134463faadc49f33e3d3b70
+warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/sith-clan-plugin
+++ b/plugins/sith-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/psenk/SithClanPlugin.git
-commit=7a9a2883b5fb1ef08577312d919d7adb0085d52e
+commit=eb4a3ec2b081212ca489f36bc6cec80ecd86ca11

--- a/plugins/sith-clan-plugin
+++ b/plugins/sith-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/psenk/SithClanPlugin.git
-commit=eb4a3ec2b081212ca489f36bc6cec80ecd86ca11
+commit=e4f996efc801121812dd72871eccee930bb72659

--- a/plugins/sith-clan-plugin
+++ b/plugins/sith-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/psenk/SithClanPlugin.git
-commit=c671f5f2dab56589a7c7c5207ff6927a3ee1b573
+commit=e145738b7d647c2d0134463faadc49f33e3d3b70

--- a/plugins/sith-clan-plugin
+++ b/plugins/sith-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/psenk/SithClanPlugin.git
-commit=e4f996efc801121812dd72871eccee930bb72659
+commit=c671f5f2dab56589a7c7c5207ff6927a3ee1b573

--- a/plugins/sith-clan-plugin
+++ b/plugins/sith-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/psenk/SithClanPlugin.git
-commit=e145738b7d647c2d0134463faadc49f33e3d3b70
+commit=6d7d1a60452b38b398b7664bbfaf8deecbdedee8
 warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/sith-clan-plugin
+++ b/plugins/sith-clan-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/psenk/SithClanPlugin.git
+commit=7a9a2883b5fb1ef08577312d919d7adb0085d52e


### PR DESCRIPTION
Plugin for the Sith clan.  Displays clan announcements, clan event schedule, member roster, and allows posting of event logs to Discord.  Allows for updating of clan info by clan leadership.  Connects to a CloudFlare worker backend, repository posted in README.