### PR TITLE
Update Looting Bag Stored XP: cleaner widget API

### DIFF
--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=46505462f79bfee538c385b5bb7d69fac61f1713
+commit=b20b0fd346b5c0c7655fccec7c2c5493dd8a71e5
 authors=ZNPKOH


### PR DESCRIPTION
Refactor to use proper RuneLite widget API constants:

- Use `ComponentID.LOOTING_BAG_LOOTING_BAG_INVENTORY` instead of hardcoded widget IDs
- Use `InterfaceID.LOOTING_BAG` constant instead of hardcoded 81
- Use `IdentityHashMap` to prevent infinite loops when traversing widget tree
- Handle items with quantity=0 reported by the widget (`Math.max(quantity, 1)`)
- Cleaner `updateFromBagItemCounts` method in SupplyTracker

No functional change for end users — same fix as #11689, just using proper API constants.