### PR TITLE
Add Barbarian Fishing Timers plugin

### DIFF
--- a/plugins/barbarian-fishing-timers
+++ b/plugins/barbarian-fishing-timers
@@ -1,2 +1,2 @@
-repository=https://github.com/staticvoid07/barbarian-fishing-timers
+repository=https://github.com/staticvoid07/barbarian-fishing-timers.git
 commit=35c202c

--- a/plugins/barbarian-fishing-timers
+++ b/plugins/barbarian-fishing-timers
@@ -1,0 +1,2 @@
+repository=https://github.com/staticvoid07/barbarian-fishing-timers
+commit=35c202c

--- a/plugins/barbarian-fishing-timers
+++ b/plugins/barbarian-fishing-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/barbarian-fishing-timers.git
-commit=35c202c9fb72c9b13225186e9ee02516b277388b
+commit=3fa8b60c20a1a716be699640b7a8d1ea1eba24aa

--- a/plugins/barbarian-fishing-timers
+++ b/plugins/barbarian-fishing-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/barbarian-fishing-timers.git
-commit=35c202c
+commit=35c202c9fb72c9b13225186e9ee02516b277388b


### PR DESCRIPTION
Adds the Barbarian Fishing Timers plugin.

Displays how long each barbarian fishing spot has been at its current position (in game ticks), with configurable color thresholds and a highlight for the spot with the lowest timer.