### PR TITLE
Update to xp-to-level-notification

### DIFF
--- a/plugins/xp-to-level-notification
+++ b/plugins/xp-to-level-notification
@@ -1,2 +1,2 @@
-repository=https://github.com/Vanillj/XpToLevelNotification.git
+repository=https://github.com/R-Dson/XpToLevelNotification.git
 commit=9b456a19bb810ff8ca5480966de81d6818f11ec2

--- a/plugins/xp-to-level-notification
+++ b/plugins/xp-to-level-notification
@@ -1,2 +1,2 @@
 repository=https://github.com/Vanillj/XpToLevelNotification.git
-commit=70666cdd7003dff6b0560eee4c32469cb3f11cd6
+commit=44783970a4f3315994e85b7bc81ed1d6dcd02364

--- a/plugins/xp-to-level-notification
+++ b/plugins/xp-to-level-notification
@@ -1,2 +1,2 @@
 repository=https://github.com/Vanillj/XpToLevelNotification.git
-commit=44783970a4f3315994e85b7bc81ed1d6dcd02364
+commit=9b456a19bb810ff8ca5480966de81d6818f11ec2


### PR DESCRIPTION
This update fixes an annoying bug that was spamming players with "0 XP left"
notifications when hitting 200m XP. I also cleaned up the backend logic, updated the config settings and bumped the gradle build version. 
