### PR TITLE
Update chat-name-colors

### DIFF
--- a/plugins/chat-name-colors
+++ b/plugins/chat-name-colors
@@ -1,3 +1,3 @@
 repository=https://github.com/rsbfox/beaglebreath-chat-name-colors.git
-commit=9c9e4ad1a728047015229b722457a878de0fcbf8
+commit=6daf520c131cb77fa73ba185bada430ad187f9f0
 authors=rsbfox,BagleBreath


### PR DESCRIPTION
Fix: Your Name Color

Was not working for a specific user. Changed it to match check in ChatNotificationsPlugin