### PR TITLE
Add movement-range

### DIFF
--- a/plugins/movement-range
+++ b/plugins/movement-range
@@ -1,0 +1,2 @@
+repository=https://github.com/mronfim/movement-range.git
+commit=8e92b0085e88083143603af0e375eaf0c19e6f60


### PR DESCRIPTION
Highlights the tiles you can reach in a configurable number of run ticks (1–3), with per-tier coloring. Each tier represents one run tick of reachable area, computed via BFS over the game's collision data — walls and obstacles are respected.

![preview](https://raw.githubusercontent.com/mronfim/movement-range/master/preview.png)

Repository: https://github.com/mronfim/movement-range