### PR TITLE
Add ObjectMarkerPlus plugin

### DIFF
--- a/plugins/object-marker-plus
+++ b/plugins/object-marker-plus
@@ -1,3 +1,3 @@
 repository=https://github.com/Shackin/ObjectMarkerPlus.git
-commit=3d708ccfd9cb0c125f8e8fbc521c957fc41717cd
+commit=9374c549d4d630d082b670a690ef17a14ac5e726
 authors=krak

--- a/plugins/object-marker-plus
+++ b/plugins/object-marker-plus
@@ -1,3 +1,3 @@
 repository=https://github.com/Shackin/ObjectMarkerPlus.git
-commit=3675280ce2551e2f1278376b0f028502bc26872
+commit=3675280ce2551e2f1278376b0f028502bc268725
 author=Krak

--- a/plugins/object-marker-plus
+++ b/plugins/object-marker-plus
@@ -1,3 +1,3 @@
 repository=https://github.com/Shackin/ObjectMarkerPlus.git
 commit=3675280ce2551e2f1278376b0f028502bc268725
-author=Krak
+authors=krak

--- a/plugins/object-marker-plus
+++ b/plugins/object-marker-plus
@@ -1,0 +1,3 @@
+repository=https://github.com/Shackin/ObjectMarkerPlus
+commit=3675280ce2551e2f1278376b0f028502bc26872
+author=Krak

--- a/plugins/object-marker-plus
+++ b/plugins/object-marker-plus
@@ -1,3 +1,3 @@
-repository=https://github.com/Shackin/ObjectMarkerPlus
+repository=https://github.com/Shackin/ObjectMarkerPlus.git
 commit=3675280ce2551e2f1278376b0f028502bc26872
 author=Krak

--- a/plugins/object-marker-plus
+++ b/plugins/object-marker-plus
@@ -1,3 +1,3 @@
 repository=https://github.com/Shackin/ObjectMarkerPlus.git
-commit=3675280ce2551e2f1278376b0f028502bc268725
+commit=3d708ccfd9cb0c125f8e8fbc521c957fc41717cd
 authors=krak


### PR DESCRIPTION
Adds Object Marker Plus plugin.

Import and export object markers via the world map orb menu. (Right click the world map orb)

Checks for invalid and duplicate entries, preventing them from being stored.