### PR TITLE
update tasks-tracker : task progress bars & fixes

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=416520eebc0fc942bada103a837997c75d73d606
+commit=c83f3663e00aef01403382e6663509d59c73d00f
 authors=perterter,JamesShelton140


### PR DESCRIPTION
Update tasks-tracker plugin
- added progress bars to tasks (e.g. catch 500 chinchompas) - most loaded from vars
- fixed bug where plugin panel caused RuneLite size to max out infinitely, requiring restart to fix
https://github.com/osrs-reldo/tasks-tracker-plugin/issues/166
- changed the build runelite plugin property
- fixed a high memory usage class (reducing plugin memory footprint by ~40%)
https://github.com/osrs-reldo/tasks-tracker-plugin/issues/171
- added a sum mode to progress bars (think echo gauntlet + non-echo gauntlet for KC)
<img width="223" height="560" alt="Screenshot 2026-05-17 185429" src="https://github.com/user-attachments/assets/4581d2a3-edfc-49d3-aafe-bb0b2a6e5da5" />
