### PR TITLE
Add B0aty guide helper plugin

### DIFF
--- a/plugins/b0aty-guide-helper
+++ b/plugins/b0aty-guide-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/noahnoah711/boaty-guide-helper.git
+commit=9970081e8a57184a341483152f204c62b62ee49a


### PR DESCRIPTION
B0aty Guide Helper — a RuneLite plugin that guides players through the full
B0aty HCIM Guide V3 as 18 episodes (12 currently implemented, 13–18 when
the wiki guide adds content). Complements Quest Helper rather than replacing
it: reuses QH step classes (NpcStep, ObjectStep, etc.) directly and hands
off individual quest walkthroughs to QH.

Features:
- World overlay, map arrow, and minimap arrow for travel/interaction steps
- Automatic detection of quest completions and skill level milestones
- Manual checkbox steps for actions the API can't detect
- Per-account progress persistence, offline progress sync on login

Plugin source: https://github.com/noahnoah711/boaty-guide-helper