### PR TITLE
update 117hd

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=f17f198c50521122720178dd828872968a17c7c4
+commit=afffded1b4ac08161001bba1a5730c0e8ff8bcf8
 authors=aHooder


### PR DESCRIPTION
Removes the `BuildInfo` stuff & switches to a standard build. Also includes some minor bug fixes.