### PR TITLE
Add Stop Misclicking Orbs

### DIFF
--- a/plugins/stop-misclicking-orbs
+++ b/plugins/stop-misclicking-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/jtclowner/stop-misclicking-orbs.git
-commit=3fbb43ede777d7d004ce44f8ac96bfd6c00471db
+commit=fe3ea88e84b80f2bc5d90b32b6f79003046e3dad

--- a/plugins/stop-misclicking-orbs
+++ b/plugins/stop-misclicking-orbs
@@ -1,0 +1,2 @@
+repository=https://github.com/jtclowner/stop-misclicking-orbs.git
+commit=08fb675ccd19ab293b178157803a845e23fcf6fe

--- a/plugins/stop-misclicking-orbs
+++ b/plugins/stop-misclicking-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/jtclowner/stop-misclicking-orbs.git
-commit=08fb675ccd19ab293b178157803a845e23fcf6fe
+commit=3fbb43ede777d7d004ce44f8ac96bfd6c00471db


### PR DESCRIPTION
## Features

Stop Misclicking Orbs is a small utility plugin that makes selected minimap orb widgets click-through while a configurable hotkey mode is active.

- Supports Hitpoints, Prayer, Run, Special Attack, World Map, XP, Activity, Wiki, and Store orbs.
- Lets users choose exactly which orbs are affected.
- Supports hold, inverse-hold, and toggle activation modes.

## Compliance

- The plugin only modifies client-side minimap orb widget click-through/menu entries.
- It only clears configured minimap orb widget actions while click-through is active.
- It restores changed widget state when inactive, on config changes, logout, and shutdown.
- It does not send, receive, or transmit any external data.
- Java 11. No reflection, JNI, native libraries, or classloader modification.
- It does not create, reorder, or prioritise NPC, object, player, inventory, spell, prayer, or world interaction menu entries.