### PR TITLE
Create ping-check

### DIFF
--- a/plugins/ping-check
+++ b/plugins/ping-check
@@ -1,0 +1,2 @@
+repository=https://github.com/jaesicc/ping-check.git
+commit=4dc45c0ed32448181f7f032b382f796150c42595


### PR DESCRIPTION
When you enter the lobby/entrance of one of the below PvM encounters, this plugin will check your ping to see if it is higher than the threshold you have set in the plugin settings. If you are above the threshold, any menu entries that would let you enter/start the content will be hidden, you'll get a chat message, and an on-screen alert that you can configure. You can toggle this on and off on a per-encounter basis.