### PR TITLE
add osrs-tcg

### DIFF
--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,0 +1,2 @@
+repository=https://github.com/Azderi/osrs-tcg.git
+commit=389c5e6b62b3492f7d0061850fad229343db1f00


### PR DESCRIPTION
OSRS TCG is a plugin that adds a card collecting game to play on the side of the grind. Credits are obtained by playing the game and can be spent on booster packs to fill up a collection of OSRS themed cards.

Party integration allows players to trade cards with each other to make it a true trading card game.