### PR TITLE
Update RuneDiary to 1.1.1 (bank sync trigger fix)

### DIFF
--- a/plugins/runediary
+++ b/plugins/runediary
@@ -1,3 +1,3 @@
 repository=https://github.com/CalciumG/runediary-plugin.git
-commit=1e5ac293d33f4cbb72cb8e94a2fc7ed9d1b56ab4
+commit=90e1c1c1cf90a34b7904473724682e40d8dfca34
 warning=This plugin submits your IP address, RSN, and numerous account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update RuneDiary to 1.1.1

Fixes excessive hub traffic from the bank value tracker. Previously the tracker fired a full profile-sync HTTP POST on every ItemContainerChanged event, so every deposit/withdraw/sort produced a network round-trip. The sync now fires only when the bank UI closes (WidgetClosed for group 12), which keeps the in-memory snapshot fresh as before but emits at most one call per banking session.