### PR TITLE
demonic-pacts-highlighter

### DIFF
--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=052d99bf83da44acee99d9f866d02ef78e8e8f40
+commit=6fdf692b75d5cb1f2a079d581a769e98af1fbb8b

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=6fdf692b75d5cb1f2a079d581a769e98af1fbb8b
+commit=71bc20817ad459b601e9e7b9e6734a993c7fc9d7

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=bb204c8705fb56be75f50c48b822a026f0ec1f44
+commit=052d99bf83da44acee99d9f866d02ef78e8e8f40

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=71bc20817ad459b601e9e7b9e6734a993c7fc9d7
+commit=26d5610ce879563bebcd6ceaf0ee0f178197c4c9

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=ae56ff5a856bfe7182f4e4ed47a656732274a05a
+commit=bb204c8705fb56be75f50c48b822a026f0ec1f44

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=26d5610ce879563bebcd6ceaf0ee0f178197c4c9
+commit=5505d2df8cf9d52f2d9df87b69a53f29925a85c9

--- a/plugins/demonic-pacts-highlighter
+++ b/plugins/demonic-pacts-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/SolutionsCMD/demonic-pacts-highlighter.git
-commit=5505d2df8cf9d52f2d9df87b69a53f29925a85c9
+commit=e6659380be9e7d04bf901eccfecc00cf7cd1042e


### PR DESCRIPTION
Pulls in three community contributions merged to main:

- Recursive widget 657 tree walk for task log sync — resilient to Jagex reshuffling child indexes between client updates (mablack01, #12)
- Skill requirements in tooltip now colored by player level: green if met, red if not (lemuelwatts, #13)
- Combat Potion task moved from General to Desert region where goat horn is obtained (J4Wx, #15)