### PR TITLE
Add who-can-craft

### DIFF
--- a/plugins/who-can-craft
+++ b/plugins/who-can-craft
@@ -1,0 +1,2 @@
+repository=https://github.com/visagex/Who-Can-Craft-Group-Ironman-Crafting-Helper.git
+commit=6ee31510d1f773e8418079ddd209e2b527ef5628


### PR DESCRIPTION
A RuneLite plugin for Group Ironman players that lets you search for craftable items and instantly see who in your group has the skill levels and materials needed to make them.