### PR TITLE
Update hotkey-toggle-sidepanels

### DIFF
--- a/plugins/hotkey-toggle-sidepanels
+++ b/plugins/hotkey-toggle-sidepanels
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/example-plugin.git
-commit=85a0bd1fbdf2b892e62805ccec82ab965f6a2fee
+commit=fa57b0e7eb1531218671af224014a17d1972636d


### PR DESCRIPTION
Customizable option to respect "Press Enter to Chat" from KeyRemapperPlugin, so the hotkeylistener is disabled if the player is currently typing in chat
