### PR TITLE
rune-vault: bump for atomic RPCs + bulk chunking + app-owned visibility

### DIFF
--- a/plugins/rune-vault
+++ b/plugins/rune-vault
@@ -1,3 +1,3 @@
 repository=https://github.com/EhhForge/RuneVault-on-RuneLite.git
-commit=05715d5c745fac20a4444ceaf38390846191f4d4
+commit=6addcc4a70a091dca4901618319a987c1d17a2b5
 warning=This plugin submits your IP address, RSN, Grand Exchange trades, inventory pickups and drops, worn equipment, bank contents, and wealth to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates `commit=` for `plugins/rune-vault`.

Highlights of the new plugin commit (6addcc4):

- **Atomic v2 RPCs** for GE buys, ground pickups, sells — eliminates fetch-then-write races
- **bulkUpsertItems chunked at 500** to avoid PostgREST URL/payload caps on large bank scans
- **Public/private visibility is now read-only in the plugin** — mirrored from the Rune Vault app via Realtime. Checkbox replaced with a tri-state badge (Public / Private / "—" when no profile). Single source of truth.
- **Open Portfolio** button uses canonical `/u/<shortId>/<slug>` URL

No new dependencies. No reflection. No `Thread.sleep` / `Thread.currentThread().interrupt()`. `warning=` unchanged (same data shape sent to the same third-party server as before).