### PR TITLE
Update tasks-tracker (revert unix fix which actually broke)

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=5b8d99946e4ad4b47e3900171e7b93023d0927e2
-authors=tylerthardy,perterter,JamesShelton140
+commit=5a3d5f2616aa5b21a94eafa6901682a0fce33eac
+authors=perterter,JamesShelton140


### PR DESCRIPTION
Sorry about the rapid fire revert. We recently pushed a fix to help visibility of tooltips on linux & mac, but it broke the usability worse.

Going to get a proper fix and test it thoroughly before sending again. Just need to unbreak unix users...