### PR TITLE
Update broken xp updater to match other sources

### DIFF
--- a/plugins/calcusource-xp-updater
+++ b/plugins/calcusource-xp-updater
@@ -1,3 +1,3 @@
 repository=https://github.com/hessrs/calcusource-xp-updater.git
-commit=bfce525ed305578f85257c7f2e543689f36e75f6
+commit=29f2557b6cc797a38dc667e2a61bb721cd0feccb
 warning=This plugin submits your player data and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Code was outdated and not sending updates correctly. New logic to handle player name and null players was used to match CML, Temple, and WiseOldMan.