### PR TITLE
Update prayer-time-infobox

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=c34f7e04d5a79e489533f9e6205a72019a244cc3
+commit=7e45f4e3a35fd8089692905092b02f48e8f8229b


### PR DESCRIPTION
Updates PvM Toolkit to source commit 7e45f4e3a35fd8089692905092b02f48e8f8229b.

Changes:
- Fix plugin metadata/version to 2.9.0 so Plugin Hub and RuneLite can pick up the latest release cleanly.
- Keep the dynamic chat-tab tracker behavior from 2.8.0.
- Add two-line tracker tab labels: value on top, tracker name underneath.
- Remove chat-tab hover tooltip support due flicker/instability in client tabs.
- Refresh README/publishing metadata to use the PvM Toolkit name.

Validation:
- Ran `./gradlew.bat test` in the plugin repository successfully.