### PR TITLE
Add OSD Display

### DIFF
--- a/plugins/osd-display
+++ b/plugins/osd-display
@@ -1,0 +1,2 @@
+repository=https://github.com/Blinqks/osd-display.git
+commit=e8532a557ccbaf575bc40329e2bef15e150a82c3

--- a/plugins/osd-display
+++ b/plugins/osd-display
@@ -1,2 +1,2 @@
 repository=https://github.com/Blinqks/osd-display.git
-commit=17242a5c5eb11fe2a358fd389db5d9aaebaa7892
+commit=8f12c46b4907dad92ca2a2353e757a4b5bb85a9a

--- a/plugins/osd-display
+++ b/plugins/osd-display
@@ -1,2 +1,2 @@
 repository=https://github.com/Blinqks/osd-display.git
-commit=196d9f14ff457e9e1359a581cd5ddd2fdcc0e0a2
+commit=17242a5c5eb11fe2a358fd389db5d9aaebaa7892

--- a/plugins/osd-display
+++ b/plugins/osd-display
@@ -1,2 +1,2 @@
 repository=https://github.com/Blinqks/osd-display.git
-commit=8f12c46b4907dad92ca2a2353e757a4b5bb85a9a
+commit=fd8824835a0bf680e1582c8207728d852161f5bb

--- a/plugins/osd-display
+++ b/plugins/osd-display
@@ -1,2 +1,2 @@
 repository=https://github.com/Blinqks/osd-display.git
-commit=e8532a557ccbaf575bc40329e2bef15e150a82c3
+commit=55ab4fb458b193a9396a4ac28e3aaecf1a505d65

--- a/plugins/osd-display
+++ b/plugins/osd-display
@@ -1,2 +1,2 @@
 repository=https://github.com/Blinqks/osd-display.git
-commit=55ab4fb458b193a9396a4ac28e3aaecf1a505d65
+commit=196d9f14ff457e9e1359a581cd5ddd2fdcc0e0a2


### PR DESCRIPTION
Adds OSD Display — a custom HUD plugin for RuneLite.

**Source repo:** https://github.com/Blinqks/osd-display
**Pinned commit:** `e8532a557ccbaf575bc40329e2bef15e150a82c3`

## What the plugin does

A combined HUD that puts the most-checked info in one configurable cluster:

- **Stat orbs** — HP / Prayer / Special Attack / Run Energy, each rendered as a draggable liquid-fill orb with a glass sheen. Left-click dispatches the same widget action as the native minimap orb (Cure / Toggle Quick Prayers / Use Special Attack / Toggle Run); right-click injects the matching native action menu.
- **XP bar** — last-trained skill icon plus a progress bar toward the next level or a user-set per-skill goal. Goals are entered via the in-game chatbox (no Swing popups). Right-click "Reset XP rate" on the bar.
- **Floating XP drops** — animated gains, configurable color modes (skill / single / rainbow / gold), text styles, animations (float / bounce / slide / fade), and an optional damage number derived from `HitsplatApplied` (exact, not estimated from HP XP).
- **Multi-skill XP summary** — separate draggable strip with rate, session XP, and ETA; switchable between last-skill and multi-skill modes. Right-click any skill on the stats tab to set a goal or toggle visibility.

## Plugin-hub compliance notes

- `enabledByDefault = false`
- BSD-2-Clause license
- No automation, no synthetic input, no memory reads — every interactive element dispatches `MenuAction.CC_OP` against the same widget the native orb uses
- Custom orb icons are restricted to `~/.runelite/osd-display-icons/` (no arbitrary filesystem reads)
- `Hide OSRS Minimap Orbs` is opt-in (default off); restores native widgets on plugin disable
- No 3D model capture, no every-frame `DrawManager` listener
- Goal dialog uses `ChatboxPanelManager`, not `JOptionPane`

Happy to iterate on review feedback.