### PR TITLE
Add ground-loot-icons plugin

### DIFF
--- a/plugins/ground-loot-icons
+++ b/plugins/ground-loot-icons
@@ -1,0 +1,3 @@
+repository=https://github.com/Fiffers/ground-loot-icons.git
+commit=fae36bffe1b206e8d493bf6daaa19da98dec73fc
+authors=Fiffers

--- a/plugins/ground-loot-icons
+++ b/plugins/ground-loot-icons
@@ -1,3 +1,3 @@
 repository=https://github.com/Fiffers/ground-loot-icons.git
-commit=fae36bffe1b206e8d493bf6daaa19da98dec73fc
+commit=58a1e2cfbb268fdc5f36fa4c53f36ab654b91ff4
 authors=Fiffers


### PR DESCRIPTION
This plugin adds item icons next to their names in right-click context menus.
<img width="239" height="214" alt="image" src="https://github.com/user-attachments/assets/bfec74d9-5c3d-4bc9-b4de-ca79d4f0cf58" />
