### PR TITLE
Add EmptyLootTracker plugin repository reference

### DIFF
--- a/plugins/empty-loot-tracker
+++ b/plugins/empty-loot-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/DylanHolmesDH/EmptyLootTracker.git
+commit=f5ec49514f1f95fe2f4336b1ae5ae54563e2cdb0


### PR DESCRIPTION
### Empty Loot Tracker

Adds a Loot Tracker-style panel that logs **all NPC kills**, including **empty drops** (shown with a red no-drop icon and `xN` count), instead of skipping no-loot kills.

#### Highlights
- Tracks kill count and loot value by NPC source
- Records and displays empty-drop kills
- Supports **grouped** view and **per-kill** view toggle
- Persists data across client restarts
- Uses GE or HA valuation display