### PR TITLE
update extra-wiki-links

### DIFF
--- a/plugins/extra-wiki-links
+++ b/plugins/extra-wiki-links
@@ -1,2 +1,2 @@
 repository=https://github.com/iskela45/runelite-extra-wiki-links.git
-commit=9b113a9a16617a91586e4f8877b19c8826fccf67
+commit=b54f43dad84f97723426d79930ea8927889f2181


### PR DESCRIPTION
Add the ability to group menu entries under a single entry in case there are more than one enabled