### PR TITLE
Add Log Adviser

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=9ee39077efcf27e7f8c33f04650f5fc03ad41b44
+commit=285fbb07974889f52aceb6e8ea921c4085fe9bd3

--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=6222545b2d7c0b95f8d5f48cddcec36d954df92b
+commit=9ee39077efcf27e7f8c33f04650f5fc03ad41b44

--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,0 +1,2 @@
+repository=https://github.com/SFranciscoSouza/LogAdviser.git
+commit=ba098eedcb5310b79fb83c6782bb95dedb549b3a

--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=ba098eedcb5310b79fb83c6782bb95dedb549b3a
+commit=0641fff1ad0c50564a3cd737a9fe4182729aa627

--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=285fbb07974889f52aceb6e8ea921c4085fe9bd3
+commit=dd321187b6707ea418d102de1e2c5be40051dcba

--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=0641fff1ad0c50564a3cd737a9fe4182729aa627
+commit=6222545b2d7c0b95f8d5f48cddcec36d954df92b

--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,3 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
 commit=dd321187b6707ea418d102de1e2c5be40051dcba
+warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds **Log Adviser**, a guide plugin for the OSRS collection log. It ranks the next slot to chase by *Time-To-Next-Slot* and surfaces guidance through a sidebar panel, an info box, and an in-world target highlight on the relevant NPC.

**Features**
- Sidebar panel listing the top-N activities to chase, ranked by expected time to the next unique slot
- Info box showing the current target activity at a glance
- Highlights the target NPC in the world via overlay
- Auto-detects account mode (Standard / Ironman / HCIM / UIM) via the OSRS Hiscores
- Optional "warm-start" of obtained items from the public TempleOSRS collection log API (opt-in, read-only)

**Bundled data:** activity / slot / NPC tables generated from a maintained spreadsheet (`tools/generate_log_data.py`).

**Networking:** read-only HTTP `GET` to `secure.runescape.com` Hiscores and (optional, opt-in) `templeosrs.com`. Both use the injected `OkHttpClient`.

**Repo:** https://github.com/SFranciscoSouza/LogAdviser
**License:** BSD 2-Clause
**Build:** `standard` (no third-party dependencies beyond `net.runelite:client` + Lombok)