### PR TITLE
Tob bank wall fix

### DIFF
--- a/plugins/tob-bank-wall-fix
+++ b/plugins/tob-bank-wall-fix
@@ -1,0 +1,3 @@
+repository=https://github.com/avahe-kellenberger/tob-bank-wall-fix
+commit=bc692c4964ea828336e98d60a524cf24d84d1c81
+

--- a/plugins/tob-bank-wall-fix
+++ b/plugins/tob-bank-wall-fix
@@ -1,3 +1,3 @@
-repository=https://github.com/avahe-kellenberger/tob-bank-wall-fix
+repository=https://github.com/avahe-kellenberger/tob-bank-wall-fix.git
 commit=909441dec0b3a23f660bb5c668f59d91a55840b9
 

--- a/plugins/tob-bank-wall-fix
+++ b/plugins/tob-bank-wall-fix
@@ -1,3 +1,3 @@
 repository=https://github.com/avahe-kellenberger/tob-bank-wall-fix
-commit=bc692c4964ea828336e98d60a524cf24d84d1c81
+commit=909441dec0b3a23f660bb5c668f59d91a55840b9
 


### PR DESCRIPTION
Prevents clicking the upper floors at ToB bank to prevent unwanted pathing. This replaces the "Tob Bank Floors" plugin, as it's been broken for a long time.

- Config option to toggle hiding upper floor rendering (does not affect behavior)