### PR TITLE
Melee loadouts now always include the Ammo slot

### DIFF
--- a/plugins/slayer-loadout
+++ b/plugins/slayer-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeN3/slayer-loadout.git
-commit=9aa58c83c89c665205bfeb0b7d7693b312d3d922
+commit=fc2a1d4122e48f214e642961786f6d7e5de09136


### PR DESCRIPTION
Melee loadouts now always include the Ammo slot, picking the best prayer blessing the player owns