### PR TITLE
Add Heal Splats plugin

### DIFF
--- a/plugins/heal-splats
+++ b/plugins/heal-splats
@@ -1,2 +1,2 @@
 repository=https://github.com/MarcusCasey/heal-splats.git
-commit=e21023adfc90b2e1c9f55c66646d491afad46191
+commit=3e62a7971208bd8359b3ff034fa2e4f5b84e7ae6

--- a/plugins/heal-splats
+++ b/plugins/heal-splats
@@ -1,0 +1,2 @@
+repository=https://github.com/MarcusCasey/heal-splats.git
+commit=e21023adfc90b2e1c9f55c66646d491afad46191


### PR DESCRIPTION
Heal Splats is a new external plugin that renders a hitsplat on the local player whenever they eat food or drink a healing potion, showing the exact amount of HP actually recovered that tick. There is one similar plugin, however it no longer functions and is being designed passed the scope of only being a hp healing only plugin, this serves as a lightweight addition for those seeking only hp restoring items.
                                                                                                                                                                                                                 
Unlike the food item's listed heal value, the splat reflects the true gain — so eating at near-full HP correctly shows the smaller number. The splat is anchored to the player's mid-body and tracks their position, matching the visual style of the game's existing damage hitsplats.                                                                                  
                                                            
All visual properties are configurable via the plugin panel: outer ring colour, centre fill colour, shine highlight colour (all as hex codes), and display duration (1–10 seconds).                            
                                                            
Triggers on: Eat and Drink menu clicks, covering all food and healing potions including Saradomin brew.                                                                                                        
                                                            
Known non-triggers: Phoenix necklace, Locator orb, Guthan's passive regen — anything that heals without a direct menu click.                                                                                   
                                                            