### PR TITLE
Add AIO Bingo plugin

### DIFF
--- a/plugins/aio-bingo
+++ b/plugins/aio-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/BajanSDK/aio-bingo-plugin.git
-commit=4f25e180c580e3241ed9588c02cf72c4daa673e4
+commit=848b7af520946d4ad2ca3f03097c31082d5fb11e

--- a/plugins/aio-bingo
+++ b/plugins/aio-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/BajanSDK/aio-bingo-plugin.git
-commit=848b7af520946d4ad2ca3f03097c31082d5fb11e
+commit=01069330215be418daf542d5e734f0f7facb1286

--- a/plugins/aio-bingo
+++ b/plugins/aio-bingo
@@ -1,0 +1,2 @@
+repository=https://github.com/BajanSDK/aio-bingo-plugin.git
+commit=4f25e180c580e3241ed9588c02cf72c4daa673e4

--- a/plugins/aio-bingo
+++ b/plugins/aio-bingo
@@ -1,3 +1,3 @@
 repository=https://github.com/BajanSDK/aio-bingo-plugin.git
-commit=01069330215be418daf542d5e734f0f7facb1286
+commit=d557eb05cca957c84b6dd4f26e7ae6cbc47fab59
 warning=This plugin submits your IP address, RSN, and drops to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/aio-bingo
+++ b/plugins/aio-bingo
@@ -1,2 +1,3 @@
 repository=https://github.com/BajanSDK/aio-bingo-plugin.git
 commit=01069330215be418daf542d5e734f0f7facb1286
+warning=This plugin submits your IP address, RSN, and drops to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Clan bingo event tracker for OSRS. Players join a bingo board via a team token,
and the plugin automatically tracks drops and PvP kills toward bingo tile completion.

Features:
- Automatic drop and PvP kill event submission
- Live bingo board display in the side panel
- Team progress tracking with tier indicators
- Leaderboard view