### PR TITLE
disable chathighlightplayer

### DIFF
--- a/plugins/chathighlightplayer
+++ b/plugins/chathighlightplayer
@@ -1,2 +1,3 @@
 repository=https://github.com/scriptnapps/chathighlightplayer.git
 commit=d9a6b1d62874de27ffae3c6eca810dc668a5460c
+disabled=requires modification from author


### PR DESCRIPTION
The plugin breaks our [rejected feature](https://github.com/runelite/runelite/wiki/Rejected-or-Rolled-Back-Features):

> Highlighting "Offline" Friends (and generic player highlighting): Not included to respect players with their messaging mode set to Private and to avoid harassing players (see https://github.com/runelite/runelite/pull/951)

To be re-enabled, the plugin must:
1. Remove the generic player highlighting feature (the always highlight groups).
2. Remove the customizable temporary highlight duration. You may set it to a duration at or below 60 seconds.

Please see the above requirements @scriptnapps. Thanks for your cooperation! We're on Discord if you'd like to chat.
