### PR TITLE
update traducao-osrs-br

### DIFF
--- a/plugins/traducao-osrs-br
+++ b/plugins/traducao-osrs-br
@@ -1,3 +1,2 @@
 repository=https://github.com/walterrezende12-tech/Traducao-OSRS-BR.git
 commit=34c68b4f57601376d550227e0a4bf1bf1efa4363
-jarSizeLimitMiB=20

--- a/plugins/traducao-osrs-br
+++ b/plugins/traducao-osrs-br
@@ -1,2 +1,3 @@
 repository=https://github.com/walterrezende12-tech/Traducao-OSRS-BR.git
-commit=cc72ae381b19e8c1f76669c84320b9259bc49cc6
+commit=34c68b4f57601376d550227e0a4bf1bf1efa4363
+jarSizeLimitMiB=20


### PR DESCRIPTION
﻿## English

Updates `traducao-osrs-br` to the validated public source commit.

This update:
- fixes Plugin Hub metadata encoding issues that caused mojibake in the plugin name and description;
- fixes runtime translation loading with duplicate-key tolerant JSON parsing;
- fixes Hans play-time dialog handling;
- publishes the full translation dataset validated locally in RuneLite;
- keeps the plugin on the standard Plugin Hub build path with `build=standard`.

Translation data in the source commit:
- 116,857 unique loaded translations;
- 112,814 static translations;
- 4,043 dynamic placeholder translations.

The plugin was locally validated with `gradlew testClasses --rerun-tasks` from a clean checkout of the public source commit.

## Portugues (pt-BR)

Atualiza o `traducao-osrs-br` para o commit publico validado da fonte do plugin.

Esta atualizacao:
- corrige os metadados que causavam texto quebrado no nome e na descricao do Plugin Hub;
- corrige o carregamento das traducoes em tempo de execucao, tolerando chaves duplicadas no JSON;
- corrige o dialogo especial do Hans sobre tempo de jogo;
- publica a base completa de traducoes validada localmente no RuneLite;
- mantem o plugin no build padrao do Plugin Hub com `build=standard`.

Dados de traducao no commit fonte:
- 116.857 traducoes unicas carregadas;
- 112.814 traducoes estaticas;
- 4.043 traducoes dinamicas com placeholders.

O plugin foi validado localmente com `gradlew testClasses --rerun-tasks` em um checkout limpo do commit publico.
