### PR TITLE
plugin: Adding UIM Looting death pile prioritization plugin

### DIFF
--- a/plugins/easy-bagging
+++ b/plugins/easy-bagging
@@ -1,0 +1,2 @@
+repository=https://github.com/X7X7X7X7/EasyBagging.git
+commit=1dd77a7f831e18d96aec5144ee3d1f1c9afa4823


### PR DESCRIPTION
The goal of this plugin is to allow UIM to quickly pickup items for their looting bags from a death pile in the correct order to expedite the process of managing a death pile.

Implementing a plugin panel that shows the ordered contents of a looting bag to allow reordering, removal of items. Opening a looting bag will update the contents of this list, and can be cleared with the reset button. This item list then enforces the ground item prioritization when selecting items in a pile.

This allows an uim to spam click their death pile, and grab their priority items, which can be quickly placed into the bag in Ferox. Currently this requires multiple plugin configurations or manual selection of pile contents which is error prone and annoying in dangerous locations.