### PR TITLE
osrs-mining-stats: bump to v0.1.1

### DIFF
--- a/plugins/osrs-mining-stats
+++ b/plugins/osrs-mining-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/alisendjsc-crypto/osrs-mining-stats.git
-commit=1d363810d7f6e6a5fcaea4655d403b1cb7fb145d
+commit=03febe59d6f682debd497cee9457b5d71807c0ae


### PR DESCRIPTION
Updates osrs-mining-stats to v0.1.1.

Fixes a v0.1.0 regression where non-standard mining yields (Barronite shards from Camdozaal Deposits, gem rocks, Sandstone, Granite, etc.) registered Mining XP correctly but did not increment Ores/hr or the session total. The internal ore enum has been expanded from 14 to 34 entries, verified against `net.runelite.api.ItemID` at master HEAD. All 31 unit tests pass, including the new regression test `barroniteShardsAreRecognizedAsOre`.

Upstream commit: alisendjsc-crypto/osrs-mining-stats@03febe59d6f682debd497cee9457b5d71807c0ae