### PR TITLE
Add BRUHsailer Guide

### DIFF
--- a/plugins/bruhsailor
+++ b/plugins/bruhsailor
@@ -1,2 +1,2 @@
 repository=https://github.com/Bobakanoosh/runelite-bruhsailor.git
-commit=9b84d5ad9769145ce876dbdd36710d84596e215b
+commit=46948ba570c23c89c82151e49fc045d55e151ca6

--- a/plugins/bruhsailor
+++ b/plugins/bruhsailor
@@ -1,2 +1,2 @@
 repository=https://github.com/Bobakanoosh/runelite-bruhsailor.git
-commit=46948ba570c23c89c82151e49fc045d55e151ca6
+commit=04d894e4ee68ba3cd9c8dc965276cacf582f57ff

--- a/plugins/bruhsailor
+++ b/plugins/bruhsailor
@@ -1,0 +1,2 @@
+repository=https://github.com/Bobakanoosh/runelite-bruhsailor.git
+commit=9b84d5ad9769145ce876dbdd36710d84596e215b


### PR DESCRIPTION
Adds the **BRUHsailer Guide** plugin — a side panel companion for the [BRUHsailer ironman guide](https://bruhsailer.com/).

### Features
- Side panel with chapter / section / step navigation, prev/next buttons, and a list view for jumping to any step.
- Per-step `Done` toggle and per-sentence checkbox bullets that strike through completed sentences.
- Inline link-outs:
  - Quest names (blue) → open in Quest Helper if installed (soft dep via reflection — no hard dep).
  - NPC names (amber) → OSRS wiki page for the NPC.
  - Location names (green) → OSRS wiki page for the location.

### Bundled data
- `guide_data.json` — BRUHsailer guide content (fetched from the public Google Doc).
- `step_mappings.json` — per-step item / quest / NPC / location mappings (generated offline).
- `quests.json` — Quest Helper enum index used for inline quest matching.

Repo: https://github.com/Bobakanoosh/runelite-bruhsailor