### PR TITLE
Update 07flip to 5866739

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=65c170d5cd09ba394e8a7bd6febe3e0151a80e3f
+commit=5866739578749a3a0027788c767db42fa08e7e85
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=53566064f52d965076ba8dbbdf0982d50295d5a5
+commit=d08c43d52d84f6e859e8f700937b6f3bed2eaf0d
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=5866739578749a3a0027788c767db42fa08e7e85
+commit=53566064f52d965076ba8dbbdf0982d50295d5a5
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Update 07flip plugin to commit 5866739.

Replaces the chatbox-rendered price card (which was unreliable due to chatbox rebuild scripts clobbering injected child widgets) with a movable Java2D overlay anchored to the GE setup screen. Right-click the overlay to pick from suggested buy/sell prices; the selected price auto-fills the custom price input. Also adds cyan empty-slot hints when a panel right-click queue is awaiting the user to pick a slot.