### PR TITLE
Add camera presets plugin

### DIFF
--- a/plugins/camera-presets
+++ b/plugins/camera-presets
@@ -1,0 +1,2 @@
+repository = https://github.com/Bulqe/runelite-osrs-camera-presets-plugin.git
+commit = b6da8bc3ef67bb371b0c3311fca9e9326e1bd9c


### PR DESCRIPTION
Adds a camera preset plugin for RuneLite.

Features:
- Save named camera presets
- Apply presets back to the camera
- Per-preset toggles for zoom, tilt, and angle
- Duplicate, delete, and reorder presets
- Per-preset hotkeys
- Smooth camera transitions

This plugin is a sidebar utility only and does not automate gameplay.
