### PR TITLE
Create antidrag-blacklist

### DIFF
--- a/plugins/antidrag-blacklist
+++ b/plugins/antidrag-blacklist
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/bop-plugins.git
-commit=0859337788dd3b58bcada0bcbf564cee4f5bda76
+commit=37413bce9095e84a0c15321e928c11061e82f54d

--- a/plugins/antidrag-blacklist
+++ b/plugins/antidrag-blacklist
@@ -1,0 +1,2 @@
+repository=https://github.com/bopsec/bop-plugins.git
+commit=0859337788dd3b58bcada0bcbf564cee4f5bda76


### PR DESCRIPTION
Customizable blacklist for items that should be excluded from the RuneLite default Anti Drag plugin's drag delay.


---
This could certainly be a feature of the original plugin, but I don't trust myself to mess with base client features :P