### PR TITLE
Create exchange-lens

### DIFF
--- a/plugins/exchange-lens
+++ b/plugins/exchange-lens
@@ -1,0 +1,2 @@
+repository=https://github.com/mackenzie0cameron0/Exchange-lens.git
+commit=4a2e673064c9bc41c5218b64d973154c086dc582


### PR DESCRIPTION
Adds Exchange Lens, a Grand Exchange flipping assistant.

It ranks flips from live OSRS Wiki real-time prices, shows suggested
buy/sell prices in the GE offer screen, and tracks completed flips in a
pop-out history window (overview, recommendations, and item-search tabs
with per-item price/volume charts).

The plugin is only designed to advise. it reads market data and the player's own GE
offer events, and never automates input or trades.

Repo: https://github.com/mackenzie0cameron0/Exchange-lens
License: BSD-2-Clause