### PR TITLE
Add Kitchen Roast plugin

### DIFF
--- a/plugins/kitchen-roast
+++ b/plugins/kitchen-roast
@@ -1,0 +1,2 @@
+repository=https://github.com/kbosch2000/kitchen-roast.git
+commit=f6db7e4fe37e8b9b2c5a5a85c4a2734440c5ebac


### PR DESCRIPTION
Adds Kitchen Roast, a RuneLite external plugin that plays a random local WAV clip when you burn food while cooking.

Repository: https://github.com/kbosch2000/kitchen-roast