### PR TITLE
Add OSRS MCP plugin

### DIFF
--- a/plugins/claude-osrs
+++ b/plugins/claude-osrs
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/claude-osrs-plugin.git
-commit=8589ee382143057f391f9cc0f401641c559c5117
+commit=be431daea89db5d4d8a504fb214ae28e183d2ea1
 authors=nickbeddows-ctrl

--- a/plugins/claude-osrs
+++ b/plugins/claude-osrs
@@ -1,0 +1,3 @@
+repository=https://github.com/nickbeddows-ctrl/claude-osrs-plugin.git
+commit=79fda2215b9c05a0e044a5caeab0f5152b1ceaf5
+authors=nickbeddows-ctrl

--- a/plugins/claude-osrs
+++ b/plugins/claude-osrs
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/claude-osrs-plugin.git
-commit=ffe1cfcf0ca0777d98887416ded2e556f3e3bc7c
+commit=8589ee382143057f391f9cc0f401641c559c5117
 authors=nickbeddows-ctrl

--- a/plugins/claude-osrs
+++ b/plugins/claude-osrs
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/claude-osrs-plugin.git
-commit=79fda2215b9c05a0e044a5caeab0f5152b1ceaf5
+commit=ffe1cfcf0ca0777d98887416ded2e556f3e3bc7c
 authors=nickbeddows-ctrl

--- a/plugins/claude-osrs
+++ b/plugins/claude-osrs
@@ -1,3 +1,0 @@
-repository=https://github.com/nickbeddows-ctrl/claude-osrs-plugin.git
-commit=441d272498a8795c07a165b645b79173ee4bfe1d
-authors=nickbeddows-ctrl

--- a/plugins/claude-osrs
+++ b/plugins/claude-osrs
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/claude-osrs-plugin.git
-commit=c47af9436823f527dc2b6b6b809defeb689ece31
+commit=441d272498a8795c07a165b645b79173ee4bfe1d
 authors=nickbeddows-ctrl

