### PR TITLE
Add gim-shed plugin

### DIFF
--- a/plugins/gim-shed
+++ b/plugins/gim-shed
@@ -1,2 +1,2 @@
 repository=https://github.com/Conduitflow/GIMShed.git
-commit=6833121e486a3ea30bc46046cb06cfdbeadd3550
+commit=fe6fcaf5fb6ec2b607afaf334ea2943b59feeb36

--- a/plugins/gim-shed
+++ b/plugins/gim-shed
@@ -1,0 +1,2 @@
+repository=https://github.com/Conduitflow/GIMShed.git
+commit=6833121e486a3ea30bc46046cb06cfdbeadd3550


### PR DESCRIPTION
Adds a small cosmetic plugin that renames the **Group Storage** interface title to a configurable string (default "The Shed"). Affects only the title bar widget that loads with the SHARED_BANK interface (group ID 724); does not modify any other UI element, menu entry, or game state.

Source: https://github.com/Conduitflow/GIMShed