### PR TITLE
Add yellowlog plugin

### DIFF
--- a/plugins/yellowlog
+++ b/plugins/yellowlog
@@ -1,2 +1,2 @@
 repository=https://github.com/finnss/yellowLog.git
-commit=c8719769db85c84987cad6195cc280226aa8d20e
+commit=7287d91a03ddc58162266190c0c7dd7e37f452ffe

--- a/plugins/yellowlog
+++ b/plugins/yellowlog
@@ -1,0 +1,2 @@
+repository=https://github.com/finnss/yellowLog.git
+commit=c8719769db85c84987cad6195cc280226aa8d20e


### PR DESCRIPTION
A RuneLite plugin that changes the color Collection Log entries to yellow if all items _except the pet_ are acquired.

## Features

- Changes color of Collection Log entries if the player has collected all items except the pet, where applicable.
- NB: The logs are not marked yellow _until the player clicks on the log_ (so that the plugin can check for completeness)
- The above can be fixed by also installing the **WikiSync** plugin. If installed, YellowLog autodetects this and uses Wiki data about the player to mark all relevant Collection Logs yellow automatically.

## Compliance

- Gather no player data except collection log data
- No game input is injected
- Java 11 compatible, no reflection, no JNI
