### PR TITLE
Update Barbarian Fishing Timers to v1.1

### DIFF
--- a/plugins/barbarian-fishing-timers
+++ b/plugins/barbarian-fishing-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/barbarian-fishing-timers.git
-commit=dadbb67e4d0b2350f03e2bff34dd521da007dbee
+commit=366533f34e0e4f46e9a0bdbdc52a2274159f5c05


### PR DESCRIPTION
Updates Barbarian Fishing Timers to v1.1.

Fixes notification logic that was not reliably triggering when a fishing spot beside the player moved.