### PR TITLE
Eye of Ayak treated as powered staff (no spell) + required-shield tas…

### DIFF
--- a/plugins/slayer-loadout
+++ b/plugins/slayer-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeN3/slayer-loadout.git
-commit=c98721aeeab8a5276bf908f50e3f09b6b2d576a8
+commit=e25bd8c6b8a82f7516998f9082d939ff80a32209


### PR DESCRIPTION
…ks exclude 2H weapons

- Eye of Ayak is now recognised as a powered staff. It has a built-in attack and cannot autocast a spellbook spell, so the Magic loadout no longer shows a spell next to it; its DPS is also modelled at its true 3-tick speed and base max hit of floor(Magic / 3) - 6.
- Tasks that mandate a shield (e.g. Fossil Island wyverns, which require an anti-wyvern shield to block the icy breath) no longer recommend a two-handed weapon. A 2H weapon would leave no off-hand for the required shield, so only one-handed weapons are now considered for those tasks.