### PR TITLE
Update configurable-slayer-task-overlay

### DIFF
--- a/plugins/configurable-slayer-task-overlay
+++ b/plugins/configurable-slayer-task-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/configurable-slayer-task-overlay.git
-commit=3f334c95d1169a303d563e2388fe9f0e73549140
+commit=bb733292dfef62a170335c7fbb349f8ef1d78956


### PR DESCRIPTION
Fix plugin load and overlay behavior

Defer database access to client thread to fix load failure and overlay flickering.
Only re-enable overlay when checking slayer gem/helm if not already engaged.

Fixes NathanVegetable/configurable-slayer-task-overlay#1 and NathanVegetable/configurable-slayer-task-overlay#2