### PR TITLE
Add Webweaver Swap plugin

### DIFF
--- a/plugins/webweaver-swap
+++ b/plugins/webweaver-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/Ftwpker/webweaver-swap-plugin.git
-commit=9296b988a708e63fb8d56c12894d21d171cfa9a7
+commit=e0d346065c7cc1b8cd10a8e8869f874fb8d7347e

--- a/plugins/webweaver-swap
+++ b/plugins/webweaver-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/Ftwpker/webweaver-swap-plugin.git
-commit=6c6328d5b362569b9d130b01e547c24697dbe9e9
+commit=9296b988a708e63fb8d56c12894d21d171cfa9a7

--- a/plugins/webweaver-swap
+++ b/plugins/webweaver-swap
@@ -1,0 +1,2 @@
+repository=https://github.com/Ftwpker/webweaver-swap-plugin.git
+commit=0b848dd48cc629a8baa34ec6062dc248bc1f9c69

--- a/plugins/webweaver-swap
+++ b/plugins/webweaver-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/Ftwpker/webweaver-swap-plugin.git
-commit=0b848dd48cc629a8baa34ec6062dc248bc1f9c69
+commit=6c6328d5b362569b9d130b01e547c24697dbe9e9


### PR DESCRIPTION
Adds Webweaver Swap, a cosmetic plugin that swaps Webweaver bow visuals to Craw's bow.

Features:
- Swap the Webweaver shot visuals to Craw's bow
- Render the equipped Webweaver bow as Craw's bow