### PR TITLE
Update Shortest Path to 1.19.0

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=9435629cb73afcf1dc0b9c88d25b7859219b0114
+commit=0fa115ea81ebfa708528a96f2a401dfaf2d1f111
 authors=Skretzo,FIrgolitsch,wvanderp

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=a52c69e72b03373b44765b35c8d424213cc57395
+commit=e5607c1c078124ff8b5313252f89dd99694322c0
 authors=Skretzo,FIrgolitsch,wvanderp

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=0c0f800a04de02e23db086ce857200e8147c6a6f
+commit=34b02ff1ebf5fc9f5c508e19f75c45b8d9423282
 authors=Skretzo,FIrgolitsch,wvanderp

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=82ef4d83b1f3f08f879146c4a7c651e1cb409aac
+commit=0c0f800a04de02e23db086ce857200e8147c6a6f
 authors=Skretzo,FIrgolitsch,wvanderp

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=e5607c1c078124ff8b5313252f89dd99694322c0
+commit=82ef4d83b1f3f08f879146c4a7c651e1cb409aac
 authors=Skretzo,FIrgolitsch,wvanderp

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=e6ca02aa71d30056050d2041f3eef54ea4f84075
+commit=9435629cb73afcf1dc0b9c88d25b7859219b0114
 authors=Skretzo,FIrgolitsch,wvanderp

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=34b02ff1ebf5fc9f5c508e19f75c45b8d9423282
+commit=aac69f480b6d6b36df068bfaf4bfa1ab9533becb
 authors=Skretzo,FIrgolitsch,wvanderp

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=00b01ed4842d928f35f6ab4b4b49867374bc98bf
+commit=e6ca02aa71d30056050d2041f3eef54ea4f84075
 authors=Skretzo,FIrgolitsch,wvanderp

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=aac69f480b6d6b36df068bfaf4bfa1ab9533becb
+commit=00b01ed4842d928f35f6ab4b4b49867374bc98bf
 authors=Skretzo,FIrgolitsch,wvanderp


### PR DESCRIPTION
The second of the large releases. Large rework of internal workings to fix some major problems.

All changes are listed under the 1.19.0 milestone:
https://github.com/Skretzo/shortest-path/milestone/1?closed=1

A large part of the changes is in the test package due to some testing validation tools we built (https://skretzo.github.io/shortest-path/). It shouldn't pollute the final plugin package.

After this one is approved, we will shortly push 1.19.1 as well, which will be just a reformat of all code files to align with the RuneLite code conventions and fix final linting issues.