### PR TITLE
Update loot-lookup to v1.2.1

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,3 +1,3 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=b8563a0ce44385246c9ae6b1f82b3cf3ad32f288
+commit=f267c38c900d6bd58a53e690d8c26756a5f00030
 authors=donth77,riktenx,iProdigy


### PR DESCRIPTION
- Fix Royal Titans drops and multi-word wiki lookups ([#48](https://github.com/donth77/loot-lookup-plugin/issues/48)): Eldric the Ice King showed
  Branda's drops because both were redirected to the combined Royal Titans page. Now
  scrapes each titan's own page, and resolves all lookups via case-insensitive
  Special:Lookup.