### PR TITLE
Confliction gauntlets (magic hands BiS) + Avernic treads all 8 variations (ranged/magic feet)

### DIFF
--- a/plugins/slayer-loadout
+++ b/plugins/slayer-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeN3/slayer-loadout.git
-commit=c4088b5a21cb5a23c9d6a945e2952f1b6783ee5b
+commit=c98721aeeab8a5276bf908f50e3f09b6b2d576a8


### PR DESCRIPTION
Two gear additions this release:

- Confliction gauntlets — added as best-in-slot Magic hands, above the Tormented
  bracelet. Its passive grants a second accuracy roll after a miss on the same
  target, but only with one-handed magic weapons, so it's disabled with two-handers
  such as Tumeken's shadow.
- Avernic treads — all eight variations added across the feet slots. Pegasian forms
  surface for Ranged and eternal forms for Magic, with (max) at the top as the highest
  offensive boots for all three styles; the existing melee feet entry already covers
  the melee forms. They give no prayer bonus and slightly less defence than
  Guardian/Echo boots.