### PR TITLE
Add scapestack-sync

### DIFF
--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
+commit=97b47fe5fe887e127492d8853fd1431b38a058f9


### PR DESCRIPTION
Adds Scapestack Sync v0.2.0, a RuneLite plugin that syncs opt-in account-progress signals to Scapestack so /next can stop guessing from public Hiscores alone.

## Current review state
- Plugin Hub PR: #12227
- Status: Plugin Hub PR #12227 open
- Detail: Offline reviewer packet. Run without --offline for live GitHub status when API quota is available.
- Checks: Run npm run plugin:release-check:live to confirm current GitHub checks and pin status.
- PR body copy: Offline mode cannot inspect live PR body copy.

## What it captures after player opt-in
- RSN used for the claim
- Plugin version and sync status
- Quest and diary completion
- Loaded collection-log item IDs
- Slayer task, points, streak and block-list state
- Local install token only as Authorization bearer on claim/sync requests

## What it never captures
- RuneScape password or account login
- bank, inventory, equipment or GE offers
- chat messages, friends list or private messages
- mouse clicks, key presses or gameplay inputs
- screenshots, client files, config folders, IP or machine fingerprint

## Game integrity
- Read-only plugin: it reads RuneLite client state and never clicks, types, swaps menus, changes prayers, moves the player or performs game actions.
- No overlays, alerts or in-client recommendations that could automate gameplay decisions; recommendations live in the external web app after opt-in sync.
- No item, inventory, equipment, bank, trade, GE offer or wealth data is collected by the plugin.

## Consent defaults
- Auto-sync on login defaults off.
- Sync on quest complete defaults off.
- Quest-complete sync is also gated behind Auto-sync on login; enabling the quest-complete setting alone never sends a payload.
- No progress POST happens until the player enables Auto-sync on login from RuneLite settings.
- Show chat feedback defaults on so players see when sync starts, succeeds, fails, or needs a fresh claim.

## Network and auth
- Default endpoint: `https://www.scapestack.org/api/sync`.
- The claim endpoint is derived as `/api/sync/claim` from the configured sync URL.
- The raw local install token is sent only as an `Authorization: Bearer <token>` for claim/sync requests.
- Scapestack stores `sha256(token)` for the RSN claim; it does not store the raw token.
- HTTP claim/readiness/sync work runs on a background Thread, not RuneLite's client thread.
- Shutdown interrupts the named daemon sync worker and cancels the in-flight OkHttp sync call before any further chat feedback is queued.

## Web-app merge behavior
- Successful sync chat includes the verified `/next?rsn=...&source=plugin-sync&bank=none` link for that RSN.
- `bank=none` is intentional: RuneLite sync does not send bank, inventory, equipment, GE offers or wealth.
- Players can still paste a bank into the web app separately; that browser-only bank context is never sent to the plugin.
- While Plugin Hub review is pending, Scapestack still works with Hiscores, bank paste, TempleOSRS, WOM and collectionlog.net.

## Web-app merge contract
- The plugin is an account-progress verifier, not a bank uploader.
- Successful sync chat links to `/next?rsn=...&source=plugin-sync&bank=none` so the web app treats RuneLite payloads as bankless by default.
- `source=plugin-sync` tells Scapestack to load the verified account payload for coverage labels; it does not remove bank, gear or tracker caveats by itself.
- `bank=none` prevents stale browser bank context from being silently reused after a plugin-only sync.
- Players who want gear-aware advice paste Bank Memory or Bank Tags into the web app separately; that browser-only bank context is never sent back to RuneLite.
- /next, /slayer, /dps, /goals and player profiles all show readiness rails so players can see Bank, RSN and RuneLite sync as separate evidence signals.
