### PR TITLE
update attacktimer

### DIFF
--- a/plugins/attacktimer
+++ b/plugins/attacktimer
@@ -1,3 +1,3 @@
 repository=https://github.com/ngraves95/attacktimer.git
-commit=506d859c86c3a3348bf9ce0c86bfcf77c787255c
+commit=43e97e9362ad80631c1fb44c90df451b8fad3147
 authors=ngraves95,Lexer747


### PR DESCRIPTION
Adds support for Yama: https://github.com/ngraves95/attacktimer/pull/140, will show the correct attack speed:
* Player is in the shadow crash sweet spot on the right tick
* Kills a Void flare with the purging staff spec

Cleans up usage of deprecated Runelite APIs. And re-syncs our soft fork of `getAttackStyles` from the attack style plugin.

Adds to the README an update list.