### PR TITLE
Add Group Ironman Tracker plugin

### DIFF
--- a/plugins/group-ironman-tracker
+++ b/plugins/group-ironman-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Dan-AGL/Group-Ironman-Tracker.git
-commit=455e2f4da29c6eb0dfacb0402d5ff72ff4271974
+commit=9be8f2f8c794cea2149becb55a530aab47f2b1d0

--- a/plugins/group-ironman-tracker
+++ b/plugins/group-ironman-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Dan-AGL/Group-Ironman-Tracker.git
-commit=9be8f2f8c794cea2149becb55a530aab47f2b1d0
+commit=0b35688e797a59d4e73463286fce28478a1fbe83

--- a/plugins/group-ironman-tracker
+++ b/plugins/group-ironman-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Dan-AGL/Group-Ironman-Tracker.git
+commit=455e2f4da29c6eb0dfacb0402d5ff72ff4271974

--- a/plugins/group-ironman-tracker
+++ b/plugins/group-ironman-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Dan-AGL/Group-Ironman-Tracker.git
-commit=0b35688e797a59d4e73463286fce28478a1fbe83
+commit=e15400e1bf6dbf82125097af5adc577d75855d35
 warning=This plugin submits your IP address, RSN, and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/group-ironman-tracker
+++ b/plugins/group-ironman-tracker
@@ -1,2 +1,3 @@
 repository=https://github.com/Dan-AGL/Group-Ironman-Tracker.git
 commit=0b35688e797a59d4e73463286fce28478a1fbe83
+warning=This plugin submits your IP address, RSN, and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds Group Ironman Tracker, a RuneLite plugin for syncing shared Group Ironman activity across group members.

The plugin tracks and shares recent:
- boss kill-count sessions
- boss drops
- collection log unlocks
- combat task completions
- quest completions
- achievement diary completions
- level-ups

The plugin uses an external backend for persistent group synchronization.