### PR TITLE
Add ZMI Helper plugin

### DIFF
--- a/plugins/zmi-helper
+++ b/plugins/zmi-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/NathanVegetable/runelite-zmi-helper.git
+commit=1b118d9b7ad174945bb13f13802d3dccf4c88353

--- a/plugins/zmi-helper
+++ b/plugins/zmi-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/runelite-zmi-helper.git
-commit=1b118d9b7ad174945bb13f13802d3dccf4c88353
+commit=4a98c0e5c33ee6ad9fa9e2e43c80dd0bf9f06ef1

--- a/plugins/zmi-helper
+++ b/plugins/zmi-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/runelite-zmi-helper.git
-commit=16cc810c3a3c4969896bff7b8c0f4c4f20a94be6
+commit=055c50ac688daba7761f0324eec6a1dd5b5f6e68

--- a/plugins/zmi-helper
+++ b/plugins/zmi-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/runelite-zmi-helper.git
-commit=055c50ac688daba7761f0324eec6a1dd5b5f6e68
+commit=9c79bd5aa19e4265cda42fd3046d6db16a517272

--- a/plugins/zmi-helper
+++ b/plugins/zmi-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/runelite-zmi-helper.git
-commit=4a98c0e5c33ee6ad9fa9e2e43c80dd0bf9f06ef1
+commit=4a98c0e29f5b6c897d93fc696a4fd57f8aef9ddc

--- a/plugins/zmi-helper
+++ b/plugins/zmi-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/runelite-zmi-helper.git
-commit=4a98c0e29f5b6c897d93fc696a4fd57f8aef9ddc
+commit=16cc810c3a3c4969896bff7b8c0f4c4f20a94be6


### PR DESCRIPTION
Adds ZMI Helper, a RuneLite plugin for Ourania Altar (ZMI) runecrafting.

Features:
- Pouch charge tracking - Text reminder and notification when any pouch has 1 fill remaining before degradation
- Run energy management - Spell highlight and low-energy reminder when energy drops below threshold
- Prayer altar highlighting - Highlights Chaos altar when prayer is low
- Ourania Teleport highlight - Highlights spell and spellbook tab when inventory and pouches are empty (ready to leave)

Plugin repository: https://github.com/NathanVegetable/runelite-zmi-helper
Commit: 1b118d9b7ad174945bb13f13802d3dccf4c88353