### PR TITLE
Add QuestPath

### DIFF
--- a/plugins/questpath
+++ b/plugins/questpath
@@ -1,0 +1,3 @@
+repository=https://github.com/ripperosa/questpath.git
+commit=0c891359eb0a273fa7e4abf1f668cf077e271faa
+authors=Rodney

--- a/plugins/questpath
+++ b/plugins/questpath
@@ -1,3 +1,0 @@
-repository=https://github.com/ripperosa/questpath.git
-   commit=5479c7c7545eadd9e0213c954aba7366d5b393e2
-   authors=Rodney

--- a/plugins/questpath
+++ b/plugins/questpath
@@ -1,3 +1,3 @@
 repository=https://github.com/ripperosa/questpath.git
-   commit=53993331fa2278c061d54510a160ea3dea282039
+   commit=5479c7c7545eadd9e0213c954aba7366d5b393e2
    authors=Rodney

--- a/plugins/questpath
+++ b/plugins/questpath
@@ -1,0 +1,3 @@
+repository=https://github.com/ripperosa/questpath.git
+   commit=53993331fa2278c061d54510a160ea3dea282039
+   authors=Rodney


### PR DESCRIPTION
QuestPath — quest prerequisite visualizer and planner for OSRS.

## What it does
Pick any target quest, miniquest, or achievement diary. The plugin shows
the full prerequisite tree color-coded by completion, surfaces unmet skill
walls, and produces a topologically-ordered plan including training-method
suggestions weighted by Time / GP / AFK preference.

## Data
257 quests / miniquests / diaries bundled as static JSON, derived from
Quest Helper's open-source helper classes (BSD-2-Clause). No Quest Helper
code is bundled — only structured requirement data parsed from their source.
The bundle is generated by a Python script at build time; the plugin makes
zero network requests at runtime.

## Notes for reviewers
- Reflection: the optional "Open in Quest Helper" hand-off uses reflection
  on Quest Helper's QuestManager (no public API exists). It is gated behind
  an opt-in config (`enableQuestHelperHandoff`, default false), so default
  users never trigger reflection. Happy to remove this entire path if it's
  a concern — it's isolated to one class (`integration/QuestHelperBridge.java`)
  and one button on the info card.
- No HTTP, no file I/O outside the standard plugin config dir, no input
  injection, no PvM/PvP overlays.
- LICENSE: BSD 2-Clause (matches Quest Helper's license, since we extract
  data from their source).