### PR TITLE
Update npc-max-hit plugin to 1.3.1

### DIFF
--- a/plugins/npc-max-hit
+++ b/plugins/npc-max-hit
@@ -1,2 +1,2 @@
 repository=https://github.com/hirzalla/npc-max-hit.git
-commit=4993e6cd3e6b40aa7c71ee1776331b78a9724db4
+commit=31727477fa4d047a79bcb16ba2894dc82b0b69a3


### PR DESCRIPTION
changes  `showInMenu`  config item default `false` -> `true`