### PR TITLE
Update demonic-pacts-highlighter

### DIFF
--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=8d4da3c21db856e80f3353341957a86d83a4b38f
+commit=bc58e88e13e05ae9f7bb313f6966bd3a034e26fc

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=ed53e714d5abb85931b497afff5e07cc18250f19
+commit=33ffd85de144415a0add99db9342093f17ed9aa7

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=33ffd85de144415a0add99db9342093f17ed9aa7
+commit=8d4da3c21db856e80f3353341957a86d83a4b38f

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=17db1ea42a57205c501a3dbebdb13348a0193005
+commit=ed53e714d5abb85931b497afff5e07cc18250f19


### PR DESCRIPTION
Updated plugin with fixes from review feedback:

- Fixed stacked ground item tooltips — now scans all menu entries on a tile instead of only the top entry
- Added per-account task completion tracking using RSProfile configuration
- Added auto-detection of task completions via game chat messages
- Added right-click "Mark Task Complete" / "Unmark Task Complete" menu entries on highlighted NPCs and items
- Added config section for completion: Hide Completed Tasks, Auto-Detect Completion, Show Completed In Tooltip
- Completion data loads on login and clears on logout, so multiple accounts are tracked independently