### PR TITLE
add minion-info

### DIFF
--- a/plugins/minion-info
+++ b/plugins/minion-info
@@ -1,0 +1,2 @@
+repository=https://github.com/Enriath/external-plugins.git
+commit=bf4842437fd16eb90593899734818a5ff2f6a6ef


### PR DESCRIPTION
A small simple plugin to show the settings of your minion whistle in the style of an RS3 tooltip

<img width="239" height="201" alt="tooltip" src="https://github.com/user-attachments/assets/692137d7-3a44-4110-8cd5-e101ec158dc2" />
