### PR TITLE
Update Shortest Path to 1.20.4

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=5ccc2fda4c5cb630973c972f7507b004df829568
+commit=06938f5198c21408d39c5e447eb5bc9452806ade
 authors=Skretzo,FIrgolitsch,wvanderp


### PR DESCRIPTION
Small data fix to remove F2P shortcut not available in members' worlds. Need proper F2P support for this.