### PR TITLE
Remove permanent highlight feature and restrict highlight duration

### DIFF
--- a/plugins/chathighlightplayer
+++ b/plugins/chathighlightplayer
@@ -1,3 +1,3 @@
 repository=https://github.com/scriptnapps/chathighlightplayer.git
-commit=d9a6b1d62874de27ffae3c6eca810dc668a5460c
+commit=14e86feffb046137b3c7709e434d821bf63871f2
 disabled=requires modification from author

--- a/plugins/chathighlightplayer
+++ b/plugins/chathighlightplayer
@@ -1,3 +1,3 @@
 repository=https://github.com/scriptnapps/chathighlightplayer.git
-commit=c72a1d077e1dc21bf7be3255150328fad82b5a23
+commit=d00d786e54650a766b7f4fa7874d2f3804ff217e
 authors=Aiirik

--- a/plugins/chathighlightplayer
+++ b/plugins/chathighlightplayer
@@ -1,3 +1,3 @@
 repository=https://github.com/scriptnapps/chathighlightplayer.git
-commit=6beab2305563ec157d30835654745bf7f52b4428
-disabled=requires modification from author
+commit=c72a1d077e1dc21bf7be3255150328fad82b5a23
+authors=Aiirik

--- a/plugins/chathighlightplayer
+++ b/plugins/chathighlightplayer
@@ -1,3 +1,3 @@
 repository=https://github.com/scriptnapps/chathighlightplayer.git
-commit=14e86feffb046137b3c7709e434d821bf63871f2
+commit=6beab2305563ec157d30835654745bf7f52b4428
 disabled=requires modification from author


### PR DESCRIPTION
As per request, I have removed the following features as requested by admins:

-Remove the generic player highlighting feature (the always highlight groups).

-Remove the customizable temporary highlight duration. You may set it to a duration at or below 60 seconds.

Now it will only temp highlight players from 5 seconds - 60 seconds (hard limit on 60 seconds) similar to how the plugin started. No more permanent highlight. 

I worked on most of these features. I thought it was a cool feature I was adding but had no ideal it was breaking the rules. It would only highlighted players in your surroundings that you would select, but I can understand your point. So sorry about that. 

I hope this resolves the issues.

I'm the contributor who made these new features. https://github.com/[scriptnapps](https://github.com/scriptnapps) is the original author who allowed me to "take over" the project to improve it. 