### PR TITLE
Update Inventory Setups to v1.24.0

### DIFF
--- a/plugins/inventory-setups
+++ b/plugins/inventory-setups
@@ -1,2 +1,2 @@
 repository=https://github.com/dillydill123/inventory-setups.git
-commit=70c6607c30dee6d15025df6401ea0f44dac4e66f
+commit=afd6e45adb24a90d3411c9760b84d2b43bfe7489


### PR DESCRIPTION
Adds the ability to save the player's current attack option in setups.

<img width="212" height="271" alt="image" src="https://github.com/user-attachments/assets/26616d7a-3a35-47c8-bc56-82b039ebcbc4" />