### PR TITLE
Added Verzik Camera Fix plugin.

### DIFF
--- a/plugins/verzik-camera-fix
+++ b/plugins/verzik-camera-fix
@@ -1,0 +1,2 @@
+repository=https://github.com/avahe-kellenberger/verzik-camera-fix.git
+commit=baef9d61cf184c16b0183b39435cbb574585fc70

--- a/plugins/verzik-camera-fix
+++ b/plugins/verzik-camera-fix
@@ -1,2 +1,2 @@
 repository=https://github.com/avahe-kellenberger/verzik-camera-fix.git
-commit=baef9d61cf184c16b0183b39435cbb574585fc70
+commit=be9ede03f4165508ef6e29fc800d1c50fa27d89c


### PR DESCRIPTION
This plugin prevents the camera from rotating when entering Verzik's room, and also hides the southernmost wall.

[verzik_camera.webm](https://github.com/user-attachments/assets/3658b8f6-bc6a-440a-8ba5-35ba8043c483)
