### PR TITLE
Update 07flip to adec535

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=be7265e18fac5e9e4a96a3df14ea59955025928e
+commit=adec535fe5646f528022510059e0c6df64074117
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Update 07flip plugin to commit adec535.

**Trade-sync regression fix + automatic backlog recovery.** Two paired plugin-side fixes for a server-submission regression that landed in our May 14 release.

### The regression

The May 14 `correctness pass` commit (43c634f) moved server submission from per-fill POSTs to terminal-state-only - the right call, because the per-fill version was producing duplicate rows server-side. But the new gating routes the POST through `recordTrade`, which is gated upstream by `recordIfNewFills`'s `if (deltaQty <= 0) return;` early-return.

When a fast-filling offer maxes `quantitySold` in its last `BUYING`/`SELLING` tick (very common for liquid items), the subsequent `BOUGHT`/`SOLD` event arrives with `deltaQty=0`, the early-return fires, and the terminal POST never happens. Local recording continued working (`clearPartialFlag` ran), but the trade was silently never sent upstream. The server side confirmed this matched the nginx data exactly: tracker POSTs dropped from ~100/day to 0-2/day immediately on May 14.

### Fix 1 - POST on zero-delta terminal observations

`recordIfNewFills`'s early-return now checks the offer's state. If it's `BOUGHT` / `SOLD` / `CANCELLED_BUY` / `CANCELLED_SELL`, it routes to a new `finaliseAndPostExistingRow` helper that mirrors `recordTrade`'s tail: flips `partial=false` locally for `BOUGHT`/`SOLD`, then POSTs the row to `/api/runelite/tracker`. Same gating as the existing path (`shareTradeData` + non-empty `apiKey`). The server's fingerprint dedup makes any incidental duplicate POST a safe no-op.

### Fix 2 - Startup bulk re-sync via /tracker/bulk

Adds `postTradeRecordsBulk` to the API client and a matching `doBulkSyncToServer` plugin method that runs once at startup right after the existing pull-direction `doSyncTrackerHistory`. Walks the local `tradeHistory` (capped at `MAX_TRADE_HISTORY=200`, well under the endpoint's 500-row request cap) and ships the lot in a single request. Server dedups via `unique_trade(userId, itemId, tradedAt, isBuy)` so already-known rows come back in the duplicate counter rather than as inserts.

This recovers every affected user's May 14 ? fix-release backlog automatically - no user action needed, no UI button. Affected accounts will see their missed trades populate on the first client restart after this build lands.

### Reviewer notes

- Both fixes are plugin-side only. No new external dependencies.
- The new `/tracker/bulk` endpoint was added on the 07flip.com side specifically for this recovery. Same Bearer-apiKey auth as `/tracker`, same User-Agent, byte-identical field shape so the existing serialiser maps over cleanly.
- Rate limit on `/tracker/bulk`: 5 req/min/IP, well under our once-per-startup usage.
- New compute / IO at startup: one extra HTTP request per session. `shareTradeData` toggle + apiKey gating are honoured exactly as in the existing tracker code.
- No data sent that wasn't already being sent - `/tracker/bulk` just batches the same row shape as `/tracker`.