### PR TITLE
Update prayer-time-infobox

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=7e45f4e3a35fd8089692905092b02f48e8f8229b
+commit=47147a011e45cf891c8b97e3cd5a714b85ccb5ac


### PR DESCRIPTION
Updates PvM Toolkit to source commit 47147a011e45cf891c8b97e3cd5a714b85ccb5ac.

Changes:
- Reorganize the plugin config into cleaner sections.
- Replace the separate tracker reset toggles with one reset dropdown and one reset button.
- Keep tracker mode defaulted to Forever.
- Enable the Trade button clock by default.
- Disable the inventory full warning by default.
- Refresh README and Plugin Hub metadata with clearer feature information.

Validation:
- Ran `./gradlew.bat test` in the plugin repository successfully with JDK 11.