### PR TITLE
Add BA Healer Order

### DIFF
--- a/plugins/ba-healer-order
+++ b/plugins/ba-healer-order
@@ -1,0 +1,2 @@
+repository=https://github.com/tcourter1/ba-healer-order.git
+commit=e11ded4341dc941d61e228ad6fa0730f8d6c6502


### PR DESCRIPTION
Adds BA Healer Order, a Barbarian Assault helper plugin that displays Penance Healer spawn order, highlights tracked healers, and tracks successful poisoned-food usage per healer.