### PR TITLE
Add LeaguesSync plugin

### DIFF
--- a/plugins/leaguessync
+++ b/plugins/leaguessync
@@ -1,3 +1,3 @@
-repository=https://github.com/RPBTwisted/leaguessync
+repository=https://github.com/RPBTwisted/leaguessync.git
 commit=dc68167252899f4fe4939b076e57d075365b38cd
 warning=This plugin submits your username and completed task IDs to a 3rd-party server (osrsleaguetracker.com) not controlled or verified by RuneLite developers.

--- a/plugins/leaguessync
+++ b/plugins/leaguessync
@@ -1,3 +1,3 @@
 repository=https://github.com/RPBTwisted/leaguessync.git
-commit=dc68167252899f4fe4939b076e57d075365b38cd
+commit=0356f1fc22a479f38441169d31dab7ed943f5b8b
 warning=This plugin submits your username and completed task IDs to a 3rd-party server (osrsleaguetracker.com) not controlled or verified by RuneLite developers.

--- a/plugins/leaguessync
+++ b/plugins/leaguessync
@@ -1,0 +1,3 @@
+repository=https://github.com/RPBTwisted/leaguessync
+commit=dc68167252899f4fe4939b076e57d075365b38cd
+warning=This plugin submits your username and completed task IDs to a 3rd-party server (osrsleaguetracker.com) not controlled or verified by RuneLite developers.

--- a/plugins/leaguessync
+++ b/plugins/leaguessync
@@ -1,3 +1,3 @@
 repository=https://github.com/RPBTwisted/leaguessync.git
 commit=0356f1fc22a479f38441169d31dab7ed943f5b8b
-warning=This plugin submits your username and completed task IDs to a 3rd-party server (osrsleaguetracker.com) not controlled or verified by RuneLite developers.
+warning=This plugin submits your IP address, username and completed task IDs to a 3rd-party server (osrsleaguetracker.com) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## LeaguesSync

Syncs Demonic Pacts League task completion to a personal task tracker at [osrsleaguetracker.com](https://osrsleaguetracker.com).

## What data is sent

On a 30-second interval (only while logged in), the plugin reads completed league task IDs from the game client and POSTs the following to `osrsleaguetracker.com`:

```json
{
  "league_tasks": [0, 1, 2, ...]
}
```

The endpoint is `POST /sync/{username}` where `{username}` is the local player's display name — the same name already visible on the account.

No passwords, no IP addresses, no chat, no inventory — only the username and the set of completed task IDs.

## Server source

The server is open source and included in the same repository:
https://github.com/RPBTwisted/leaguessync/blob/main/server/main.py

It stores only username, completed task IDs, and a last-sync timestamp. No other data is persisted.

## Warning line

A `warning=` line is included in the plugin entry acknowledging the third-party server.

## Plugin repository

https://github.com/RPBTwisted/leaguessync