### PR TITLE
Add AFK Sandstone

### DIFF
--- a/plugins/afk-sandstone
+++ b/plugins/afk-sandstone
@@ -1,0 +1,2 @@
+repository=https://github.com/alexandevcom/afk-sandstone.git
+commit=f2a7cdc2046aa1ffc9a50896708516d95846bfa0


### PR DESCRIPTION
Sandstone mining helper for the Desert Quarry. Features:

- Session tracker: live inventory sand yield (1kg=1, 2kg=2, 5kg=4, 10kg=8 buckets), grinder capacity parsed from chat and NPC dialog, sand/hr production rate, and elapsed time
- Idle flash when mining animation stops; full-inventory flash when carrying 28/28
- 3D convex-hull outlines on active sandstone rocks, name-matched so granite and other rocks are ignored

Repo: https://github.com/alexandevcom/afk-sandstone