### PR TITLE
Update kick-history v1.1.0

### DIFF
--- a/plugins/kick-history
+++ b/plugins/kick-history
@@ -1,2 +1,2 @@
 repository=https://github.com/itsdukey/Kick-History.git
-commit=f66637874c2e5f5144bfc3c40d6aa674e95a8e57
+commit=f9e86c50637e36bf007a22ec266bca5bbfda37a3


### PR DESCRIPTION
v1.1.0 - The Friends Chat Update


Strict FC Whitelist: Only tracks kicks in your configured "Target FC Name" (supports multiple chats via comma). Clan Chat tracking removed.

Upgraded Webhooks: Discord logs now show the kicked player's exact world (e.g., W611) and the permanent chat owner's name.

Chat Hop Safety: Instantly wipes pending kicks when changing chats to prevent log misfires.

Cleaner UI: Redesigned side panel stops text-wrapping and centers headers.

In-Game Guide: Step-by-step setup tutorial added directly to the config panel.

Performance: Menu clicks are now zero-lag thanks to config caching. Added crash protections for fresh installs.