### PR TITLE
Update `hunter-rumours` to `1.3.8`

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,3 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=47db8fa1d95057981bc969a320feb080c88c71e7
+commit=277dc2e3c80884894d7480e382a64997af200770
 authors=geel9,DapperMickie


### PR DESCRIPTION
- Fixes previous fix, which did not account for the Woodsman relic's additional 2x xp