### PR TITLE
Add Flask Fervour Cooldown

### DIFF
--- a/plugins/flask-fervour-cooldown
+++ b/plugins/flask-fervour-cooldown
@@ -1,2 +1,2 @@
 repository=https://github.com/ParadoxGods/flask-fervour-cooldown.git
-commit=d954af3318a3e942c8f1a82e439e8b3aa4f044d1
+commit=ca954e45639faec1b5d51ccfc05182a7039b8e85

--- a/plugins/flask-fervour-cooldown
+++ b/plugins/flask-fervour-cooldown
@@ -1,2 +1,2 @@
 repository=https://github.com/ParadoxGods/flask-fervour-cooldown.git
-commit=db0a2c2da7290dcaec048b1907e9db7ce67f08db
+commit=d954af3318a3e942c8f1a82e439e8b3aa4f044d1

--- a/plugins/flask-fervour-cooldown
+++ b/plugins/flask-fervour-cooldown
@@ -1,0 +1,2 @@
+repository=https://github.com/ParadoxGods/flask-fervour-cooldown.git
+commit=db0a2c2da7290dcaec048b1907e9db7ce67f08db


### PR DESCRIPTION
Adds Flask Fervour Cooldown, a Leagues Flask of Fervour cooldown overlay/highlight plugin.

Plugin repository:
https://github.com/ParadoxGods/flask-fervour-cooldown

Plugin commit:
db0a2c2da7290dcaec048b1907e9db7ce67f08db

The plugin uses standard build metadata, includes a BSD 2-Clause license, and has a 48×48 icon.png generated from the provided new_icon.png asset.