### PR TITLE
Add Crafting Guild Bank Helper

### DIFF
--- a/plugins/crafting-guild-bank-helper
+++ b/plugins/crafting-guild-bank-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/jtclowner/crafting-guild-bank-helper.git
+commit=34215a8eb395f8f2b785609c501cab4f3a520c8b


### PR DESCRIPTION
## Features

Crafting Guild Bank Helper is a small overlay plugin that predicts and highlights the location of the Crafting Guild bank chest while teleporting with a crafting cape or max cape.

- Shows a predicted bank chest clickbox during the teleport animation.
- Highlights the real bank chest clickbox once the player arrives.
- Supports crafting cape, crafting cape (t), and max cape Crafting Guild teleports.
- Includes configurable highlight colour, fill, fill opacity, and outline width.

## Compliance

- The plugin only draws client-side overlay highlights.
- It does not automate input, send clicks, move the mouse, or choose menu options.
- It does not send, receive, or transmit any external data.
- Java 11. No reflection, JNI, native libraries, external dependencies, or classloader modification.