### PR TITLE
Update configurable-slayer-task-overlay

### DIFF
--- a/plugins/configurable-slayer-task-overlay
+++ b/plugins/configurable-slayer-task-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/configurable-slayer-task-overlay.git
-commit=01c80fd5ac2410819f0b87c7135ba96e9d4cabd4
+commit=3f334c95d1169a303d563e2388fe9f0e73549140


### PR DESCRIPTION
Fix task change detection false positive

Fixes NathanVegetable/configurable-slayer-task-overlay#1 where overlay was reactivating after every kill. Changed task comparison to use name equality instead of reference equality.