### PR TITLE
Add Prayer Time Infobox plugin

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,0 +1,2 @@
+repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
+commit=5d6ac7c1ca6729ef49bce4e6c32e85967699dbaf


### PR DESCRIPTION
## Summary
Adds Prayer Time Infobox to the RuneLite Plugin Hub.

## Plugin
Shows prayer time remaining as a top-left infobox using the same prayer drain timing as the prayer orb. The timer counts down smoothly, uses a prayer potion icon, and turns red during the final 30 seconds.