### PR TITLE
Add GIM Tasks plugin

### DIFF
--- a/plugins/gim-tasks
+++ b/plugins/gim-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/gim-tasks-plugin.git
-commit=0719c99ef2c65e2c6f4d4acba3f48e1f21ef50ae
+commit=0719c993d43813ccfabd8224a8b187a52a82eded

--- a/plugins/gim-tasks
+++ b/plugins/gim-tasks
@@ -1,0 +1,2 @@
+repository=https://github.com/PlumpPanda-123/gim-tasks-plugin.git
+commit=02b5f159b0b2e65ea80b03b2ceddce8952b4dc81

--- a/plugins/gim-tasks
+++ b/plugins/gim-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/gim-tasks-plugin.git
-commit=dfe1699f25c6065acad5c3bc4fd97c2892c39b1c
+commit=598f0e8df7990ec5d063cbb029ae8af2ce918118

--- a/plugins/gim-tasks
+++ b/plugins/gim-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/gim-tasks-plugin.git
-commit=3f4c11717402326f5a339efb51572630d05165cc
+commit=295b69cf85bfd2ecdf6a485dddcc221cd5e81794

--- a/plugins/gim-tasks
+++ b/plugins/gim-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/gim-tasks-plugin.git
-commit=02b5f159b0b2e65ea80b03b2ceddce8952b4dc81
+commit=49bd91739dd5ef3ca59231cdbbfead99d8dd7283

--- a/plugins/gim-tasks
+++ b/plugins/gim-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/gim-tasks-plugin.git
-commit=295b69cf85bfd2ecdf6a485dddcc221cd5e81794
+commit=75955c195c963bab73e85bb03f2be6d8a7107e09

--- a/plugins/gim-tasks
+++ b/plugins/gim-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/gim-tasks-plugin.git
-commit=598f0e8df7990ec5d063cbb029ae8af2ce918118
+commit=ee77d2c7f8eaf9ac060705f45754a6778b84e698

--- a/plugins/gim-tasks
+++ b/plugins/gim-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/gim-tasks-plugin.git
-commit=49bd91739dd5ef3ca59231cdbbfead99d8dd7283
+commit=3f4c11717402326f5a339efb51572630d05165cc

--- a/plugins/gim-tasks
+++ b/plugins/gim-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/gim-tasks-plugin.git
-commit=0719c993d43813ccfabd8224a8b187a52a82eded
+commit=dfe1699f25c6065acad5c3bc4fd97c2892c39b1c

--- a/plugins/gim-tasks
+++ b/plugins/gim-tasks
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/gim-tasks-plugin.git
-commit=75955c195c963bab73e85bb03f2be6d8a7107e09
+commit=0719c99ef2c65e2c6f4d4acba3f48e1f21ef50ae


### PR DESCRIPTION
## GIM Tasks

A shared task board for Group Ironman teams of up to 4 players.

### What it does
- Adds a side panel with a real-time shared task list synced across all group members
- Players can create tasks (name, skill, quantity, priority), assign them to group members, claim unassigned tasks, update progress, and mark tasks complete
- In-game toast notification when a new task is assigned to the current player
- Status badges colour-coded by state (Unassigned / Claimed / In Progress / Completed)
- Skill icons displayed on each task card
- Member bar showing task count per player plus unassigned task count
- Polls a self-hosted backend every 10 seconds

### Backend
Players self-host a small Node.js/Express backend (or deploy to Railway free tier) backed by Firebase Firestore. The plugin communicates only with the player's own backend — no third-party data collection.

### Config
- Backend URL (self-hosted)
- Shared API key
- Group ID
- Player username