### PR TITLE
log-adviser: bump commit, plugin now makes no network requests

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,3 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=dd321187b6707ea418d102de1e2c5be40051dcba
-warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.
+commit=22e5be5e94569dae8c83252679c54a349b139d20


### PR DESCRIPTION
Follow-up to the merged Log Adviser submission, replacing #12010.

In review, @riktenx added a `warning=` line because the plugin fetched the player's collection log from TempleOSRS (a third-party server).

The plugin has since been changed to make **zero network requests at all**:

- `TempleOsrsClient` (TempleOSRS collection-log fetch) — **removed**
- `HiscoreRankFetcher` (the `secure.runescape.com` Hiscores fetch) — **also removed**, along with the sidebar rank / slots-logged display that depended on it

All data now ships bundled with the plugin, and collection-log progress is tracked purely from in-game events (the "new item" chat message and the collection-log widget). Nothing is sent anywhere.

New plugin commit: [`SFranciscoSouza/LogAdviser@22e5be5`](https://github.com/SFranciscoSouza/LogAdviser/commit/22e5be5e94569dae8c83252679c54a349b139d20)

This PR:
- Bumps `commit=` to `22e5be5e94569dae8c83252679c54a349b139d20`
- Drops the `warning=` line, which no longer applies (no third-party — or any — network access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)