### PR TITLE
Update inf-colo-additions

### DIFF
--- a/plugins/inf-colo-additions
+++ b/plugins/inf-colo-additions
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/bop-plugins.git
-commit=2b5898498b021624a3c4645ce7b83a4f218c0065
+commit=1f43d651ce7453a71e85aee3200ae27ece465bef


### PR DESCRIPTION
Only hide colo objects in colo instance

Somehow hiding colo objects made some inferno NPCs not show up