### PR TITLE
Add Bone Mining Notifier plugin

### DIFF
--- a/plugins/bone-mining-notifier
+++ b/plugins/bone-mining-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/staticvoid07/bone-mining-notifier.git
+commit=0b9f22d84debfb49be61b3dd717c37237331d001


### PR DESCRIPTION
Notifies the player when a calcified rock depletes in a cardinal direction (N/S/E/W) directly adjacent to them, helping minimise tick loss while mining calcified rocks in Varlamore.