### PR TITLE
Update prayer-time-infobox

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=69840be43700b7e0d6bd0f52b8c0045be66d1479
+commit=851b0685cbc27917772dbbbf3918ed3a96d5ceb8


### PR DESCRIPTION
Hotfix update for `prayer-time-infobox` / PvM Toolkit to source commit `851b0685cbc27917772dbbbf3918ed3a96d5ceb8`.

This fixes the 3.1.0 startup failure caused by the stats panel navigation icon not being packaged as a runtime resource in the Plugin Hub standard build.

Changes:
- move `icon.png` into `src/main/resources` so it is included in the plugin jar
- add a safe fallback for stats panel icon loading so a missing icon cannot prevent startup
- shorten side-panel quick-control text to avoid clipping
- ignore local dev RuneLite log files

Validated locally with:
- `./gradlew.bat test`
- `./gradlew.bat shadowJar`
- verified the jar contains `icon.png` and the `PvmToolkitStats*` classes

Also scanned the plugin for reflection and other obvious Plugin Hub review risks; no reflection remains.