### PR TITLE
Update tzhaar-hp-tracker

### DIFF
--- a/plugins/tzhaar-hp-tracker
+++ b/plugins/tzhaar-hp-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/buchus-plugins.git
-commit=46ae04c1126375bd4f839352fe088fa826fd0d49
+commit=6fd80225af7a8abe413f8e7f57026cf9de7343a6


### PR DESCRIPTION
Hides the HP overlay text if the NPC is dead