### PR TITLE
Add Slayer Loadout plugin

### DIFF
--- a/plugins/slayer-loadout
+++ b/plugins/slayer-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeN3/slayer-loadout.git
-     commit=0858a45b4f8a0e64fee19ecf449d3fffacf0a616
+commit=0858a45b4f8a0e64fee19ecf449d3fffacf0a616

--- a/plugins/slayer-loadout
+++ b/plugins/slayer-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeN3/slayer-loadout.git
-commit=faf282691f85b8f7ad4d1bbc9c2cda946bdc6ef3
+commit=deb1b7d30236201a1020ed519788ca2ec02c2486

--- a/plugins/slayer-loadout
+++ b/plugins/slayer-loadout
@@ -1,0 +1,2 @@
+repository=https://github.com/MikeN3/slayer-loadout.git
+     commit=0858a45b4f8a0e64fee19ecf449d3fffacf0a616

--- a/plugins/slayer-loadout
+++ b/plugins/slayer-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeN3/slayer-loadout.git
-commit=0858a45b4f8a0e64fee19ecf449d3fffacf0a616
+commit=faf282691f85b8f7ad4d1bbc9c2cda946bdc6ef3


### PR DESCRIPTION
BiS Gear {} Adds Slayer Loadout — a side panel showing the best gear you own (Melee/Ranged/Magic) and a DPS estimate for your current slayer task. Read-only, no automation, no network calls.