### PR TITLE
Create heal-indicators

### DIFF
--- a/plugins/heal-indicators
+++ b/plugins/heal-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/Necrotress/heal-indicators.git
+commit=1866bc987ef2855171f0e0f9bd31423d01f9f6b9

--- a/plugins/heal-indicators
+++ b/plugins/heal-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Necrotress/heal-indicators.git
-commit=4fe3eeebff9e91315df7170fa1405b829a638f15
+commit=02e7f111b7bee7745eb7ebc50adca677bacbc8e2

--- a/plugins/heal-indicators
+++ b/plugins/heal-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Necrotress/heal-indicators.git
-commit=1866bc987ef2855171f0e0f9bd31423d01f9f6b9
+commit=3139c0a9578751914f99d17e49df1f668982fd69

--- a/plugins/heal-indicators
+++ b/plugins/heal-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Necrotress/heal-indicators.git
-commit=3139c0a9578751914f99d17e49df1f668982fd69
+commit=4fe3eeebff9e91315df7170fa1405b829a638f15


### PR DESCRIPTION
Heal Indicators+ displays heal and prayer restore splats when you heal you HP/Prayer, Similar to the Vitality plugin with more customization options.