### PR TITLE
Add gielinor-dailies plugin

### DIFF
--- a/plugins/gielinor-dailies
+++ b/plugins/gielinor-dailies
@@ -1,0 +1,2 @@
+repository=https://github.com/nativvstudios/gielinor-dailies-plugin.git
+commit=7c844c4f3e9a3024cf8197b21eda0be3cbcb7a75

--- a/plugins/gielinor-dailies
+++ b/plugins/gielinor-dailies
@@ -1,2 +1,2 @@
 repository=https://github.com/nativvstudios/gielinor-dailies-plugin.git
-commit=7c844c4f3e9a3024cf8197b21eda0be3cbcb7a75
+commit=928f2f300b3d22ed43d3e580beeee4393a95437e

--- a/plugins/gielinor-dailies
+++ b/plugins/gielinor-dailies
@@ -1,2 +1,3 @@
 repository=https://github.com/nativvstudios/gielinor-dailies-plugin.git
 commit=928f2f300b3d22ed43d3e580beeee4393a95437e
+warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Gielinor Dailies

A RuneLite plugin that syncs your OSRS stats, XP gains, boss kills, and quest progress with your [Gielinor Dailies](https://gielinordailies.com) dashboard for task tracking and planning.

### Features
- Automatically pushes skill levels, XP gains, and boss KC to your Gielinor Dailies account
- Tracks quest state changes and syncs progress
- In-game overlay showing daily/weekly tasks with progress
- Sidebar panel with task management, priority indicators, and announcements
- Visual and audio task completion celebrations

### How it works
Users create an account at gielinordailies.com, add their OSRS character, generate an API token, and enter it in the plugin config. The plugin matches their RSN on login and begins syncing. All data is pushed to the user's own authenticated account via Bearer token — no data is shared or exposed publicly.

### Dependencies
No additional dependencies
