### PR TITLE
Add Rune Kite Streak plugin

### DIFF
--- a/plugins/rune-kite-streak
+++ b/plugins/rune-kite-streak
@@ -1,2 +1,2 @@
 repository=https://github.com/anthonyal2k/rune-kite-streak.git
-commit=27660472e0f08ce9e53c0409611f26f6e15d722d
+commit=07ae0414f397aefd3487a1246dd34ff54cabd64d

--- a/plugins/rune-kite-streak
+++ b/plugins/rune-kite-streak
@@ -1,2 +1,2 @@
 repository=https://github.com/anthonyal2k/rune-kite-streak.git
-commit=d097a41d72b4c7abf38a1104b697b08f7bdd4bb4
+commit=ac17194a18f0a43a60eaaa779d32b45ea43f0ddc

--- a/plugins/rune-kite-streak
+++ b/plugins/rune-kite-streak
@@ -1,2 +1,2 @@
 repository=https://github.com/anthonyal2k/rune-kite-streak.git
-commit=ac17194a18f0a43a60eaaa779d32b45ea43f0ddc
+commit=b8eb999db77d474175ea2965c65a01a716e2e394

--- a/plugins/rune-kite-streak
+++ b/plugins/rune-kite-streak
@@ -1,2 +1,2 @@
 repository=https://github.com/anthonyal2k/rune-kite-streak.git
-commit=b8eb999db77d474175ea2965c65a01a716e2e394
+commit=27660472e0f08ce9e53c0409611f26f6e15d722d

--- a/plugins/rune-kite-streak
+++ b/plugins/rune-kite-streak
@@ -1,2 +1,2 @@
-repository=https://github.com/anthonyal2k/rune-kite-streak
+repository=https://github.com/anthonyal2k/rune-kite-streak.git
 commit=d097a41d72b4c7abf38a1104b697b08f7bdd4bb4

--- a/plugins/rune-kite-streak
+++ b/plugins/rune-kite-streak
@@ -1,0 +1,2 @@
+repository=https://github.com/anthonyal2k/rune-kite-streak
+commit=d097a41d72b4c7abf38a1104b697b08f7bdd4bb4

--- a/plugins/rune-kite-streak
+++ b/plugins/rune-kite-streak
@@ -1,2 +1,2 @@
 repository=https://github.com/anthonyal2k/rune-kite-streak.git
-commit=07ae0414f397aefd3487a1246dd34ff54cabd64d
+commit=1a26195b877c877be62a007cf8d6c8cc97bb20fb

--- a/plugins/rune-kite-streak
+++ b/plugins/rune-kite-streak
@@ -1,2 +1,2 @@
 repository=https://github.com/anthonyal2k/rune-kite-streak.git
-commit=1a26195b877c877be62a007cf8d6c8cc97bb20fb
+commit=ad82a518bad9bc92d93684ac69e5e032a3391e17

--- a/plugins/rune-kite-streak
+++ b/plugins/rune-kite-streak
@@ -1,2 +1,2 @@
 repository=https://github.com/anthonyal2k/rune-kite-streak.git
-commit=ad82a518bad9bc92d93684ac69e5e032a3391e17
+commit=6ed1be1b218747b2e25822e3bad5af24d140f642


### PR DESCRIPTION
Adds the Rune Kite Streak plugin, which tracks consecutive Wilderness Agility Course laps that result in a Rune Kiteshield drop.