### PR TITLE
wilderness-alarm-plus: New plugin

### DIFF
--- a/plugins/wilderness-alarm-plus
+++ b/plugins/wilderness-alarm-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/WuzeO/wilderness-alarm-plus.git
-commit=255c282b42b9594040d7a3c73b82526aac19c3af
+commit=08fbaf64e0b36f14136f637d2138d362d0880caa

--- a/plugins/wilderness-alarm-plus
+++ b/plugins/wilderness-alarm-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/WuzeO/wilderness-alarm-plus.git
-commit=08fbaf64e0b36f14136f637d2138d362d0880caa
+commit=c3845a4bc4517f1f21d60bf5b467676cf09b957f

--- a/plugins/wilderness-alarm-plus
+++ b/plugins/wilderness-alarm-plus
@@ -1,0 +1,2 @@
+repository=https://github.com/WuzeO/wilderness-alarm-plus.git
+commit=255c282b42b9594040d7a3c73b82526aac19c3af


### PR DESCRIPTION
Adds a new plugin: **Wilderness Alarm+**.

Flashes the screen red when an attackable player (someone within your wilderness combat bracket = your combat level ± wilderness level) is visible nearby, and optionally blue for out-of-bracket players. Both flashes are individually toggleable. Outside the wilderness the overlay is silent (gated on `VARBIT_IN_WILDERNESS`).

Source: https://github.com/WuzeO/wilderness-alarm-plus
License: BSD 2-Clause
