### PR TITLE
Add Clan Applicants Webhook plugin

### DIFF
--- a/plugins/clan-applicants-webhook
+++ b/plugins/clan-applicants-webhook
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-applicants-webhook-plugin.git
-commit=d0e2e8e42b5648ab44980cc2dcc6a5121bfd0378
+commit=1370a9e0e39786c3bbc945228c179a7e9a866a4e

--- a/plugins/clan-applicants-webhook
+++ b/plugins/clan-applicants-webhook
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-applicants-webhook-plugin.git
-commit=1370a9e0e39786c3bbc945228c179a7e9a866a4e
+commit=50e67b17efe7a30ed6e50643c466482475b4ffda

--- a/plugins/clan-applicants-webhook
+++ b/plugins/clan-applicants-webhook
@@ -1,0 +1,2 @@
+repository=https://github.com/porcupine-fish/clan-applicants-webhook-plugin.git
+commit=179b280cd3a25704756969f6d3801ed0725886e8

--- a/plugins/clan-applicants-webhook
+++ b/plugins/clan-applicants-webhook
@@ -1,2 +1,2 @@
 repository=https://github.com/porcupine-fish/clan-applicants-webhook-plugin.git
-commit=179b280cd3a25704756969f6d3801ed0725886e8
+commit=d0e2e8e42b5648ab44980cc2dcc6a5121bfd0378


### PR DESCRIPTION
# Clan Applicants Webhook Plugin

## Plugin
A tiny plugin to capture the game message:
- `PlayerX has applied to join your clan.`

It sends the notification to the URL specified in the plugin settings.

## Rationale
When you use the recruitment desk and someone applies to the clan, the message appears as a game message and not a clan message. It would be an easy fix for Jagex, and maybe there's a reason why it's not a clan message, but here's the plugin in case they don't make that change.

## JSON payload
```
{
  "applicant": "PlayerX",
  "message": "PlayerX has applied to join your clan.",
  "seenBy": "PlayerY",
  "timestamp": "2026-05-11T08:42:15.123Z"
}
```
- `seenBy` is the player who has the invitations open on the clan recruitment board.

## Error handling UX
The plugin will post a game message if there is a problem with the webhook URL specified, when an applicant applies.
It will tell you the HTTP error code.

## Testing
- Tested with the recruitment desk in error case and in happy case.

## Future enhancements
- Support direct discord webhook URL JSON payload (add a checkbox in settings to enable / disable this type of payload)
