### PR TITLE
Add Waypointer plugin

### DIFF
--- a/plugins/waypointer
+++ b/plugins/waypointer
@@ -1,3 +1,3 @@
 repository=https://github.com/Mitchole/waypointer.git
-commit=edd3e33119383748cbba493af02a815d3a89aa87
+commit=0f38c5115012d267305f5d46fc43815caf05afea
 authors=Mitchole

--- a/plugins/waypointer
+++ b/plugins/waypointer
@@ -1,0 +1,3 @@
+repository=https://github.com/Mitchole/waypointer.git
+commit=edd3e33119383748cbba493af02a815d3a89aa87
+authors=Mitchole


### PR DESCRIPTION
Adds Waypointer, a plugin for saving in-game locations and pathing to them.

- Repository: https://github.com/Mitchole/waypointer
- License: BSD 2-Clause

What it does: save tiles as named waypoints, organise them into categories, search the library, and one-click path to any waypoint through the Shortest Path integration. It also ships a small curated set of preset locations and a nearest-landmark bar.
