### PR TITLE
Update advanced-hp-bar to `1.6.3`

### DIFF
--- a/plugins/advanced-hp-bar
+++ b/plugins/advanced-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/chrisreydev/advanced-hp-bar-plugin.git
-commit=4b156c38511312ccbc766fe3bdb36b97bc196d7a
+commit=6edda04bb2cbc6cdaa1122b40bc641b110eb69cc


### PR DESCRIPTION
* Hide extra HP bars during various skilling activities