### PR TITLE
Update world-recolor to 1.1.1

### DIFF
--- a/plugins/world-recolor
+++ b/plugins/world-recolor
@@ -1,2 +1,2 @@
 repository=https://github.com/cubeee/world-recolor.git
-commit=26d2ceabc226fa607df138ad8f18e7cbb01daa3f
+commit=1f88a9af3e9b2bbbcc6f6bd498276298b8529fe4


### PR DESCRIPTION
* Add fault tolerancy to region id parsing. Could cause plugin to not start and even hid it from the plugin list
* Apply tile recoloring to bridge tiles