### PR TITLE
Add OSRSBuddy plugin

### DIFF
--- a/plugins/osrsbuddy
+++ b/plugins/osrsbuddy
@@ -1,0 +1,2 @@
+repository=https://github.com/fakeluddepuding-jpg/osrsbuddy-runelite-plugin.git
+commit=48e0ec9a484c57d6fce704662897f8b6c375515f

--- a/plugins/osrsbuddy
+++ b/plugins/osrsbuddy
@@ -1,2 +1,2 @@
 repository=https://github.com/fakeluddepuding-jpg/osrsbuddy-runelite-plugin.git
-commit=8da0bb7166dc6bf0b10ad5cc6604ac15f5f713ff
+commit=6b3c8d3743017562560a58895e5d76b9b2d91105

--- a/plugins/osrsbuddy
+++ b/plugins/osrsbuddy
@@ -1,2 +1,3 @@
 repository=https://github.com/fakeluddepuding-jpg/osrsbuddy-runelite-plugin.git
 commit=6b3c8d3743017562560a58895e5d76b9b2d91105
+warning=This plugin submits your IP address, RSN, and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrsbuddy
+++ b/plugins/osrsbuddy
@@ -1,2 +1,2 @@
 repository=https://github.com/fakeluddepuding-jpg/osrsbuddy-runelite-plugin.git
-commit=48e0ec9a484c57d6fce704662897f8b6c375515f
+commit=986f15983185c6e0c681d4b4e639732335d4589f

--- a/plugins/osrsbuddy
+++ b/plugins/osrsbuddy
@@ -1,2 +1,2 @@
 repository=https://github.com/fakeluddepuding-jpg/osrsbuddy-runelite-plugin.git
-commit=986f15983185c6e0c681d4b4e639732335d4589f
+commit=8da0bb7166dc6bf0b10ad5cc6604ac15f5f713ff


### PR DESCRIPTION
Adds OSRSBuddy, a plugin that syncs character data (skills, quests, 
inventory, equipment, bank) to osrsbuddy.com after the user explicitly 
pairs their account with a code from the website.

The website is yet to be published, since this functionality is a big part of the launch of the website.

The plugin does not interact with Jagex credentials or session tokens.