### PR TITLE
update tobqol to v1.4.0

### DIFF
--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=03773de9b0f7b829193889130a5beb027726cffe
+commit=3e5400a7f2dc77773329ae1717166c2f79d546ad

--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=be8f6d80b0b56ad2797c9a8cb88e4015416f01db
+commit=03773de9b0f7b829193889130a5beb027726cffe

--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=7a6d3b4cb75e00f977070db68637d5ba07ed8e96
+commit=963de21318e0bd1cb917bb4b63514d86d898775e

--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,2 +1,2 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=3e5400a7f2dc77773329ae1717166c2f79d546ad
+commit=7a6d3b4cb75e00f977070db68637d5ba07ed8e96


### PR DESCRIPTION
- fixes: typo in Justiciar Legguards for Loot Tracker
- fixes: NRE for region checks
- fixes: Verzik Death Ball Alarm using Sotetseg's Death Ball Alarm volume config
- adjusts: audio handling is now using RuneLite's AudioPlayer implementation, resolving multiple audio tracks in mixer
- adds: CoX Sotetseg Projectile Theme
- adds: Nylo Highlight Color config options
- adds: Nylo Bigs can be toggled to still display the tile overlay if they are considered dead
- fixes: Maiden Room Complete time diffing an invalid time key and will now compare to the 30% time as originally intended