### PR TITLE
Add default-deposit plugin

### DIFF
--- a/plugins/default-deposit
+++ b/plugins/default-deposit
@@ -1,0 +1,2 @@
+repository=https://github.com/jack-sleath/osrs-runelite-default-bank-options.git
+commit=0de9d732d71a56c1151851197ad919d107af4c25


### PR DESCRIPTION
Adds **Default Deposit** — a small plugin that sets a global default left-click deposit amount (`1 / 5 / 10 / All`) for inventory items while the bank is open.

## Why this isn't redundant with existing RuneLite features

- The vanilla bank UI's `1 / 5 / 10 / X / All` selectors at the bottom of the bank handle the **withdraw** side; there's no equivalent for deposits.
- The built-in Menu Entry Swapper offers (a) a single global shift-click-deposit amount and (b) per-item left-click customisation via shift+right-click. Neither gives a **global** left-click deposit default across all inventory items.

## What the plugin does

- `onPostMenuSort` — if the user has configured a non-default deposit amount, find the matching `Deposit-N` entry on `ComponentID.BANK_INVENTORY_ITEM_CONTAINER`, retype it to `MenuAction.CC_OP`, and swap it into the top-of-menu slot (same trick the built-in MenuEntrySwapper uses for its bank-op swap).
- `onMenuOpened` — when shift is held and a bank-inventory entry is present, inject a "Set default deposit" submenu so the user can change the default inline.
- Config persists via `ConfigManager` under `defaultbankoptions.defaultDeposit`.

## Repo / release

- Source: https://github.com/jack-sleath/osrs-runelite-default-bank-options
- Pinned to tag `v0.2.0` (commit `0de9d732d71a56c1151851197ad919d107af4c25`).
- BSD 2-Clause licensed.
- No third-party dependencies beyond what `runelite-client` already brings in.