### PR TITLE
Runeshop calculator

### DIFF
--- a/plugins/mikematrix-osrs
+++ b/plugins/mikematrix-osrs
@@ -1,2 +1,2 @@
 repository=https://github.com/mikematrix-osrs/runelite-rune-shop-plugin.git
-commit=a2f65d8498352bd799b6f43f0d973e4311bedc34
+commit=9dab2bb621317812c0c9b011b40c7dadd7beb05a

--- a/plugins/mikematrix-osrs
+++ b/plugins/mikematrix-osrs
@@ -1,0 +1,2 @@
+repository=https://github.com/mikematrix-osrs/runelite-rune-shop-plugin.git
+commit=a2f65d8498352bd799b6f43f0d973e4311bedc34

--- a/plugins/mikematrix-osrs
+++ b/plugins/mikematrix-osrs
@@ -1,2 +1,2 @@
 repository=https://github.com/mikematrix-osrs/runelite-rune-shop-plugin.git
-commit=2cc23e2308e8c9469dd8feb76e3e52ac10625677
+commit=9c7d72c923710ef1d2e2a9ecf05ea36d97a0fd4a

--- a/plugins/mikematrix-osrs
+++ b/plugins/mikematrix-osrs
@@ -1,2 +1,2 @@
 repository=https://github.com/mikematrix-osrs/runelite-rune-shop-plugin.git
-commit=9dab2bb621317812c0c9b011b40c7dadd7beb05a
+commit=2cc23e2308e8c9469dd8feb76e3e52ac10625677


### PR DESCRIPTION
Calculates the total GP cost of buying runes from OSRS shops, accounting for price inflation per unit and world hopping. Supports pack buying for Air, Water, Earth, Fire, Mind, and Chaos runes. Standalone side panel — no game interaction.