### PR TITLE
Add The Lobster Pot Clan Plugin

### DIFF
--- a/plugins/lobster-pot
+++ b/plugins/lobster-pot
@@ -1,0 +1,2 @@
+repository=https://github.com/datlalo/The-Lobster-Pot---Clan-Plugin.git
+commit=893fabefd5f0a93d00f564f25d8be643a8c1d4ea

--- a/plugins/lobster-pot
+++ b/plugins/lobster-pot
@@ -1,2 +1,3 @@
 repository=https://github.com/datlalo/The-Lobster-Pot---Clan-Plugin.git
 commit=893fabefd5f0a93d00f564f25d8be643a8c1d4ea
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
This is a plugin for the members of the clan "The Lobster Pot" so they can get updates on news, events, broadcasts and see their current clan rank and progress.