### PR TITLE
Add osrs-tcg

### DIFF
--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=e4fe9a189d28ece5dbf72e693766ffac4097a5dd
+commit=690de26ac8658b01c2a78a8a6d1cfe18efcad246

--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,0 +1,2 @@
+repository=https://github.com/Azderi/osrs-tcg.git
+commit=1a7ba25c6abe7261a7478d71a8ae5851b522c911

--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=690de26ac8658b01c2a78a8a6d1cfe18efcad246
+commit=e24793852120b067296f91ffcebc77a204fc1001

--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=1a7ba25c6abe7261a7478d71a8ae5851b522c911
+commit=e4fe9a189d28ece5dbf72e693766ffac4097a5dd

--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=e24793852120b067296f91ffcebc77a204fc1001
+commit=72957a20e1f65897c13c3a174e70305e3dadfd98

--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=72957a20e1f65897c13c3a174e70305e3dadfd98
+commit=ccf3e8d57a7d91a831e7f7debb73178b206163a2


### PR DESCRIPTION
OSRS TCG is a plugin that adds a trading card game to the side of the grind. Credits are obtained in various ways playing the game and can be spent on booster packs to build a collection.

Party integration allows players to trade cards with each other.