### PR TITLE
Update 07flip to 591f1eb

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=091ea1b119e16baa043176134402d039e8c64de3
+commit=591f1eb7d8a837b4adbfaa082b8ee7608fa3231c
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates the 07Flip GE flip-finder plugin to commit 591f1eb.

Switches the realised-profit calculator from FIFO to **LIFO** cost-basis matching (a sell consumes the newest open buy lot first). This pairs a freshly-bought cheaper batch with the sells that flip it, instead of charging an older, more expensive bag of the same item against current sells. Total realised profit is unchanged; only per-flip attribution differs. This matches the matching order used by the 07flip.com server so the two stay consistent.

All data is read from 07flip.com's public API. No player data is sent beyond the existing opt-in trade sync, and no new third-party dependencies are added.