### PR TITLE
Add account-history plugin

### DIFF
--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,3 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
 commit=148e9f2276918c0037100f94e467716e61b069bb
-warning=This plugin submits your RSN and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.
+warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,3 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
-commit=de2a9cbe88d5c8d0f86c9ebdb91d75b701594be2
+commit=ad12073b9754ff16a7d8aacb7b610e8a1551f0c9
 warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,0 +1,2 @@
+repository=https://github.com/josephmr/account-history.git
+commit=87875aa750c520026679e1a67dd4bd4a31aefb91

--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,3 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
-commit=ad12073b9754ff16a7d8aacb7b610e8a1551f0c9
+commit=1a8cfbb68bf027dfd4068988790be153083cdba7
 warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,3 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
-commit=148e9f2276918c0037100f94e467716e61b069bb
+commit=de2a9cbe88d5c8d0f86c9ebdb91d75b701594be2
 warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,2 +1,2 @@
 repository=https://github.com/josephmr/account-history.git
-commit=b759eb4811e033a8bdcc6bf75d1cb01c005d9995
+commit=295b69585d83a706a3d8fbee78aefb5b0d0b37cb

--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,2 +1,2 @@
 repository=https://github.com/josephmr/account-history.git
-commit=87875aa750c520026679e1a67dd4bd4a31aefb91
+commit=b759eb4811e033a8bdcc6bf75d1cb01c005d9995

--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,2 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
-commit=295b69585d83a706a3d8fbee78aefb5b0d0b37cb
+commit=148e9f2276918c0037100f94e467716e61b069bb
+warning=This plugin submits your RSN and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
The account history plugin tracks notable events for a given account and sends those events to the https://maxcape.net server. The goal is to provide a historical account of an accounts progression so players can look back at what levels, drops, boss kills they have gotten in a timeline view.

This is similar to tools like WiseOldMan and TempleOSRS, but neither of them let you keep track of **when** special milestones were achieved on your account.

The logic in this plugin is **very** similar to the logic in the [Discord Dink](https://github.com/pajlads/DinkPlugin) plugin. Both just track specific events and send HTTP requests to the server with that metadata. There is a config setting that must be enabled before any requests are sent.

Here is a small example of what the resulting view looks like on https://maxcape.net:

<img width="928" height="1117" alt="image" src="https://github.com/user-attachments/assets/151e60ae-3b71-493f-8151-18d51d76d901" />
