### PR TITLE
Add osrs-tcg

### DIFF
--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,0 +1,2 @@
+repository=https://github.com/Azderi/osrs-tcg.git
+commit=0dfed627665c31f4a50cb916a39bbfcabf6d0d94


### PR DESCRIPTION
OSRS TCG is a plugin that adds a trading card game to the side of the grind. Credits are obtained in various ways playing the game and can be spent on booster packs to build a collection.

Party integration allows players to trade cards with each other.