### PR TITLE
Add Fire at will Timer plugin

### DIFF
--- a/plugins/fire-at-will-timer
+++ b/plugins/fire-at-will-timer
@@ -1,3 +1,3 @@
 repository=https://github.com/theshane0314/fire-at-will-plugin.git
-commit=643753bd7721693a63dd5d42a99c542922a8675b
+commit=7167bccc17e64d5729935c12aed48edb6c3d1991
 authors=Shalysa

--- a/plugins/fire-at-will-timer
+++ b/plugins/fire-at-will-timer
@@ -1,3 +1,3 @@
 repository=https://github.com/theshane0314/fire-at-will-plugin.git
-commit=7167bccc17e64d5729935c12aed48edb6c3d1991
+commit=ebfd0d6fb306e97b98e03baa522352a783444e45
 authors=Shalysa

--- a/plugins/fire-at-will-timer
+++ b/plugins/fire-at-will-timer
@@ -1,0 +1,3 @@
+repository=https://github.com/theshane0314/fire-at-will-plugin.git
+commit=643753bd7721693a63dd5d42a99c542922a8675b
+authors=Shalysa


### PR DESCRIPTION
Adds the **Fire at will Timer** plugin.

**What it does:** Tracks the in-game `Fire at will!` crew call during boat combat (Sailing). Starts a 10 minute countdown when the call is issued, displays it as a small tile or large tile, color-shifts at configurable warning / alert thresholds, and notifies via RuneLite's standard Notifier on warning, alert, or expiry. Detects manual cancellation via `Attack my targets!` / `Await further orders!` calls.

**Repo:** https://github.com/theshane0314/fire-at-will-plugin
**Author:** Shalysa