### PR TITLE
log-adviser: fix Farmer's outfit collection log slots for Body-type-B characters

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=53fa3f2050c0595530ca1051ec7c9d68ac716efa
+commit=d636c05f4fbc23cc64ded945b8945f569429502a

--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=d636c05f4fbc23cc64ded945b8945f569429502a
+commit=f4e835c07aa6fbe4ac7e3568d790ee6b29288b56


### PR DESCRIPTION
Bumps the pinned commit for **log-adviser** to `d636c05`.

### What this fixes

Each Tithe Farm Farmer's outfit piece is a single collection log slot but can be filled by two different items depending on the character's body type (A/B):

| Slot | Body type A | Body type B |
|---|---|---|
| Farmer's boro trousers | 13640 | 13641 |
| Farmer's shirt/jacket | 13642 | 13643 |
| Farmer's boots | 13644 | 13645 |
| Farmer's strawhat | 13646 | 13647 |

The plugin's slot data only carried the Body-type-A id, so a Body-type-B player's items matched nothing in either sync path (collection-log widget scrape or chat notification), and up to four slots were missed — leaving the plugin's collected total below the in-game total.

The update maps each Body-type-B id (and the shirt/jacket chat names that the slash slot name never matches) onto its canonical id, and canonicalises obtained items so the stored set only ever holds canonical ids (no double-counting). Previously-missing slots self-heal on the next collection log open; no user action or data reset required.

A focused JUnit test covers slot resolution for both body types, name resolution, canonicalisation, and the no-double-count guarantee. `./gradlew build` is green.