### PR TITLE
Add yama-shoebop plugin

### DIFF
--- a/plugins/yama-shoebop
+++ b/plugins/yama-shoebop
@@ -1,0 +1,2 @@
+repository=https://github.com/BrendanMichaelGallant/yama-shoebop.git
+commit=95859cbc9c295b4e9b73d88385b9f8022c5f4ed6

--- a/plugins/yama-shoebop
+++ b/plugins/yama-shoebop
@@ -1,2 +1,2 @@
 repository=https://github.com/BrendanMichaelGallant/yama-shoebop.git
-commit=4422245208a7d743621b40cb6c036b5236ae0887
+commit=16f4ed0a4b93a8753d76a01d1cc57f324a2e59ef

--- a/plugins/yama-shoebop
+++ b/plugins/yama-shoebop
@@ -1,2 +1,2 @@
 repository=https://github.com/BrendanMichaelGallant/yama-shoebop.git
-commit=95859cbc9c295b4e9b73d88385b9f8022c5f4ed6
+commit=89cf672f8c6458f028bcf5ae2d4b3b9143f8dcdb

--- a/plugins/yama-shoebop
+++ b/plugins/yama-shoebop
@@ -1,2 +1,2 @@
 repository=https://github.com/BrendanMichaelGallant/yama-shoebop.git
-commit=89cf672f8c6458f028bcf5ae2d4b3b9143f8dcdb
+commit=651cacbd9623c97ea81ab750474d88ebc37cef7b

--- a/plugins/yama-shoebop
+++ b/plugins/yama-shoebop
@@ -1,2 +1,2 @@
 repository=https://github.com/BrendanMichaelGallant/yama-shoebop.git
-commit=651cacbd9623c97ea81ab750474d88ebc37cef7b
+commit=4422245208a7d743621b40cb6c036b5236ae0887


### PR DESCRIPTION
Adds Yama Shoebop, a small plugin for the Demonic Pacts League (Leagues VI). When the player casts the League Home Teleport (animation 13764), the plugin plays a short bundled audio clip and suppresses the in-game teleport sound during the cast. Movement to a different tile cancels the clip and clears the mute window.

Audio is bundled as a 16-bit PCM WAV under src/main/resources.

Repo: https://github.com/BrendanMichaelGallant/yama-shoebop