### PR TITLE
update ge-iq-sync

### DIFF
--- a/plugins/ge-iq-sync
+++ b/plugins/ge-iq-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/LarsJ95/ge-iq-runelite-plugin.git
-commit=f51945d31611c800f9455f48de8cc2af006e4cac
+commit=600131930e5c3c433cd31ad4c25f8bf54b4b2437
 warning=This plugin submits your IP address and grand exchange data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/ge-iq-sync
+++ b/plugins/ge-iq-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/LarsJ95/ge-iq-runelite-plugin.git
-commit=600131930e5c3c433cd31ad4c25f8bf54b4b2437
+commit=259e906c284f455e6dfc918f21905041b00ca5e5
 warning=This plugin submits your IP address and grand exchange data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
v1.2: read sync.

The plugin now polls `/api/sync-pull` on the GE IQ server every 60s and shows
three counters in the sidebar panel:

- **Watching** — items the user has starred in the webapp
- **Active flips** — open portfolio slots
- **Investments** — active investment holdings

Trades still push the existing direction (RuneLite → GE IQ). Read direction
is additive and best-effort: failures are logged at debug level, last good
state is kept until the next successful pull.

Server endpoint is rate-limited at 5s/code and returns 404 when the code has
no synced data yet.

Plugin commit: https://github.com/LarsJ95/ge-iq-runelite-plugin/commit/600131930e5c3c433cd31ad4c25f8bf54b4b2437