### PR TITLE
Update Looting Bag Stored XP: diagnostic logging

### DIFF
--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=34d81bd4da244209922af07b7fb3156c6d2841bf
+commit=e664b5178f7c88c1064d9fa62d94f951077c9bd1
 authors=ZNPKOH


### PR DESCRIPTION
Adds INFO-level diagnostic logging to help diagnose why items aren't being detected on some clients. Logs container and widget item counts every 3 seconds while the bag widget is open.