### PR TITLE
Add Merch Lens

### DIFF
--- a/plugins/merch-lens
+++ b/plugins/merch-lens
@@ -1,2 +1,2 @@
 repository=https://github.com/RealGrind/merch-lens.git
-commit=11dcb8b62038be622a7aa002f58fbe5ef691b1f6
+commit=c95c67d484c1947bc2868e9c18ff2445f9720d6b

--- a/plugins/merch-lens
+++ b/plugins/merch-lens
@@ -1,0 +1,2 @@
+repository=https://github.com/RealGrind/merch-lens.git
+commit=11dcb8b62038be622a7aa002f58fbe5ef691b1f6


### PR DESCRIPTION
Adds Merch Lens, a RuneLite plugin for Grand Exchange market watching, flip research, item screening, and local GE offer tracking.