### PR TITLE
Update seca-tears plugin to v1.0.2

### DIFF
--- a/plugins/seca-tears
+++ b/plugins/seca-tears
@@ -1,2 +1,2 @@
 repository=https://github.com/STRIKERnz/Seca-Tears.git
-commit=a0541314cb56d6e5d72bd19f0978e9d809f564b9
+commit=4539f4764b2217627d56cf78256bcab2d0dca3b4


### PR DESCRIPTION
1.0.2 - 2026-05-02

    Restricted menu handling to supported farming patch object menus and Herbiboar NPC menus.
    Ignored unrelated menus such as ground items, inventory items, widgets, players, and RuneLite overlays.
    Improved warning cleanup so only this plugin's overhead text is cleared.
    Tightened action and target matching to reduce false positives.
    Changed startup and shutdown logging to debug level.