### PR TITLE
Update Bone Mining Notifier commit hash

### DIFF
--- a/plugins/bone-mining-notifier
+++ b/plugins/bone-mining-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/bone-mining-notifier.git
-commit=0b9f22d84debfb49be61b3dd717c37237331d001
+commit=96bdd10c31060792305b503ec960034d1734a2a4


### PR DESCRIPTION
Updates the commit hash to fix the author name in runelite-plugin.properties (was real name, now GitHub username).