### PR TITLE
Update Looting Bag Stored XP: detection fix + new features

### DIFF
--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=34d81bd4da244209922af07b7fb3156c6d2841bf
+commit=6a7e7674dcea3feab93fd14ed7fe931cbc7d378f
 authors=ZNPKOH

--- a/plugins/looting-bag-stored-xp
+++ b/plugins/looting-bag-stored-xp
@@ -1,3 +1,3 @@
 repository=https://github.com/ZNPKOH/looting-bag-stored-xp.git
-commit=6a7e7674dcea3feab93fd14ed7fe931cbc7d378f
+commit=ed40c6bc11965610cd04559ec89c73a9db21584b
 authors=ZNPKOH


### PR DESCRIPTION
Verified working with local IDE testing (sorry for the noisy PRs earlier — now using insecure-write-credentials to test properly).

### Main fix
- **Use ItemManager.canonicalize()** for looting bag items. The bag stores items with noted IDs (e.g. id 208 for grimy ranarr instead of 207), which is why the previous version found no herbs.

### New features
- Show current Herblore level + projected level after processing all bag contents
- Track bird's nest items as crushed nest equivalents (crushable 1:1 for Saradomin brew)
- Right-click "Configure" menu entry on the screen overlay

### Polish
- Only rebuild side panel when bag contents actually change (fixes potion dropdown closing every game tick)