### PR TITLE
Bump commit to ca59066 (v0.2.0)

### DIFF
--- a/plugins/osrs-mining-stats
+++ b/plugins/osrs-mining-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/alisendjsc-crypto/osrs-mining-stats.git
-commit=03febe59d6f682debd497cee9457b5d71807c0ae
+commit=ca59066bca98854314757e0853862b3ce2e81304


### PR DESCRIPTION
v0.2.0 — diff against the v0.1.1 distribution (03febe59).

The detection contract is the load-bearing change. v0.1.x recognized success events by checking inventory increments against an ItemID enum, which silently zero-rated any yield outside the enum (Barronite shards before v0.1.1, future content drops generally). v0.2.0 replaces the gate with coincidence detection: a pickaxe-family animation must be recent, then a Mining XP delta and an inventory increment must arrive within ~1 game tick of each other. The animation gate kills the Wintertodt false-positive case. Display names still prefer the curated Ores list; ItemManager provides the fallback for unknown IDs.

The overlay auto-hides while idle and no events fall inside the rolling window. Title text color signals state at a glance: green while actively mining, light gray when visible only because the rolling window still has events.

Rolling-window state now persists per character via ConfigManager. Save on plugin shutdown, client disconnect, and world hop; load on next login if the snapshot is under 60 minutes old (matches the existing in-memory retention cap). Short OSRS disconnects no longer reset the counter.

No new automation, no hidden-info exposure. 58/58 tests green locally. Source: https://github.com/alisendjsc-crypto/osrs-mining-stats