### PR TITLE
Hiscore Notifications Version 1.0.1 update

### DIFF
--- a/plugins/hiscore-notifications
+++ b/plugins/hiscore-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/malafel-dev/hiscore-notifications.git
-commit=6f259e6b34ecd6adc756d87277ac7379a1fec83f
+commit=16dd61d58f37155cb516568a5f03b10b08dc323e

--- a/plugins/hiscore-notifications
+++ b/plugins/hiscore-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/malafel-dev/hiscore-notifications.git
-commit=4026bad15927bd2f3c1942285345731b0c870ea3
+commit=6f259e6b34ecd6adc756d87277ac7379a1fec83f


### PR DESCRIPTION
Fixes bugs:
- [Request spam when trying to fetch hiscores for an invalid game mode](https://github.com/malafel-dev/hiscore-notifications/issues/3)

Implements features:
- [Skiller and 1-def pure support](https://github.com/malafel-dev/hiscore-notifications/issues/1)
- [Interval configuration for ranks between 1-99 and 100-999, instead of 1-999](https://github.com/malafel-dev/hiscore-notifications/issues/2)