### PR TITLE
update tasks-tracker - wiki based skill filtering

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=95ca32bf0d3eca625304ff0c817c0b57a3af4744
+commit=0564714e058ee3b73e889842438791f540b3088f
 authors=perterter,JamesShelton140


### PR DESCRIPTION
Added wiki based skill filtering for League 6 tasks (the game doesn't serve the data)

Edited styling a little bit