### PR TITLE
Create pvp-arena-points

### DIFF
--- a/plugins/pvp-arena-points
+++ b/plugins/pvp-arena-points
@@ -1,0 +1,2 @@
+repository=https://github.com/euclio/pvp-arena-points.git
+commit=e2dfbe4963220835ec1f01c5a3f17a891efe4fa4


### PR DESCRIPTION
This plugin adds an infobox tracking your current PvP Arena Reward Points while inside Emir's Arena or on a PvP Arena World.