### PR TITLE
log-adviser: remove third-party warning (TempleOSRS call removed)

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,3 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=dd321187b6707ea418d102de1e2c5be40051dcba
-warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.
+commit=760682235de42179c3167960d6ce7ca9718db5bc


### PR DESCRIPTION
Follow-up to the merged Log Adviser submission.

In review, @riktenx added a `warning=` line because the plugin fetched the player's collection log from TempleOSRS (a third-party server), exposing IP + RSN.

That integration has now been **completely removed** from the plugin ([SFranciscoSouza/LogAdviser@7606822](https://github.com/SFranciscoSouza/LogAdviser/commit/760682235de42179c3167960d6ce7ca9718db5bc)): `TempleOsrsClient` is deleted along with the warm-start path and its config item. The plugin now makes a single outbound call — to Jagex's own `secure.runescape.com` Hiscores endpoint, the same one RuneLite core uses — so no IP/RSN reaches any third-party server.

This PR therefore:
- Bumps `commit=` to the new `760682235de42179c3167960d6ce7ca9718db5bc`
- Removes the now-unnecessary `warning=` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)