### PR TITLE
Fixes for demonic-pacts-highlighter

### DIFF
--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=052d99bf83da44acee99d9f866d02ef78e8e8f40
+commit=6fdf692b75d5cb1f2a079d581a769e98af1fbb8b

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=6fdf692b75d5cb1f2a079d581a769e98af1fbb8b
+commit=71bc20817ad459b601e9e7b9e6734a993c7fc9d7

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=bb204c8705fb56be75f50c48b822a026f0ec1f44
+commit=052d99bf83da44acee99d9f866d02ef78e8e8f40

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=71bc20817ad459b601e9e7b9e6734a993c7fc9d7
+commit=26d5610ce879563bebcd6ceaf0ee0f178197c4c9

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=ae56ff5a856bfe7182f4e4ed47a656732274a05a
+commit=bb204c8705fb56be75f50c48b822a026f0ec1f44


### PR DESCRIPTION
Tool item blocklist (Chisel, Knife, moulds, Vial of water)
Pets excluded from NPC highlighting
Fishing spots now highlighted (via object-task fallback)
Fishing spots show correct fish per spot type (no more cross-contamination)
Region toggles
