### PR TITLE
Update prayer-time-infobox to latest Combat Potions commit

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=a9582e19ca2598328cb77be41a6e60fc6f9e7235
+commit=bd3e584d18ff38f5969fbf1ec753960d6082b034


### PR DESCRIPTION
## Summary
- updates the `prayer-time-infobox` Plugin Hub manifest to the latest `Combat Potions` source commit
- includes the plugin restart fix so it can be disabled and enabled again cleanly
- adds `Anti-venom+` support as a selectable combat timer

## Validation
- built successfully with `./gradlew.bat build shadowJar`
- launched in RuneLite developer mode and verified `CombatPotionTimersPlugin` loads cleanly