### PR TITLE
Update corp-boosting-qol

### DIFF
--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol
-commit=ff1d50281607bc85685d83e6d64c53079bbc4db6
+commit=a1be5b0699d1b4914af2873fc8775ec5d15a10eb

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=59f6337cbb3e2d011b221a2ac232c1806065244a
+commit=d11cf4ac5dfc4c00416210fdd9b1669c6dd3d672

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol
-commit=a1be5b0699d1b4914af2873fc8775ec5d15a10eb
+commit=3332f980e351e0ea4828cddd64c8c7b849368c86

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=a66654af8999f3599737e18df80a421bb7c6851e
+commit=5db3c4227adb4bc4b66b4050b9b599b3f0ca8e07

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=ad6c0a73aeb4990eea49ededc3de86dbffe2bcf2
+commit=59f6337cbb3e2d011b221a2ac232c1806065244a

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=d11cf4ac5dfc4c00416210fdd9b1669c6dd3d672
+commit=d1171069c8b143ae3eae58c76d308d4d607eff09

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,0 +1,2 @@
+repository=https://github.com/BPM-OSRS/corp-boosting-qol
+commit=ff1d50281607bc85685d83e6d64c53079bbc4db6

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
-repository=https://github.com/BPM-OSRS/corp-boosting-qol
+repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
 commit=3332f980e351e0ea4828cddd64c8c7b849368c86

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=391ac2c9e35006db0736057a4169a126bbf45c1c
+commit=ad6c0a73aeb4990eea49ededc3de86dbffe2bcf2

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=99951e7358d7511e6b7526307d3a30e9ed72feb6
+commit=391ac2c9e35006db0736057a4169a126bbf45c1c

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=d1171069c8b143ae3eae58c76d308d4d607eff09
+commit=a66654af8999f3599737e18df80a421bb7c6851e

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=3332f980e351e0ea4828cddd64c8c7b849368c86
+commit=99951e7358d7511e6b7526307d3a30e9ed72feb6


### PR DESCRIPTION
## Corp Boosting QOL — Major Update

This is a significant overhaul touching nearly every system in the plugin. Summary below for reviewers.

### Alert Overlay System (new)
Replaced the single fullscreen combat overlay with a unified alert system. All active alerts now split the screen into equal vertical slices side by side — combat idle, vengeance ready, quick prayer down, and wrong spellbook each get their own slice with an icon and configurable colour overlay. Each alert has independent toggles for the icon and the colour overlay.

### Blood Fury Tracking
- Switched from hitsplat-based to animation-based tracking (Osmumten's Fang, Noxious Halberd both styles, Elder Maul) — more accurate, matches actual game mechanic
- Now auto-updates when recharging with a blood shard (parses the MESBOX confirmation message)
- Fixed 1-tick "inspect amulet" flash on login

### Supply Tracking
- All supply checks now include bank + noted items in inventory
- All counts (blood fury, tome, serp, staff, supplies, house tabs, zulrah scales) persist across logouts per account
- Fixed false positive warnings triggering on bank close and on teleport
- Added: Divine Super Combat Potion(4), Anglerfish, House Teleport Tablets, Zulrah Scales

### Splasher
- Added DMM Toxic Staff of the Dead support
- Added all three Serpentine Helm variants (regular, magma, tanzanite)
- Zulrah scales tracking added to splasher section

### Rune Pouch
- Warning now shows globally (not just inside Corp Cave)

### Other
- Lunar spellbook warning restricted to Corp Cave only
- Config reorganized into sections: Corp Cave, Vengeance, Quick Prayer, Lunar Spellbook, Supplies, Splasher