### PR TITLE
Update venator-path-finder to 1.0.1

### DIFF
--- a/plugins/venator-path-finder
+++ b/plugins/venator-path-finder
@@ -1,3 +1,3 @@
 repository=https://github.com/Maximuis94/runelite-plugins.git
-commit=94e793a8f3e595c08859a3006115eb6975f1bbfc
+commit=9b17c406a730b305c40918e1e6d4a023691b78b5
 authors=maximuis94


### PR DESCRIPTION
Improved path finder logic, eliminating certain incorrectly identified potential paths.