### PR TITLE
log-adviser: bump to 53fa3f2

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=783177e6b4d291db2fb4fa4d65dfee2ade6d670b
+commit=53fa3f2050c0595530ca1051ec7c9d68ac716efa


### PR DESCRIPTION
Updates the pinned commit for Log Adviser to 53fa3f2.

Changes since the previously pinned commit:
- Merchant's paint and Helmet of the Moon collection-log rates adjusted.