### PR TITLE
Update configurable-slayer-task-overlay

### DIFF
--- a/plugins/configurable-slayer-task-overlay
+++ b/plugins/configurable-slayer-task-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/configurable-slayer-task-overlay.git
-commit=1c900ac5c5d37fc060d11acde58b82c21fc0c77f
+commit=01c80fd5ac2410819f0b87c7135ba96e9d4cabd4


### PR DESCRIPTION
First update since the takeover from the prior owner. Bundles bug fixes and behavior improvements that have accumulated on the fork.

### Features

- Configurable task proximity distance for auto-hiding the overlay (replaces the old on/off toggle; `0` disables)
- Dismiss overlay and shortest path automatically when reaching the task area or fighting the task NPC ([#22](https://github.com/mathiaslj/configurable-slayer-task-overlay/issues/22))
- Use varbits for slayer task info instead of chat parsing ([#13](https://github.com/mathiaslj/configurable-slayer-task-overlay/issues/13))

### Fixes

- Wall Beasts default info now uses Games Necklace instead of Fairy Ring AJQ ([#23](https://github.com/mathiaslj/configurable-slayer-task-overlay/issues/23))
- Zygomites task recognition ([#24](https://github.com/mathiaslj/configurable-slayer-task-overlay/issues/24))
- Fleshcrawlers task name space handling ([#18](https://github.com/mathiaslj/configurable-slayer-task-overlay/issues/18))

### Behavior

- Suppress overlay and path on login for existing tasks (no flash on world hop)
- Refresh overlay and path when checking the slayer gem/helm
- Clear shortest path on task completion, on arrival at the task area, and while the overlay is dismissed (only if we set it)
- Contains-based name matching for task lookup and fighting detection
