### PR TITLE
update color-locked: collection log sync, heartbeat XY, schema 91

### DIFF
--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,3 +1,3 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=9bfad2667c367b9e9a9d63c094b7e4b7782bd59c
+commit=73e4b5117b2af987e9a4f11a847c59616ed39511
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,3 +1,3 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=c50172bebe699a545ac2e52dc0d4c4f378bc5099
+commit=9bfad2667c367b9e9a9d63c094b7e4b7782bd59c
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/color-locked
+++ b/plugins/color-locked
@@ -1,3 +1,3 @@
 repository=https://github.com/unidarkshin/osrs-color-lock-runelite.git
-commit=73e4b5117b2af987e9a4f11a847c59616ed39511
+commit=4728a8eea0eff95f8682f107ad16173643336123
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Summary
- Collection log hub sync: login snapshot (`totalCount`) and `newDrop` PATCHes when clog varps increase; optional `collectionItem` from chat.
- Heartbeat sends `presence.worldX/Y/plane` for future nearby-group logic on the hub.
- Includes prior release items: quest color-lock bypass, disk manifest cache, NPC shop overlay fix, items schema 91.

## Hub note
`collectionLog` / world tile fields are forward-compatible; Color Lock hub handler for these fields is still TBD (contract v13).

## Plugin commit
https://github.com/unidarkshin/osrs-color-lock-runelite/commit/4728a8eea0eff95f8682f107ad16173643336123
