### PR TITLE
Add Anvil

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,0 +1,3 @@
+repository=https://github.com/AhmedFathy2001/anvil-plugin.git
+commit=afac30ea3b36b69985ab6ffe9b8774b314b0c6f9
+warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=2926f4dee6d237118502c2a9765cbc45255f98f2
+commit=35be150f61e4fafab97f81704591e0acb999ad2d
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=afac30ea3b36b69985ab6ffe9b8774b314b0c6f9
+commit=2926f4dee6d237118502c2a9765cbc45255f98f2
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Anvil

Companion plugin for the [Anvil](https://github.com/AhmedFathy2001/anvil-plugin) clan-events platform — an Old School RuneScape clan-operations site that runs bingo events, weekly SotW/BotW competitions, and keeps a live clan roster synced from in-game.

### What it does

- **Verification overlay** — burns a site-generated daily codeword and UTC timestamp into every screenshot so bingo evidence is tamper-evident.
- **Auto-submit tracked drops** — when a drop matching a bingo tile hits a player's loot, the plugin screenshots, uploads, and files a submission to their team's board with zero clicks.
- **Manual side-panel submission** — fallback for drops the auto-detect misses (pet drops, off-loot collection-log drops).
- **Weekly auto-enrollment** — on login, asks the site whether a SotW/BotW is active and locks the player's baseline in a single round-trip.
- **Admin clan-roster sync** — admins can paste a one-time 6-char code to bind a long-lived admin token to their RSN, then push the in-game clan roster to the site with one click.

### External communication

The plugin only talks to the Anvil site URL the user configures themselves (per-user, per-clan). No fixed third-party endpoints. The manifest carries a `warning=` line disclosing that screenshots + IP are sent to that user-configured server.

### Source

- Repo: https://github.com/AhmedFathy2001/anvil-plugin
- Tag: `v1.0.0` (commit `afac30ea3b36b69985ab6ffe9b8774b314b0c6f9`)
- License: BSD-2-Clause