### PR TITLE
update prayer-time-infobox

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=46aa4fefaf2ae0cea3c11e775c16a14014388c80
+commit=7286cce91f40d7700b66476b540c85420b3c24f5


### PR DESCRIPTION
Updates `prayer-time-infobox` / PvM Toolkit to commit `7286cce91f40d7700b66476b540c85420b3c24f5`.

Changes in this plugin update:
- removes the Mahogany protection helper
- simplifies warning settings with configurable redness and blink seconds
- adds a Trade button clock option
- keeps PvM timers, cannon warnings, inventory info, and Slayer helpers under the PvM Toolkit plugin

Validation:
- Ran `gradlew.bat test` successfully in the plugin repository.