### PR TITLE
Add "Matching Lootbeam" plugin

### DIFF
--- a/plugins/matching-lootbeams
+++ b/plugins/matching-lootbeams
@@ -1,0 +1,2 @@
+repository=https://github.com/blakelockley/runelite-matching-lootbeams.git
+commit=49440a9026768235c3a77ff3e225bee99ff449c2


### PR DESCRIPTION
This is a simple plugin that will create loot beams that match the primary colour of the drop. For example a Zentye shard will have strong orange loot beam and a Serpentine helm will have a bright green loot beam. This can be configured via a minimum value threshold.