### PR TITLE
Update Blert to 0.9.8

### DIFF
--- a/plugins/blert
+++ b/plugins/blert
@@ -1,4 +1,4 @@
 repository=https://github.com/blert-io/plugin.git
-commit=fe193477e57eb1dd79a82f6d564214bc05f7861c
+commit=b7dcda3ffffbde3c2514e40b7325998ad94e435e
 authors=frolv
 warning=This plugin submits your IP address, RSN, and data about your raids to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Correctly handles Sote maze proc preventing players from dying.