### PR TITLE
Add cosmetic-cannon plugin

### DIFF
--- a/plugins/cosmetic-cannon
+++ b/plugins/cosmetic-cannon
@@ -1,0 +1,2 @@
+repository=https://github.com/FigmentsOSRS/Cosmetic-Cannon-Plugin.git
+commit=be198b540bde46f84e16e0fedeec4ff5c1d864c1

--- a/plugins/cosmetic-cannon/cosmetic-cannon
+++ b/plugins/cosmetic-cannon/cosmetic-cannon
@@ -1,0 +1,2 @@
+repository=https://github.com/FigmentsOSRS/Cosmetic-Cannon-Plugin.git
+commit=90f35a850fe8221ac482940997d2b760c1c613cb

--- a/plugins/cosmetic-cannon/cosmetic-cannon
+++ b/plugins/cosmetic-cannon/cosmetic-cannon
@@ -1,2 +1,2 @@
 repository=https://github.com/FigmentsOSRS/Cosmetic-Cannon-Plugin.git
-commit=bf46d4245c06a2feccd7a34b70d3fe1577ea8458
+commit=be198b540bde46f84e16e0fedeec4ff5c1d864c1

--- a/plugins/cosmetic-cannon/cosmetic-cannon
+++ b/plugins/cosmetic-cannon/cosmetic-cannon
@@ -1,2 +1,2 @@
 repository=https://github.com/FigmentsOSRS/Cosmetic-Cannon-Plugin.git
-commit=90f35a850fe8221ac482940997d2b760c1c613cb
+commit=bf46d4245c06a2feccd7a34b70d3fe1577ea8458

--- a/plugins/cosmetic-cannon/cosmetic-cannon
+++ b/plugins/cosmetic-cannon/cosmetic-cannon
@@ -1,2 +1,0 @@
-repository=https://github.com/FigmentsOSRS/Cosmetic-Cannon-Plugin.git
-commit=be198b540bde46f84e16e0fedeec4ff5c1d864c1


### PR DESCRIPTION
Replaces dwarf multicannon cannonball projectiles with custom visuals, configurable per firing direction.

- Supports standard cannonball (ID 53), granite cannonball (ID 1443), and cannon reskin variant (ID 2018)
- - Four swap modes: Random, Rainbow Cycle, Custom (per direction preset), and Experimental (raw ID entry)
- - Direction detection via source/target WorldPoint vector math (atan2), 8 compass directions
- - 70+ preset projectile visuals sourced from boss projectiles and other in-game graphics
- - Swap technique based on the Chinbompa method