### PR TITLE
Add valuable-drops-party plugin

### DIFF
--- a/plugins/valuable-drops-party
+++ b/plugins/valuable-drops-party
@@ -1,2 +1,2 @@
 repository=https://github.com/Fossferous/runelite-valuable-drops.git
-commit=e9e43642715ef2f27770f89de6ed9a7445070890
+commit=5bdbb5f10507898f2acbbca019a8bad2017b7728

--- a/plugins/valuable-drops-party
+++ b/plugins/valuable-drops-party
@@ -1,2 +1,2 @@
 repository=https://github.com/Fossferous/runelite-valuable-drops.git
-commit=25cdae367dbeb91373a61f5bb2c61f6694105da9
+commit=95807b35a083ac33b5e1ba097ba200493fcb27dd

--- a/plugins/valuable-drops-party
+++ b/plugins/valuable-drops-party
@@ -1,0 +1,2 @@
+repository=https://github.com/Fossferous/runelite-valuable-drops.git
+commit=25cdae367dbeb91373a61f5bb2c61f6694105da9

--- a/plugins/valuable-drops-party
+++ b/plugins/valuable-drops-party
@@ -1,2 +1,2 @@
 repository=https://github.com/Fossferous/runelite-valuable-drops.git
-commit=95807b35a083ac33b5e1ba097ba200493fcb27dd
+commit=8351ff9bccb2297ccbca2b93e0f0a1fd2bd20351

--- a/plugins/valuable-drops-party
+++ b/plugins/valuable-drops-party
@@ -1,2 +1,2 @@
 repository=https://github.com/Fossferous/runelite-valuable-drops.git
-commit=8351ff9bccb2297ccbca2b93e0f0a1fd2bd20351
+commit=86009ccfb98296620efba58824132773ff18688e

--- a/plugins/valuable-drops-party
+++ b/plugins/valuable-drops-party
@@ -1,2 +1,2 @@
 repository=https://github.com/Fossferous/runelite-valuable-drops.git
-commit=86009ccfb98296620efba58824132773ff18688e
+commit=e9e43642715ef2f27770f89de6ed9a7445070890


### PR DESCRIPTION
Adds the **Valuable Drops Party** plugin.

### Description
This plugin hooks into RuneLite's native `PartyService` to automatically broadcast high-value drops to party members in the game chat. It includes a custom UI panel that acts as a session loot history, displaying drops received by anyone in the active party.

### Features
* Broadcasts drops from NPCs, Players, and LootTracker sources (Raids, Barrows, Clues).
* Calculates total drop value using both Grand Exchange and High Alch prices via the RuneLite `ItemManager`.
* Configurable minimum GP threshold (default 1,000,000 gp).
* Built-in toggle to always broadcast 0-value highly sought-after untradeables (e.g. Pets, Champion Scrolls, Mutagens).
* Custom sidebar `PluginPanel` that tracks the party's drop history for the session with high-res item icons.

### Repository
https://github.com/Fossferous/runelite-valuable-drops
