### PR TITLE
fbclan-plugin: bump to 2539e90

### DIFF
--- a/plugins/fbclan-plugin
+++ b/plugins/fbclan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/orgonag/fbclan-plugin.git
-commit=d1d118c3807a7ce28d1a1cac0da82002f48f2ed7
+commit=2539e908a81f2658700d54ba6ca3d8ab96896616
 warning=This plugin submits your IP address, RSN, drop data, and Party to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Two bug fixes since the previous version:
- LFG row "updated_at" timestamp is no longer reset on every 30s poll, so the panel's "X min ago" timer now ticks correctly.
- Snapshot currentRsn before submitting the shutdown cleanup task; wipes LFG status on runelite shutdown orioerky