### PR TITLE
Mining Stats

### DIFF
--- a/plugins/osrs-mining-stats
+++ b/plugins/osrs-mining-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/alisendjsc-crypto/osrs-mining-stats.git
-commit=1f273acf59b5971c006fb068dccbd94b33651671
+commit=1d363810d7f6e6a5fcaea4655d403b1cb7fb145d

--- a/plugins/osrs-mining-stats
+++ b/plugins/osrs-mining-stats
@@ -1,0 +1,2 @@
+repository=https://github.com/alisendjsc-crypto/osrs-mining-stats.git
+commit=1f273acf59b5971c006fb068dccbd94b33651671


### PR DESCRIPTION
Mining Stats: replaces the standard Mining plugin's drifting per-hour rate with one computed over a rolling window of active mining time only. AFK gaps are excised from the denominator; per-ore breakdown shows the player's current activity.

The standard plugin uses `total_ores / total_session_time`, so the rate sags as the session lengthens, even at constant pace; this fixes that.

Source: https://github.com/alisendjsc-crypto/osrs-mining-stats (tag v0.1.0, commit 1f273acf59b5971c006fb068dccbd94b33651671)

Pure passive overlay — no automation, no input simulation, no clicks.