--- a/plugins/claude-osrs
+++ b/plugins/claude-osrs
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/claude-osrs-plugin.git
-commit=be431daea89db5d4d8a504fb214ae28e183d2ea1
+commit=c47af9436823f527dc2b6b6b809defeb689ece31
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=34fd501133820297ab517a34f24e165e08091157
+commit=3073393e43ba36e7c8d4e3a50c7d634e70f746fb
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=a708cc0d82ae15f3349bdb52ca3c7648bb3f26ed
+commit=856f3df0a5e32d3e80627d165af2d06df232100e
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=c6307566e35d04caa64594805664e7d0f99e0d5e
+commit=7a2e2d90b584033d7d2f6f51c37159e92b7612d5
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=33e8dc3a5378b9a17d9cd625cb9073e37f1f5ac7
+commit=6c36834654a7bc7e44f89148954bb0cc8c6e995a
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=c81b64235a876e0cd61bfd36603b353bf476680f
+commit=cc0ca51b389fede4a7a43f92c997cb00f2697587
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=dfa5dfc5c1f9a90dbfd17efd57047d4d31c7cfad
+commit=847f808a3dc6a7c8b469c4ec96e18655c2646fe8
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=f462d9ea8e39e03eb68360f590df62b971e032e9
+commit=057ef97f219a7b8ad2825e6b164100072f8cfeba
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=9b7eea91d1d7ceec7e892f6d9a09d7f1cbac8a1a
+commit=5f26601cb710858c7d2c3b6856d84d544a5a156c
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=3073393e43ba36e7c8d4e3a50c7d634e70f746fb
+commit=73bd0b7f36cef4d33e5e1c99d62a576d7e39d0c5
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=cc0ca51b389fede4a7a43f92c997cb00f2697587
+commit=b456e887f1d74c314b5b172cf7e10559301c0767
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=41e0e6d00b8b085d9ebbecbb9d9f7932a2dfd422
+commit=f323c86a41b65267a619d07f7597deda483f191e
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=f323c86a41b65267a619d07f7597deda483f191e
+commit=7632cfe79dae5c98111cca547c1fab2f743a53b5
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=856f3df0a5e32d3e80627d165af2d06df232100e
+commit=5ff28a520081628067b096fdf399a90e4ba02f44
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=97e8e9f041f3a3c2c4928963800681890ce1f60c
+commit=34fd501133820297ab517a34f24e165e08091157
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=3c8cf6375c59d979f066e3a5e11dd6858aefe236
+commit=c81b64235a876e0cd61bfd36603b353bf476680f
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=1edbb56408be913b54275a73e7c7d2ce774005e7
+commit=860511f6718c16e4e5ee751faf0e268d2919691c
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=d9e746b0bb8bd1831d0b049d5c006863224cf299
+commit=03ada7024f31477cf1691a76afd7954bbacdc8ff
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=48ca9216033eaaf625f37bb08cdaebc4c09ed2f4
+commit=9b7eea91d1d7ceec7e892f6d9a09d7f1cbac8a1a
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=847f808a3dc6a7c8b469c4ec96e18655c2646fe8
+commit=33e8dc3a5378b9a17d9cd625cb9073e37f1f5ac7
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=03ada7024f31477cf1691a76afd7954bbacdc8ff
+commit=8582db20cb0482fcfdec219c3b4c0847c15ebecf
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=7a2e2d90b584033d7d2f6f51c37159e92b7612d5
+commit=f218354049d85f5f1c79cb7e890b509c2577c933
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=8582db20cb0482fcfdec219c3b4c0847c15ebecf
+commit=b58beffbbfa185814828e9dac09fb2e05f8ab48d
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=f218354049d85f5f1c79cb7e890b509c2577c933
+commit=d75bf2e11ee178169810a8a0b3812d9afdeb24be
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=0bd6c0af76a42c4fab1dd9ae1c8ea7edda6c4fd7
+commit=bc7b4f0894cf93c8d6d35bf560395e0684c2c090
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,0 +1,3 @@
+repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
+commit=2ad8697ee1b1e00c106f735b9e9904c8604b0117
+authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=860511f6718c16e4e5ee751faf0e268d2919691c
+commit=a88ba7167f0dda8a0d676593ca71b0e7b0acc331
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=5f26601cb710858c7d2c3b6856d84d544a5a156c
+commit=41e0e6d00b8b085d9ebbecbb9d9f7932a2dfd422
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=5ff28a520081628067b096fdf399a90e4ba02f44
+commit=97e8e9f041f3a3c2c4928963800681890ce1f60c
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=bbe008d58dcf61ff4ba71a216d93678f6677dc4c
+commit=a708cc0d82ae15f3349bdb52ca3c7648bb3f26ed
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=a8c73beadd0cc97ce74897aec23bf74d684d11fc
+commit=d9e746b0bb8bd1831d0b049d5c006863224cf299
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=c1e167c8acedc83e2f00436670227e716118d54d
+commit=f462d9ea8e39e03eb68360f590df62b971e032e9
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=2e02b7cb0ee20286c07cf360a8d2e2ce40e4c6f5
+commit=c1e167c8acedc83e2f00436670227e716118d54d
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=4dd62df2e9abfa4b37c506d8327a30c5f90650b1
+commit=dfa5dfc5c1f9a90dbfd17efd57047d4d31c7cfad
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=90e8595415290e527fc64ede8f497f8de86283c1
+commit=2e02b7cb0ee20286c07cf360a8d2e2ce40e4c6f5
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=057ef97f219a7b8ad2825e6b164100072f8cfeba
+commit=4dd62df2e9abfa4b37c506d8327a30c5f90650b1
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=b456e887f1d74c314b5b172cf7e10559301c0767
+commit=0bd6c0af76a42c4fab1dd9ae1c8ea7edda6c4fd7
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=6c36834654a7bc7e44f89148954bb0cc8c6e995a
+commit=3c8cf6375c59d979f066e3a5e11dd6858aefe236
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=7c4f4d7c7c6dfe0f0399800d38b34cea49e2f9f9
+commit=a8c73beadd0cc97ce74897aec23bf74d684d11fc
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=ca65f3e512b5358cac7a44258cb6f99a561d145e
+commit=bbe008d58dcf61ff4ba71a216d93678f6677dc4c
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=8263ca10ea334b39511dda3eb066093ee5fd5db7
+commit=90e8595415290e527fc64ede8f497f8de86283c1
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=a88ba7167f0dda8a0d676593ca71b0e7b0acc331
+commit=7c4f4d7c7c6dfe0f0399800d38b34cea49e2f9f9
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=afd7a1c264d3ca27d3cce99d568a4786672d35e2
+commit=ca65f3e512b5358cac7a44258cb6f99a561d145e
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=bc7b4f0894cf93c8d6d35bf560395e0684c2c090
+commit=c6307566e35d04caa64594805664e7d0f99e0d5e
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=b58beffbbfa185814828e9dac09fb2e05f8ab48d
+commit=2deb0034fdba7517ed25c38fa998e0fd8e012700
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=2ad8697ee1b1e00c106f735b9e9904c8604b0117
+commit=48ca9216033eaaf625f37bb08cdaebc4c09ed2f4
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=7632cfe79dae5c98111cca547c1fab2f743a53b5
+commit=afd7a1c264d3ca27d3cce99d568a4786672d35e2
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=d75bf2e11ee178169810a8a0b3812d9afdeb24be
+commit=1edbb56408be913b54275a73e7c7d2ce774005e7
 authors=nickbeddows-ctrl

--- a/plugins/osrs-mcp
+++ b/plugins/osrs-mcp
@@ -1,3 +1,3 @@
 repository=https://github.com/nickbeddows-ctrl/osrs-mcp-plugin.git
-commit=73bd0b7f36cef4d33e5e1c99d62a576d7e39d0c5
+commit=8263ca10ea334b39511dda3eb066093ee5fd5db7
 authors=nickbeddows-ctrl


### PR DESCRIPTION
## OSRS MCP

Exposes RuneLite client data via a local MCP (Model Context Protocol) server, letting any MCP-compatible AI assistant see your stats, gear, inventory and location to give context-aware in-game advice.

> Originally built with Claude AI in mind, but MCP is an open standard — any MCP-compatible assistant can connect to it.

### How it works
- Plugin starts a local HTTP MCP server on `127.0.0.1:8282`
- AI tools connect via `mcp-remote` as a stdio bridge
- Three connection modes: **Local** (same machine), **LAN** (same network), **Cloud relay** (any network, no extra software)

### Tools exposed
- `get_all` — all player data in one call
- `get_player_stats` — skill levels, XP, XP to next level, combat level
- `get_equipment` — equipped items by slot
- `get_inventory` — inventory contents and quantities
- `get_location` — world coordinates and area name

### Privacy
- Server only binds to `127.0.0.1` by default (never exposed externally)
- Per-toggle controls for stats, equipment, inventory, location, and username
- Optional auth token for LAN and cloud relay setups
- Read-only — never sends commands to the game

### Connection modes
- **Local** — same machine, default, no config needed beyond the basic setup
- **LAN** — devices on the same subnet; plugin detects and displays the local IP automatically
- **Cloud relay** — SSH tunnel via serveo.net (SSH is built into macOS and Windows 10+); guided setup flow built into the plugin panel

### Setup
See the plugin panel or README for full setup instructions including Claude Desktop, Cursor, Windsurf, and generic MCP config.