### PR TITLE
Skipper's Ledger

### DIFF
--- a/plugins/captains-ledger
+++ b/plugins/captains-ledger
@@ -1,0 +1,2 @@
+repository=https://github.com/windyr12/captains-ledger.git
+commit=d5c203c1ffc7e638c0aa2afa408a8fe4a0d7b972

--- a/plugins/captains-ledger
+++ b/plugins/captains-ledger
@@ -1,2 +1,2 @@
 repository=https://github.com/windyr12/captains-ledger.git
-commit=d5c203c1ffc7e638c0aa2afa408a8fe4a0d7b972
+commit=8be4696b5835c5879950ec5ca17281058c63a055


### PR DESCRIPTION
# Skipper's Ledger

A plugin for tracking community trawling trips. Essentially a taximeter for ironmen.

## Features

- Track crew members using the net (standing on the same tile as you)
- Track time per player
- Track depositing/banking players
- Automatically set ironmen as banking. Can be manually overridden
- Calculate GP owed based on an hourly rate as well as total GP earned during the trip.
- End individual player trips
- Track paid/unpaid status
- Copy a trip summary to clipboard

NOTE: The plugin was developed with the name "Captain's Ledger" until I discovered there's an existing plugin named "Captain's Log". I changed the display name to "Skipper's Ledger" to avoid confusion, but the code still refers to it as CaptainsLedger