### PR TITLE
log-adviser: page-sync tracking + activity data refresh

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=22e5be5e94569dae8c83252679c54a349b139d20
+commit=783177e6b4d291db2fb4fa4d65dfee2ade6d670b


### PR DESCRIPTION
Updates the **Log Adviser** plugin (`plugins/log-adviser`) to commit `783177e6b4d291db2fb4fa4d65dfee2ade6d670b`.

### Changes since the currently-pinned commit
- **Collection-log page-sync tracking** — tracks which collection-log pages have actually been opened/scraped (keyed by the game's `COLLECTION_LAST_TAB` / `COLLECTION_LAST_CATEGORY` varbits), persisted per character via RSProfile config.
- Sidebar panel now shows `X / Y log slots` and `Synced: X / Y pages` counters.
- New viewport overlay surfacing sync progress.
- Target infobox flags advice as potentially stale (orange `!` + hint) until the log is fully synced; infobox time formatting reworked for readability.
- Bundled activity/slot/map data refreshed (new activity + slots); test expectations updated.

No new network access — the plugin remains fully offline (`build=standard`).
