### PR TITLE
update revenant-gear-checker (add plugin screenshot)

### DIFF
--- a/plugins/revenant-gear-checker
+++ b/plugins/revenant-gear-checker
@@ -1,3 +1,3 @@
 repository=https://github.com/Spiderkill93/Revenant-gear-checker.git
-commit=c0b5d1d1b1cc4c889049265c47c1533b6cb677a4
+commit=efe559d0f85cf0313d01142df0e47019548a47e6
 


### PR DESCRIPTION
Adds a screenshot of the plugin panel to the plugin hub listing.