### PR TITLE
update ge-iq-sync

### DIFF
--- a/plugins/ge-iq-sync
+++ b/plugins/ge-iq-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/LarsJ95/ge-iq-runelite-plugin.git
-commit=1bc0e46481243008542244b67e5b56157e9e0364
+commit=c37e0ce50224555c16e621aa3e5496756dff03d8
 warning=This plugin submits your IP address and grand exchange data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/ge-iq-sync
+++ b/plugins/ge-iq-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/LarsJ95/ge-iq-runelite-plugin.git
-commit=c37e0ce50224555c16e621aa3e5496756dff03d8
+commit=f51945d31611c800f9455f48de8cc2af006e4cac
 warning=This plugin submits your IP address and grand exchange data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Summary
Updates the **GE IQ Sync** plugin with a sidebar navigation button and plugin panel for at-a-glance sync status.

Plugin source: https://github.com/LarsJ95/ge-iq-runelite-plugin (commit `c37e0ce`)

## What changed
- **Navigation button** registered via `ClientToolbar` so the plugin is accessible from the RuneLite right-hand sidebar (like Flipping Utilities, GP Per Hour, etc.).
- **PluginPanel** showing:
  - Sync status (`Connected` / `Disabled` / `Not configured`)
  - Sync code (read from config)
  - Total trades synced (persistent across sessions via `ConfigManager`)
  - Last sync timestamp (relative: `30s ago`, `2m ago`, …)
  - "Open GE IQ" button that launches https://ge-iq.com in the browser
- Panel refreshes on `ConfigChanged` and after each successful sync.

## Files changed
Only `commit=` bump in `plugins/ge-iq-sync` (1bc0e46 → c37e0ce). All plugin code lives in the external repo.

## Third-party interaction
No change to network behaviour — still POSTs trades to `https://ge-iq.com/api/trade` as approved in the original PR (#11218). The new "Open GE IQ" button only launches a browser URL.