### PR TITLE
Add drop-rates-clog

### DIFF
--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=325ad677d688376da1c57169170affb0781a12b0
+commit=5ba27a0fc99fe492ba18f240c4e9531dd9c1089d

--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=b722c40a478e644abb371ad24aa04abeaa567d37
+commit=325ad677d688376da1c57169170affb0781a12b0

--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=b7caca64b172d1d95b04f667fac2d6fbfdeb17a5
+commit=b722c40a478e644abb371ad24aa04abeaa567d37

--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
-﻿repository=https://github.com/pairofcrocs/drop-rates-clog.git
+repository=https://github.com/pairofcrocs/drop-rates-clog.git
 commit=b7caca64b172d1d95b04f667fac2d6fbfdeb17a5

--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,0 +1,2 @@
+﻿repository=https://github.com/pairofcrocs/drop-rates-clog.git
+commit=b7caca64b172d1d95b04f667fac2d6fbfdeb17a5


### PR DESCRIPTION
Adds the **Clog Drop Rates** plugin.

Shows drop rates in a tooltip when hovering over items in the Collection Log. Drop rate data is bundled as a JSON resource — no external service calls are made.

- Plugin repo: https://github.com/pairofcrocs/drop-rates-clog