### PR TITLE
Update Wildy QoL

### DIFF
--- a/plugins/pet-spell-blocker
+++ b/plugins/pet-spell-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/Sacca-1/Wildy-QoL.git
-commit=4161b5af3e8624c0de326e260bb357c364f26073
+commit=acb38277501b95ea782b25cf2ec4c00809bc9b35


### PR DESCRIPTION
Adds an extensive overlay of equipment warnings for common wildy/PvP setups:
* Wrong/low ammo warnings;
* Wrong/low runes warnings;
* Wrong spellbook warnings;
* Uncharged / low charged items warnings;
* Lack of teleport warnings.

These issues are detected based on common patterns in valid setups and suppressed when not relevant to the user.

Since this has a lot of moving parts, the feature is gated behind a "preview" config checkbox while I have some test users figure out any edge cases to avoid confusion with the rest of the users.

https://github.com/Sacca-1/Wildy-QoL/pull/12