### PR TITLE
Update 07flip to 591f1eb

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=c341909cf84b079f4c51f2d3147de1690dd88de3
+commit=091ea1b119e16baa043176134402d039e8c64de3
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates the 07Flip GE flip-finder plugin to commit 591f1eb.

Two coordinated changes:

**Capital-aware Optimiser (Plan tab):** per-slot capital allocation with honest, buy-limit-paced fill estimates, optional minimum-profit input, a "Stop buying" partial-fill action, one-click per-slot item swap on pending slots, slot-count suggestions, and a completed-positions history.

**Profit accounting:** the realised-profit calculator now uses LIFO cost-basis matching (newest buy first) instead of FIFO, so a freshly-bought cheaper batch is paired with the sells that flip it rather than an older, pricier bag of the same item. This matches the 07flip.com server's P&L computation.

Also refines the Capital filter (affordable-within-total-capital, persistent on/off toggle).

All data is read from 07flip.com's public API. No player data is sent beyond the existing opt-in trade sync, and no new third-party dependencies are added.