### PR TITLE
Add Drop History plugin

### DIFF
--- a/plugins/drop-history
+++ b/plugins/drop-history
@@ -1,0 +1,2 @@
+repository=https://github.com/markuskkramer/drop-history
+commit=c47ca2576649ed0f98f4ee3fbe606f37c1bf9de2

--- a/plugins/drop-history
+++ b/plugins/drop-history
@@ -1,2 +1,2 @@
 repository=https://github.com/markuskkramer/drop-history.git
-commit=e3f30f6e44617fdc16570e852726ba9ad7f1bc36
+commit=cc0c2d69333f7d0a51b2c0cab6ac99018af58525

--- a/plugins/drop-history
+++ b/plugins/drop-history
@@ -1,2 +1,2 @@
-repository=https://github.com/markuskkramer/drop-history
+repository=https://github.com/markuskkramer/drop-history.git
 commit=e3f30f6e44617fdc16570e852726ba9ad7f1bc36

--- a/plugins/drop-history
+++ b/plugins/drop-history
@@ -1,2 +1,2 @@
 repository=https://github.com/markuskkramer/drop-history.git
-commit=cc0c2d69333f7d0a51b2c0cab6ac99018af58525
+commit=39c44230ce79fc849b2369a959b7c7f1f4c4c8fc

--- a/plugins/drop-history
+++ b/plugins/drop-history
@@ -1,2 +1,2 @@
 repository=https://github.com/markuskkramer/drop-history
-commit=c47ca2576649ed0f98f4ee3fbe606f37c1bf9de2
+commit=e3f30f6e44617fdc16570e852726ba9ad7f1bc36


### PR DESCRIPTION
Tracks what kill count you received each collection log item at. Shows a tooltip when hovering items in the collection log. Includes a one-time historical import from the loot tracker.