### PR TITLE
Add `Gauntlet History` plugin

### DIFF
--- a/plugins/gauntlet-history
+++ b/plugins/gauntlet-history
@@ -1,0 +1,2 @@
+repository=https://github.com/roccogalluzzo/gauntlet-history.git
+commit=189e2cd1a4796791dc5ddfe2db2d0b1f9683e4a2


### PR DESCRIPTION
Adds `Gauntlet History to the Plugin Hub.

It's a plugin that tracks every Gauntlet and Corrupted Gauntlet run: kills, deaths, prep/fight times, and detailed boss-fight performance and exports them to a self-contained HTML report.