### PR TITLE
Update Looting Bag Stored XP: poll both container and widget

### DIFF
--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=b20b0fd346b5c0c7655fccec7c2c5493dd8a71e5
+commit=34d81bd4da244209922af07b7fb3156c6d2841bf
 authors=ZNPKOH


### PR DESCRIPTION
Fix detection by polling BOTH the looting bag ItemContainer (516) AND the entire widget tree of group 81 every game tick. Previous version only walked from a single child (81:5) which didn't always contain the items.