### PR TITLE
Update raids death indicator

### DIFF
--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=6a4f4d362f622a52ea9265d3ee2e428c5aded0ea
+commit=9ed95119e98bf12f579c71af2daa613cd61770bf


### PR DESCRIPTION
Change config key name for conservative hit predictor to force disable it.