### PR TITLE
log-adviser: bump to 9680555

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=ad9c9b891c5a3dbc94f659e583ffedf34d72ea30
+commit=96805558792dc96b8dd49f3589fc31ee3feab431


### PR DESCRIPTION
Updates the pinned commit for log-adviser to `96805558792dc96b8dd49f3589fc31ee3feab431`.

Changes since the previously pinned commit (`ad9c9b8`, merged in #12057):
- Exclude iron-auto-completed slots (Merchant's paint, 32110) from iron-account advice while leaving mains unaffected
- Add Firemaking 50 requirement for activity 56