### PR TITLE
Update advanced-hp-bar to `1.6.0`

### DIFF
--- a/plugins/advanced-hp-bar
+++ b/plugins/advanced-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/chrisreydev/advanced-hp-bar-plugin.git
-commit=b95f6d3a7ce74c178b636cb8d8e236e459d99b86
+commit=cda833bce44030af85c7f149827b2e0be0f1ecc4


### PR DESCRIPTION
* Fix other players' hp bars not showing up
* New config options to show/hide NPC and Other Players' hp bars