### PR TITLE
Update forestry-banking-helper

### DIFF
--- a/plugins/forestry-banking-helper
+++ b/plugins/forestry-banking-helper
@@ -1,2 +1,2 @@
-repository=https://github.com/Nuktukk/forestry-banking-helper
+repository=https://github.com/Nuktukk/forestry-banking-helper.git
 commit=08492c8

--- a/plugins/forestry-banking-helper
+++ b/plugins/forestry-banking-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Nuktukk/forestry-banking-helper.git
-commit=a2967f2f4b65bdd7566e00c23aca5676875b13ed
+commit=d26044977367d89b3307642a749ee7f3bb752cad

--- a/plugins/forestry-banking-helper
+++ b/plugins/forestry-banking-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Nuktukk/forestry-banking-helper.git
-commit=4c36d11bf78cb6338a3dcf7936990f0085e2a6c7
+commit=5c75a2c96a003947760968992475a6a9a109b565

--- a/plugins/forestry-banking-helper
+++ b/plugins/forestry-banking-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Nuktukk/forestry-banking-helper.git
-commit=32d2defce30a395a2bfa046ed46c8af5d3cb4e7c
+commit=cf482065294c22e9d5fda6cf68c25b1456dd1114

--- a/plugins/forestry-banking-helper
+++ b/plugins/forestry-banking-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Nuktukk/forestry-banking-helper
+commit=08492c8

--- a/plugins/forestry-banking-helper
+++ b/plugins/forestry-banking-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Nuktukk/forestry-banking-helper.git
-commit=d26044977367d89b3307642a749ee7f3bb752cad
+commit=4c36d11bf78cb6338a3dcf7936990f0085e2a6c7

--- a/plugins/forestry-banking-helper
+++ b/plugins/forestry-banking-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Nuktukk/forestry-banking-helper.git
-commit=08492c8
+commit=08492c84e5dc652faa4c0eaba283335c69329f45

--- a/plugins/forestry-banking-helper
+++ b/plugins/forestry-banking-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Nuktukk/forestry-banking-helper.git
-commit=cf482065294c22e9d5fda6cf68c25b1456dd1114
+commit=a2967f2f4b65bdd7566e00c23aca5676875b13ed

--- a/plugins/forestry-banking-helper
+++ b/plugins/forestry-banking-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Nuktukk/forestry-banking-helper.git
-commit=08492c84e5dc652faa4c0eaba283335c69329f45
+commit=32d2defce30a395a2bfa046ed46c8af5d3cb4e7c


### PR DESCRIPTION
Fix menu swaps not firing - removed incorrect widget ID comparison that prevented the swap code from ever running.