### PR TITLE
Add collection-log-commands

### DIFF
--- a/plugins/collection-log-commands
+++ b/plugins/collection-log-commands
@@ -1,2 +1,2 @@
 repository=https://github.com/unk-user-shade/collection-log-commands.git
-commit=6321c293b5983fbd6279212873a7c5c5371591ba
+commit=2e334b8dcaaf20e768d6e9b995dcf8de108e338b

--- a/plugins/collection-log-commands
+++ b/plugins/collection-log-commands
@@ -1,0 +1,2 @@
+repository=https://github.com/unk-user-shade/collection-log-commands.git
+commit=6321c293b5983fbd6279212873a7c5c5371591ba

--- a/plugins/collection-log-commands
+++ b/plugins/collection-log-commands
@@ -1,2 +1,2 @@
 repository=https://github.com/unk-user-shade/collection-log-commands.git
-commit=2e334b8dcaaf20e768d6e9b995dcf8de108e338b
+commit=dfe62f7252356c78024a360405eed3f3b6370d87


### PR DESCRIPTION
Adds Collection Log Commands, a RuneLite plugin that lets users share cached collection log progress in chat with !log commands, including missing-item views, aliases, summary output, and verbose/condensed formatting modes.