### PR TITLE
Add Combat HUD plugin

### DIFF
--- a/plugins/combat-hud
+++ b/plugins/combat-hud
@@ -1,2 +1,2 @@
-repository=https://github.com/upsetsingleevent/OSRSHUD
+repository=https://github.com/upsetsingleevent/OSRSHUD.git
 commit=d752333f4794ab71ea18fc843c690fee64d89f7b

--- a/plugins/combat-hud
+++ b/plugins/combat-hud
@@ -1,0 +1,2 @@
+repository=https://github.com/upsetsingleevent/OSRSHUD
+commit=d752333f4794ab71ea18fc843c690fee64d89f7b


### PR DESCRIPTION
Adds a compact, display-only HUD that floats above the local player showing:

- **Buff timers** (e.g. antifire, stamina, stat boosts) that flash when near expiry
- **Attack cooldown** in ticks, with automatic weapon-speed detection from the equipped item
- **Spec indicator** — a dot + energy % that lights up when the threshold is met

The plugin is strictly read-only. It reads game state (varbits, skill levels, equipment slot) and draws text/shapes via an overlay. It never injects input, modifies menus, sends clicks, or interacts with the game in any way.
