### PR TITLE
Update repository URL in boss-voicer (Plugin Takeover)

### DIFF
--- a/plugins/boss-voicer
+++ b/plugins/boss-voicer
@@ -1,3 +1,3 @@
-repository=https://github.com/GaelL42/boss_voicer.git
+repository=https://github.com/Endrit-alt/boss_voicer.git
 commit=46efb22d948a3a969011e16fb74c572f466b3c73
 authors=GaelL42

--- a/plugins/visibilityenhancer
+++ b/plugins/visibilityenhancer
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/Visibility-Enhancer.git
-commit=7912f78008f0f73bba5499cc00370954ebe64297
+commit=4e8f7fc9158402975facda8d0cffa883ed7a2429


### PR DESCRIPTION
I would like to takeover the plugin. There have been issues posted on the the plugin and the author has not interacted with any of them for over 2 years.

I would like to update the plugin with new custom voice lines.

I have asked for collaborator access without a reply so far : https://github.com/GaelL42/boss_voicer/issues/7