### PR TITLE
Add will-it-land plugin repository information

### DIFF
--- a/plugins/will-it-land
+++ b/plugins/will-it-land
@@ -1,2 +1,2 @@
 repository=https://github.com/EthonSmoth/will-it-land.git
-commit=b28b0ae77abb37e5286a71e96c5da1e95e0c5d72
+commit=b9ad572d25acde7bfe831ef83b6ef36efb5eb79d

--- a/plugins/will-it-land
+++ b/plugins/will-it-land
@@ -1,2 +1,2 @@
 repository=https://github.com/EthonSmoth/will-it-land.git
-commit=b9ad572d25acde7bfe831ef83b6ef36efb5eb79d
+commit=b9ad572e2f25956d2d2a67bed1b5cfda4dd60157

--- a/plugins/will-it-land
+++ b/plugins/will-it-land
@@ -1,2 +1,2 @@
 repository=https://github.com/EthonSmoth/will-it-land.git
-commit=de091d80d2c916e3c9b3d8aff71629b4b0aeefed
+commit=16542d07a4fed682545e0abcb34c3523999a0579

--- a/plugins/will-it-land
+++ b/plugins/will-it-land
@@ -1,0 +1,2 @@
+repository=https://github.com/EthonSmoth/will-it-land.git
+commit=de091d80d2c916e3c9b3d8aff71629b4b0aeefed

--- a/plugins/will-it-land
+++ b/plugins/will-it-land
@@ -1,2 +1,2 @@
 repository=https://github.com/EthonSmoth/will-it-land.git
-commit=16542d07a4fed682545e0abcb34c3523999a0579
+commit=97b14a56014136e85a58b6d85a55c46521232b7a

--- a/plugins/will-it-land
+++ b/plugins/will-it-land
@@ -1,2 +1,2 @@
 repository=https://github.com/EthonSmoth/will-it-land.git
-commit=97b14a56014136e85a58b6d85a55c46521232b7a
+commit=b28b0ae77abb37e5286a71e96c5da1e95e0c5d72


### PR DESCRIPTION
Added `build=standard` to `runelite-plugin.properties` in the plugin repo and pushed it. Could the checks be rerun when you have a moment? Thanks!