### PR TITLE
Add Wiki Chat

### DIFF
--- a/plugins/wiki-chat
+++ b/plugins/wiki-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/flowercodes/osrs-wiki-chat-plugin.git
-commit=3fe7bffc23fba0ef1a7e6946f38ed417d0ebe2af
+commit=798cbea9a7f3e071218162b50960f8010aadee69
 warning=This plugin submits your IP address and the text of your typed questions to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/wiki-chat
+++ b/plugins/wiki-chat
@@ -1,0 +1,3 @@
+repository=https://github.com/flowercodes/osrs-wiki-chat-plugin.git
+commit=3fe7bffc23fba0ef1a7e6946f38ed417d0ebe2af
+warning=This plugin submits your IP address and the text of your typed questions to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/wiki-chat
+++ b/plugins/wiki-chat
@@ -1,3 +1,3 @@
 repository=https://github.com/flowercodes/osrs-wiki-chat-plugin.git
-commit=798cbea9a7f3e071218162b50960f8010aadee69
+commit=fe9f06e25ce905c5e67135ad3139dd86619f8243
 warning=This plugin submits your IP address and the text of your typed questions to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Adds **Wiki Chat**: an OSRS wiki chatbot in a RuneLite side panel.

## What it does

- Side panel where users can ask any OSRS question and get streamed, cited answers from the OSRS wiki
- Right-click "Ask AI" on items, NPCs, or objects with Examine — pre-fills a question about the target
- Hybrid retrieval: vector search over ~2,000 indexed wiki pages + live MediaWiki search on every query, so coverage extends to the long tail
- Bring-your-own-key for Gemini / OpenAI / Anthropic (no shared quotas)

## Privacy

Data submitted to the 3rd-party server (Cloudflare Worker): user's IP and the text of typed questions. No game state, no account info. Privacy disclosure is in the README, a warning is configured on the backend URL config item, and the manifest includes the standard warning string.

## Links

- Repo: https://github.com/flowercodes/osrs-wiki-chat-plugin
- Commit: 3fe7bffc23fba0ef1a7e6946f38ed417d0ebe2af