### PR TITLE
Lending Tracker: fix cross-machine invite codes & sync reliability

### DIFF
--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=af437e4ac00ca30c9e8675141125ca0978053bbb
+commit=9cc974928a970a0eaa916a7428d23ec40bd3dcea

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=e52dbe4d7d6060dd199783d94e363d6fb7db3b5f
+commit=04be5658c36e0dbb57630dfdc1da1d92fd274b2a

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=04be5658c36e0dbb57630dfdc1da1d92fd274b2a
+commit=712a6cb81f5c0fdee7d89c54b44957b7d28dd0b0

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=2de650dc0a04f26da8a0e7472220cb5ef3060ea0
+commit=e52dbe4d7d6060dd199783d94e363d6fb7db3b5f

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=9cc974928a970a0eaa916a7428d23ec40bd3dcea
+commit=2de650dc0a04f26da8a0e7472220cb5ef3060ea0


### PR DESCRIPTION
Patch update

- Fixed invite codes failing to join across computers.
- Cloud Sync now activates immediately when toggled on (no restart).
- Invite codes are confirmed published before sharing; clearer join error messages.
- Added a relay keepalive and catch-up sync so joiners get current group state.
- "Invite to Lending Group" now anchors on the player "Report" option.

Cloud Sync remains opt-in and off by default. No new dependencies.