### PR TITLE
Update prayer-time-infobox

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=bd3e584d18ff38f5969fbf1ec753960d6082b034
+commit=6b9cf69687110088cdcc742f64258c7c32e89106


### PR DESCRIPTION
﻿Updates the existing prayer-time-infobox Plugin Hub entry to the latest source commit.

Changes in the plugin source:
- Renames the plugin display to PvM Toolkit while keeping the same Plugin Hub entry.
- Adds Slayer helpers for superior spawn flashing, Death Spawn hiding, and superior examine hints.
- Adds inventory free-space infobox with inventory value tooltip.
- Keeps combat potion and prayer timer warning behavior, with slower three-flash warnings.

Validation:
- Ran `./gradlew.bat build shadowJar` successfully in the plugin repository with Java 11.
- Ran `git diff --check` for the Plugin Hub manifest change.
- Ran Plugin Hub `prep` successfully locally. Full packager execution is Linux/CI-oriented and cannot complete on this Windows checkout because it invokes `package/gradlew` directly.
