### PR TITLE
Add thrall-highlighter plugin

### DIFF
--- a/plugins/thrall-highlighter
+++ b/plugins/thrall-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/Sung-Rai/thrall-highlighter.git
+commit=27b696567c016ce7f8b8286cc6ec2448b59264a5


### PR DESCRIPTION
The thrall highlighter plugin offers an interface to outline your thralls, as well as provide unique colours for the different thrall types. You can also hide the thralls in the interface, allowing you to keep thralls hidden and toggle the entity hider plugin on/off without messing with thralls' visibility settings.