### PR TITLE
Add transmute-hider plugin repository information

### DIFF
--- a/plugins/transmute-hider
+++ b/plugins/transmute-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/Robbejj/transmute-hider.git
+commit=1db783c01f2920813f082177574a9288ff1715b1


### PR DESCRIPTION
Simple plugin that hides the annoying visual effects of the Transmute relic in Leagues VI