### PR TITLE
Add Revenant Gear Checker

### DIFF
--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,2 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=58531524076f92978476677eadd6e3b5f5b4e7c3
+commit=a339c4d988e8c1465947b870baa6835a45a34f99
+

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,2 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=498034cfaafc3a81e6db7719041a6d53f6a0804b
+commit=d1ceafd8a84fc9b842f43abb6d7326e5a3dc0c49
+

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,3 +1,2 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=5d37c78c7af104ec7d4a7020d9e66c70a54860e6
-
+commit=498034cfaafc3a81e6db7719041a6d53f6a0804b

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,2 +1,2 @@
-repository=https://github.com/Spiderkill93/Revenant-gear-checker
+repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
 commit=1ce9e14aa8333e29f2974b445089ed739d088a31

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,2 +1,2 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=1ce9e14aa8333e29f2974b445089ed739d088a31
+commit=58531524076f92978476677eadd6e3b5f5b4e7c3

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,0 +1,2 @@
+repository=https://github.com/Spiderkill93/Revenant-gear-checker
+commit=1ce9e14aa8333e29f2974b445089ed739d088a31

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,3 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=a339c4d988e8c1465947b870baa6835a45a34f99
+commit=5d37c78c7af104ec7d4a7020d9e66c70a54860e6
 

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,3 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=98946c303c404a75675404c73e701ac383519db3
+commit=d3fd1413ae9d956426dd96df27ff92af434a496d
 

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,3 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=126319a5803be94772f049884b8247ad06639fc3
+commit=98946c303c404a75675404c73e701ac383519db3
 

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,3 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=d3fd1413ae9d956426dd96df27ff92af434a496d
+commit=c0b5d1d1b1cc4c889049265c47c1533b6cb677a4
 

--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,3 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=d1ceafd8a84fc9b842f43abb6d7326e5a3dc0c49
+commit=126319a5803be94772f049884b8247ad06639fc3
 


### PR DESCRIPTION
A RuneLite panel plugin that checks whether your equipped gear is correctly set up to safespot Revenants in the Revenant Caves.

Revenants pick the attack style you have the lowest defence roll against. On certain tiles they will attempt to melee you, giving you the opportunity to safespot them. This plugin shows your current defence bonuses and whether both the ranged and magic defence conditions are met.

The panel updates automatically whenever you change your equipped gear or every game tick. It also includes a clickable link to the full gear checker and safespot guide on hcim.net.