### PR TITLE
Update dont-telegrab-npcs to v1.0.4

### DIFF
--- a/plugins/dont-telegrab-npcs
+++ b/plugins/dont-telegrab-npcs
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/dont-telekinetic-grab-npcs.git
-commit=80de1186c81a27cb1f5bbb760daa6551408859d4
+commit=426e70d5fdf3201e0a32b58397527b9b52dcf3a0


### PR DESCRIPTION
Add veiled krakens to default whitelist (1 line change)