### PR TITLE
Add Slayer Task Logger

### DIFF
--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,3 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
 commit=58a7a0f2bb1b3603302e2a8c42b7130e7a999ef0
+warning=This plugin can send slayer event data to an external webhook URL configured by the user. The webhook is disabled by default.

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=93ae3996d0823d136c40531df0bfa1adfcbc05db
+commit=39f4e2cedfd9a2b9520dd33d09005a7c1596e3b7
 warning=This plugin can send slayer event data to an external webhook URL configured by the user. The webhook is disabled by default.

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=39f4e2cedfd9a2b9520dd33d09005a7c1596e3b7
+commit=fbf7dbe298b383f8c7bafbe3d175eb4db1a52f0e
 warning=This plugin can send slayer event data to an external webhook URL configured by the user. The webhook is disabled by default.

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/staticvoid07/slayer-task-logger.git
+commit=1161180c44387546cd2c470123bb25a4a7d72c42

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=c74bf58167320fbfa6e8ef5203c9a389ec6ecfda
+commit=501fd05fd88b99960dbaa255a40835c2208db3fe

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=1161180c44387546cd2c470123bb25a4a7d72c42
+commit=7910e8ccde7bb62b584e2a0286dd5ed7ddca1e19

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=624c8518160f490782f72c7b0557f8bc6aaca75a
+commit=c74bf58167320fbfa6e8ef5203c9a389ec6ecfda

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=4a1bbd91a4c0902775df7e7595086fb22707996d
+commit=624c8518160f490782f72c7b0557f8bc6aaca75a

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=279f10c4d972dbd206a356a997c0903ca176392c
+commit=93ae3996d0823d136c40531df0bfa1adfcbc05db
 warning=This plugin can send slayer event data to an external webhook URL configured by the user. The webhook is disabled by default.

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=58a7a0f2bb1b3603302e2a8c42b7130e7a999ef0
+commit=279f10c4d972dbd206a356a997c0903ca176392c
 warning=This plugin can send slayer event data to an external webhook URL configured by the user. The webhook is disabled by default.

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=501fd05fd88b99960dbaa255a40835c2208db3fe
+commit=bfd543cfd07a9299d6559aeedf7d2910ebef19ab

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=76693622b8eb8f4bff62ac9c88f2712735927a29
+commit=58a7a0f2bb1b3603302e2a8c42b7130e7a999ef0

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=2e5c4b4e825b0bac87c15bd213b7f55442696fa8
+commit=4a1bbd91a4c0902775df7e7595086fb22707996d

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=bfd543cfd07a9299d6559aeedf7d2910ebef19ab
+commit=54ebd60a2e994c48204398a2e28f4910be95ee9b

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=7910e8ccde7bb62b584e2a0286dd5ed7ddca1e19
+commit=2e5c4b4e825b0bac87c15bd213b7f55442696fa8

--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=54ebd60a2e994c48204398a2e28f4910be95ee9b
+commit=76693622b8eb8f4bff62ac9c88f2712735927a29


### PR DESCRIPTION
Adds the Slayer Task Logger plugin.

## What it does
- Logs slayer events to `~/.runelite/slayer-log.txt`
- Sends Dink notifications for each event type (requires Dink plugin with external plugin requests enabled)
- POSTs structured JSON to a user-configured webhook URL (optional)

## Event types
- **New task** — fires when a slayer master assigns a task (supports standard and Konar message formats)
- **Task completed** — fires on completion, logs monster, assigned amount, kill count, XP, task streak, and points
- **Task skipped** — fires when a task is cancelled, reads current task from varbits so it correctly identifies tasks swapped in via slayer cape task storage
- **Superior spawn** — fires when a superior slayer creature appears
- **Cape perk proc** — fires when a slayer master offers a favour (supports standard and Konar dialog)