### PR TITLE
Update ground-loot-icons

### DIFF
--- a/plugins/ground-loot-icons
+++ b/plugins/ground-loot-icons
@@ -1,3 +1,3 @@
 repository=https://github.com/Fiffers/ground-loot-icons.git
-commit=58a1e2cfbb268fdc5f36fa4c53f36ab654b91ff4
+commit=c2a37d1f983ca76a0944216857d613daace026fd
 authors=Fiffers


### PR DESCRIPTION
This PR implements support for really long right-click menus that are scrollable