### PR TITLE
Add Sorted Bank plugin

### DIFF
--- a/plugins/sorted-bank
+++ b/plugins/sorted-bank
@@ -1,0 +1,2 @@
+repository=https://github.com/g-Clef-Cannon/SortedBank.git
+commit=55de46ddcdeb45a8c4110b7a7ad6d9ebe4323161

--- a/plugins/sorted-bank
+++ b/plugins/sorted-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/g-Clef-Cannon/SortedBank.git
-commit=55de46ddcdeb45a8c4110b7a7ad6d9ebe4323161
+commit=154523e79e15e3139d27c43de041a67fec2af734

--- a/plugins/sorted-bank
+++ b/plugins/sorted-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/g-Clef-Cannon/SortedBank.git
-commit=154523e79e15e3139d27c43de041a67fec2af734
+commit=ea64b140263f19e865e992b84cfb861314d9d4c8


### PR DESCRIPTION
Adds Sorted Bank, a client-side bank organization plugin that sorts and filters the bank display without moving actual bank items.

Plugin repository: https://github.com/g-Clef-Cannon/SortedBank
Commit: ea64b140263f19e865e992b84cfb861314d9d4c8