### PR TITLE
Update RuneDiary to 1.1.0 (seasonal world handling)

### DIFF
--- a/plugins/runediary
+++ b/plugins/runediary
@@ -1,3 +1,3 @@
 repository=https://github.com/CalciumG/runediary-plugin.git
-commit=114b5a8617be6bf4abe7258d4fcff1589864376d
+commit=1e5ac293d33f4cbb72cb8e94a2fc7ed9d1b56ab4
 warning=This plugin submits your IP address, RSN, and numerous account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
 Update runediary to 1.1.0

Skips plugin sync on seasonal worlds (Leagues / DMM / beta) so leagues data doesn't overwrite the main account's plugin tables in the hub DB.

Plugin changes: https://github.com/CalciumG/runediary-plugin/compare/114b5a86...1e5ac293