### PR TITLE
Add osrs-tcg

### DIFF
--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,0 +1,2 @@
+repository=https://github.com/Azderi/osrs-tcg.git
+commit=87690a31eb28b179ac37b4c25b8536a10f88dc18


### PR DESCRIPTION
OSRS TCG adds a card collecting game experience on the side of the grind. Credits obtained by gaining XP, leveling up and killing monsters. Credits can be spent on booster packs to build a collection of cards built from wiki data.

Party plugin integration allows sending cards to other players.