### PR TITLE
update runesocial

### DIFF
--- a/plugins/runesocial
+++ b/plugins/runesocial
@@ -1,4 +1,4 @@
 repository=https://github.com/RuneSocial/runesocial-plugin.git
-commit=df3d082df6635b5fba15c36f32280ba57cf2ebe5
+commit=3a4265e6e9d7d12cf0dedb1136c4a2bbecb6093e
 authors=Lomecan
 warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Fix: pollNearbyPlayers was being called off the client thread, causing client.getPlayers() and getWorldLocation() to silently return empty/null results. Moved client API calls inside clientThread.invoke() so nearby players are correctly fetched and sent to the batch endpoint.