### PR TITLE
Update Shortest Path to 1.20.5

### DIFF
--- a/plugins/shortest-path
+++ b/plugins/shortest-path
@@ -1,3 +1,3 @@
 repository=https://github.com/Skretzo/shortest-path.git
-commit=06938f5198c21408d39c5e447eb5bc9452806ade
+commit=f3a579496dda48468212489ec0b37db91bda5f44
 authors=Skretzo,FIrgolitsch,wvanderp


### PR DESCRIPTION
Some improvements to supported locations, league transports and sailing teleport handling.

- Added lumberyard fence
- Fixed max cape for league
- Fixed elite lumbrdige diary requirement for fairy rings with banking
- Now preventing teleports from the middle of the ocean
- Improve display hints for league teleports
- Improve teleport location for evil eye