### PR TITLE
Add Doom Audio Cues plugin

### DIFF
--- a/plugins/doom-audio-cues
+++ b/plugins/doom-audio-cues
@@ -1,0 +1,1 @@
+repository=https://github.com/astolfogamer-osrs/Doom-for-audio.git

--- a/plugins/doom-helper-for-ADHD
+++ b/plugins/doom-helper-for-ADHD
@@ -1,0 +1,1 @@
+https://github.com/astolfogamer-osrs/Doom-for-ADHD.git


### PR DESCRIPTION
Hi! This plugin provides distinct audio alerts for different projectile types (Mage and Range) to improve gameplay clarity and accessibility. I have removed all overlays and visual timers to ensure full compliance with the third-party client guidelines. The plugin is now purely focused on audio cues.