### PR TITLE
crime-scene: add icon and instance marker persistence

### DIFF
--- a/plugins/crime-scene
+++ b/plugins/crime-scene
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/crime-scene.git
-commit=0b82035da740be9bd37cbe10aa3663343f983466
+commit=374e461b9433ab778ca616ad2fa76a839ae5014b


### PR DESCRIPTION
Updates the Crime Scene plugin to commit 374e461:
- Adds the Plugin Hub icon.
- Persists death markers inside instanced regions (raids, instanced bosses) using template-chunk coordinates, so markers reappear correctly on return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)