### PR TITLE
Update forestry-spawn-helper to 1.0.3

### DIFF
--- a/plugins/forestry-spawn-helper
+++ b/plugins/forestry-spawn-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Oelderoth/forestry-force-spawn-plugin.git
-commit=ced97352c86684554d1dfc1ad5f5d4cf0e38f3d9
+commit=d2e44d15c01e25ce0586c716c7bb4dff77d14b96


### PR DESCRIPTION
Updating Forestry Spawn Helper to 1.0.3

Changes:
- Adding support for detecting and tracking Camphor, Ironwood, and Rosewood trees
