### PR TITLE
Add Combat Indicator plugin

### DIFF
--- a/plugins/combat-indicator-plugin.txt
+++ b/plugins/combat-indicator-plugin.txt
@@ -1,0 +1,2 @@
+repository=https://github.com/66lexel999/combat-indicator-plugin
+commit=b67f338d68c56f96000c5d430ae091d40665ba34


### PR DESCRIPTION
Adds a Combat Indicator plugin that shows whether the player 
is idle, walking, or in combat via a colored overlay.
Visual only - no automation.