### PR TITLE
Add Crime Scene plugin

### DIFF
--- a/plugins/crime-scene
+++ b/plugins/crime-scene
@@ -1,0 +1,2 @@
+repository=https://github.com/Diogo-G-Dias/crime-scene.git
+commit=0b82035da740be9bd37cbe10aa3663343f983466


### PR DESCRIPTION
Adds **Crime Scene**, a plugin that marks the tile where tracked players die — friends list (default), friends chat, clan, and optionally your own deaths and NPCs — with the in-game skull sprite and a per-tile death count. Hovering a marked tile lists who died there and how many times, and a side panel shows a Players/NPCs death leaderboard. Markers persist per RuneLite profile.

All data stays local: no HTTP/network, no reflection, Java 11, BSD-2 licensed.

Repository: https://github.com/Diogo-G-Dias/crime-scene

🤖 Generated with [Claude Code](https://claude.com/claude-code)
