### PR TITLE
Update RuneDiary to 1.2.0 (update from hiscores on logout)

### DIFF
--- a/plugins/runediary
+++ b/plugins/runediary
@@ -1,3 +1,3 @@
 repository=https://github.com/CalciumG/runediary-plugin.git
-commit=90e1c1c1cf90a34b7904473724682e40d8dfca34
+commit=4e584a1847ae78ce9d86408bc9afa4005a1c877f
 warning=This plugin submits your IP address, RSN, and numerous account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
  ### Changes
  - **Hiscores on logout**  new `HiscoresFetcher` pulls the player's hiscores when they log out and includes them in the
  profile sync payload.
  - **Seasonal world handling** sync is skipped on Leagues / DMM / beta worlds to prevent seasonal data from the main profile in the hub.