### PR TITLE
update tasks-tracker

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=a15f98a95f30c3edbdb28b8e0ca0f3791056c2a2
+commit=416520eebc0fc942bada103a837997c75d73d606
 authors=perterter,JamesShelton140


### PR DESCRIPTION
Highlights:
- Removed the default shift+space keybind, and changed config key to wipe for all users
- Removed okhttp caching - a few users on Windows had write conflicts in their cache when using 2 clients (our CDN GitHub 😂 has a 5 minute cache header anyways, so it wasn't much of a cache anyways)

Changes:
[remove default hotkey for complete custom task](https://github.com/osrs-reldo/tasks-tracker-plugin/commit/261cdf8551e73f959b2c9f2f1a9fef3de9be9f49)
    [remove okhttp caching for task json data](https://github.com/osrs-reldo/tasks-tracker-plugin/commit/cdc147b032a3bff52eb8ec4cc449866cf2993f99)
    [remove premade route manifest cache](https://github.com/osrs-reldo/tasks-tracker-plugin/commit/9594916c284eb50e7af72069f0d644eeb4238d56)
    [remove os league tools advert](https://github.com/osrs-reldo/tasks-tracker-plugin/commit/137a8057b39fd752747c629c890d7543ce299d8c)