### PR TITLE
Added new plugin real-loot-key-value (beta)

### DIFF
--- a/plugins/real-loot-key-value
+++ b/plugins/real-loot-key-value
@@ -1,0 +1,2 @@
+repository=https://github.com/dev-elie/real-loot-key-value.git
+commit=90443c22c3f8eef13b3178ebc155dcfca86b8666


### PR DESCRIPTION
# Real Loot Key Value

Real Loot Key Value shows the real Grand Exchange value of PvP loot keys directly in the loot chest interface.

The Old School RuneScape loot key chest can round the displayed value down to the nearest million. That makes the value look lower than it really is, sometimes by a large amount. A key worth 1.9M, for example, can appear much closer to 1M in the default interface.

This plugin fixes that UI problem by overlaying a more accurate value on the loot key tab. Coin stacks are counted as their exact GP amount, and item stacks are valued using RuneLite Grand Exchange price data.

The plugin is display-only. It does not change loot, add actions, click anything for you, store data, or send any information anywhere.


| Before | After |
| ------------- | ------------- |
| <img width="412" height="428" alt="Screenshot From 2026-06-05 17-22-20" src="https://github.com/user-attachments/assets/acae153c-61a9-4f5e-a7a2-1a059d318130" /> | <img width="412" height="428" alt="Screenshot From 2026-06-05 17-22-03" src="https://github.com/user-attachments/assets/2d312711-c859-4d85-ae80-dfd17c9f96e2" /> |
