### PR TITLE
Add HDR plugin

### DIFF
--- a/plugins/hdr
+++ b/plugins/hdr
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/HDR.git
-commit=39848902e4ea2b036f7b745a5192e57eb5787279
+commit=231f9beee917cf8376610233065a607b9ef78636

--- a/plugins/hdr
+++ b/plugins/hdr
@@ -1,0 +1,2 @@
+repository=https://github.com/Endrit-alt/HDR.git
+commit=39848902e4ea2b036f7b745a5192e57eb5787279


### PR DESCRIPTION
HDR (High Dynamic Range) is a RuneLite plugin that improves the lighting and color of OSRS terrain.

It changes the look of ground tiles in different areas of the game, making dark areas easier to see and bright areas less harsh. Basically a High Dynamic Range plugin.

Works with 117 and GPU.

It can : 

- Brighten dark terrain
- Reduce overly bright terrain
- Adjust color saturation
- Use different settings for different areas