### PR TITLE
Update modern-chat: bug fix message filtering and recolor issues

### DIFF
--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=aa998118b25f96e1eea5e3e2b098781d6ce09c2e
+commit=443d13ceada259af5f568a0051bc48db1c648dcf

--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=a11f696ec2d169187a7c63a2e00dcadf59416ffe
+commit=182480d8ce8a7adf04ab494b88ea741d4f19ed9b

--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=563b0cc16fba2dfdd7e3c67c5d29bb4aba976bf9
+commit=aaf254897061835b308ff42321ad27b5af7727a2

--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=f391830bbb2292270686aca496c9939608c5fd49
+commit=a11f696ec2d169187a7c63a2e00dcadf59416ffe

--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=0d38ff8f7532aa99d6e14d4c906bee284a886803
+commit=aa998118b25f96e1eea5e3e2b098781d6ce09c2e

--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=9787e390c32479341d83344bec3816eca67730e3
+commit=563b0cc16fba2dfdd7e3c67c5d29bb4aba976bf9

--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=24e39195d0c995915a2ad318cfea95f70bf0ac2d
+commit=9787e390c32479341d83344bec3816eca67730e3

--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=182480d8ce8a7adf04ab494b88ea741d4f19ed9b
+commit=0d38ff8f7532aa99d6e14d4c906bee284a886803

--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=443d13ceada259af5f568a0051bc48db1c648dcf
+commit=24e39195d0c995915a2ad318cfea95f70bf0ac2d


### PR DESCRIPTION
Resolves https://github.com/BenDol/Modern-Chat/issues/27
Resolves https://github.com/BenDol/Modern-Chat/issues/28
Resolves https://github.com/BenDol/Modern-Chat/issues/29

Bonus:
- Add setting to remove the "Chat With" menu entry
- Add option to preserve chat focus on outside click
- Replace glyph vector stroking with stamped bitmap approach to resolve performance issues with the text outline drawing
- Skip chatbox resizing when legacy chat is displayed to resolve strange resize issues with legacy window showing