### PR TITLE
Update gim hub to 1.5.0

### DIFF
--- a/plugins/gim-hub
+++ b/plugins/gim-hub
@@ -1,4 +1,4 @@
 repository=https://github.com/wouterrutgers/gim-hub-plugin.git
-commit=ca95ab30b9edb106dfb7bd793e245e2ca4158abe
+commit=394302f052b5a459a3a189ce16d992deb19032fd
 authors=wouterrutgers,EllarBooher
 warning=This plugin sends your player data (including your items, world map location, xp values, collection log information), and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This plugin didn't send any data for for seasonal events, but we wanted to include it this time.

The GIM Hub frontend will be updated with a button to swap between normal data and leagues data. I'll release that update on Wednesday or right after this version gets merged.