### PR TITLE
Update annoyance mute

### DIFF
--- a/plugins/annoyance-mute
+++ b/plugins/annoyance-mute
@@ -1,3 +1,3 @@
 repository=https://github.com/Broooklyn/runelite-external-plugins.git
-commit=4a25af7cc8b5d7cb7bdfff555422f121467db535
+commit=e964e9073c3a6740325d6026833782aa57c4da37
 authors=jzomdev


### PR DESCRIPTION
Remove debug annoyance mute, visual sounds does the job fine enough and min/max points was removed making it useless.

When onAmbientSoundEffectCreated runs and the id is -1 mute the sound regardless of user preference, fixes a bug with magic trees respawning being an issue, not sure if other ids will have the same issue tbh