### PR TITLE
notable-players

### DIFF
--- a/plugins/notable-players
+++ b/plugins/notable-players
@@ -1,0 +1,2 @@
+repository=https://github.com/pairofcrocs/notable-players-osrs.git
+commit=79a2ceb775488b0de09e2858c18b9cc893a42195


### PR DESCRIPTION
Adds Notable Players, a plugin that highlights notable players (curated content creators and unique accounts, plus auto-detected Jagex Mods and a user-managed custom list) when they appear near you in-game. Each match gets a configurable model outline, tile, label, minimap text, and an info-panel entry with the reason they're notable.

Repo: https://github.com/pairofcrocs/notable-players-osrs

The bundled list is fetched from the plugin's GitHub repository on startup and falls back to the JSON shipped in the JAR if the request fails. Users can disable the network fetch in the plugin config.