### PR TITLE
Update account-history plugin

### DIFF
--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,3 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
-commit=8c195759ab7b7f64511304a9bae9ea7d734d9623
-warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, quests, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.
+commit=3fcb7c470f97a35a4f5a1fe1a1d12caac18bab76
+warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,3 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
-commit=bdac19491567e0f3a542dfcf20ccc91b5b0abc60
+commit=0ac4e6e01f7961081bca46c76fcd8c4ad3458192
 warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,3 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
-commit=1a8cfbb68bf027dfd4068988790be153083cdba7
-warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.
+commit=8c195759ab7b7f64511304a9bae9ea7d734d9623
+warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, quests, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,3 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
-commit=3fcb7c470f97a35a4f5a1fe1a1d12caac18bab76
+commit=bdac19491567e0f3a542dfcf20ccc91b5b0abc60
 warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Fix a bug with collection log entry names
- Add quest completion tracking.
- Reduce frequency of account initialization logic being run due to `LOGGED_IN` game state changes
- Renames the plugin from  "Account History" to "MaxCape" to match the associated maxcape.net domain/branding
- Add icon.png for plugin hub icon