### PR TITLE
leaguessync: update commit — skill/quest sync, seasonal world guard

### DIFF
--- a/plugins/leaguessync
+++ b/plugins/leaguessync
@@ -1,3 +1,3 @@
 repository=https://github.com/RPBTwisted/leaguessync.git
-commit=174d3dfeb0f35cdc1bc2ee573f879ca5c0d0f9f8
+commit=479547579ee83a8de3e0f3e2f1e72e04f7192e47
 warning=This plugin submits your IP address, username and completed task IDs to a 3rd-party server (osrsleaguetracker.com) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates the `leaguessync` plugin to the latest commit.

Changes in this release:
- Plugin now only syncs when logged into a seasonal (leagues) world — prevents main-game profile data being submitted when hopping to a non-leagues world
- Sync payload now includes real skill levels and quest completion states alongside league tasks, to support a "Requirements Met" filter on the tracker website