### PR TITLE
Update protect-item-notifier to 1.0.0

### DIFF
--- a/plugins/protect-item-notifier
+++ b/plugins/protect-item-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/cubeee/protect-item-notify.git
-commit=912fad3b020a2af22f8230d7c6934ffc401ca327
+commit=20271a6fa8c5e4750654adf0932251a706c988c3


### PR DESCRIPTION
* Update support url to point to new repo
* New option for hiding icon on high risk worlds
* Fix the issues reported in the original repo:
  * scaling is now limited to client size, no more limitless scaling that causes OOM
  * icon is no longer shown in safe pvp