### PR TITLE
Update cox analytics to 1.0.4

### DIFF
--- a/plugins/cox-analytics
+++ b/plugins/cox-analytics
@@ -1,2 +1,2 @@
 repository=https://github.com/DangItOSRS/cox-analytics.git
-commit=8cc196c9e4b873e3f0115a8236f1a06e187265aa
+commit=102ddd9385a5c2abfe4782d60f44d87184275478

--- a/plugins/cox-analytics
+++ b/plugins/cox-analytics
@@ -1,2 +1,2 @@
 repository=https://github.com/DangItOSRS/cox-analytics.git
-commit=102ddd9385a5c2abfe4782d60f44d87184275478
+commit=60c3d373ef8956d60b549dc90bd2a37e7f843cb9


### PR DESCRIPTION
Changes included: https://github.com/DangItOSRS/cox-analytics/pull/6

- Fix bug where floor and olm splits were not being recorded after relogging during a raid
- Unregister party packet on shutdown