### PR TITLE
Add Camera Snapshots plugin

### DIFF
--- a/plugins/camerasnapshots
+++ b/plugins/camerasnapshots
@@ -1,0 +1,2 @@
+repository=https://github.com/BPM-OSRS/camerasnapshots
+commit=296cb69eb10f434e7433bbd574edcc084e7d7204


### PR DESCRIPTION
Adds the Camera Snapshots plugin.

Saves and loads exact camera angle and zoom presets (yaw, pitch, zoom) per account with hotkeys. Unlike existing compass plugins this saves your precise angle, not just cardinal directions. Supports 5 slots.