### PR TITLE
Update cox-analytics to 1.0.3

### DIFF
--- a/plugins/cox-analytics
+++ b/plugins/cox-analytics
@@ -1,2 +1,2 @@
 repository=https://github.com/DangItOSRS/cox-analytics.git
-commit=f7bc06f16ee81ae91f7482dbf582a0bb85560200
+commit=8cc196c9e4b873e3f0115a8236f1a06e187265aa


### PR DESCRIPTION
This release includes the following changes
- [Bugfix] https://github.com/DangItOSRS/cox-analytics/pull/1
- [Feature] https://github.com/DangItOSRS/cox-analytics/pull/2 (Default OFF)
- [Update] https://github.com/DangItOSRS/cox-analytics/pull/3 (Update links to match my github/discord after ownership transfer)
- [Feature] https://github.com/DangItOSRS/cox-analytics/pull/5 (Send splits to party default ON (non-breaking) receive splits from party default OFF)