### PR TITLE
Update no-misclick-repot

### DIFF
--- a/plugins/no-misclick-repot
+++ b/plugins/no-misclick-repot
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/bop-plugins.git
-commit=c1b656d8351d357d15c29a2130c7dce8afb0bebb
+commit=ef2ffb76fffb2fe23fa54c49eb0d47f30bb9d834


### PR DESCRIPTION
Adds regular super combat and ranging potions with their own thresholds (ref https://github.com/bopsec/bop-plugins/issues/2 and multiple messages on other platforms)