### PR TITLE
Add shift-drop-block

### DIFF
--- a/plugins/shift-drop-block
+++ b/plugins/shift-drop-block
@@ -1,0 +1,2 @@
+repository=https://github.com/BrendanMichaelGallant/shift-drop-block.git
+commit=5f026d1ad6105054fd78cdba04e0aa886241055e


### PR DESCRIPTION
Adds Shift Drop Block, a small plugin that prevents dropping items in protected inventory slots. Users can configure protected slots by index (0-27) or by item ID.
Repo: https://github.com/BrendanMichaelGallant/shift-drop-block