### PR TITLE
Add goalplanner

### DIFF
--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-goal-tracker.git
-commit=59b6b82bcc5f66e516bb6f9c3c2f5635eb149843
+commit=7ee1eaac91d58c21b679c2d48e371d69dbd7f6ca

--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,2 @@
-repository=https://github.com/ajkatz/runelite-goal-tracker.git
-commit=7ee1eaac91d58c21b679c2d48e371d69dbd7f6ca
+repository=https://github.com/ajkatz/runelite-goal-planner.git
+commit=f41062307e8db4cc0ae74ec867f7d3cfc15420c2

--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,0 +1,2 @@
+repository=https://github.com/ajkatz/runelite-goal-tracker.git
+commit=59b6b82bcc5f66e516bb6f9c3c2f5635eb149843

--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-goal-planner.git
-commit=f41062307e8db4cc0ae74ec867f7d3cfc15420c2
+commit=ffdd49e66740a6291f04d3881dc0b22ce84f82cb

--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-goal-planner.git
-commit=ffdd49e66740a6291f04d3881dc0b22ce84f82cb
+commit=907c5334f2cb53422b6d81837699e7a07d6ef416

--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-goal-planner.git
-commit=907c5334f2cb53422b6d81837699e7a07d6ef416
+commit=7185659b7a18e6d70ba875bb5e62a1e8818d266d


### PR DESCRIPTION
## Goal Planner

A goal/grind tracker and planner plugin for OSRS with prerequisite graph seeding.

**Source**: https://github.com/ajkatz/runelite-goal-tracker

## What it does

- Track goals across skills, quests, diaries, combat achievements, boss KC, collection log, item/resource grinds, account metrics, and custom goals
- Auto-updates from live game state (XP drops, quest state, varbits/varplayers for diaries and CAs, bank + inventory for item grinds)
- When adding a quest/boss goal, auto-seeds the full prerequisite chain (skill requirements, prior quests, recommended combat level)
- Sections, tags, bulk multi-select actions, undo/redo
- Public Java API so other plugins can query and create goals programmatically

## Note on existing Goal Tracker plugin

There is an existing ``goal-tracker`` plugin by Toofifty. This submission is a separate plugin with a distinct name and scope:
- Toofifty's Goal Tracker: manual goal lists with preset bundles, progress bars, JSON import/export
- Goal Planner (this): auto-tracking from game state + prerequisite graph auto-seeding across all OSRS achievement types, plus a public API for external plugin integration

The positioning is complementary, not competing. Different UX and different target user.

## Known rough edges (to address in a follow-up)

Apologies in advance — a lot of functionality is hidden in right-click menus and context actions in this first release. I'm planning a UX pass in a follow-up to surface the most-used actions more prominently and streamline discoverability. The ``[Experimental v0.1.0]`` tag in the description reflects that this is a first cut.

## Technical notes

- BSD 2-Clause licensed
- JDK 11, no runtime third-party dependencies beyond RuneLite client
- No network calls (except to the OSRS wiki for CA task data caching), no external services, no game-input automation
- Marked ``[Experimental v0.1.0]`` in description - persistence format may change before 1.0