### PR TITLE
Update 07flip to 8bb3e9f

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=be7265e18fac5e9e4a96a3df14ea59955025928e
+commit=8bb3e9fe016bdbe9f5d918c7f119ed4660688a59
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Update 07flip plugin to commit 8bb3e9f.

**What this changes (small follow-up to #12078)**

Tightens the new `Invested` row on the Trades stats panel so it only counts gp tied up in **live GE activity right now**:

- gp held by the GE for offers in the `BUYING` state - unchanged
- cost basis of items currently sitting in offers in the `SELLING` state, pro-rated by the qty still waiting to fill

The previous build was summing the cost basis of every `OpenPosition` from the FIFO calculator, which inflated the number with two things the user doesn't think of as "invested in the GE":

1. Items the user bought and hoarded in their bank without listing
2. Phantom open positions from older buys whose matching sells rolled out of the 200-row rolling trade history

On a heavy flipper's account the loose definition overstated Invested by 200-400M gp from inventory hoarding alone. The tightened definition matches the panel's "money tied up in the GE right now" reading.

**Implementation notes for reviewers**

- All work happens client-side; no new external API calls
- `MyTradesStatsPanel.update()` gains a `heldCostBasisInActiveSells` parameter. Older 5-arg / 6-arg overloads remain as compatibility shims that pass `0L`, so no behaviour change for any caller that hasn't been migrated
- The cost-basis filter walks `ProfitCalculator.openPositions` and uses `remainingCostBasis / remainingQty` as per-unit cost, capped at the qty currently in the active sell. SOLD and CANCELLED_SELL states are deliberately excluded (items are gone or returned to bank)
- 2% GE-tax haircut on the held side is unchanged - still a conservative estimate of tax that'll be skimmed when the active sells fill
- Tooltip wording updated from "items waiting to sell" ? "items in active sell offers" so the row's meaning is unambiguous

Verified on a real GE state: 8 active offers (4 buys totalling 191M, 4 sells with combined cost basis ~93M), Invested = 282.5M, which reconciles exactly with the listing prices and the FIFO cost basis from prior buys.