### PR TITLE
Enchanted symbol protector

### DIFF
--- a/plugins/enchanted-symbol-protector
+++ b/plugins/enchanted-symbol-protector
@@ -1,0 +1,2 @@
+repository=https://github.com/ZacharyHJacobson/enchanted-symbol-protector.git
+commit=403e616705f55c05636e9fe12b6a25d9ecd271b9

--- a/plugins/enchanted-symbol-protector
+++ b/plugins/enchanted-symbol-protector
@@ -1,2 +1,2 @@
 repository=https://github.com/ZacharyHJacobson/enchanted-symbol-protector.git
-commit=403e616705f55c05636e9fe12b6a25d9ecd271b9
+commit=c10d28b65802715cfffc2aba44f11a40877a93ec


### PR DESCRIPTION
This plugin prevents activating the Enchanted Symbol if it would be lost on death.  The Enchanted Symbol is commonly used for respawning quickly to exit the deep Wilderness during clue solving, but has a low value and can easily be lost.  

The plugin checks the player's inventory, equipped items, and quiver ammo to figure out how many items are on them, including quantities.  If it's more than the number of items lost on death, the "Activate" event is consumed.