### PR TITLE
Add potion-quantity-labels

### DIFF
--- a/plugins/potion-quantity-labels
+++ b/plugins/potion-quantity-labels
@@ -1,0 +1,2 @@
+repository=https://github.com/theldurin/potion-quantity-labels.git
+commit=d79aaf4966ed1afcf53f084e3e14061f44d6e92f

--- a/plugins/potion-quantity-labels
+++ b/plugins/potion-quantity-labels
@@ -1,2 +1,2 @@
 repository=https://github.com/theldurin/potion-quantity-labels.git
-commit=d79aaf4966ed1afcf53f084e3e14061f44d6e92f
+commit=de5ba25cc02d021e9273a82400b2c28e56ea3498


### PR DESCRIPTION
This plugin adds a quantity label to each potion in the Potion Storage interface, allowing you to better visualize just how many potions are actually stored.