### PR TITLE
update tasks-tracker - use standard build property

### DIFF
--- a/plugins/tasks-tracker
+++ b/plugins/tasks-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-reldo/tasks-tracker-plugin.git
-commit=416520eebc0fc942bada103a837997c75d73d606
+commit=61b4d0c93dfda476d61ec71caf4d1062a8a821d9
 authors=perterter,JamesShelton140


### PR DESCRIPTION
No plugin updates, just using the `build=standard` property for auto reviews