### PR TITLE
Add Better Item Identification plugin

### DIFF
--- a/plugins/better-item-identification
+++ b/plugins/better-item-identification
@@ -1,2 +1,2 @@
 repository=https://github.com/Hotdogwaterguy/Better-Item-Identification.git
-commit=eb9f525aa9f5359e9b3e373edb7b2366febebcc9
+commit=4a4d26a893df233b64e193b30015740e8d35944f

--- a/plugins/better-item-identification
+++ b/plugins/better-item-identification
@@ -1,0 +1,2 @@
+repository=https://github.com/Hotdogwaterguy/Better-Item-Identification.git
+commit=eb9f525aa9f5359e9b3e373edb7b2366febebcc9


### PR DESCRIPTION
Learning java in school trying to help improve item identification plugin by offering more options to label. The only difference currently is separating finished potions and unfinished potions which was not possible with the built-in plugin, it was bothering me that in order to have labels on my unfinished potions I had to also enable it for potions such as brews, restores, etc which are visually obvious from one another. I plan to create more options for other types of items that are visually difficult to discern from one another.