### PR TITLE
Create no-misclick-repot

### DIFF
--- a/plugins/no-misclick-repot
+++ b/plugins/no-misclick-repot
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/example-plugin.git
-commit=90ed1bc62ca282001be9150287fe83b7c9f46810
+commit=6c5a3c492a77c781f022bb8fdf0fc5a015dc8199

--- a/plugins/no-misclick-repot
+++ b/plugins/no-misclick-repot
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/example-plugin.git
-commit=edc543684501bd2b39a390a203d4860ea43a0832
+commit=90ed1bc62ca282001be9150287fe83b7c9f46810

--- a/plugins/no-misclick-repot
+++ b/plugins/no-misclick-repot
@@ -1,0 +1,2 @@
+repository=https://github.com/bopsec/example-plugin.git
+commit=edc543684501bd2b39a390a203d4860ea43a0832


### PR DESCRIPTION
Inserts a no-op "Waiting..." option to the top of the menuoption of potion items when you are still under the effect of the potion.
![img](https://i.imgur.com/SzGjNVB.gif)
Can still right click sip if needed, with customizable repot time (in ticks) when the menuoption is no longer deprioritized.
Shift click drop will also still work, it is only if "Drink" (or "Eat", but currently unused) is the top option.
Reducing your stats to below the boost threshold will also allow you to left click drink again.


Currently supports
- Divine potions (not all of them)
- Prayer regen
- Goading
- Antipoison/Venom
- CoX Overload and Enhance
- ToA Salt and Liquid adrenaline