### PR TITLE
Add repository and commit information for seca-tears

### DIFF
--- a/plugins/seca-tears
+++ b/plugins/seca-tears
@@ -1,0 +1,2 @@
+repository=https://github.com/STRIKERnz/Seca-Tears.git
+commit=66378daf20000d7047003ebe5c4ed29c3999ed3d


### PR DESCRIPTION
When you do **not** have Magic secateurs equipped or in your inventory:

- **Moves "Pick" or "Harvest" below "Inspect"** in the right-click menu, making accidental mis-clicks less likely.
- **Changes the left-click action** away from "Pick"/"Harvest", so a single click no longer immediately harvests the patch.
- **Warns you** if you still click "Pick" or "Harvest" — via a **chat message** and/or **overhead text** above your character.

When you have Magic secateurs equipped or in your inventory, all behaviour returns to normal.