### PR TITLE
Update Looting Bag Stored XP: fix bag detection + icon

### DIFF
--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=b7a495e75f11bcc9793aebad473c8e329c5030ef
+commit=9c7a31afe1c516c3387412b38ac7ebb02b2f9d7c
 authors=ZNPKOH


### PR DESCRIPTION
## Update for Looting Bag Stored XP

### Fixes
- **Fix looting bag detection**: Plugin now reads the looting bag contents when the widget opens (via WidgetLoaded event for group 81). Previously, ItemContainerChanged only fires on content changes, so simply viewing the bag wouldn't trigger detection.
- **Add Plugin Hub icon** (icon.png)

### Tested
- Build passes
- Uses standard build.gradle (build=standard)