### PR TITLE
Add Inventory Hover Highlighter plugin

### DIFF
--- a/plugins/inventory-highlighter
+++ b/plugins/inventory-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/Emtec-byte/InventoryHighlighter.git
+commit=ab1de3ec96610d0036018f1213cc056bb9d8707c


### PR DESCRIPTION
Plugin that outlines configured items when you hover them in inventory-style interfaces.

- Highlight matching items only while they are hovered
- Wildcard matching support (e.g., `rune*` matches all rune items)
- Multiple highlight styles (outline, fill, click box or both)
- Choose between item sprite or full click box highlighting
- Scratch pad text box for quick copy/paste configuration changes