### PR TITLE
Update loot-lookup to v1.2.0

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,3 +1,3 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=8b11b7f07fd779850727c0c9ec0b114d95380ea4
+commit=b8563a0ce44385246c9ae6b1f82b3cf3ad32f288
 authors=donth77,riktenx,iProdigy


### PR DESCRIPTION
- **Fix missing quantity values on perfect-kill drops** - where the wiki uses semicolon alternates like "25; 38"
  - [https://github.com/donth77/loot-lookup-plugin/issues/36](https://github.com/donth77/loot-lookup-plugin/issues/36)
  - [https://github.com/donth77/loot-lookup-plugin/issues/26](https://github.com/donth77/loot-lookup-plugin/issues/26)
- **Add Lookup Drops to the right-click menu on pickpocketable NPCs**
  - [https://github.com/donth77/loot-lookup-plugin/issues/43](https://github.com/donth77/loot-lookup-plugin/issues/43)
- **Add "Excluded monsters" config option** - for a comma-separated list of NPC names or IDs to hide the right-click menu on
  - [https://github.com/donth77/loot-lookup-plugin/issues/28](https://github.com/donth77/loot-lookup-plugin/issues/28)
- **Add "Pinned sections" config option** - to pin matching sections to the top of the drops panel, with a pinned icon indicator on each pinned section's header
  - [https://github.com/donth77/loot-lookup-plugin/issues/34](https://github.com/donth77/loot-lookup-plugin/issues/34)
- **Add a filter popover in the toolbar** - to show/hide individual sections per lookup, with "Check all" and "Uncheck all" shortcuts.
