### PR TITLE
Update immersive-dialogue - Fix avatar-widget

### DIFF
--- a/plugins/immersive-dialogue
+++ b/plugins/immersive-dialogue
@@ -1,2 +1,2 @@
 repository=https://github.com/DjilanoS/osrs-immersive-dialogue.git
-commit=f6e3dbc0f86d2cbbc7b42a15aad53389cd48fa97
+commit=a0fe42fe540b4fbc2ece8dbd53c345640237f97c


### PR DESCRIPTION
Apologies for this update so soon after the initial "add plugin", forgot to push this fix prior to submitting the plugin to plugin-hub. :sweat_smile: 

**Problem:**
The avatar widgets were gone after the user re-logged.

**Fix:** 
Dropped the head widget references whenever the client tears down the world, so the next `renderHead()` rebuilds the container on the fresh post-login interface root. `ImmersiveDialoguePlugin.java`  now reset on session-ending game states.