### PR TITLE
Add Demonic Leagues Task Checklist

### DIFF
--- a/plugins/demonic-leagues-task-checklist
+++ b/plugins/demonic-leagues-task-checklist
@@ -1,2 +1,2 @@
 repository=https://github.com/alexshiao99/demonic-leagues-task-checklist.git
-commit=6a104eb46b98aac57f2010fde28c7aa53e92d3a6
+commit=d30e394d87a79976f365ef49c852e7ed03ed84ab

--- a/plugins/demonic-leagues-task-checklist
+++ b/plugins/demonic-leagues-task-checklist
@@ -1,2 +1,2 @@
 repository=https://github.com/alexshiao99/demonic-leagues-task-checklist.git
-commit=d30e394d87a79976f365ef49c852e7ed03ed84ab
+commit=a9b5d42b8dbf4aff45178c6084fcc996d9fcc1f2

--- a/plugins/demonic-leagues-task-checklist
+++ b/plugins/demonic-leagues-task-checklist
@@ -1,0 +1,2 @@
+repository=https://github.com/alexshiao99/demonic-leagues-task-checklist.git
+commit=6a104eb46b98aac57f2010fde28c7aa53e92d3a6


### PR DESCRIPTION
New plugin that tracks Demonic Pacts (Leagues VI)  task completion from the sidebar.
Features:
- All leagues task with completion tracker
- Overlay to display currently selected task
- Filter by region
- Filter by unmet skill requirement
- Filter for incomplete tasks