### PR TITLE
Update kill-clog to 1.2.0

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=832ceb7e0e85f6137f6a0a8cc7a44584caf1b6c5
+commit=33d8c938df037a3dd5ff7abf87369af3786234d1
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=fc61c26b14deb6bb762170a3034751c1d86a4ead
+commit=7836268553a15ba48cbf484a4839d86eb6d12f45
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=c8c971cfac97944741588ba823d58de16e8d01e6
+commit=832ceb7e0e85f6137f6a0a8cc7a44584caf1b6c5
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=33d8c938df037a3dd5ff7abf87369af3786234d1
+commit=66429e49689c83a4da27792dc8ce848803ab5948
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=66429e49689c83a4da27792dc8ce848803ab5948
+commit=fc61c26b14deb6bb762170a3034751c1d86a4ead
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=7836268553a15ba48cbf484a4839d86eb6d12f45
+commit=fa86e1bec7afbd9525df45045084b172069d8aaf
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update Kill Clog from `c8c971c` → `7836268` (v1.2.0).

### Right click options and qol
- Right-click options added to friends list, ignore list, friends chat, clan + guest clan, GIM panel, chatbox, and private chat
- auto nav to Kill Clog side panel on right-click lookup
- One-time chat warning when player right-click menu's 4 plugin slots are full

### Bug fixes
- Plugin deactivation and reactivation during sync caused silent failure
- Autocomplete double-insertion after plugin reload
- Auto-lookup on login no longer fires on world hops or teleports
- Iron/GIM badge no longer briefly shows regular at login

### Performance and polish 
- Disk writes coalesced per player 
- 3 min Temple failure cooldown from session-long
- Hand cursors removed

### Plugin Hub listing
- Description rewritten to "HiScores Overhaul with Collection Log Integration" (was "Kills. Clogs. Colors.")
- Icon: transparent background (was a dark rectangle) and chalice scaled up for better visibility in listings

### Internal modernization
- Migrated to `gameval.InterfaceID` namespace
- Account type detection via `VarbitID.IRONMAN` 
- Menu entry creation via `client.getMenu().createMenuEntry()` 
- `-Xlint:deprecation` enabled in build 