### PR TITLE
Update tasks-tracker post league release (& add author)

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=ae96e136b01abffd566cfe2a4441f9062006576e
-authors=tylerthardy,JamesShelton140
+commit=5a3d5f2616aa5b21a94eafa6901682a0fce33eac
+authors=tylerthardy,perterter,JamesShelton140


### PR DESCRIPTION
Fixes in this PR:
- Allow users to delete task from a route
- Fixed League 6 task data export

_**Added my OSRS GitHub account so I can PR from that instead.**_
I'm removing this one from the authors in the next PR. I'll also post in Discord to make aware. Please let me know if it's an issue.