### PR TITLE
Update Looting Bag Stored XP: read items from widget

### DIFF
--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=9c7a31afe1c516c3387412b38ac7ebb02b2f9d7c
+commit=8f4081b3dfeb08da72014b5e9b9ae215acd52b3b
 authors=ZNPKOH


### PR DESCRIPTION
## Update for Looting Bag Stored XP

### Fix
Previously the plugin tried to read from the ItemContainer (id 516) which is only updated when contents change — not when the bag is opened. Now the plugin:

1. Listens for `WidgetLoaded(81)` to know when the looting bag UI opens
2. While the widget is open, reads items directly from widget child 5 every game tick
3. Falls back to ItemContainer if widget reading fails

This fixes the "No herbs detected" issue when users open the looting bag via View/Check.

### Removed
- Demo data button (no longer needed)