### PR TITLE
Add Demonic Pacts League Task Highlighter

### DIFF
--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
+commit=932d479f23c1f64acb4c929ec1016821a5acbb91

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=932d479f23c1f64acb4c929ec1016821a5acbb91
+commit=5288d09506b9d67b81724051d3d162e73558a278

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=5288d09506b9d67b81724051d3d162e73558a278
+commit=b7b4151d09183e703f2dde8f23842a939301f4bf

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=4510efd8f69a2f27562fe634fe19301f4dd44f60
+commit=17db1ea42a57205c501a3dbebdb13348a0193005

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=b7b4151d09183e703f2dde8f23842a939301f4bf
+commit=4510efd8f69a2f27562fe634fe19301f4dd44f60


### PR DESCRIPTION
Plugin: Demonic Pacts League Task Highlighter
Highlights in-game NPCs, items, and ground objects that are related to Demonic Pacts League tasks. Designed to help players quickly identify task targets while playing the league without constantly tabbing out to the wiki.
Features:

NPC overlays — colored convex hulls around task-target NPCs with difficulty labels
Item overlays — colored borders on task-related items in inventory, bank, and equipment
Ground item overlays — tile highlights and labels for task items on the ground
Rich hover tooltips showing task name, description, points, area, skill/quest requirements, and quantity needed
Color-coded by difficulty tier (Easy/Medium/Hard/Elite/Master)
Fully configurable — toggle each overlay type, tooltip fields, colors, and border width independently

Task coverage: 200+ matchable tasks from the wiki including defeat NPC, equip item, craft/create, fishing, mining, woodcutting, cooking, herblore, and boss/raid tasks across all league areas.
Source: https://github.com/SolutionsCMD/demonic-pacts-highlighter