### PR TITLE
Update kill-clog to 1.2.2

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=c8c971cfac97944741588ba823d58de16e8d01e6
+commit=2f02bc3104517ad497fbc2eae9d5a3606b252c65
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update Kill Clog from \`c8c971c\` → \`2f02bc3\` (v1.2.2).

### v1.2.2
- Don't await executor termination on shutdown (per @LlemonDuck review). Pending tasks are drained to a fresh executor before \`old.shutdown()\`, so the await was redundant defense and was blocking the caller thread.

### Right click options and qol
- Right-click "Kill Clog" lookup on friends list, ignore list, friends chat, clan + guest clan, GIM panel, chatbox, and private chat
- auto nav to Kill Clog side panel on right-click lookup
- Double-click magnifying-glass in search bar to look up self
- One-time chat warning when player right-click menu's 4 plugin slots are full

### Bug fixes
- Plugin deactivation and reactivation during sync caused silent failure
- Autocomplete double-insertion after plugin reload
- Right-click missing on chatbox names
- Auto-lookup on login no longer fires on world hops or teleports
- Iron/GIM badge no longer briefly shows regular at login

### Performance and polish
- Disk writes coalesced per player with 500ms debounce, drained on shutdown
- 3 min Temple failure cooldown from session-long
- Hand cursors removed
- Dead code cleanup, null guards on player options + menu target

### Plugin Hub listing
- Description rewritten to "HiScores Overhaul with Collection Log Integration"
- Icon: transparent background, chalice scaled up
- build=standard for automated review