### PR TITLE
fix: reset Mark of Darkness reminder on player death (#17)

### DIFF
--- a/plugins/markofdarknesshelper
+++ b/plugins/markofdarknesshelper
@@ -1,3 +1,3 @@
 repository=https://github.com/Nick2bad4u/MarkOfDarknessHelper.git
-commit=c92e8aa672e8a1cb29d3e79492f83227de60f62f
+commit=3fcb1efca9c057694ea4759797c8a6a603cb06fd
 authors=nick2bad4u, salverrs


### PR DESCRIPTION
fix: reset Mark of Darkness reminder on player death (#17)

The buff is lost when the player dies, but the timer continued
counting down without showing the recast reminder. 

- Track whether the Mark of Darkness buff is active via `isMarkActive`
  in the overlay
- Add `resetOnDeath()` to the overlay which immediately triggers the
  recast reminder if the buff was active
- Subscribe to `ActorDeath` in the plugin and call `resetOnDeath()`
  when the local player dies