### PR TITLE
npc-idle-timer-plugin: update README config screenshot

### DIFF
--- a/plugins/npc-idle-timer-plugin
+++ b/plugins/npc-idle-timer-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/Vinnie-Singleton/npc-idle-timer-plugin.git
-commit=995cbeaec1145925cfbae92d2a362090e85a46f7
+commit=d12a759bd8753b729a25dc074dde35869cecb142
 authors=Vinnie-Singleton, lejeffe, vonpawn


### PR DESCRIPTION
Bumps the pinned commit for npc-idle-timer-plugin to d12a759, a README/docs-only change that replaces the imgur-hosted sample config image with a repo-hosted screenshot reflecting the current settings panel (timer-persistence and respawn-aware options).

No plugin code changes.