### PR TITLE
Update prayer-time-infobox

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=6b9cf69687110088cdcc742f64258c7c32e89106
+commit=46aa4fefaf2ae0cea3c11e775c16a14014388c80


### PR DESCRIPTION
﻿Updates PvM Toolkit to the latest source commit.

Changes include:
- Cannon empty/repair screen warnings and optional notification toggles.
- Reliable RuneLite notification ping for potion, prayer, and cannon expiry events.
- Prayer ping now only fires when prayer points actually reach 0.
- Mahogany protection helper overlay and warning style options.

Validation:
- `./gradlew.bat build shadowJar` passed in the plugin source repository.
- `git diff --check` passed for the Plugin Hub manifest update.
