### PR TITLE
Bump commit to 6adad93 (v0.3.1 — restore base-game wall-rock detection)

### DIFF
--- a/plugins/osrs-mining-stats
+++ b/plugins/osrs-mining-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/alisendjsc-crypto/osrs-mining-stats.git
-commit=ca59066bca98854314757e0853862b3ce2e81304
+commit=6adad93adc22c04f590bc578534d1506b616c83c


### PR DESCRIPTION
v0.3.1 closes the v0.3.0 base-game regression that triggered rollback PR #11676. Root cause: `MiningAnimations` was importing pickaxe animation IDs from the legacy `net.runelite.api.AnimationID` namespace, which only exposes floor-mining variants per pickaxe tier. Wall-mounted rock activities (Camdozaal barronite, Varlamore calcified rocks, Trahaearn mine, Motherlode ore veins, Prifddinas, etc.) emit the `_WALL` variant animation per swing — animation IDs that the legacy namespace does not define as constants. The animation gate therefore never activated for any wall-rock activity, the gate's gating chain stayed closed, and the overlay auto-hid because the rolling window stayed empty.

Fix: migrated `MiningAnimations` to `net.runelite.api.gameval.AnimationID`, mirroring the coverage set used by RuneLite's first-party `mining` plugin (`net.runelite.client.plugins.mining.MiningAnimation.MINING_ANIMATIONS`). Now covers all pickaxe tiers across `{standard, wall, noreachforward, power_swing}` variants, plus cosmetic pickaxe variants (3a, gilded, infernal, dragon-pretty, all Trailblazer cosmetics, Zalcano, league-trailblazer).

Test-coverage gap closed: new `PluginEventRoutingTest` exercises the plugin's `@Subscribe` dispatch layer with synthetic event streams. The pre-existing 76 gate-isolation tests didn't catch this regression because they bypass `MiningAnimations.isMiningAnimation`. Net test count: 84 pass + 1 ignored. Empirically validated on v0.2.0 by reproducing the failure with adamant pickaxe at calcified rocks (wall) while coal rocks (floor) worked fine on the same character.