### PR TITLE
Bump commit to 8e7ac81 (v0.3.2 — revert bank handler, yield blacklist, gate-heartbeat fix)

### DIFF
--- a/plugins/osrs-mining-stats
+++ b/plugins/osrs-mining-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/alisendjsc-crypto/osrs-mining-stats.git
-commit=6adad93adc22c04f590bc578534d1506b616c83c
+commit=8e7ac81a7969faa381357418fd3f1f89e54b0f89


### PR DESCRIPTION
v0.3.2 changeset:

- **Revert v0.3.0 bank handler architecture.** Empirical settle: Endless Harvest auto-bank on a fresh OSRS Leagues alt produces zero detection on v0.3.1 (no overlay, no events recorded). That's the architecture's exact intended target case, and it failed — the load-bearing assumption (bank events fire while bank UI is closed) is empirically false. Full revert across `MiningSuccessGate`, `MiningStatsPlugin`, `InventoryDelta` (~80 LOC removed). Direct-to-bank auto-deposit relics now documented as a known limitation; recovering them requires screen-scraping the chat log or polling the bank container, both out of scope.

- **Yield blacklist for categorically-non-mining items.** OSRS Leagues coin-drop and smithing relics inflated v0.3.1 Ores/hr to ~375k and collapsed inventory ETA to 0s via the `freeSlots / (oresPerHour / 3600)` formula. Curated exclude-set in `InventoryDelta.itemsGained` covering coins (995), all furnace bars (bronze→rune + gold + silver), uncut gems from mining (sapphire/emerald/ruby/diamond/dragonstone), clue geodes (all four tiers), clue scrolls (all five tiers including Leagues beginner), scroll box (beginner). Negative-filter only — anything not on the list still passes through, preserving v0.2.0's "future Jagex yield won't silently zero-rate" property.

- **Animation-gate heartbeat (regression fix).** v0.3.1 base-game testing surfaced two display regressions. (1) Title indicator never turned green during active mining: `AnimationChanged` fires only on animation-ID transitions, but pickaxe animations frequently loop in-place during continuous mining without re-emitting an ID change, leaving the gate's `lastMiningAnimationMs` frozen at the first swing's transition. Added `@Subscribe onGameTick` heartbeat that polls `client.getLocalPlayer().getAnimation()` per game tick (~600ms) and refreshes the gate. Mirrors the first-party `mining` plugin's tick-based detection pattern.

- **Wall-clock auto-hide (regression fix).** (2) Overlay never auto-hid after the player walked away from mining: `RollingWindow.currentActiveTime` caps the trailing gap at `afkThresholdMs`, freezing both `currentActive` and the rate cutoff once the AFK threshold elapses; events stayed inside the window forever. Added `RollingWindow.hasEventsWithinWallTime` which scans the events deque tail-first against wall-clock; overlay swaps `rate > 0` for the wall-clock check. Rate calculation itself is unchanged (still active-time-based, which is the right semantic for "mining rate excluding AFK").

Tests: 85 pass locally (IntelliJ). Added per-blacklist-category fixtures in `InventoryDeltaTest`, 4 heartbeat tests including a 30-tick continuous-mining simulation in `PluginEventRoutingTest`, 7 wall-clock tests in `RollingWindowTest` (including the regression guard that proves wall-clock check drains correctly while active-time-based rate stays > 0 post-AFK). Stripped 13 v0.3.0 bank-watch tests; un-`@Ignore`'d `bankEventBetweenXpAndInventory_doesNotStealInventoryEmit` (passes naturally post-revert). Inventory-only Path B tests unchanged.