### PR TITLE
Update Spell Reminder to v1.10.0

### DIFF
--- a/plugins/thrall-helper
+++ b/plugins/thrall-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/PortAGuy/thrall-helper.git
-commit=c04e3d6d4e2be4c79d24e5c4c34cc33b844b3bbb
+commit=b4a7dd54f59626d670bc9cdf825a5844d0965730


### PR DESCRIPTION
- Changes to how hotkeys are implemented, allowing for one key to dismiss multiple reminders
- Added support for Magic Imbue
- Swapped deprecated SpriteIDs for GameVals