### PR TITLE
Add Item Drop Lookup plugin

### DIFF
--- a/plugins/item-drop-lookup
+++ b/plugins/item-drop-lookup
@@ -1,0 +1,2 @@
+repository=https://github.com/vz6h2pvt78-afk/runelite-item-drop-lookup.git
+commit=70f73868219e91ed948f1f9b22f22d8692565f04

--- a/plugins/item-drop-lookup
+++ b/plugins/item-drop-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/vz6h2pvt78-afk/runelite-item-drop-lookup.git
-commit=70f73868219e91ed948f1f9b22f22d8692565f04
+commit=1b7cca26023c405b064777d12407134718c4ff87

--- a/plugins/item-drop-lookup
+++ b/plugins/item-drop-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/vz6h2pvt78-afk/runelite-item-drop-lookup.git
-commit=1b7cca26023c405b064777d12407134718c4ff87
+commit=e2e6b96e7f0db7683e853ac86bb992c541b085de


### PR DESCRIPTION
Adds Item Drop Lookup, a RuneLite sidebar plugin for looking up Old School RuneScape item drop sources.

Current alpha features:
- Search items by name
- Show monster drop sources
- Show drop rates and quantities
- Show GE prices when available
- Show selected non-NPC sources, such as rewards and shops
- Uses local generated data resources based on OSRS Wiki data

This is an early alpha submission. Data coverage and parsing quality are still being improved, especially for clue scroll sources, unusual NPCs, and non-monster sources.