### PR TITLE
Add free-eats

### DIFF
--- a/plugins/free-eats
+++ b/plugins/free-eats
@@ -1,0 +1,2 @@
+repository=https://github.com/guccifurs/free-eats.git
+commit=3ca57bb73241556167021a0b5471331a93060b66


### PR DESCRIPTION
adds free eats, a small overlay that shows when hard food can be eaten without delaying your next hit