### PR TITLE
Add OSRS Wealth Tracker by GE Hound

### DIFF
--- a/plugins/osrs-wealth-tracker-by-ge-hound
+++ b/plugins/osrs-wealth-tracker-by-ge-hound
@@ -1,0 +1,2 @@
+repository=https://github.com/WyattLB/osrs-wealth-tracker-by-ge-hound.git
+commit=2de433f5b017fde5197c7e252c7c686fa8351e4e


### PR DESCRIPTION
A passive, read-only plugin that tracks total OSRS net worth (bank + inventory + equipment) over time.

Features:
- Snapshots on bank open and login
- Sidebar panel with net worth history chart (1D / 7D / 30D / All)
- Breakdown by bank, inventory, and equipment
- Top 3 item movers between snapshots
- Optional in-game overlay
- CSV export
- GE or High Alch pricing
- Looting bag, seed vault, and GIM storage support

No network requests — all data stays local per account.