### PR TITLE
update tp-animation-replacer to v1.0.3

### DIFF
--- a/plugins/tp-animation-replacer
+++ b/plugins/tp-animation-replacer
@@ -1,2 +1,2 @@
 repository=https://github.com/STRIKERnz/Teleport-Animation-Replacer.git
-commit=297b5c106cc14efa5f1c5bae4a2289e1f53cc207
+commit=2bf804fa513e996b8abec38dc2fff912263034ca

--- a/plugins/tp-animation-replacer
+++ b/plugins/tp-animation-replacer
@@ -1,2 +1,2 @@
 repository=https://github.com/STRIKERnz/Teleport-Animation-Replacer.git
-commit=f9b9748c2240aaeddad2f3efb9f0f62498e1c4fe
+commit=297b5c106cc14efa5f1c5bae4a2289e1f53cc207


### PR DESCRIPTION
Added
- Pendent of Ates teleport preset (cast + arrival): animation, graphic, and sound IDs added and usable as an override.

 Changed
- Improved override suppression so original teleport sounds (including Pendent of Ates and Ring of Shadows) are muted when overridden.
- Fixed per-variant Ring of Shadows overrides so changing colour correctly updates the graphic even though the animation id is shared.