### PR TITLE
Update lazy-farming

### DIFF
--- a/plugins/lazy-farming
+++ b/plugins/lazy-farming
@@ -1,3 +1,3 @@
 repository=https://github.com/Speaax/Farming-Helper.git
-commit=5bea79274b08570243a44af159317ad4c9925cf3
+commit=cf2a63974aba9ca10b899d405f8e2052adf32eb3
 authors=Speaax, JThomasDevs

--- a/plugins/lazy-farming
+++ b/plugins/lazy-farming
@@ -1,3 +1,3 @@
 repository=https://github.com/Speaax/Farming-Helper.git
-commit=cf2a63974aba9ca10b899d405f8e2052adf32eb3
+commit=3736bb14f4a4bc8fb8fc44ebfde697a6df54f627
 authors=Speaax, JThomasDevs

--- a/plugins/lazy-farming
+++ b/plugins/lazy-farming
@@ -1,3 +1,3 @@
 repository=https://github.com/Speaax/Farming-Helper.git
-commit=3736bb14f4a4bc8fb8fc44ebfde697a6df54f627
+commit=6e8350d842b441d17a0331c984cf76a1500d3347
 authors=Speaax, JThomasDevs


### PR DESCRIPTION
- Pendant of Ates requirements fixed to only require one charged pendant as opposed to multiple pendants when configured locations used PoA teleports more than once.
- "None" teleport option added to all locations across all patches, providing users a way to skip teleport requirements for any given patch.
- Migrated custom constants to their proper Runelite API values.
- UI fixed so that back arrow and name field in run edit screen no longer overlap.
- UI behavior fixed to allow users to edit the run name while in the run edit screen.
This PR addresses the following issues:
[#40](https://github.com/Speaax/Farming-Helper/issues/40) 
[#83](https://github.com/Speaax/Farming-Helper/issues/83)