### PR TITLE
update attacktimer

### DIFF
--- a/plugins/attacktimer
+++ b/plugins/attacktimer
@@ -1,3 +1,3 @@
 repository=https://github.com/ngraves95/attacktimer.git
-commit=bcd5d22327ce9392069d239c88c6ad6d7a32f9ec
+commit=506d859c86c3a3348bf9ce0c86bfcf77c787255c
 authors=ngraves95,Lexer747


### PR DESCRIPTION
Sorry for the large diff but this should make all future diffs smaller, the only change is https://github.com/ngraves95/attacktimer/commit/506d859c86c3a3348bf9ce0c86bfcf77c787255c which enables linting and a format checker for the plugin. There's no functional changes to the plugin at all.