### PR TITLE
Fix exception on destroy/disable

### DIFF
--- a/plugins/prestige-mode
+++ b/plugins/prestige-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/nick-michael/rl-prestige-mode.git
-commit=68edb657f009256758364adc245def28c1999563
+commit=3c861a5a07538b32c97c035b137d59b4f564de23

--- a/plugins/prestige-mode
+++ b/plugins/prestige-mode
@@ -1,3 +1,2 @@
 repository=https://github.com/nick-michael/rl-prestige-mode.git
-commit=6680d4b422fab36cbb53a8634f37824cf2ce243e
-unavailable=broken
+commit=68edb657f009256758364adc245def28c1999563


### PR DESCRIPTION
Updated the commit hash for the prestige mode plugin.

- Fixes widget index for numerator/denominator

- Fixes an issue when disabling a skill or disabling the plugin which was causing an uncaught exception.
```
Uncaught exception:
java.lang.AssertionError: must be called on client thread
```