### PR TITLE
fbclan-plugin: bump to 2a117ed

### DIFF
--- a/plugins/fbclan-plugin
+++ b/plugins/fbclan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/orgonag/fbclan-plugin.git
-commit=109a78f8fad76768babcc83df40f709b4043baa0
+commit=2a117ed01ad76fcb97666ebe532ccc99a8a2968a
 warning=This plugin submits your IP address, RSN, and drop data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Includes four merged changes since the last release:

- fix: make LfgPanel.currentRsn volatile for cross-thread visibility (#2)
- feat(lfg): reset updated_at when a player changes activity (#3)
- docs: describe the 60-minute LFG TTL instead of the daily wipe (#4)
- feat(lfg): color LFG names green/red by in-game clan channel presence (#5)