### PR TITLE
Update pvp-leaderboard

### DIFF
--- a/plugins/pvp-leaderboard
+++ b/plugins/pvp-leaderboard
@@ -1,3 +1,3 @@
 repository=https://github.com/findarian/pvp-leaderboard.git
-commit=4bb742b3e71914663ee1fee28f010b141d00ff14
+commit=3b732f24f152b8268a6a42d5a6e0b2695c220d7a
 warning=This submits your IP address, in-game username, and PvP fight statistics to a 3rd-party service not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Add per-member accept-range greyout, zero-config auto-join, alt displacement; fix rank-retry leak and accepts-range clip

Lobby/matchmaking feature pass plus two bug fixes:

- Per-member accept-range: LobbyMember gains minRankIdx/maxRankIdx
  (UNKNOWN_RANK_IDX sentinel that renders normally, never greys every
  row). Rows where the viewer is outside a member's band grey out with
  a coloured 'Accepts fights from min to max rating'  label and a
  disabled Fight chip. New LobbyService.updateRankRange pushes
  lobby/update_range, throttled to one send per 5s (RANGE_UPDATE_MIN_
  INTERVAL_MS) with trailing-edge coalescing.
- Zero-config auto-join: qualifying users auto-join advertising all
  unlocked styles; Leave Lobby is a sticky opt-out (LobbyPreferences
  userLeftLobby) cleared only by a manual Go-to-lobby.
- Linked-alt displacement: handle server lobby/displaced via new
  LobbyEventListener.onDisplacedByAlt, dropping the panel back to the
  gate without auto-rejoin.
- Invite popup rewrite: single click-instruction body with the inline
  sidebar nav icon and a rank-coloured sender name.
- Fix leaked rank-retry task: WebSocketLobbyService.stop() now cancels
  rankRetryHandle and is invoked from plugin shutDown() so the periodic
  retry no longer outlives the plugin on RuneLite's shared scheduler.
- Fix accepts-range label vertical clip: hard <br> forces the HTML
  label to report its true multi-line height so the wrapped tail is no
  longer cut off.
- Rewrite README for the public plugin-hub listing.