### PR TITLE
Create wiki-lookup-plugin

### DIFF
--- a/plugins/wiki-lookup-plugin
+++ b/plugins/wiki-lookup-plugin
@@ -1,2 +1,2 @@
-repository=https://github.com/dlackmann/Wiki-Lookup-Plugin
+repository=https://github.com/dlackmann/Wiki-Lookup-Plugin.git
 commit=86d917a

--- a/plugins/wiki-lookup-plugin
+++ b/plugins/wiki-lookup-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/dlackmann/Wiki-Lookup-Plugin.git
-commit=8742a3d52630ad0d73ffd178b17ae0dda3083c8c
+commit=a6a9906ac1d7cf1a44b01f3df9bb76cbbcaf2a00

--- a/plugins/wiki-lookup-plugin
+++ b/plugins/wiki-lookup-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/dlackmann/Wiki-Lookup-Plugin.git
-commit=19557edbe8291eb9e386f1bdfd33533fb8e7c1da
+commit=002ab8d6b32fad29c5590589fc014d0124547c40

--- a/plugins/wiki-lookup-plugin
+++ b/plugins/wiki-lookup-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/dlackmann/Wiki-Lookup-Plugin.git
-commit=002ab8d6b32fad29c5590589fc014d0124547c40
+commit=8742a3d52630ad0d73ffd178b17ae0dda3083c8c

--- a/plugins/wiki-lookup-plugin
+++ b/plugins/wiki-lookup-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/dlackmann/Wiki-Lookup-Plugin
+commit=86d917a

--- a/plugins/wiki-lookup-plugin
+++ b/plugins/wiki-lookup-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/dlackmann/Wiki-Lookup-Plugin.git
-commit=86d917a
+commit=86d917a4451714552fcf70d689400aaf60a7357c

--- a/plugins/wiki-lookup-plugin
+++ b/plugins/wiki-lookup-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/dlackmann/Wiki-Lookup-Plugin.git
-commit=a53ea1da5e17605ccb683b6a34dcba93df9d9de0
+commit=19557edbe8291eb9e386f1bdfd33533fb8e7c1da

--- a/plugins/wiki-lookup-plugin
+++ b/plugins/wiki-lookup-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/dlackmann/Wiki-Lookup-Plugin.git
-commit=a6a9906ac1d7cf1a44b01f3df9bb76cbbcaf2a00
+commit=37473b0b5bf794891a6d86d1d3171e50017b26f0

--- a/plugins/wiki-lookup-plugin
+++ b/plugins/wiki-lookup-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/dlackmann/Wiki-Lookup-Plugin.git
-commit=86d917a4451714552fcf70d689400aaf60a7357c
+commit=a53ea1da5e17605ccb683b6a34dcba93df9d9de0


### PR DESCRIPTION
plugin that lets you right click an item and pull a short description from the wiki of what it is. Also provides some other quick useful stats if the item is a piece of gear, if it can be high alch'd or sold on the GE. 