### PR TITLE
Add ba-wave-info

### DIFF
--- a/plugins/ba-wave-info
+++ b/plugins/ba-wave-info
@@ -1,0 +1,2 @@
+repository=https://github.com/sonnypb/runelite-plugins.git
+commit=20ff438a59f937e701b4aec6a0f0afe0cbed9195


### PR DESCRIPTION
Barbarian Assault plugin that displays number of npc spawns and reserve spawns based on player role.