### PR TITLE
update traducao-osrs-br v2

### DIFF
--- a/plugins/traducao-osrs-br
+++ b/plugins/traducao-osrs-br
@@ -1,2 +1,2 @@
 repository=https://github.com/walterrezende12-tech/Traducao-OSRS-BR.git
-commit=34c68b4f57601376d550227e0a4bf1bf1efa4363
+commit=1e37b312724596c6f0aad09693f900a79ef76bd8


### PR DESCRIPTION
﻿## English

Updates `traducao-osrs-br` to the validated v2 public source commit.

This update:
- keeps the Plugin Hub descriptor minimal, changing only `commit=`;
- does not add `jarSizeLimitMiB` because the built JAR is below the default 10 MiB limit;
- keeps `build=standard` in the source repository metadata;
- removes the corpus collector from the published plugin source;
- adds v2 translation coverage for separate dictionaries: dialogs, skill guide, quests, items/books, menu entries, overhead text, and game messages;
- fixes menu translation data so the JSON is valid and includes common options such as `Attack`.

Validation performed on the public source commit:
- `gradlew build` passed;
- JSON dictionaries parse successfully;
- built JAR size measured at approximately 6.4 MB;
- source archive estimate measured at approximately 6.45 MB;
- bytecode/source scan found no known Plugin Hub disallowed APIs.

## Portugues (pt-BR)

Atualiza o `traducao-osrs-br` para o commit publico validado do plugin v2.

Esta atualizacao:
- mantem o arquivo do Plugin Hub minimo, alterando somente `commit=`;
- nao adiciona `jarSizeLimitMiB`, porque o JAR fica abaixo do limite padrao de 10 MiB;
- mantem `build=standard` nos metadados do repositorio fonte;
- remove o coletor de corpus da fonte publicada do plugin;
- adiciona a cobertura v2 com dicionarios separados: dialogos, skill guide, quests, items/livros, menu, overhead e game messages;
- corrige o JSON de menu e inclui opcoes comuns como `Attack`.

Validacao feita no commit fonte publico:
- `gradlew build` passou;
- os dicionarios JSON parseiam corretamente;
- JAR medido em aproximadamente 6,4 MB;
- source archive estimado em aproximadamente 6,45 MB;
- varredura de fonte/bytecode nao encontrou APIs proibidas conhecidas do Plugin Hub.
