### PR TITLE
Add ClanFinder

### DIFF
--- a/plugins/clanfinder
+++ b/plugins/clanfinder
@@ -1,0 +1,3 @@
+repository=https://github.com/OSRSClanFinder/clanfinder-runelite-plugin.git
+commit=3df9bd881b7f4349607293170d933feabf71b424
+warning=This plugin makes JSON listing requests, banner image requests, and event data requests to osrsclanfinder.com. Listed member totals are site listing data from Wise Old Man group stats or manual counts, not live online status. These external requests expose your IP address to that service, which is not controlled or verified by the RuneLite Developers.

--- a/plugins/clanfinder
+++ b/plugins/clanfinder
@@ -1,3 +1,3 @@
 repository=https://github.com/OSRSClanFinder/clanfinder-runelite-plugin.git
-commit=d709f5d148e9aababce3f722a18debb847edd684
+commit=081755c3bcc8e18d7f93ffebbacf94f80b72571a
 warning=This plugin makes JSON listing requests, banner image requests, and event data requests to osrsclanfinder.com. Listed member totals are site listing data from Wise Old Man group stats or manual counts, not live online status. These external requests expose your IP address to that service, which is not controlled or verified by the RuneLite Developers.

--- a/plugins/clanfinder
+++ b/plugins/clanfinder
@@ -1,3 +1,3 @@
 repository=https://github.com/OSRSClanFinder/clanfinder-runelite-plugin.git
-commit=081755c3bcc8e18d7f93ffebbacf94f80b72571a
+commit=9a420be702b6b692c231bac6e345280561801d0f
 warning=This plugin makes JSON listing requests, banner image requests, and event data requests to osrsclanfinder.com. Listed member totals are site listing data from Wise Old Man group stats or manual counts, not live online status. These external requests expose your IP address to that service, which is not controlled or verified by the RuneLite Developers.

--- a/plugins/clanfinder
+++ b/plugins/clanfinder
@@ -1,3 +1,3 @@
 repository=https://github.com/OSRSClanFinder/clanfinder-runelite-plugin.git
-commit=3df9bd881b7f4349607293170d933feabf71b424
+commit=d709f5d148e9aababce3f722a18debb847edd684
 warning=This plugin makes JSON listing requests, banner image requests, and event data requests to osrsclanfinder.com. Listed member totals are site listing data from Wise Old Man group stats or manual counts, not live online status. These external requests expose your IP address to that service, which is not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Adds ClanFinder, a read-only RuneLite sidebar plugin for browsing approved OSRS clan recruitment listings from osrsclanfinder.com.

The plugin displays public listing data, listed member totals, requirements, event information, and banner thumbnails. Member totals are listing data from Wise Old Man group stats or manually entered counts, not live online clan/member status.

The plugin does not automate gameplay, inject game menu entries, send chat messages, join clans, request RuneScape credentials, submit RSNs, or scrape private clan data.
