### PR TITLE
Add To the Top plugin

### DIFF
--- a/plugins/to-the-top
+++ b/plugins/to-the-top
@@ -1,0 +1,2 @@
+repository=https://github.com/blueueberryguy/ToTheTop.git
+commit=29da2af304c00edd96264aae5e53672b0dc0e92d


### PR DESCRIPTION
A plugin that keeps left-click on a contested ground-item pile trained on the items you actually care about. Useful for farming specific drops.

