### PR TITLE
Add True tile renderer plugin

### DIFF
--- a/plugins/true-tile-renderer
+++ b/plugins/true-tile-renderer
@@ -1,0 +1,2 @@
+repository=https://github.com/CHRl5/true-tile-renderer.git
+commit=767c52eb281ced5feee3c2a878e8ae1d865c5aa4

--- a/plugins/true-tile-renderer
+++ b/plugins/true-tile-renderer
@@ -1,2 +1,2 @@
 repository=https://github.com/CHRl5/true-tile-renderer.git
-commit=767c52eb281ced5feee3c2a878e8ae1d865c5aa4
+commit=9001c1567a9f25d97b41e4e4b05d5180dbfe10a8


### PR DESCRIPTION
# Description

True Tile Renderer visualizes the server-true position in Old School RuneScape by anchoring player and selected NPC overlays to their actual server-side tile, rather than the smoothed client position.
This helps distinguish between the rendered model's position and the server's true tile, and is especially useful in PvM, boss fights, and for understanding tile-based movement and attacks.

## Key features:

 - Hides the local player model, showing a live-animated outline on the true tile instead.
 - Draws true-tile outlines and mirrored overlays (names, health bars, overheads, hitsplats) for selected NPCs or current combat targets.
 - Supports customizable outline colors, width, feathering, and NPC selection.

The plugin aims to make true tile behavior readable at a glance and assist with movement-heavy content, boss spacing, and model drift detection.

