### PR TITLE
Update compact-orbs to v1.7.6

### DIFF
--- a/plugins/compact-orbs
+++ b/plugins/compact-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/its-cue/compact-orbs.git
-commit=98be9fd82434dde56100134d06a7b2d5d1ac5b5d
+commit=79f50fd7c333e7b150ea2b79d7dfb08082d2a345


### PR DESCRIPTION
- remove handling for the Wiki plugin button visibility
- fix conflict between `Hide Wiki banner` & Wiki plugin button
- fix incorrect Store/Activity/Wiki/World map positions when in fixed mode
- fix slot ordering not accounting for orbs hidden by in-game settings
- fix incorrect script id for TOPLEVEL_SUBCHANGE (logout x)
- remove unused methods/variables