### PR TITLE
Update crime-scene to 1.1.0

### DIFF
--- a/plugins/crime-scene
+++ b/plugins/crime-scene
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/crime-scene.git
-commit=374e461b9433ab778ca616ad2fa76a839ae5014b
+commit=32d01b409ca89703733f4befbf0d8cd2cfa86f02


### PR DESCRIPTION
Updates the Crime Scene plugin to commit `32d01b4` (v1.1.0).

Changes:
- New "Mark other players" config toggle (off by default) — marks any player's death tile, not just friends/friends chat/clan members.
- Right-click a leaderboard row in the side panel to delete that specific tracker; removes the name from every tile and drops tiles left with no deaths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)