### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=3c5a01cb16bb2441f4bc12505b39d503d13728e8
+commit=9c08d94780573fe096be1f6827e186b97f2f4327
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary

- Correct the hover-state tax display on the GE overlay and prevent a brief flicker on the profit line.
- Fix occasional incorrect unit prices when backfilling trades from the GE History tab.