### PR TITLE
Update dynamic-line-of-sight to 1.1.3

### DIFF
--- a/plugins/dynamic-line-of-sight
+++ b/plugins/dynamic-line-of-sight
@@ -1,3 +1,3 @@
 repository=https://github.com/Maximuis94/runelite-plugins.git
-commit=0e6970b4a895ce6b04c66bd1e04565817e37cd73
+commit=cf3b942f08177a875a883ad88b402daae8c41999
 authors=maximuis94


### PR DESCRIPTION
Reorganized the configuration panel
Modified some of the configuration descriptions
Fixed a bug that would cause only the largest line of sight to show up after switching profiles 
Configuration changes are now processed in batches 
Added a RenderLayer class used to sort the lines of sight that are to be drawn from smallest to largest before drawing them
Removed obsolete static variables