### PR TITLE
update color-locked

### DIFF
--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,3 +1,3 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=6566e7b
+commit=6566e7b497cb0331407a83479b7b9734366b9ccb
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,3 +1,3 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=403bde8b4a0e6d5186f39721ecf13181f5742f86
+commit=6566e7b
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update `color-locked` plugin to commit `6566e7b`.

Changes since last approved commit (`403bde8`):
- Fix OutOfMemoryError: replace byte[]→String→JsonElement manifest parse with Gson JsonReader streaming (~160MB peak → ~3MB)
- Add HEAD-request check to skip redundant manifest downloads when schema is unchanged
- Cache normalized color tokens to eliminate per-frame GC pressure in overlay
- Add expandable "Drop sources" per item in lookup panel (lazy single-item fetch)
- Replace Desktop.browse with LinkBrowser.browse, validate wiki URLs before opening
- Update plugin/config descriptions for accuracy (player names + skill stats sent to hub)
- Add cross-platform memory increase instructions to README

Full diff: https://github.com/unidarkshin/osrs-color-lock-runelite/compare/403bde8..6566e7b