### PR TITLE
Add "Dynamic Treads" plugin

### DIFF
--- a/plugins/dynamic-treads
+++ b/plugins/dynamic-treads
@@ -1,0 +1,2 @@
+repository=https://github.com/blakelockley/runelite-dynamic-treads.git
+commit=08431d91c1163ab9f7218c5919ecf7c2d3858fcc


### PR DESCRIPTION
The dynamic treads plugin is a dynamic cosmetic transmogs for the Avernic treads (max) and its variants that visually swaps the boots back into their input Cerb boots forms (Prims, Pegasians, Eternals) depending on your current main hand weapon to match the attack style.