### PR TITLE
Add log-basket plugin

### DIFF
--- a/plugins/log-basket
+++ b/plugins/log-basket
@@ -1,0 +1,2 @@
+repository=https://github.com/aidanmastro/log-basket-plugin.git
+commit=9013d9ba09c025676207b24231917acd75c65ba4


### PR DESCRIPTION
Adds Log Basket: a plugin that tracks and displays the log count inside a log basket / forestry basket. Inventory and equipment overlay only.

Repo: https://github.com/aidanmastro/log-basket-plugin