### PR TITLE
Add OSRS Item Browser plugin

### DIFF
--- a/plugins/osrs-item-browser
+++ b/plugins/osrs-item-browser
@@ -1,0 +1,2 @@
+repository=https://github.com/Vivialdi/osrs-item-browser
+commit=da9e0e36db2a5d1dc19908d235d50333de96cc7f

--- a/plugins/osrs-item-browser
+++ b/plugins/osrs-item-browser
@@ -1,2 +1,2 @@
-repository=https://github.com/Vivialdi/osrs-item-browser
-commit=da9e0e36db2a5d1dc19908d235d50333de96cc7f
+repository=https://github.com/Vivialdi/osrs-item-browser.git
+commit=23e7dc4dc64f1638f2a44888b6b886582874ed7d

--- a/plugins/osrs-item-browser
+++ b/plugins/osrs-item-browser
@@ -1,2 +1,2 @@
 repository=https://github.com/Vivialdi/osrs-item-browser.git
-commit=23e7dc4dc64f1638f2a44888b6b886582874ed7d
+commit=e6bf8c1c3d3cb1e3c6ba28d9b2794d6f20117da9


### PR DESCRIPTION
An item browser sidebar for OSRS, inspired by JEI from Minecraft.

Features:
- Search all ~14,000 OSRS items from the game cache
- GE price + high alch profit/loss
- Crafting recipes with clickable ingredients
- Used to craft (parsed from wiki Products section)
- Drop sources with monster locations and rates
- Shop sources with GE-relative price coloring
- Equipment bonuses (attack/defense table)
- Path to monster spawn (integrates with Shortest Path plugin)
- Recently viewed history + favorites (persisted between sessions)
- Right-click any in-game item → "JEI Lookup"

Wiki data is fetched from the public OSRS Wiki API. All results are cached per session to minimize requests.