### PR TITLE
Add a item tracking panel to profit-tracker plugin

### DIFF
--- a/plugins/profit-tracker
+++ b/plugins/profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/mrhappyasthma/runelite-profit-tracker.git
-commit=4ad4cd07aa55a10da7b2bee55331d17008eefdf3
+commit=7842d08a5b3b2505264a91fb5666fc4389b9dcc3


### PR DESCRIPTION
This can be used to monitor items gained/lost as well as for debugging.