### PR TITLE
Update Twitch Live Loadout to v2.3.4

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=1d73566141ec93acb5b1dd90df16c3ecc2f74595
+commit=abb93800d55e53009a0cda289f43ff24b3bb12e8

--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=bde72f42d9a9fc098799afe954f72d2c8938f392
+commit=1d73566141ec93acb5b1dd90df16c3ecc2f74595

--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=abb93800d55e53009a0cda289f43ff24b3bb12e8
+commit=e79b59d073faf6b909851d691b9a04f0235f79e8


### PR DESCRIPTION
fix: fixed minor issue where Leagues VI pact node IDs are being collected indefinitely when re-opening the interface. Missed a proper data cleanup.