### PR TITLE
Update advanced-hp-bar to `1.3.0`

### DIFF
--- a/plugins/advanced-hp-bar
+++ b/plugins/advanced-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/chrisreydev/advanced-hp-bar-plugin.git
-commit=8ccc97e9481440f7dc904c6fdea9302608982387
+commit=2660bd5318eea7e386d74bc443bafe202647db2b


### PR DESCRIPTION
* Removes extra HP Bars
* Redraws Boss HP Bars as bigger rather than default 30 width