### PR TITLE
Update click-to-minimize

### DIFF
--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=5e319f15e8247a099ba65a5a2e7e46d280756550
+commit=f7052552dc77c06ebe5dabc90ca4ac1c729923a5

--- a/plugins/click-to-minimize
+++ b/plugins/click-to-minimize
@@ -1,2 +1,2 @@
 repository=https://github.com/WaylonJ/OSRS_ClickToMinimize.git
-commit=f7052552dc77c06ebe5dabc90ca4ac1c729923a5
+commit=4be86b422d94a9af88b4e5d3b090de25c6c077ed


### PR DESCRIPTION
[Addition] Added new config option to allow window to be sent in to back of windows. This will help prevent alt-tabs immediately bringing the window back to focus.