### PR TITLE
Add Resourceman Mode plugin

### DIFF
--- a/plugins/resourceman-mode
+++ b/plugins/resourceman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/Resourcemanmode/Resourceman.git
-commit=4101bfe41d52c6061d25e4a025f3552daf2057c1
+commit=ec2c3e5668cf25b04e2c51d9da969a2b86ece902

--- a/plugins/resourceman-mode
+++ b/plugins/resourceman-mode
@@ -1,0 +1,2 @@
+repository=https://github.com/Resourcemanmode/Resourceman.git
+commit=ebec80c98980c7ee23499f30643be92992229488

--- a/plugins/resourceman-mode
+++ b/plugins/resourceman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/Resourcemanmode/Resourceman.git
-commit=ebec80c98980c7ee23499f30643be92992229488
+commit=4101bfe41d52c6061d25e4a025f3552daf2057c1


### PR DESCRIPTION
Resourceman Mode is a plugin that enforces self-obtained resources only. Players cannot buy, trade, or pick up resources from other players. Weapons and armour can be freely traded. Resources must be gathered through skilling, monster drops, quest rewards, or group content. The goal is to make skilling feel meaningful, while being able to trade weapons and armor freely - the way many of us played in the early days.