### PR TITLE
Update kill-clog to 1.4.1

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=ee0262a52e27374f808af7a2b076a061848b7b38
+commit=ae2ff40aee46d4e5524ee163345fefc46119311e
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=b0a486a3d7104b9161ee647f14c5a903e259cf98
+commit=f4ee7cfadc187f55cb82a9116371427d001ad36f
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=dbd13a71f515cb0559576386d7bdee1b112cd5ce
+commit=b0a486a3d7104b9161ee647f14c5a903e259cf98
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=3d850cc83deffec3daed9370923e203d9f777fbe
+commit=ee0262a52e27374f808af7a2b076a061848b7b38
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=ae2ff40aee46d4e5524ee163345fefc46119311e
+commit=dbd13a71f515cb0559576386d7bdee1b112cd5ce
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=e97795bf26d04c0ad4407f1c319bf33a7f388416
+commit=3d850cc83deffec3daed9370923e203d9f777fbe
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Kill Clog to 1.4.1 (edited from 1.4.0)

Changes:
- Adds RuneProfile collection-log lookup for public player data.
- Expands comparison mode summaries and tooltip polish.
- Adds combat achievement tier display inside PvM summaries (local and RuneProfile-synced public)
- Refreshes README screenshots and plugin metadata.
- Adds "lookup" as opt-in option for right click menu text
- adds configuration toggles for right menu locations
- moves comparison mode into default search bar instead of 2nd search bar
- adds support for Resource Packs (border sprites and fill for tooltips)
- adds GOTR rift count to skill summary

Local verification:
- .\gradlew.bat compileJava checkstyleMain checkstyleTest test --rerun-tasks
