### PR TITLE
update tasks-tracker - use standard build property

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=416520eebc0fc942bada103a837997c75d73d606
+commit=c83f3663e00aef01403382e6663509d59c73d00f
 authors=perterter,JamesShelton140


### PR DESCRIPTION
No plugin updates, just using the `build=standard` property for auto reviews

Update PR to follow