### PR TITLE
Update follow-cam — fix 180° camera orientation offset

### DIFF
--- a/plugins/follow-cam
+++ b/plugins/follow-cam
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/follow-cam-plugin.git
-commit=27e8d4230cea48455b77629fcf8234fa4f94cf03
+commit=b90ea117ce09ceedfd6837450530554363f302dc

--- a/plugins/follow-cam
+++ b/plugins/follow-cam
@@ -1,2 +1,2 @@
 repository=https://github.com/PlumpPanda-123/follow-cam-plugin.git
-commit=827d4dee68de807de3cbd7fcb86b9b0a5b6f89fd
+commit=27e8d4230cea48455b77629fcf8234fa4f94cf03


### PR DESCRIPTION
Fixes a 180° direction offset in the Follow Cam plugin.

Player orientation 0 = south, but camera yaw 0 = north. The original submission assumed they shared the same reference direction. The fix adds a 180° (1024 JAU) correction so the camera correctly faces the same direction the player is moving.

Confirmed working in-game by the author.