### PR TITLE
Log Adviser: add Bosun's workbench schematic slot

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=96805558792dc96b8dd49f3589fc31ee3feab431
+commit=cebe88681deda18a3187223d77daf26c8cdd1bce


### PR DESCRIPTION
Bumps the pinned commit of [SFranciscoSouza/LogAdviser](https://github.com/SFranciscoSouza/LogAdviser) from `9680555` to `cebe886`.

The only change between those two commits is [SFranciscoSouza/LogAdviser@cebe886](https://github.com/SFranciscoSouza/LogAdviser/commit/cebe88681deda18a3187223d77daf26c8cdd1bce), which adds the Bosun's workbench schematic (item id 33423) to the plugin's static data:

- adds an `activity_map.json` row under activity 130 ("Exploring sailing islands") so the slot is recognised and a time-to-get is attributed to it (dropRateAttempts 2.0 = ~10 min at the activity's 12/hr rate, matching the Troubled Tortugans quest duration that auto-grants the schematic)
- adds the matching `slots.json` row so the collection-log widget scrape and chat-message hooks recognise the slot when the player obtains it
- bumps the two hard-coded row-count asserts in the dev launcher to match

No code changes; data-only addition.