### PR TITLE
Update raids death indicator

### DIFF
--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=ce1a8ce5d0ef2325a816a0cdfa3f19b484950639
+commit=352112edc11376e8e37ac0aae25f7e9960f54955


### PR DESCRIPTION
These patch sets refactor some of the code in raids death indicator to be easier on the eyes and make things consistent.

Additionally these refactors uncovered a race in the ToA handler, address, this patch addresses that.