### PR TITLE
Add Looting Bag Stored XP plugin

### DIFF
--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=c1b0312a16c90bac92aaff17376605b3d0aa94c0
+commit=2961b9bb2488923f74f3ca5d578baa8cbbf0ecd6
 authors=ZNPKOH

--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=513dab9030a7ad7feee70f77495bef710caa4db0
+commit=b7a495e75f11bcc9793aebad473c8e329c5030ef
 authors=ZNPKOH

--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,0 +1,3 @@
+repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
+commit=c1b0312a16c90bac92aaff17376605b3d0aa94c0
+authors=ZNPKOH

--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=2961b9bb2488923f74f3ca5d578baa8cbbf0ecd6
+commit=513dab9030a7ad7feee70f77495bef710caa4db0
 authors=ZNPKOH


### PR DESCRIPTION
## Looting Bag Stored XP

A plugin for UIM (Ultimate Ironman) players that tracks potential XP stored in their Looting Bag.

### Features
- **Herblore XP tracking** — calculates cleaning + potion-making XP for all herbs in the bag
- **Potion selector** — choose target potion per herb (e.g., Prayer potion vs Defence potion from Ranarr)
- **Vials of water tracking** — shows how many vials you have vs need
- **Secondary ingredient tracking** — shows availability of secondaries
- **In-game overlay** — compact XP totals overlay
- **Side panel** — detailed breakdown per herb with combo box selector

### Why
UIM players can't bank, so the Looting Bag is one of the few storage options. Planning Herblore training requires knowing exactly what XP is available across all stored herbs and whether you have the right secondaries.

### Repository
https://github.com/ZNPKOH/looting-bag-stored-xp