### PR TITLE
takeover `clan-chat-country-flags`

### DIFF
--- a/plugins/clan-chat-country-flags
+++ b/plugins/clan-chat-country-flags
@@ -1,2 +1,2 @@
-repository=https://github.com/melkypie/clanchatcountryflags.git
+repository=https://github.com/rmobis/clan-chat-country-flags.git
 commit=e3bee0d8f7ebc1b31aa8cfa26bd7064cff8a351b

--- a/plugins/clan-chat-country-flags
+++ b/plugins/clan-chat-country-flags
@@ -1,2 +1,2 @@
 repository=https://github.com/rmobis/clan-chat-country-flags.git
-commit=e3bee0d8f7ebc1b31aa8cfa26bd7064cff8a351b
+commit=aa8866fac701da48fbc3f2ae61986ac0708d03eb


### PR DESCRIPTION
I'm requesting to take over the development of the [clan-chat-country-flags](https://github.com/melkypie/ClanChatCountryFlags) plugin by @melkypie.

It has not seen active development for close to 3 years now and is lacking updates for newly released servers. I've requested collaborator access over a month ago in [this PR](https://github.com/melkypie/ClanChatCountryFlags/issues/14), but have not heard back from the original maintainer.