### PR TITLE
Update raids death indicator

### DIFF
--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=352112edc11376e8e37ac0aae25f7e9960f54955
+commit=feeb3c2e42a5893f4f0842c3ab04e3494839f068


### PR DESCRIPTION
This patch set will hopefully once and for all make the predictor more reliable. It adds the following:

- Performance tests for the predictor

- Rather than waiting for a single fraction to be available, which is not always possible. If there's as single leaf in the prediction tree left, use the fractions available there to see if all would agree on a single result.

- Make functions synchronized, this should hopefully remove any races still remaining.

- Clear highlight on enemy heal or hitting 0 health. This should prevent Akkha from being highlighted the entirety of p3.

With all these combined the uncalibrated predicted hit performances went from ~42% worst case, to a 92% accuracy worst case.