### PR TITLE
update brimhaven-agility to 1.4.0

### DIFF
--- a/plugins/brimhaven-agility
+++ b/plugins/brimhaven-agility
@@ -1,2 +1,2 @@
 repository=https://github.com/kagof/rl-plugin-brimhaven-agility.git
-commit=974064d75630402e170de9f5e04d422d88c5d101
+commit=ef961b044c94888595c85edc70d8c0c37631a305


### PR DESCRIPTION
* new configurable feature - removing the hint arrow once the ticket has been claimed

This can be added now as runelite v1.12.24 contains this change https://github.com/runelite/runelite/pull/19407 which previously prevented it, as it slightly broke a feature in the bundled Agility plugin.