### PR TITLE
Update bankstanding

### DIFF
--- a/plugins/bankstanding
+++ b/plugins/bankstanding
@@ -1,3 +1,3 @@
 repository=https://github.com/mhollink/bankstanding-plugin.git
-commit=be720f4b1769bd5fe6f7a1666940f9e0981595c8
+commit=52613f6e20611d0388795165f71c8c5aa91f2701
 authors=mhollink,opaf-osrs


### PR DESCRIPTION
- Removed the initial 5 minute delay before marking players as AFK
- Fixed the timer displayed on the debug overlay
- Added a developer-mode chat command to reset the Bankstanding level
- Replaced the `!lvl` command to not overlap/break the existing chat commands.