### PR TITLE
Add ultimate-stat-tracker plugin

### DIFF
--- a/plugins/ultimate-stat-tracker
+++ b/plugins/ultimate-stat-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/cabrilliant/UltimateStatTracker.git
-commit=ecb3d5e0b49eead0394e37b2b6a6c049f31d9c26
+commit=df092968ae04f315293e3eb581d19abe72b8797a

--- a/plugins/ultimate-stat-tracker
+++ b/plugins/ultimate-stat-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/cabrilliant/UltimateStatTracker.git
-commit=df092968ae04f315293e3eb581d19abe72b8797a
+commit=8dd03b61fe4acde669d659fe81700865feb057b1

--- a/plugins/ultimate-stat-tracker
+++ b/plugins/ultimate-stat-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/cabrilliant/UltimateStatTracker.git
+commit=eda64c28d3b35d2b5c489df1739a93ebdb0a58c8

--- a/plugins/ultimate-stat-tracker
+++ b/plugins/ultimate-stat-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/cabrilliant/UltimateStatTracker.git
-commit=eda64c28d3b35d2b5c489df1739a93ebdb0a58c8
+commit=0285b408cb059ae0620c8755a5a3c488a5effe1b

--- a/plugins/ultimate-stat-tracker
+++ b/plugins/ultimate-stat-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/cabrilliant/UltimateStatTracker.git
-commit=0285b408cb059ae0620c8755a5a3c488a5effe1b
+commit=ecb3d5e0b49eead0394e37b2b6a6c049f31d9c26

--- a/plugins/ultimate-stat-tracker
+++ b/plugins/ultimate-stat-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/cabrilliant/UltimateStatTracker.git
-commit=305481a3b0f26a785d6fe5e40accb94378c6aeba
+commit=c3bf5f73be0a5be6729c3c7c50e87e6b5dc4db6e

--- a/plugins/ultimate-stat-tracker
+++ b/plugins/ultimate-stat-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/cabrilliant/UltimateStatTracker.git
-commit=8dd03b61fe4acde669d659fe81700865feb057b1
+commit=305481a3b0f26a785d6fe5e40accb94378c6aeba


### PR DESCRIPTION
This plugin tracks and displays a plethora of stats across account lifetime. This is largely done through game chat messages although there is some tracking that relies on hitsplats and/or game ticks. This plugin was requested by many users on the 2007scape subreddit https://www.reddit.com/r/2007scape/comments/1qjxv23/suggestion_interface_to_see_your_accounts/

some examples of whats tracked is types of logs cut, rocks mined, etc. damage taken and received. items examined. lots more