### PR TITLE
Added Sawmill Basket Helper

### DIFF
--- a/plugins/sawmill-basket-helper
+++ b/plugins/sawmill-basket-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/got2bhockey/sawmill-basket-helper.git
+commit=f88cddbf4ec25e99145f312ed89282b9bb149c87


### PR DESCRIPTION
A small quality-of-life plugin for plank-making. When the player is within 4 tiles of a sawmill operator (Varrock, Woodcutting Guild, Prifddinas, Auburnvale), it promotes the log basket's Empty option to left-click so logs can be dumped into the inventory in one click instead of right-click → Check → Empty.

- Supports the log basket and forestry basket (open/closed)
- "Empty" is a subop of "Check", so it's cloned to the top level (same approach as the built-in Menu Entry Swapper); the original right-click menu is unchanged
- Only acts near an operator, the menu is left untouched everywhere else; hold Shift to suppress