### PR TITLE
Update 420-kc to 1.1.0

### DIFF
--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420kcp.git
-commit=b6c10673defe1a3f32c5e24a2d1951018897ae2f
+commit=7b2e5212e4787024d637b36345427ef51d05d9f9

--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420kcp.git
-commit=cc182d564f94e2352b0fd9aa2ec6f20feeb7a95f
+commit=b6c10673defe1a3f32c5e24a2d1951018897ae2f


### PR DESCRIPTION
Update 420 kc from `cc182d5` → `b6c1067` (v1.1.0).

### Changes
- Icon: transparent background, scaled-up chalice (matches Kill Clog's listing icon style)
- Tag: added `kill clog` for cross-discoverability with companion plugin
- Version bumped to 1.1.0

No source changes. No new dependencies. No new endpoints.