### PR TITLE
Update pvp-leaderboard

### DIFF
--- a/plugins/pvp-leaderboard
+++ b/plugins/pvp-leaderboard
@@ -1,3 +1,3 @@
 repository=https://github.com/findarian/pvp-leaderboard.git
-commit=aea0f2fd832466fb2eab38e26e586b292bc5c63d
+commit=62adf1fadbd9b0d6f9da21feb6777ea46f3f2021
 warning=This submits your IP address, in-game username, and PvP fight statistics to a 3rd-party service not controlled or verified by RuneLite developers.


### PR DESCRIPTION
PvP Matchmaking (socket lobby)
- New WebSocket connection to wss://api.pvp-leaderboard.com/prod for the opt-in
  matchmaking sidepanel. Sends/receives lobby roster, invites, fight-confirmation,
  and the final world + meeting-place handoff.
- Authenticates with the RuneLite-generated install UUID (query param)
- Display name is broadcast to other opted-in players while joined to the lobby. (Must actually go into the lobby, reset options takes them out of the lobby)

Domain migration
- Public site / shards / whitelist / profile pages moved from
  devsecopsautomated.com to https://pvp-leaderboard.com
  REST API stays on the existing execute-api gateway URL

Misc
- Self-profile preview row + Refresh count button on the gate.
- SMURF_GUARD v2 (≥20 kills+deaths required in a style before queuing it).
- Smaller UX fixes around invite cancel / decline banner / fight session timeout.