### PR TITLE
Add detect-auto-alchers plugin

### DIFF
--- a/plugins/detect-auto-alchers
+++ b/plugins/detect-auto-alchers
@@ -1,0 +1,2 @@
+repository=https://github.com/FalseProfit/Detect-Auto-Alchers.git
+commit=6dee4cf10406aec47db716a6c540facacb465983


### PR DESCRIPTION
Adds Detect Auto Alchers, a local-only informational plugin that highlights nearby players based on observable alchemy-like activity, fire-staff evidence, and hiscores lookup.

Review notes:
- Does not click menu options or automate gameplay.
- Does not automatically submit reports.
- Does not upload, crowdsource, or expose player information over HTTP.
- Uses RuneLite/client APIs and local files only.
- No third-party runtime dependencies.
- `build=standard`.