### PR TITLE
Add Music Visualizer plugin

### DIFF
--- a/plugins/music-visualizer
+++ b/plugins/music-visualizer
@@ -1,3 +1,3 @@
 repository=https://github.com/ScottyOBrien/music-visualizer.git
-commit=2659cc64df6ea9b02cfc2507b4252bc9e0ae861e
+commit=e3059dced0bbcdea3e4680253cc112fd4cbe52d2
 authors=ScottyOBrien

--- a/plugins/music-visualizer
+++ b/plugins/music-visualizer
@@ -1,3 +1,3 @@
 repository=https://github.com/ScottyOBrien/music-visualizer.git
-commit=e3059dced0bbcdea3e4680253cc112fd4cbe52d2
+commit=9b7129788d97c4d8a1aa488c11840ddc644dd199
 authors=ScottyOBrien

--- a/plugins/music-visualizer
+++ b/plugins/music-visualizer
@@ -1,0 +1,3 @@
+repository=https://github.com/ScottyOBrien/music-visualizer.git
+commit=2659cc64df6ea9b02cfc2507b4252bc9e0ae861e
+authors=ScottyOBrien

--- a/plugins/music-visualizer
+++ b/plugins/music-visualizer
@@ -1,3 +1,3 @@
 repository=https://github.com/ScottyOBrien/music-visualizer.git
-commit=9b7129788d97c4d8a1aa488c11840ddc644dd199
+commit=8dbc3a7f2ae8334cba8270477cba0ca46f0c47f4
 authors=ScottyOBrien


### PR DESCRIPTION
Flashes nearby objects in time with the notes of the current OSRS music track. Pulls MIDI from the local OSRS cache via runelite-cache's TrackLoader, parses with javax.sound.midi, flashes each object in player radius on the matching note. Local-only, sends no data. Source: https://github.com/ScottyOBrien/music-visualizer