### PR TITLE
Add Divine Dialogue

### DIFF
--- a/plugins/divine-dialogue
+++ b/plugins/divine-dialogue
@@ -1,0 +1,2 @@
+repository=https://github.com/GarnetDivine/divine-dialogue.git
+commit=7a50e689d9e380d92ebf110641874b7a4e31e006

--- a/plugins/divine-dialogue
+++ b/plugins/divine-dialogue
@@ -1,2 +1,2 @@
 repository=https://github.com/GarnetDivine/divine-dialogue.git
-commit=7a50e689d9e380d92ebf110641874b7a4e31e006
+commit=25baa95f6fc056e96c5f3d94d12471e0a0def357


### PR DESCRIPTION
Adds Divine Dialogue, a plugin that mirrors NPC and player dialogue into a configurable overlay window separate from the OSRS chatbox. Intended primarily for Let's Play recordings and streams where the chatbox is typically obscured, but also useful as an accessibility aid for larger, repositionable dialogue text.

Read-only: does not modify game state, automate gameplay, inject menu entries, intercept input, or make network calls. Uses only standard RuneLite overlay and widget APIs.

Second entry in the Divine family, following Divine: Skies.