### PR TITLE
npc-idle-timer-plugin: respawn-aware timer restore + opt-in restart at 0

### DIFF
--- a/plugins/npc-idle-timer-plugin
+++ b/plugins/npc-idle-timer-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Vinnie-Singleton/npc-idle-timer-plugin.git
-commit=96d7873bd599a6707769b70a25360c080083caf3
+commit=995cbeaec1145925cfbae92d2a362090e85a46f7
 authors=Vinnie-Singleton, lejeffe, vonpawn


### PR DESCRIPTION
Updates the npc-idle-timer-plugin manifest to the latest fork commit.

Changes since the currently pinned commit:

- Restore a cached timer only when the NPC server index matches, so a fishing spot that respawns on the same tile after you teleport away starts fresh instead of inheriting a stale timer stuck at 0.
- New opt-in config "Restart timer when it reaches 0" (`recycleTimerAtZero`, default off) that restarts a timer at 0 instead of leaving it pinned there.

Both are off by default, so existing behavior is unchanged unless enabled.

Plugin PR: Vinnie-Singleton/npc-idle-timer-plugin#1
