### PR TITLE
Update `hunter-rumours` to `1.3.9`

### DIFF
--- a/plugins/hunter-rumours
+++ b/plugins/hunter-rumours
@@ -1,3 +1,3 @@
 repository=https://github.com/geel9/runelite-hunter-rumours.git
-commit=277dc2e3c80884894d7480e382a64997af200770
+commit=18c86e968339ad8a53c639391a73ff69d13bc547
 authors=geel9,DapperMickie


### PR DESCRIPTION
- Fixes detection of 12x and 16x XP unlocks
    - The in-game guide is incorrect about the tiers at which these XP multipliers unlock :)
    - Thanks @Robbejj!