### PR TITLE
RuneProfile v2.5.1

### DIFF
--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,3 +1,3 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=5785ed3cbe7ea5a8d6f9ee595e9e4207dd6ea2fa
+commit=e19fdc206a075f1c80afcb6d32cb5b2167abfd89
 warning=This plugin submits your player data and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
- Fix plugin crash when trying to update profile from collection log, while search is not open.
- Now uses the search button as a RuneProfile sync button instead of having to use client.menuAction. (User can use search by right clicking the button)
- Remove functionality of reading all clogs as clog opens, since this required the client.menuAction to work.