### PR TITLE
Update Shortest Path to 1.23.3

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=06a69127d1aa05c9afeafff45340b35505b3f78d
+commit=b66321e140c8a638b14849026d93f950e97eb1a0
 authors=Skretzo,FIrgolitsch,wvanderp

--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=b66321e140c8a638b14849026d93f950e97eb1a0
+commit=5ccc2fda4c5cb630973c972f7507b004df829568
 authors=Skretzo,FIrgolitsch,wvanderp


### PR DESCRIPTION
Some fixes for League teleports as well as some transport hint fixes.

- Improved League region mapping
- Fixed League teleports being assigned to the wrong regions
- Fix for overlapping transport/pick-up hints
- Fixed transport costs for consumable teleports + quetzals.
- Added amount to the pick-up hint for an item (i.e. 1 law rune, 5 air runes)