### PR TITLE
Create zebak-roar-helper

### DIFF
--- a/plugins/zebak-roar-helper
+++ b/plugins/zebak-roar-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/FHaisal/zebak-roar-helper.git
+commit=bff17ec812009d08c7fb82fcaf3ffc840c335cd7

--- a/plugins/zebak-roar-helper
+++ b/plugins/zebak-roar-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/FHaisal/zebak-roar-helper.git
-commit=bff17ec812009d08c7fb82fcaf3ffc840c335cd7
+commit=9f290b270caeb003ee6ab144e5685a8cf3c41edd


### PR DESCRIPTION
A plugin to highlight jugs and safe tiles during Zebak's Great Roar