### PR TITLE
Update logout-fix-resizable-modern-osrs to v1.2

### DIFF
--- a/plugins/logout-fix-resizable-modern
+++ b/plugins/logout-fix-resizable-modern
@@ -1,2 +1,2 @@
 repository=https://github.com/psikoo/logout-fix-resizable-modern-osrs.git
-commit=b5b316cfc89ec1ee385d8c3b76303862d7f66be9
+commit=65558d42ff61d7ce5cfb71df3b667184196c216e

--- a/plugins/logout-fix-resizable-modern
+++ b/plugins/logout-fix-resizable-modern
@@ -1,2 +1,2 @@
 repository=https://github.com/psikoo/logout-fix-resizable-modern-osrs.git
-commit=05dbe98356ffca024fc2912bef808149c05d4d1e
+commit=b5b316cfc89ec1ee385d8c3b76303862d7f66be9


### PR DESCRIPTION
Fixed issue where door icon would show with bank UI open.

Fixed issue where using fkeys to change the active tab wouldnt update the stone color.