### PR TITLE
Update Twitch Live Loadout to v2.3.3

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=cbf9f6142187d8bb3e476f0ae7d6190593c0b8d8
+commit=bde72f42d9a9fc098799afe954f72d2c8938f392


### PR DESCRIPTION
Added support for the Leagues 6 Areas and Demonic Pacts syncing to Twitch. This includes an integration with the OSRS wiki demonic pact builder, which can be opened to explore the current tree. The extraction of the relics was unchanged and it support multi-logging.

Impression of what it looks like within the Twitch extension:
<img width="360" height="346" alt="Screenshot 2026-04-23 at 16 56 34" src="https://github.com/user-attachments/assets/a3306c1b-ec66-41a9-b2d7-3e9917dd85d5" />

https://github.com/user-attachments/assets/bb98b1f0-a092-4861-a600-0fcd704e1e45

