### PR TITLE
Daily Agility

### DIFF
--- a/plugins/daily-agility
+++ b/plugins/daily-agility
@@ -1,2 +1,2 @@
 repository=https://github.com/DrieVeertien/DailyAgility.git
-commit=b21d319d28d8411214dcb86113fd04304bf3dae5
+commit=31b40cb27a07e2e308f68ad025676a73fc0a44c3

--- a/plugins/daily-agility
+++ b/plugins/daily-agility
@@ -1,2 +1,2 @@
 repository=https://github.com/DrieVeertien/DailyAgility.git
-commit=31b40cb27a07e2e308f68ad025676a73fc0a44c3
+commit=eeccb618555b7480eb0589e6f200e70575a6ebef

--- a/plugins/daily-agility
+++ b/plugins/daily-agility
@@ -1,0 +1,2 @@
+repository=https://github.com/DrieVeertien/DailyAgility.git
+commit=b21d319d28d8411214dcb86113fd04304bf3dae5

--- a/plugins/daily-agility
+++ b/plugins/daily-agility
@@ -1,2 +1,2 @@
 repository=https://github.com/DrieVeertien/DailyAgility.git
-commit=eeccb618555b7480eb0589e6f200e70575a6ebef
+commit=22235efe8d99f891d9d962955b7d8ffedb28d974


### PR DESCRIPTION
Adds a plugin for players who follow a daily rooftop agility routine. Tracks lap count and Marks of Grace against configurable daily goals, with automatic reset at midnight. Includes a lap timer with rolling average, ETA calculation based on average lap time, and a toggleable overlay. All state persists across sessions via ConfigManager.