### PR TITLE
Update account-history

### DIFF
--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,3 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
-commit=0ac4e6e01f7961081bca46c76fcd8c4ad3458192
+commit=8ad8a461ec6e5adc32508300db4a871ab748305d
 warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Removes the redundant config setting for network requests.

This plugin has always had a warning here from its very first version and the config setting was a redundant warning.