### PR TITLE
Update advanced-hp-bar to 1.1.0

### DIFF
--- a/plugins/advanced-hp-bar
+++ b/plugins/advanced-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/chrisreydev/advanced-hp-bar-plugin.git
-commit=1217358810ef7c8ba544059602c3ce39660436ce
+commit=84d5fdc8956ace48d507fa7c3753bbc2dfd50a94

--- a/plugins/advanced-hp-bar
+++ b/plugins/advanced-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/chrisreydev/advanced-hp-bar-plugin.git
-commit=da27259e919d1e63ef0ec47d7e9914cf8e0646ab
+commit=1217358810ef7c8ba544059602c3ce39660436ce

--- a/plugins/advanced-hp-bar
+++ b/plugins/advanced-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/chrisreydev/advanced-hp-bar-plugin.git
-commit=a31a38cc61cb467b005328b3547e835022ff199e
+commit=da27259e919d1e63ef0ec47d7e9914cf8e0646ab

--- a/plugins/advanced-hp-bar
+++ b/plugins/advanced-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/chrisreydev/advanced-hp-bar-plugin.git
-commit=9c19e156929efbff35f92ec8a8181c8bba5486d5
+commit=a31a38cc61cb467b005328b3547e835022ff199e


### PR DESCRIPTION
## Update to version 1.1.0.

1. Adds configurable HP Bar Height,
2. Changed HP Bar Height default from 5 to 6
3. adjust default positioning
4. Block gap between HP and Prayer with black bar
5. Hides native HP Bar by using a blank sprite
6. Redraws NPC HP Bars as close to native hp bar as possible (boss hp bars will be updated)