### PR TITLE
Removed pvp from addon - ready to review

### DIFF
--- a/plugins/will-it-land
+++ b/plugins/will-it-land
@@ -1,0 +1,2 @@
+repository=https://github.com/EthonSmoth/will-it-land.git
+commit=1779c0082fe6ac49787c54e058237ddc33205ad5


### PR DESCRIPTION
removed pvp from addon - pvm only now. It helps you understand your actual accuracy in PvM by displaying a live percentage based on OSRS combat formulas, gear, prayers, and modifiers.