### PR TITLE
update `collection-log-master` to v2.0.0

### DIFF
--- a/plugins/collection-log-master
+++ b/plugins/collection-log-master
@@ -1,4 +1,4 @@
 repository=https://github.com/OSRS-Taskman/collection-log-master.git
-commit=456ad3bf3f6073ae1a796f543489e931eed90fe8
+commit=d122b39b071d2ec4d1d6d205973b06f47ccc758d
 authors=ImTedious,rmobis
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This update is mostly to migrate from using a local save and logic to instead relying on [TaskApp](https://www.osrstaskapp.com/) as the backend. Sorry for the big diff, I tried to change as little as possible for this first release.