### PR TITLE
discord-notifications: takeover

### DIFF
--- a/plugins/discord-notifications
+++ b/plugins/discord-notifications
@@ -1,2 +1,2 @@
-repository=https://github.com/cepawiel/RuneLite-Discord-Notifications.git
+repository=https://github.com/pairofcrocs/RuneLite-Discord-Notifications.git
 commit=686a54422360438bf055f0eb122cd030a091436d


### PR DESCRIPTION
Requesting takeover of the `discord-notifications` plugin.

The original repository at https://github.com/cepawiel/RuneLite-Discord-Notifications has been inactive for nearly 3 years — the last commit on master is from July 2023 (`686a544`). Community PRs have been left open without review for years (#5 from November 2023, #6 from November 2024).

The original repository has issues disabled, so I was unable to open an issue requesting collaborator access per the standard takeover process. As an alternative, I left a comment on PR #6 tagging @cepawiel asking about being added as a collaborator.

Per the takeover policy, this PR keeps the commit hash unchanged at `686a544` and only updates the repository URL to point to my fork. Issues are enabled on the fork so users can report problems.