### PR TITLE
update 117hd

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=afffded1b4ac08161001bba1a5730c0e8ff8bcf8
+commit=7668ac1bd9f150ff11412b7168284a582d624306
 authors=aHooder


### PR DESCRIPTION
Fixes an issue occurring seemingly on older launcher versions on Apple Silicon, by actually catching the potential `NoClassDefFoundError` we meant to catch, which happens to not extend `Exception`.