### PR TITLE
Update tzhaar-hp-tracker

### DIFF
--- a/plugins/tzhaar-hp-tracker
+++ b/plugins/tzhaar-hp-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/buchus-plugins.git
-commit=6dedc706f1e6b854796856bd05baf31b52147989
+commit=3e23770fdef96279c9a25b1a0a1dfd37b53961d8


### PR DESCRIPTION
- Fixed HP instantly regenerating if it takes more than 1 minute to damage the NPC
- Count main target dead from the "One bounce" sound on ABA venator stacks, customizable because of potential regens on minos, but this is unlikely, so might remove that in the future
- Added customization for how each mob should be rendered (ref https://github.com/bopsec/buchus-plugins/issues/3 & multiple direct messages on discord)