### PR TITLE
Add the new party-link plugin

### DIFF
--- a/plugins/party-link
+++ b/plugins/party-link
@@ -1,0 +1,2 @@
+repository=https://github.com/HavardPede/party-link.git
+commit=3b60aba29b2ff3c57b8c357d37a98663bd57a7cc

--- a/plugins/party-link
+++ b/plugins/party-link
@@ -1,2 +1,2 @@
 repository=https://github.com/HavardPede/party-link.git
-commit=3b60aba29b2ff3c57b8c357d37a98663bd57a7cc
+commit=de729a81255179b1678033a062e3050de4353de6


### PR DESCRIPTION
 ## Party Link — remote party control

  link: https://github.com/HavardPede/party-link

  ### What is this?

  A Plugin Hub plugin that connects RuneLite to an external server over a persistent WebSocket connection for remote party management.

  The player pairs once with a server URL and a one-time code. After that, the plugin authenticates automatically on login, identifies the player's RSN to the server, and receives commands in real time:

  - **JOIN_PARTY** — sends an in-game invitation. The player must type `::join` to accept.
  - **LEAVE_PARTY** — removes them from their current party automatically.
  - **ROLE_CHANGE** — displays a role notification.

  Each command is acknowledged after execution. That is the full scope.

  ### Why?

  Finding the right group for PvM content is clunky. You juggle Discord, manually shared passphrases, and someone always joins the wrong party.

  Imagine you want to run Theatre of Blood. You open [potionstorage.com](https://potionstorage.com), find a group that needs a mage, and join the listing. Once the group is full, the site pushes a JOIN_PARTY to everyone's client. Each player sees:

  > You have been invited to join a party as mage. Type ::join to accept.

  One command, and the whole group is in the same RuneLite party. When the raid is over and the group disbands on the site, the plugin leaves the party automatically so no one lingers in a dead session. The site knows which player is which because the plugin reports their RSN after pairing — no manual name entry needed.

  That is what this plugin enables: external tools handle discovery and matchmaking, Party Link handles the bridge into RuneLite.

  ### A note on automatic leaving

  Joining requires explicit player action (`::join`), but leaving is automatic when the server sends LEAVE_PARTY, for example when a group disbands or a player is removed from a listing. Leaving reduces server load rather than adding to it and prevents stale sessions from lingering. Happy to hear if the team would prefer confirmation here as well.

  ### Server-agnostic

  The plugin speaks an open WebSocket protocol documented in [docs/protocol.md](docs/protocol.md). Any server can implement it. A live reference implementation is available at [potionstorage.com](https://potionstorage.com).

  ### Potential future addition: world reporting

  Having the plugin report the player's current world would let a site show "join X's party — world 302" without the player saying it manually. I held off because world information can be used to locate players for PK-ing. Reporting it to a server the player has explicitly paired with feels different from broadcasting it publicly, but I wanted to flag it rather than ship it quietly.
