### PR TITLE
Metal Dragons task with dragon picker + Warning (suggested-gear) section

### DIFF
--- a/plugins/slayer-loadout
+++ b/plugins/slayer-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeN3/slayer-loadout.git
-commit=c100f6608da9edcf36ebc825f8b1fca1b5617100
+commit=8936090b6b5484a75d80d6ab34dc753fa3ffa37e


### PR DESCRIPTION
- Metal Dragons task support. Metal dragons is a multi-monster task, so the panel now shows a picker with a button for each of the six dragons (Bronze, Iron, Steel, Mithril, Adamant, Rune). It starts blank until you choose one, then shows that dragon's best-in-slot loadout and DPS. Each dragon is still previewable on its own.
- A new "Warning" section: a soft, non-mandatory counterpart to the existing Required-gear section, flagging suggested items for a monster's special mechanics - e.g. Insulated boots for Rune dragons' Electricity special, Serpentine helm for Adamant dragons' poison spit, and a super antifire reminder for Mithril dragons' long-range dragonfire.