### PR TITLE
AFK GOTR Put version into runelite-plugin.properties

### DIFF
--- a/plugins/zom-afk-gotr
+++ b/plugins/zom-afk-gotr
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=6d9b49c3a4eeb8f1ce4e9e944fa5bb0794c18934
+commit=0349ac221dd7f17655b6052cf05c8ab4d727f736


### PR DESCRIPTION
I forgot that the version of 1.5.1 needs to be in the properties file otherwise the commit hash shows up. 

<img width="239" height="81" alt="image" src="https://github.com/user-attachments/assets/412b6ce0-5178-44a3-9e96-de3bc868f944" />


oops