### PR TITLE
update tile-overlay-indicators

### DIFF
--- a/plugins/tile-overlay-indicators
+++ b/plugins/tile-overlay-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Resh404/tileindicators.git
-commit=1205abe4adb9cdcb593bdcc64a62ee814aef2f8e
+commit=dadd3114dadbb939bac85453ee3a1e6900732e31


### PR DESCRIPTION
Was not using the true tile, fixed now to use it as default also added a option to not use true tile