### PR TITLE
Add `Random Timer` plugin

### DIFF
--- a/plugins/random-timer
+++ b/plugins/random-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/matthewxmar10/random-timer-plugin.git
-commit=8523cb9c9f6f2068cabf8207284f2a3c34fba58f
+commit=3224938238d630bbfc7b590705d0063015ae447e

--- a/plugins/random-timer
+++ b/plugins/random-timer
@@ -1,2 +1,2 @@
-repository=https://github.com/matthewxmar10/random-timer-plugin
+repository=https://github.com/matthewxmar10/random-timer-plugin.git
 commit=719f256f6d36aa5213d7b29a2a1f55099df651e9

--- a/plugins/random-timer
+++ b/plugins/random-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/matthewxmar10/random-timer-plugin
+commit=719f256f6d36aa5213d7b29a2a1f55099df651e9

--- a/plugins/random-timer
+++ b/plugins/random-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/matthewxmar10/random-timer-plugin.git
-commit=719f256f6d36aa5213d7b29a2a1f55099df651e9
+commit=8523cb9c9f6f2068cabf8207284f2a3c34fba58f


### PR DESCRIPTION
A RuneLite plugin that fires a hidden alarm at a random time between two intervals you set. You set the range, but never know when it will go off. 

Useful as an awareness check, an anti-AFK prompt, or a general activity reminder. I am personally planning to use this for a Leagues-based series when available.

When you start the timer, the plugin picks a random moment between your minimum and maximum time settings. When that moment arrives:
- A sound plays - either your own custom .wav file or the built-in alarm beep
- A message appears in your chatbox
- The timer resets and waits for you to start it again

The sidebar panel shows how long the timer has been running, and a small HUD infobox displays the elapsed time on screen, but the target time is always hidden.