### PR TITLE
Add Corp Boosting QOL plugin

### DIFF
--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol
-commit=ff1d50281607bc85685d83e6d64c53079bbc4db6
+commit=a1be5b0699d1b4914af2873fc8775ec5d15a10eb

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=59f6337cbb3e2d011b221a2ac232c1806065244a
+commit=d11cf4ac5dfc4c00416210fdd9b1669c6dd3d672

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol
-commit=a1be5b0699d1b4914af2873fc8775ec5d15a10eb
+commit=3332f980e351e0ea4828cddd64c8c7b849368c86

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=ad6c0a73aeb4990eea49ededc3de86dbffe2bcf2
+commit=59f6337cbb3e2d011b221a2ac232c1806065244a

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=d11cf4ac5dfc4c00416210fdd9b1669c6dd3d672
+commit=d1171069c8b143ae3eae58c76d308d4d607eff09

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,0 +1,2 @@
+repository=https://github.com/BPM-OSRS/corp-boosting-qol
+commit=ff1d50281607bc85685d83e6d64c53079bbc4db6

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
-repository=https://github.com/BPM-OSRS/corp-boosting-qol
+repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
 commit=3332f980e351e0ea4828cddd64c8c7b849368c86

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=391ac2c9e35006db0736057a4169a126bbf45c1c
+commit=ad6c0a73aeb4990eea49ededc3de86dbffe2bcf2

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=99951e7358d7511e6b7526307d3a30e9ed72feb6
+commit=391ac2c9e35006db0736057a4169a126bbf45c1c

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=3332f980e351e0ea4828cddd64c8c7b849368c86
+commit=99951e7358d7511e6b7526307d3a30e9ed72feb6


### PR DESCRIPTION
A suite of quality-of-life tools for Corporeal Beast boosting and multi-logging.

Features:
- Combat overlay (fullscreen color flash when idle in Corp Cave)
- Vengeance, lunar spellbook, and quick prayer warnings
- Movement lock to prevent accidental walk clicks
- Blood fury charge tracking (persists across logouts)
- Rune pouch warning
- Bank supply warning (Super Restore, Sanfew Serum, Super Combat)
- Splasher charge tracking for Tome of Water, Serpentine Helm, and Toxic Staff of the Dead (all persist across logouts)
- Configurable warning overlay color