### PR TITLE
kill-clog: v1.3.2 internal panel refactor

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=753c095b461c5326c2d8e01a4e1a9800cbf627cf
+commit=e97795bf26d04c0ad4407f1c319bf33a7f388416
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
v1.3.2 is an internal refactor only. Zero behavior change. No new features, no API changes, no settings changes, no visual changes.

The panel stopped being the plugin and became the place where the plugin happens.

## What changed

`KillClogPanel.java` was a 2926-line monolith. It's now 1867 lines (-36%), with each subsystem in a dedicated class.

| class | LOC | responsibility |
|---|---|---|
| `KillClogPanel` | 1867 | layout + plugin lifecycle + listener dispatch + clog cell + glue |
| `LookupSession` | 297 | async lookup pipeline + state + version-stamp gating |
| `ComparisonController` | 754 | comparison subsystem (state + widgets + lifecycle + renderers) |
| `Cells` | 740 | cells, labels, primary + comparison rendering, tooltip data + routing |
| `ActivitiesTray` | 167 | slide animation widget (clip + separator + eased Timer) |

Plus `FourTwentyMode` enum gained `applyOverrides(JLabel, int kc)` so per-mode cell mutations live with the enum.

## Four cuts

1. **Cut 1 (LookupSession)**: extracted the async lookup pipeline. Cache + reveal-timer + parallel hiscore+clog futures + version-stamp gating + in-flight guard. Panel implements a 6-method Listener.
2. **Cut 2 (ComparisonController)**: extracted the comparison subsystem. 13 state fields, 5 widgets, 4 constants, 10 methods. Panel implements ComparisonController.Listener.
3. **Cut 3 (Cells)**: extracted cell construction + tooltip data caches + tooltip routing into a single ownership boundary.
4. **Cut 4 (Cells collapse + ActivitiesTray + FourTwentyMode helpers)**: collapsed Cells to true single-source-of-truth, extracted ActivitiesTray slide widget, moved FourTwentyMode render-helpers onto the enum. Listener interface narrowed from 18 methods to 7.

## What's deliberately NOT extracted (with reasons)

- **Primary search bar**: the asymmetry with ComparisonController is apparent not real. ComparisonController is the comparison subsystem; the primary side has no equivalent subsystem to extract.
- **Listener method bodies on the panel**: they ARE the panel boundary by design. The 6 methods dispatch lookup events to panel widgets. Wrapping them adds glue without removing coupling.
- **`doLookup` + `setSearchStatus` + `selfSearchMessage`**: single-method primary search flow. Not a subsystem.
- **Layout builders** (`buildSearchPanel`, `buildActivitiesGrid`, `buildCompareSearch`): panels do layout.
- **`updateClogCell` + clog tier icons**: clog-summary cell layout is panel-internal, tightly coupled to the info bar's clogInfoLabel.
- **420 mode supporting fields** (`cycleFourTwentyMode`, `getCapeImage`, `has420Plugin`): small, coherent, costs more glue than it removes.
- **Plugin lifecycle** (`onActivate`, `shutdown`, `onConfigChanged`, `removeNotify`): RuneLite contract.

## Why patch (1.3.2) not minor (1.4.0)

Internal refactor, zero behavior change. Strict semver says patch. v1.4.0 is reserved for the next user-visible feature bump (chat-command verb redesign, currently in design).

## Verification

- `./gradlew build` passes (checkstyle clean)
- `./gradlew run` launches RuneLite with the plugin sideloaded
- Manual smoke test against 4 lookup paths × comparison on/off × 420 mode × tray states × 6 tooltip sites, all passing
- Independent code review pass (zero behavior regressions surfaced)
- `!kclog yama` PRIVATECHATOUT path still works (the v1.3.1 fix is preserved in the refactor)

## Branch chain

Built across 4 stacked branches, then snapshot-collapsed into 4 logical commits for clean review (one commit per cut). Original 46-commit chain preserved at tag `backup/refactor-cells-collapse-20260513` in the source repo for archaeology.
