### PR TITLE
Update Shortest Path to 1.19.3 (Hotfix release)

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=ce937d1bbc14b46022e8ff2a7ad84199461046aa
+commit=94d0e15dbe35a0bdbf0c36cc82594ef9d5852bce
 authors=Skretzo,FIrgolitsch,wvanderp


### PR DESCRIPTION
Wrong varbits got assigned for the World Map container in the last update. Small hotfix release.