### PR TITLE
Bump lulinha to 68ca7e8

### DIFF
--- a/plugins/lulinha
+++ b/plugins/lulinha
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/RuneliteAddons.git
-commit=d81a79500df22eb25cf8860af4c10c90dfeffea6
+commit=68ca7e84586169ad29315fc9c40511faa2ca999e


### PR DESCRIPTION
Updates the lulinha plugin to commit `68ca7e8`.

## What's new in this update

- Overhead alert now identifies the attacker by name (e.g. `Calma Companheiro <PlayerName>`).
- Adds an optional chat-message output (toggle: `Show Chat Message`, on by default) that posts the same line to the local chat box as a `GAMEMESSAGE`.
- Tightens the trigger: the alert now only fires when a *player* (local or other) deals the 13. NPC-dealt 13s used to slip through `isMine() || isOthers()`; they no longer do.
- Removes the freeform `Overhead Text` config option; the prefix is now hardcoded.

Plugin still uses only the standard RuneLite API (`build=standard`).