### PR TITLE
update goalplanner to v0.3.1

### DIFF
--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-goal-planner.git
-commit=6b770cf98e2da6a209ef468e36eb67bc822a6b7d
+commit=3593bae5bcc989d31fd0befaa94cfb73b7877d1c

--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-goal-planner.git
-commit=7185659b7a18e6d70ba875bb5e62a1e8818d266d
+commit=6b770cf98e2da6a209ef468e36eb67bc822a6b7d


### PR DESCRIPTION
Bump the pinned commit to `6b770cf` (v0.3.1). Moves the live hub plugin from `7185659` (the currently-published pin) to v0.3.1 — shipping everything from 0.2.0, 0.3.0, and 0.3.1 at once (the intermediate bumps were never merged).

**Diff between the live pin and the new pin:** https://github.com/ajkatz/runelite-goal-planner/compare/7185659...6b770cf

## v0.3.1
- **Blocked-by-prerequisites badge.** Quest/diary/boss goals show a small warning badge when they have a direct prerequisite the player hasn't met that isn't already in their plan (computed from requirement data + live account state); click to add the missing requirements.
- **"Add requirements" for boss goals** — Incomplete-only / All, matching the existing quest & diary flows.
- **Source-size reduction.** The largest hardcoded data tables (collection-log item sources, quest/diary/boss requirement tables) moved out of compiled Java into resource files loaded at startup (TSV/JSON). No behaviour change; brings the reviewed source comfortably under the hub's token cap.

## v0.3.0 (also shipping)
- Goal **sharing** as paste-anywhere codes (single- and multi-section), importing against the recipient's own account, cross-section dependency links, one-undo imports.
- Dependency **"guide" view** (per-section nested/not-nested), in-game **Add Goal ▸ section** menus, per-section identity, completed-goal handling (archive or inline checklist), more account metrics.

## v0.2.0 (also shipping)
- Configurable side-panel font; fix for stale skill levels when seeding prerequisites right after login.

## Notes
- No new dependencies; no reflection (a pre-commit hook blocks `java.lang.reflect`).
- All goal data stays local (ConfigManager); leagues worlds use an isolated profile.

Repo: https://github.com/ajkatz/runelite-goal-planner
Pinned commit: https://github.com/ajkatz/runelite-goal-planner/commit/6b770cf (v0.3.1)
