### PR TITLE
Add RuneTrivia

### DIFF
--- a/plugins/runetrivia
+++ b/plugins/runetrivia
@@ -1,0 +1,3 @@
+repository=https://github.com/ScottyOBrien/runetrivia-plugin.git
+commit=bc668247f5543c9872203c05bf093ac0dab90e2d
+authors=ScottyOBrien

--- a/plugins/runetrivia
+++ b/plugins/runetrivia
@@ -1,3 +1,4 @@
 repository=https://github.com/ScottyOBrien/runetrivia-plugin.git
 commit=5360bf7f0c81cf3d299bd3b92332281f3c2ffdd9
 authors=ScottyOBrien
+warning=This plugin submits your IP address, RSN, and in-game location to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/runetrivia
+++ b/plugins/runetrivia
@@ -1,3 +1,3 @@
 repository=https://github.com/ScottyOBrien/runetrivia-plugin.git
-commit=bc668247f5543c9872203c05bf093ac0dab90e2d
+commit=5360bf7f0c81cf3d299bd3b92332281f3c2ffdd9
 authors=ScottyOBrien


### PR DESCRIPTION
Adds RuneTrivia — head-to-head OSRS trivia matches between nearby players. Hosted backend at api.runetrivia.com (data collection documented in plugin README). Public leaderboard at runetrivia.com.