### PR TITLE
Takeover scrollboxcounter

### DIFF
--- a/plugins/scrollboxcounter
+++ b/plugins/scrollboxcounter
@@ -1,2 +1,2 @@
-repository=https://github.com/IEarnSolo/scrollboxcounter.git
+repository=https://github.com/RonnyTommy548/scrollboxcounter.git
 commit=98c1ec30e075be7b37a01be53081908746dc1db3

--- a/plugins/scrollboxcounter
+++ b/plugins/scrollboxcounter
@@ -1,2 +1,2 @@
 repository=https://github.com/RonnyTommy548/scrollboxcounter.git
-commit=98c1ec30e075be7b37a01be53081908746dc1db3
+commit=9b4071e39dc40d6d120fbdb58be3287bf1154026


### PR DESCRIPTION
I would like to takeover the scrollboxcounter plugin.

I have a bug fix PR I'd like to get merged, and some other fixes/improvements planned. The author has been unresponsive on Discord (pings in Runelite development channel, DMs), not responding to any issues for months/reviewing PRs/no recent commit activity. As the [takeover instructions ](https://github.com/runelite/runelite/wiki/Plugin-takeover-policy)recommend, I made a [collaborator request](https://github.com/IEarnSolo/scrollboxcounter/issues/10) 7 days ago, which has received no response. I have enabled issues on my fork.