### PR TITLE
update tasks-tracker plugin for league 6 dbrow support

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=6d13289c913cf3a8e18e339a6489342d1ba8439d
+commit=ae96e136b01abffd566cfe2a4441f9062006576e
 authors=tylerthardy,JamesShelton140


### PR DESCRIPTION
## Summary

Adds `TaskSourceType` (`STRUCT`/`DBROW`) so tasks can be loaded from cache DB rows, not just structs. Needed because Jagex is moving L6 onto DB tables.

## Changes

**Core**
- `TaskSourceType` enum discriminator on task types
- `TaskFromDbRow` reads columns via `client.getDBTableField(dbRowId, colIdx, 0)`; `intParamMap`/`stringParamMap` values are column indices in this mode
- `ITask` interface; `TaskService` branches on source type
- `TaskFromDbRow.getVarpIndex()` returns `sortId` (matches cs2's flat-index completion convention)

**Safety fixes exposed by the new path**
- `TaskFromDbRow.loadData`: per-column try/catch. Sparse columns throw when queried on rows without them; previously one bad column killed the task load and cascaded to a type-switch failure.
- `processTaskStatus`: bounds-check `taskVarps.get(varbitIndex)` before `getVarpValue`. Prevents per-tick IOOB when sortIds exceed the varp range.
- `addSortedIndex` comparators: null int params coerce to 0, strings use `nullsLast`. Without this, sort throws mid-`thenCompose` and `taskTypeChanged=true` never fires - tasks load but panel never redraws.
- `getTaskIndex`: null-guarded. `containsKey` doesn't protect against a null *value*, and `addSortedIndex`'s put-null-then-replace race can strand a null if the sort throws.
- `TaskPanel`: null-guard `task.getDescription()` so missing descriptions render empty instead of "null".

**Pre-existing bug uncovered**
- `FilterService.getGlobalFilterByKey` does blocking HTTP on first call. Previously masked because every task type had `GLOBAL` filters, so `startUp()`'s off-EDT `setTaskType` always warmed the cache. A task type with empty filters leaves it cold; next EDT-driven switch to a type with GLOBAL filters throws `Blocking network calls are not allowed on the event dispatch thread` and NPEs on the null return.
- Added `FilterService.preloadFilterConfigs()` called from `startUp()` via `runAsync`, independent of saved task type.
- `setTaskType` null-guards `globalFilterConfig` as a belt-and-braces for preload failure.