### PR TITLE
Upgrade dont-telegrab-npcs to v1.0.5

### DIFF
--- a/plugins/dont-telegrab-npcs
+++ b/plugins/dont-telegrab-npcs
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/dont-telekinetic-grab-npcs.git
-commit=426e70d5fdf3201e0a32b58397527b9b52dcf3a0
+commit=46e89d45df48eb8a76c2d6f4fdb4cff4a22b6c68


### PR DESCRIPTION
- Add sailing crates to whitelist
- Add build type & version to properties