### PR TITLE
Update npc-idle-timer-plugin - fix re-enable bug, add timer persistence

### DIFF
--- a/plugins/npc-idle-timer-plugin
+++ b/plugins/npc-idle-timer-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Vinnie-Singleton/npc-idle-timer-plugin.git
-commit=228d0cff331fb4d5e5c4c27cbb931877db26cec5
-authors=lejeffe
+commit=96d7873bd599a6707769b70a25360c080083caf3
+authors=Vinnie-Singleton, lejeffe, vonpawn


### PR DESCRIPTION
Follow-up to #12094.

Bumps `commit=` and updates `authors=` now that the takeover is merged.
No new third-party dependencies.

Changes since the previously pinned commit:

- Plugin metadata: added myself to the author list, support URL
  now points at the maintained fork.
- Fixes the re-enable-while-logged-in bug (#14). rebuildAllNpcs()
  now runs on the client thread. Same diagnosis as upstream PR #15
  by cowboy-cap, credited in the commit.
- Adds an optional timer persistence feature. Timers can survive
  despawn and be restored if the same NPC respawns at the same tile
  within a configurable window. Off by default ("Remember last N
  NPCs" set to 0), so existing users see no change unless they opt
  in.