### PR TITLE
Update Looting Bag Stored XP: widget tree scan

### DIFF
--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=dfd4134590b47a28d7c0ec6b591ac7b8ce8d4b6e
+commit=46505462f79bfee538c385b5bb7d69fac61f1713
 authors=ZNPKOH

--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=8f4081b3dfeb08da72014b5e9b9ae215acd52b3b
+commit=dfd4134590b47a28d7c0ec6b591ac7b8ce8d4b6e
 authors=ZNPKOH


### PR DESCRIPTION
Fix detection by scanning widget tree (group 81) for any widgets with itemId set. Previous version only checked direct children of child 5 which didn't always work.