### PR TITLE
Add NPC Profit Tracker

### DIFF
--- a/plugins/osrs-profit-tracker
+++ b/plugins/osrs-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/kbosch2000/osrs-profit-tracker.git
-commit=00f40d98a61c10b3506b2f07f344e40bc7adddd4
+commit=050da10854e9fd1685fe5ae3299597cbfb298fec

--- a/plugins/osrs-profit-tracker
+++ b/plugins/osrs-profit-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/kbosch2000/osrs-profit-tracker.git
+commit=b93ec8da1870f1b13fed4a018dc99e1f2cbafa1d

--- a/plugins/osrs-profit-tracker
+++ b/plugins/osrs-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/kbosch2000/osrs-profit-tracker.git
-commit=2a71c5601e2d1017495c372b04da09c931a66a9f
+commit=0549b98a3fc2e31c5c986ae4b5d6d7d59776785e

--- a/plugins/osrs-profit-tracker
+++ b/plugins/osrs-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/kbosch2000/osrs-profit-tracker.git
-commit=82fb2ec72dcd9eeb034ece05bf5e099aded420f5
+commit=00f40d98a61c10b3506b2f07f344e40bc7adddd4

--- a/plugins/osrs-profit-tracker
+++ b/plugins/osrs-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/kbosch2000/osrs-profit-tracker.git
-commit=b93ec8da1870f1b13fed4a018dc99e1f2cbafa1d
+commit=82fb2ec72dcd9eeb034ece05bf5e099aded420f5

--- a/plugins/osrs-profit-tracker
+++ b/plugins/osrs-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/kbosch2000/osrs-profit-tracker.git
-commit=050da10854e9fd1685fe5ae3299597cbfb298fec
+commit=6eae55615ef0e293e8dee1b00d5c72bccfcb7c31

--- a/plugins/osrs-profit-tracker
+++ b/plugins/osrs-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/kbosch2000/osrs-profit-tracker.git
-commit=6eae55615ef0e293e8dee1b00d5c72bccfcb7c31
+commit=f9aa4323e9fdba2a566ff2d410cc2095512d17b5

--- a/plugins/osrs-profit-tracker
+++ b/plugins/osrs-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/kbosch2000/osrs-profit-tracker.git
-commit=a54ad4f4c496f2f7522e8702fe6843afa49d59cd
+commit=2a71c5601e2d1017495c372b04da09c931a66a9f

--- a/plugins/osrs-profit-tracker
+++ b/plugins/osrs-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/kbosch2000/osrs-profit-tracker.git
-commit=f9aa4323e9fdba2a566ff2d410cc2095512d17b5
+commit=a54ad4f4c496f2f7522e8702fe6843afa49d59cd


### PR DESCRIPTION
Adds NPC Profit Tracker, a RuneLite plugin that tracks NPC kill loot, supply costs, net profit, and profit per hour using OSRS Wiki real-time prices with RuneLite price fallback.\n\nPlugin repository: https://github.com/kbosch2000/osrs-profit-tracker\nCommit: b93ec8da1870f1b13fed4a018dc99e1f2cbafa1d