### PR TITLE
Update 07flip to be7265e

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=c2689aaef9752f43f56dc0557e1fc18bc3cee19b
+commit=be7265e18fac5e9e4a96a3df14ea59955025928e
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Update 07flip plugin to commit be7265e.

Highlights since the last accepted hash:

- New tabs: Plan (8-slot premium optimiser with cross-surface session sync), Screener (technical-screener matches), Dips, Alch, Tablets, Decant, Item insights.
- Trades panel polish: renamed My Trades to Trades so the label fits cleanly in the side-panel tab grid, taller nav bar for readability, new Invested snapshot row (active buy gp + cost basis of held items with a conservative 2% GE-tax haircut).
- Fix: sell-side double-tax in the FIFO profit calculator. `GrandExchangeOffer.getSpent()` returns the **net** amount for sells; the calculator was treating it as gross and deducting the 2% sales tax a second time, inflating reported losses on high-value flips. Capital tracking had the same root cause and is also fixed.
- README: removed the stray paid tag from the Merch Alerts row in the feature-compare table.