### PR TITLE
Add Ba-Ba Baboon Labels plugin

### DIFF
--- a/plugins/baba-baboon-labels
+++ b/plugins/baba-baboon-labels
@@ -1,0 +1,2 @@
+repository=https://github.com/YOUR_USERNAME/baba-baboon-labels.git
+commit=059970d61af261a9afdc04f36871ac75ca8265af


### PR DESCRIPTION
Adds Ba-Ba Baboon Labels, an accessibility-focused Tombs of Amascut helper that displays text labels above Ba-Ba puzzle room baboons. This is mainly to help players with colourblindness.

The plugin only renders visual labels such as USE RANGED, USE MAGIC, and USE MELEE. It does not automate player input, gear switching, prayer switching, attacks, movement, or menu actions.