### PR TITLE
tile-overlay-indicators

### DIFF
--- a/plugins/improved-tile-indicators
+++ b/plugins/improved-tile-indicators
@@ -1,2 +1,2 @@
-repository=https://github.com/Resh404/tileindicators.git
-commit=39299a3266bb1762fcce6e2ced356bad4ee78245
+repository=https://github.com/LeikvollE/tileindicators.git
+commit=c367969cdaad43ff5c6047abe67a7d390e134caf

--- a/plugins/improved-tile-indicators
+++ b/plugins/improved-tile-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Resh404/tileindicators.git
-commit=34b6c1a70ce5b1564d5ad9b1cbea2980cabddb8c
+commit=39299a3266bb1762fcce6e2ced356bad4ee78245

--- a/plugins/improved-tile-indicators
+++ b/plugins/improved-tile-indicators
@@ -1,2 +1,2 @@
-repository=https://github.com/LeikvollE/tileindicators.git
-commit=c367969cdaad43ff5c6047abe67a7d390e134caf
+repository=https://github.com/Resh404/tileindicators.git
+commit=34b6c1a70ce5b1564d5ad9b1cbea2980cabddb8c

--- a/plugins/tile-overlay-indicators
+++ b/plugins/tile-overlay-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Resh404/tileindicators.git
-commit=e3a72ab165248910be6157471fadc73090e305a5
+commit=dacf58a65cf0c3a73765587c674c49ab5cb11eac

--- a/plugins/tile-overlay-indicators
+++ b/plugins/tile-overlay-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Resh404/tileindicators.git
-commit=dacf58a65cf0c3a73765587c674c49ab5cb11eac
+commit=07c0264ca434f29a0ccf4489f7d17e4223a3e6a7

--- a/plugins/tile-overlay-indicators
+++ b/plugins/tile-overlay-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/Resh404/tileindicators.git
+commit=e3a72ab165248910be6157471fadc73090e305a5


### PR DESCRIPTION
This PR updates the `improved-tile-indicators` plugin entry to point to a fork with new functionality. Since the original maintainer is unresponsive, these enhancements have been developed in a separate repository.

The new features are described in: https://github.com/Resh404/tileindicators/pull/1