### PR TITLE
Add Fire Timer Plus

### DIFF
--- a/plugins/fire-timer-plus
+++ b/plugins/fire-timer-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/notmessing/fire-timer-plus.git
-commit=e9a087ea8634781f3b9e1ddc70e6ed9fe689e9f7
+commit=9f218ed274b120b30b26df12acad582677969e2c

--- a/plugins/fire-timer-plus
+++ b/plugins/fire-timer-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/notmessing/fire-timer-plus.git
-commit=7a1bbe5779ceffe425d2e445ce8f2390ea5f7346
+commit=588fccf54fde80f72472f934c38bf3c69bbac9e5

--- a/plugins/fire-timer-plus
+++ b/plugins/fire-timer-plus
@@ -1,0 +1,2 @@
+repository=https://github.com/notmessing/fire-timer-plus.git
+commit=e9a087ea8634781f3b9e1ddc70e6ed9fe689e9f7

--- a/plugins/fire-timer-plus
+++ b/plugins/fire-timer-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/notmessing/fire-timer-plus.git
-commit=9f218ed274b120b30b26df12acad582677969e2c
+commit=7a1bbe5779ceffe425d2e445ce8f2390ea5f7346


### PR DESCRIPTION
Adds **Fire Timer Plus** — a RuneLite plugin that displays a countdown timer over player-made fires and Forester's Campfires.

Source: https://github.com/notmessing/fire-timer-plus
Commit: 9f218ed274b120b30b26df12acad582677969e2c

### What it does

- Tracks regular player-made fires (200-tick countdown), like the existing `fire-timer` plugin.
- Adds full support for Forester's Campfires from the Forestry update: detects which log type was used to light or refuel the campfire via the Firemaking XP drop, infers the per-log burn time, and updates the countdown live across refuels.
- Configurable display unit (raw ticks or `m:ss`), with `m:ss` driven off wall-clock time so seconds tick down evenly.
- Optional "allow negative" mode — a campfire countdown can go past 0 to signal someone refueled it after our estimate ran out.

### Relationship to the existing `fire-timer` plugin

This is adapted from [`autumn-smellegy/fire-timer`](https://github.com/autumn-smellegy/fire-timer) (which is itself a fork of `alevine/fire-timer`). The original plugin only handles regular cooking fires and hasn't seen a commit in ~4 years; campfire support is a substantial enough scope expansion that submitting as a separate plugin felt cleaner than asking upstream to merge it. Original BSD-2-Clause copyright and authorship are preserved in `LICENSE` and the git history.

### Screenshots and full feature list

In the [project README](https://github.com/notmessing/fire-timer-plus/blob/master/README.md).
