### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=eeb5286b06b965059cd2c5d13231db8de7f7db1f
+commit=112c61addf20fb9c89045a0f096d3ea0f6dde10c
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=cb2bd232cbe4c98c72f196a42948da344bb766d2
+commit=eeb5286b06b965059cd2c5d13231db8de7f7db1f
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=b363507b455a619061efeaf29e4550e70273cb2b
+commit=4204d391a42fcbf2f02e6e75e1d0038dc6874d62
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=e5254b67073d1904fb6b8f4e181358a4d97a3f74
+commit=7752a61392551f85953fb2b3c765f51147c39c71
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=8e452b456b183485381626f6916a5657e72395c8
+commit=e5254b67073d1904fb6b8f4e181358a4d97a3f74
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=9ab0bd5c7017bbe15f2d3c464211ffb9e3c6efa0
+commit=cb2bd232cbe4c98c72f196a42948da344bb766d2
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=4204d391a42fcbf2f02e6e75e1d0038dc6874d62
+commit=f4c1d0d19f8b3057baa7c722258dd08e1f07e097
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=112c61addf20fb9c89045a0f096d3ea0f6dde10c
+commit=b363507b455a619061efeaf29e4550e70273cb2b
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=f4c1d0d19f8b3057baa7c722258dd08e1f07e097
+commit=8e452b456b183485381626f6916a5657e72395c8
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
This release includes five improvements to GE session tracking, bank wealth capture, and flip suggestion accuracy:

- **Stuck sell queue**: Sell offers that completed but were not properly cleared could block subsequent sells in the same session. The queue is now correctly drained on offer completion.
- **Stale GE slot timers**: Slot timers were not being reset when a slot was emptied, causing incorrect time-remaining displays on fresh offers placed in reused slots.
- **Stale flip cleanup race condition**: A race condition during plugin restart could cause active flips to be incorrectly cleaned up while the GE history was still loading.
- **Bank gear value tracking**: Bank snapshots now capture equipped gear and item-level inventory separately, allowing the backend to price these server-side for accurate total wealth calculation.
- **Offline sell duplication**: Sell offers completed while offline were being incorrectly marked as estimates when synced, causing duplicate entries in flip tracking.
- **GE-only flip suggestions**: Flip suggestions are now only displayed when the player has the Grand Exchange interface open, preventing suggestions from appearing in irrelevant contexts.