### PR TITLE
update tan-leather-cast-tracker

### DIFF
--- a/plugins/tan-leather-cast-tracker
+++ b/plugins/tan-leather-cast-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/biceroy/tan-leather-cast-tracker.git
-commit=ae9823d55f8abc922504152a76b6c9349bb8134b
+commit=23276a96b3f0a87d54b08697d8d0fd26bda37e88


### PR DESCRIPTION
1.1 update for Tan Leather Cast Tracker.

- Track cowhide and snake hide in addition to the four dragon hides
- Cast countdown timer dim during the spell animation, suppressed on the final cast of a batch
- Lunar spellbook highlight on Tan Leather while at least 5 tannable hides are in inventory
- Context-aware inefficient-tan warning ("need N more" up to 25 hides, "deposit N" above)
- Out-of-runes warning driven by the in-game chat message
- Out-of-hides screen dim and low-hides notification split into independent toggles
- Modern RuneLite Notification API with sane pre-configured defaults