### PR TITLE
Add clue-delayed-gratification plugin repository info

### DIFF
--- a/plugins/clue-delayed-gratification
+++ b/plugins/clue-delayed-gratification
@@ -1,0 +1,2 @@
+repository=https://github.com/rubenmay1/clue-delayed-gratification.git
+commit=c1eacb0b5fc9d8ad94321c5fab3b2baadb3e09e0


### PR DESCRIPTION
Block opening clue caskets until a minimum stack size has been accumulated.