### PR TITLE
Added No Trolls In Raids plugin

### DIFF
--- a/plugins/no-trolls-in-raids
+++ b/plugins/no-trolls-in-raids
@@ -1,0 +1,2 @@
+repository=https://github.com/BloatPlug/No-Trolls-in-Raids.git
+commit=9e8cfbfc1c64dbfc3b515234063646525aafd572


### PR DESCRIPTION
Highlights ignored players in Theatre of Blood and Tombs of Amascut party boards by turning their names red.

Uses the player's in-game Ignore List automatically.