### PR TITLE
Update prayer-time-infobox to Combat Potions

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=992e40fc57e3393793543a4072d5512c99b25d09
+commit=b035f48fdbc92652e7b4629ec803f03ad41af2e6

--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=b035f48fdbc92652e7b4629ec803f03ad41af2e6
+commit=a9582e19ca2598328cb77be41a6e60fc6f9e7235

--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=5d6ac7c1ca6729ef49bce4e6c32e85967699dbaf
+commit=992e40fc57e3393793543a4072d5512c99b25d09


### PR DESCRIPTION
## Summary
- updates the `prayer-time-infobox` plugin manifest to the latest source commit
- expands the plugin into `Combat Potions`, with support for common combat potion timers like overloads, divines, antifires, and extended super antifire
- adds per-potion visibility toggles plus final-warning behavior with red text and a flashing screen during the last 10 seconds
- includes the local dev-profile launch fix used to avoid conflicts with an already installed Plugin Hub copy during developer-mode testing

## Validation
- built successfully with `./gradlew.bat build shadowJar`
- launched in RuneLite developer mode and verified the plugin loads as `Combat Potions`