### PR TITLE
add color-locked

### DIFF
--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=8b8887566e6e7b7c3c2faedd01e390c968bbb777
+commit=8e526323fdb9c51467eb7e8c5dfeafc0824f82e1

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=c4467d7586a245c6fbbcb12cfb2d8ec880c28d58
+commit=403bde8b4a0e6d5186f39721ecf13181f5742f86

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=96683989665ac8adea7c2413565fc8be2cef9f43
+commit=d868e166d84d064541e56ec2e129c925faf31183

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,2 +1,3 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
 commit=403bde8b4a0e6d5186f39721ecf13181f5742f86
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=8e526323fdb9c51467eb7e8c5dfeafc0824f82e1
+commit=96683989665ac8adea7c2413565fc8be2cef9f43

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=71f5a8b6dd63e8fba876d38750ef38197d4843ce
+commit=8b8887566e6e7b7c3c2faedd01e390c968bbb777

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=d868e166d84d064541e56ec2e129c925faf31183
+commit=c4467d7586a245c6fbbcb12cfb2d8ec880c28d58

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=5f7dfca973d85212572eaaf47742daff94d53465
+commit=71f5a8b6dd63e8fba876d38750ef38197d4843ce

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,0 +1,2 @@
+repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
+commit=5f7dfca973d85212572eaaf47742daff94d53465


### PR DESCRIPTION
## Plugin: Color Locked

Group Iron color-lock enforcement plugin.

- Blocks Eat/Drink/Equip/Wield/Wear on items restricted by the player's assigned color
- Strips Mine/Chop when carrying a restricted pickaxe or axe
- Marks restricted items with a red overlay in inventory, bank, and worn equipment
- Includes a sidebar for looking up which items each color can use
- Syncs assigned color and item rules from a hub group, or runs standalone with manual settings

**Repository:** https://github.com/unidarkshin/osrs-color-lock-runelite
**License:** BSD-2-Clause
**No third-party dependencies** — only RuneLite client APIs and transitive Gson.