### PR TITLE
Add OSRS Dashboard plugin

### DIFF
--- a/plugins/osrs-dashboard
+++ b/plugins/osrs-dashboard
@@ -1,0 +1,2 @@
+repository=https://github.com/Seafoodguru/osrs-dashboard-plugin.git
+commit=1111349c3407bc180f91eb568f5fd8471d8ebe96

--- a/plugins/osrs-dashboard
+++ b/plugins/osrs-dashboard
@@ -1,2 +1,2 @@
 repository=https://github.com/Seafoodguru/osrs-dashboard-plugin.git
-commit=1111349c3407bc180f91eb568f5fd8471d8ebe96
+commit=2814c8a418bedd6b23dd0d4659ab41330f51ff4e


### PR DESCRIPTION
Adds **OSRS Dashboard**, a companion plugin for a self-hosted progress dashboard used by a private Ironman friend group.

**What it does:** observes XP (`StatChanged`), boss kill counts (chat KC messages), notable loot (`NpcLootReceived` above a configurable gp threshold), quest completions (`Quest` state to `FINISHED`), and login/logout sessions, and POSTs them as JSON to a backend.

**Transparency / phone-home:** the plugin talks **only** to a backend URL the user enters themselves (defaults to `http://localhost:4100`), and sends **nothing** until the user supplies both that URL and a personal ingest token. A master "Send data" toggle disables it entirely. The backend derives the account from the token, so no account name or other identity is ever sent by the client.

**Rules:** read-only observation plus outbound telemetry to the user's own server. No automation, no input simulation, no game-state modification.

**Dependencies:** only OkHttp and Gson, both bundled with `runelite-client`, so no `verification-metadata.xml` is required. Builds green against `latest.release` (tested on client 1.12.26.3).
