### PR TITLE
Add npc-heatmap plugin repository information

### DIFF
--- a/plugins/npc-heatmap
+++ b/plugins/npc-heatmap
@@ -1,0 +1,2 @@
+repository=https://github.com/phzd/npc-heatmap.git
+commit=8a3dbaeb9fbf1ea28921330e7992cac507f5c637


### PR DESCRIPTION
This plugin tracks where NPCs stand over time and displays a heatmap of their most frequent tiles.
This should be helpful for identifying where to place a canon or to AFK.