### PR TITLE
Update advanced-hp-bar to `1.2.0`

### DIFF
--- a/plugins/advanced-hp-bar
+++ b/plugins/advanced-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/chrisreydev/advanced-hp-bar-plugin.git
-commit=54949bf4e9e6e7b716d208a865a7997c2b947195
+commit=94b0c21cdb65090e0f4c22c8f832237dc4b328bd


### PR DESCRIPTION
* Adds New Feature: Show Prayer Bar when any prayer is active even if out of combat
* Adjust default Y Offset to prevent overheads overlap