### PR TITLE
log-adviser: bump to ad9c9b8

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=f4e835c07aa6fbe4ac7e3568d790ee6b29288b56
+commit=ad9c9b891c5a3dbc94f659e583ffedf34d72ea30


### PR DESCRIPTION
Updates the pinned commit for log-adviser to `ad9c9b891c5a3dbc94f659e583ffedf34d72ea30`.

Changes since the previously pinned commit (`f4e835c`):
- Quest and Skill requirements logic
- Skip list implementation
- Added requirement list