### PR TITLE
Revert osrs-mining-stats to v0.2.0 (v0.3.0 regression; fix pending)

### DIFF
--- a/plugins/osrs-mining-stats
+++ b/plugins/osrs-mining-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/alisendjsc-crypto/osrs-mining-stats.git
-commit=33a8b62b43f879cae17bccd268cc65c7210fbc05
+commit=ca59066bca98854314757e0853862b3ce2e81304


### PR DESCRIPTION
Reverts the pinned commit for `osrs-mining-stats` to `ca59066bca98854314757e0853862b3ce2e81304` (the v0.2.0 SHA distributed via PR #11659).

## Why

v0.3.0 (PR #11671, merged earlier today) introduced a regression in base-game mining detection. The overlay fails to render during normal mining sessions even though the plugin loads cleanly with no exceptions in the client log. Multiple users (myself included) confirmed the issue post-distribution. v0.2.0 was the last verified-working distributed release.

## What this PR does

Manifest-only one-line revert: `commit=33a8b62b43f879cae17bccd268cc65c7210fbc05` → `commit=ca59066bca98854314757e0853862b3ce2e81304`. No source-repo changes. No test changes. Restores the binary that has been smoke-tested across the v0.2.0 clan-distributed validation window.

## Pending

v0.3.1 fix is in progress in the source repo. The regression's root cause is being instrumented and diagnosed — once isolated, a corrected version will be filed as a follow-up hub PR.

## Source

https://github.com/alisendjsc-crypto/osrs-mining-stats