### PR TITLE
Update Barbarian Fishing Timers

### DIFF
--- a/plugins/barbarian-fishing-timers
+++ b/plugins/barbarian-fishing-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/barbarian-fishing-timers.git
-commit=3fa8b60c20a1a716be699640b7a8d1ea1eba24aa
+commit=dadbb67e4d0b2350f03e2bff34dd521da007dbee


### PR DESCRIPTION
Updates Barbarian Fishing Timers to add a notification when a fishing spot directly beside the player moves, and fixes a case where the notification could be suppressed if two spots swapped positions.