### PR TITLE
Add clan-promotion-tracker plugin marker

### DIFF
--- a/plugins/clan-promotion-tracker
+++ b/plugins/clan-promotion-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/nlobdell/clan-promotion-tracker.git
-commit=0847777e67d414ba2bd2f6bb146f194858d95df2
+commit=6cb91afed48446118df43b154c78f5957bfe9a35
 warning=This plugin sends clan member usernames and join-date-based queries to the Wise Old Man API to calculate promotion recommendations.

--- a/plugins/clan-promotion-tracker
+++ b/plugins/clan-promotion-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/nlobdell/clan-promotion-tracker.git
-commit=5ac42503e94b618e2a09822a2ba588b3a6f47a94
+commit=083d0e42f413e88b8719199485c0562cfa0b367f
 warning=This plugin sends clan member usernames and join-date-based queries to the Wise Old Man API to calculate promotion recommendations.

--- a/plugins/clan-promotion-tracker
+++ b/plugins/clan-promotion-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/nlobdell/clan-promotion-tracker.git
-commit=083d0e42f413e88b8719199485c0562cfa0b367f
+commit=0847777e67d414ba2bd2f6bb146f194858d95df2
 warning=This plugin sends clan member usernames and join-date-based queries to the Wise Old Man API to calculate promotion recommendations.

--- a/plugins/clan-promotion-tracker
+++ b/plugins/clan-promotion-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/nlobdell/clan-promotion-tracker.git
+commit=5ac42503e94b618e2a09822a2ba588b3a6f47a94
+warning=This plugin sends clan member usernames and join-date-based queries to the Wise Old Man API to calculate promotion recommendations.

--- a/plugins/clan-promotion-tracker
+++ b/plugins/clan-promotion-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/nlobdell/clan-promotion-tracker.git
 commit=6cb91afed48446118df43b154c78f5957bfe9a35
-warning=This plugin sends clan member usernames and join-date-based queries to the Wise Old Man API to calculate promotion recommendations.
+warning=This plugin submits your IP address and clan member RSNs to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds a new Plugin Hub marker for Clan Promotion Tracker.

- repository: https://github.com/nlobdell/clan-promotion-tracker.git
- commit: 6cb91afed48446118df43b154c78f5957bfe9a35
- warning: includes WOM external API usage note

This PR only adds plugins/clan-promotion-tracker.