### PR TITLE
Update kill-clog to 1.3.0

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=c8c971cfac97944741588ba823d58de16e8d01e6
+commit=629aa1411b3a3cfd9db0349fc1a90bf7f5396515
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update Kill Clog from `c8c971c` → `629aa14` (v1.3.0).

### v1.3.0
- `!kclog [boss]` in any chat tab replaces your chat line with your collection log progress for that boss, plus inline sprites of every unique already obtained.
- `!missing [boss]` flips it: count and sprites of everything still unobtained.
- Common boss shorthand works (`vork`, `cox`, `tob`, `jad`, `nm`, `pnm`, `cg`, `thermy`, `cerb`, `huey`, etc.). Partial typing falls through to substring match.
- Self-lookup auto-refreshes when the local player chats, so a long session stays current without a manual sync.
- Unranked GIM helmet support (green trim).
- Clue summary tooltip resized to fit 6 and 7 digit ranks and scores.

### v1.2.2
- Shutdown no longer blocks the RuneLite caller thread.

### v1.2.1 / v1.2.0
- Right-click "Kill Clog" lookup on player names from friends list, ignore list, friends chat, clan + guest clan, GIM panel, chatbox, and private messages. Side panel auto-opens.
- Double-click the magnifying-glass icon to look up yourself.
- One-time chat warning when the player right-click menu's 4 plugin slots are full.
- World-hop auto-lookup no longer overwrites a researched player.
- Auto-lookup fires once per session instead of on every world hop or teleport.
- Iron/GIM badge no longer flashes regular at login.
- Disk writes coalesced and drained on shutdown.
- Temple failure cooldown reduced to 3 minutes.
- Plugin Hub icon scaled up + transparent background.
- Description rewritten to "HiScores Overhaul with Collection Log Integration."

if 1.3.0's diff is more than the queue can absorb right now, happy to slim this down to just the manifest icon and description bumps from 1.2.0 and ship the rest in a followup. lmk <3