### PR TITLE
Update color-locked

### DIFF
--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,3 +1,3 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=66959ed58cb904c77e729995d627b9dde627b075
+commit=c50172bebe699a545ac2e52dc0d4c4f378bc5099
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,3 +1,3 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=6566e7b497cb0331407a83479b7b9734366b9ccb
+commit=66959ed58cb904c77e729995d627b9dde627b075
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Summary
- Color swatch dots on item hover showing which colors can use it
- Alt+hover tooltip showing group member names mapped to each color
- Restricted item marks now appear in GIM group storage
- Achievement diary completions sent on heartbeat
- Shortened config descriptions and plugin properties
- Sidebar: new Info tab, "Shared items" rename, charged-suffix dedup

## Commit
`66959ed58cb904c77e729995d627b9dde627b075`