### PR TITLE
Create food-decolouring

### DIFF
--- a/plugins/food-decolouring
+++ b/plugins/food-decolouring
@@ -1,2 +1,2 @@
 repository=https://github.com/Steele578/food-decolouring.git
-commit=c38c5530b3902faaa93343a43c0ef6d9912dbc2d
+commit=f64d2c7133fca4c243107286a57027c53f3f1295

--- a/plugins/food-decolouring
+++ b/plugins/food-decolouring
@@ -1,0 +1,2 @@
+repository=https://github.com/Steele578/food-decolouring.git
+commit=c38c5530b3902faaa93343a43c0ef6d9912dbc2d


### PR DESCRIPTION
Plugin provides toggleable options to revert the sprites of specific sailing and hunter foods back to what they were prior to May 14 2026.
Forked from https://github.com/ThePharros/food-coloring/ to have the exact opposite functionality.