### PR TITLE
Update advanced-hp-bar to `1.6.1`

### DIFF
--- a/plugins/advanced-hp-bar
+++ b/plugins/advanced-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/chrisreydev/advanced-hp-bar-plugin.git
-commit=cda833bce44030af85c7f149827b2e0be0f1ecc4
+commit=7a97e47028503db4b37dfdbe7eb04717f0aca88e


### PR DESCRIPTION
* Adjust render ordering for NPC/Other Players' HP Bars so they don't draw over Advanced HP Bar