### PR TITLE
Bump commit to 33a8b62 (v0.3.0)

### DIFF
--- a/plugins/osrs-mining-stats
+++ b/plugins/osrs-mining-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/alisendjsc-crypto/osrs-mining-stats.git
-commit=ca59066bca98854314757e0853862b3ce2e81304
+commit=33a8b62b43f879cae17bccd268cc65c7210fbc05


### PR DESCRIPTION
Bumps the pinned commit for `osrs-mining-stats` to `33a8b62b43f879cae17bccd268cc65c7210fbc05` for v0.3.0.

## What changed

Detection contract widens by exactly one disjunct on the item-source signal: the bank container is now a valid secondary surface alongside the player inventory. The animation gate (3-second pickaxe-family activity window) and Mining-XP-delta coincidence (1200ms / ~2 game ticks) are unchanged. A bank-positive delta is counted only if no inventory-negative delta occurred within the same window — the manual-banking filter that prevents a deposit-all from being misread as a mining yield.

## Why

Distributed clan testing of v0.2.0 surfaced a recurring failure surface in OSRS Leagues. With the auto-bank or auto-smelt relics active in Leagues VI "Demonic Pacts" (Hotfoot, etc.), mined items route directly to the bank — the player inventory never receives them, so v0.2.0's inventory-only detection observes no item-source signal and counts nothing. Leagues events run for around 50-60 days but recur only roughly annually — a documented limitation would persist across multiple year-long cycles. The architectural fix also generalizes cleanly to any future auto-deposit content.

## Scope

Detection-contract widening only. No new config toggles, no changes to the rolling window, the AFK accounting, the per-ore breakdown, the session-persistence layer, the title-color indicator, the auto-hide logic, or the icon. The Wintertodt false-positive killer (animation gate must be pickaxe-family) is preserved.

## Hub-rule compliance

Passive overlay only. The bank container is read via the existing `ItemContainerChanged` event subscription path used elsewhere in the hub (e.g., Bank Memory plugin). No input automation, no hidden-information exposure, no API misuse. Same posture as v0.1.x and v0.2.0.

## Tests

76/76 green: 58 v0.2.0 baseline + 13 new `MiningSuccessGateTest` cases (Leagues happy path, manual-banking filter, baseline-on-first-bank-snapshot, multi-tick auto-deposit, held-diff merging, reset hygiene, partial deposits) + 5 new `InventoryDeltaTest` cases for the new `hasNegativeDelta` helper.

## Source

https://github.com/alisendjsc-crypto/osrs-mining-stats