### PR TITLE
Update no-misclick-repot

### DIFF
--- a/plugins/no-misclick-repot
+++ b/plugins/no-misclick-repot
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/bop-plugins.git
-commit=d38f277400937c7279f9b5d4da6b83be9e2031da
+commit=c1b656d8351d357d15c29a2130c7dce8afb0bebb


### PR DESCRIPTION
Added config options for potions that previously didn't have one

Added config to allow repotting divines subX hp for redemption purposes

Added config for overlays for cooldown before repotting is "allowed", defaulted to on