### PR TITLE
npc-idle-timer-plugin: takeover of dormant plugin

### DIFF
--- a/plugins/npc-idle-timer-plugin
+++ b/plugins/npc-idle-timer-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Vinnie-Singleton/npc-idle-timer-plugin.git
-commit=d7e221159e2ec8e62381bf65969a99f49c5901e0
+commit=228d0cff331fb4d5e5c4c27cbb931877db26cec5
 authors=lejeffe

--- a/plugins/npc-idle-timer-plugin
+++ b/plugins/npc-idle-timer-plugin
@@ -1,3 +1,3 @@
-repository=https://github.com/vonpawn/npc-idle-timer-plugin.git
+repository=https://github.com/Vinnie-Singleton/npc-idle-timer-plugin.git
 commit=d7e221159e2ec8e62381bf65969a99f49c5901e0
 authors=lejeffe


### PR DESCRIPTION
This changes the npc-idle-timer-plugin manifest to point at a maintained fork. The commit hash is unchanged, per the plugin takeover policy.

Background:
- The current repository, vonpawn/npc-idle-timer-plugin, has had no development activity since 2023-12-14 (commit d7e2211, the hash pinned in this manifest).
- The plugin has a bug where disabling it while logged in leaves it unable to re-enable until the player relogs. This is reported in upstream issues #11, #13 and #14. A fix was submitted as upstream PR #15 on 2026-03-29 and remains unreviewed.
- I opened upstream issue #16 on 2026-05-06 requesting collaborator access, and tagged the current maintainer (lejeffe) the same day. There has been no response after two weeks.
- The repository is not archived or disabled, so this follows the standard 30-day-dormancy contact path rather than the 60-day expedited claim.

I am sending this PR with the commit hash unchanged so the maintainers can attempt to contact the author. I have fixes ready for the re-enable bug and a feature to persist timer state across despawn/teleport (addressing issue #12), which I will submit as a follow-up commit and hash bump once access is settled.

Upstream references:
- issue #16: https://github.com/vonpawn/npc-idle-timer-plugin/issues/16
- PR #15: https://github.com/vonpawn/npc-idle-timer-plugin/pull/15
- issue #12: https://github.com/vonpawn/npc-idle-timer-plugin/issues/12
