### PR TITLE
update granite-tracker

### DIFF
--- a/plugins/granite-tracker
+++ b/plugins/granite-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Outlashed/granite-tracker.git
-commit=889cb9fa4230c62cab09d40bde3af44681108418
+commit=23a7e619dd9c7acc85dcfafc7a449aa38860339a


### PR DESCRIPTION
Fix first ore not being tracked after plugin start due to varp baseline not being initialized on reset.