### PR TITLE
Add Final Boss clan plugin

### DIFF
--- a/plugins/fbclan-plugin
+++ b/plugins/fbclan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/orgonag/fbclan-plugin.git
-commit=efa215079a662a7077e8bb7699f87ff7db6838a8
+commit=3bc0e457601682beda533d5544ad117f370b08e9

--- a/plugins/fbclan-plugin
+++ b/plugins/fbclan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/orgonag/fbclan-plugin.git
-commit=3bc0e457601682beda533d5544ad117f370b08e9
+commit=a7c60398773ffb1ab19fda7ea17ffe3ee0ce823e

--- a/plugins/fbclan-plugin
+++ b/plugins/fbclan-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/orgonag/fbclan-plugin.git
+commit=efa215079a662a7077e8bb7699f87ff7db6838a8

--- a/plugins/fbclan-plugin
+++ b/plugins/fbclan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/orgonag/fbclan-plugin.git
-commit=a7c60398773ffb1ab19fda7ea17ffe3ee0ce823e
+commit=4a4a3c285ef592c7884ae6d40844ab1d3c2689d4
 warning=This plugin submits your IP address, RSN, and drop data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/fbclan-plugin
+++ b/plugins/fbclan-plugin
@@ -1,2 +1,3 @@
 repository=https://github.com/orgonag/fbclan-plugin.git
 commit=a7c60398773ffb1ab19fda7ea17ffe3ee0ce823e
+warning=This plugin submits your IP address, RSN, and drop data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Plugin: Final Boss

Clan tools for the **Final Boss** OSRS clan.

### Features
- **Clan Verification** — Verifies membership via the Wise Old Man API (Group 1055)
- **Drop Logging** — Logs valuable drops (1M+ GP) to a shared Supabase database with Row Level Security
- **Discord Notifications** — Optional webhook for drop alerts in Discord
- **Looking For Group** — Find clan members to group up with (8 activity types, list/grouped views)

### Technical Details
- Uses injected `OkHttpClient` for all HTTP calls (WOM, Supabase, Discord)
- All network calls run on background threads via `ScheduledExecutorService`
- No reflection, no raw threads, no internal API access
- Supabase anon key is intentionally public — protected by RLS policies
- BSD 2-Clause license

### Repository
https://github.com/orgonag/fbclan-plugin