### PR TITLE
Create map-of-alacrity

### DIFF
--- a/plugins/map-of-alacrity
+++ b/plugins/map-of-alacrity
@@ -1,0 +1,2 @@
+repository=https://github.com/Sacca-1/map-of-alacrity.git
+commit=bab893c93413141548da32142d98f90013b3d5b2


### PR DESCRIPTION
New plugin which adds markers of the available teleports of the map of alacrity to the world map, and triggers the matching menu actions when the markers are clicked.