### PR TITLE
Add Loot Table Viewer

### DIFF
--- a/plugins/improved-loot-tracker
+++ b/plugins/improved-loot-tracker
@@ -1,2 +1,2 @@
-repository=https://https://github.com/Oufqt/improved-loot-tracker
+repository=https://https://github.com/Oufqt/improved-loot-tracker.git
 commit=64a7d270465a28316b45db96170b495bfd35135a

--- a/plugins/improved-loot-tracker
+++ b/plugins/improved-loot-tracker
@@ -1,0 +1,2 @@
+repository=https://https://github.com/Oufqt/improved-loot-tracker
+commit=64a7d270465a28316b45db96170b495bfd35135a

--- a/plugins/improved-loot-tracker
+++ b/plugins/improved-loot-tracker
@@ -1,2 +1,2 @@
-repository=https://https://github.com/Oufqt/improved-loot-tracker.git
+repository=https://github.com/Oufqt/improved-loot-tracker.git
 commit=64a7d270465a28316b45db96170b495bfd35135a

--- a/plugins/improved-loot-tracker
+++ b/plugins/improved-loot-tracker
@@ -1,2 +1,0 @@
-repository=https://github.com/Oufqt/improved-loot-tracker.git
-commit=840e17edd6f0c26bda855a4dbd778b145da32ba6

--- a/plugins/improved-loot-tracker
+++ b/plugins/improved-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Oufqt/improved-loot-tracker.git
-commit=64a7d270465a28316b45db96170b495bfd35135a
+commit=840e17edd6f0c26bda855a4dbd778b145da32ba6

--- a/plugins/loot-table-viewer
+++ b/plugins/loot-table-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/Oufqt/Loot-Table-Viewer.git
-commit=c45eb5718461cb8f8cb2189834b8014dac841c15
+commit=ecff73168761cfbd6520a7925db393c586b81eb7

--- a/plugins/loot-table-viewer
+++ b/plugins/loot-table-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/Oufqt/Loot-Table-Viewer.git
-commit=f0b778bc42a6187d7f6663e509b7408c3d83a028
+commit=c45eb5718461cb8f8cb2189834b8014dac841c15

--- a/plugins/loot-table-viewer
+++ b/plugins/loot-table-viewer
@@ -1,0 +1,2 @@
+repository=https://github.com/Oufqt/Loot-Table-Viewer.git
+commit=f0b778bc42a6187d7f6663e509b7408c3d83a028


### PR DESCRIPTION
This plugin tracks received loot by source and displays OSRS Wiki-style potential drop tables in the RuneLite side panel.