### PR TITLE
Add Ba-Ba Baboon Labels plugin

### DIFF
--- a/plugins/baba-baboon-labels
+++ b/plugins/baba-baboon-labels
@@ -1,2 +1,2 @@
-repository=https://github.com/YOUR_USERNAME/baba-baboon-labels.git
+repository=https://github.com/SonnyVlecon/baba-baboon-labels.git
 commit=059970d61af261a9afdc04f36871ac75ca8265af

--- a/plugins/baba-baboon-labels
+++ b/plugins/baba-baboon-labels
@@ -1,0 +1,2 @@
+repository=https://github.com/YOUR_USERNAME/baba-baboon-labels.git
+commit=059970d61af261a9afdc04f36871ac75ca8265af

--- a/plugins/baba-baboon-labels
+++ b/plugins/baba-baboon-labels
@@ -1,3 +1,3 @@
-repository=https://github.com/YOUR_USERNAME/baba-baboon-labels.git
+repository=https://github.com/sonnyvlecon/baba-baboon-labels.git
 commit=1380f5c64305369ad06d3d6e4b3951af30fee52d
 

--- a/plugins/baba-baboon-labels
+++ b/plugins/baba-baboon-labels
@@ -1,2 +1,3 @@
-repository=https://github.com/SonnyVlecon/baba-baboon-labels.git
-commit=059970d61af261a9afdc04f36871ac75ca8265af
+repository=https://github.com/YOUR_USERNAME/baba-baboon-labels.git
+commit=1380f5c64305369ad06d3d6e4b3951af30fee52d
+

--- a/plugins/baba-baboon-labels
+++ b/plugins/baba-baboon-labels
@@ -1,3 +1,3 @@
 repository=https://github.com/sonnyvlecon/baba-baboon-labels.git
-commit=1380f5c64305369ad06d3d6e4b3951af30fee52d
+commit=7e132e5fe3fc87c9afa48f1d7bb4d6642b5fa0a0
 


### PR DESCRIPTION
Adds Ba-Ba Baboon Labels, an accessibility-focused Tombs of Amascut helper that displays text labels above Ba-Ba puzzle room baboons. This is to help people with colourblindness.

The plugin only renders visual labels such as USE RANGED, USE MAGIC, and USE MELEE. It does not automate player input, gear switching, prayer switching, attacks, movement, or menu actions.