### PR TITLE
add extra-wiki-links

### DIFF
--- a/plugins/extra-wiki-links
+++ b/plugins/extra-wiki-links
@@ -1,2 +1,2 @@
 repository=https://github.com/iskela45/runelite-extra-wiki-links.git
-commit=c7a56a72244a67388d027a64bbcf06961d824205
+commit=cf374863e64e829b976c12e22e41408c2bf593ed

--- a/plugins/extra-wiki-links
+++ b/plugins/extra-wiki-links
@@ -1,0 +1,2 @@
+repository=https://github.com/iskela45/runelite-extra-wiki-links.git
+commit=c7a56a72244a67388d027a64bbcf06961d824205

--- a/plugins/extra-wiki-links
+++ b/plugins/extra-wiki-links
@@ -1,2 +1,2 @@
 repository=https://github.com/iskela45/runelite-extra-wiki-links.git
-commit=cf374863e64e829b976c12e22e41408c2bf593ed
+commit=9b113a9a16617a91586e4f8877b19c8826fccf67


### PR DESCRIPTION
Adds right-click wiki links on skills in the skills tab. Link options as of now are level-up table, temporary boosts, quests, and training guides for members, F2P, ironman, and UIM accounts.  

Each link type is individually toggleable in the plugin's settings.  


<img width="284" height="230" alt="Kuvakaappaus_20260410_172535" src="https://github.com/user-attachments/assets/b390f8a6-fbc3-4ee0-9499-adf23e7a3154" />
