### PR TITLE
update 117hd

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=7668ac1bd9f150ff11412b7168284a582d624306
+commit=8223a979eeb09919ec5b7b1506088b3db3b1c640
 authors=aHooder


### PR DESCRIPTION
This is a small patch which fixes the bug causing the Sotetseg maze to be slightly visible in hard mode Theatre of Blood. Otherwise it only includes JSON changes, including various minor improvements for the league.