### PR TITLE
Add repository and commit information for will-it-land

### DIFF
--- a/plugins/will-it-land
+++ b/plugins/will-it-land
@@ -1,0 +1,2 @@
+repository=https://github.com/EthonSmoth/will-it-land
+commit=de091d80d2c916e3c9b3d8aff71629b4b0aeefed


### PR DESCRIPTION
Added `build=standard` to `runelite-plugin.properties` in the plugin repo and pushed it. Could the checks be rerun when you have a moment? Thanks!