### PR TITLE
New Plugin: Shortest Grave

### DIFF
--- a/plugins/shortest-grave
+++ b/plugins/shortest-grave
@@ -1,3 +1,3 @@
 repository=https://github.com/FIrgolitsch/shortest-grave.git
-commit=dd71b8af646e8ab8f2b9ed62f697fd8ec5db9c88
+commit=db2c1ce1cb5fcf48d7aac13e130e3cf079617534
 authors=FIrgolitsch

--- a/plugins/shortest-grave
+++ b/plugins/shortest-grave
@@ -1,3 +1,3 @@
 repository=https://github.com/FIrgolitsch/shortest-grave.git
-commit=3fdbaa55e03a6805436a6820724f15b84258eca1
+commit=dd71b8af646e8ab8f2b9ed62f697fd8ec5db9c88
 authors=FIrgolitsch

--- a/plugins/shortest-grave
+++ b/plugins/shortest-grave
@@ -1,0 +1,3 @@
+repository=https://github.com/FIrgolitsch/shortest-grave.git
+commit=3fdbaa55e03a6805436a6820724f15b84258eca1
+authors=FIrgolitsch


### PR DESCRIPTION
Releasing Shortest Grave! A small plugin that integrates with Shortest Path to plan a route to the players' gravestone after death.

- Keeps track of the location the player died and plans a path to that location after respawn.
- Overrides Shortest Path path colour if desired
- Checks if a gravestones has spawned and plans conditionally.
    - Can be overridden if desired.