### PR TITLE
Create zebak-roar-helper

### DIFF
--- a/plugins/zebak-roar-helper
+++ b/plugins/zebak-roar-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/FHaisal/zebak-roar-helper
+commit=94755c6bb4fb5877bd9d7a490a283d349bacf35a

--- a/plugins/zebak-roar-helper
+++ b/plugins/zebak-roar-helper
@@ -1,2 +1,2 @@
-repository=https://github.com/FHaisal/zebak-roar-helper
+repository=https://github.com/FHaisal/zebak-roar-helper.git
 commit=94755c6bb4fb5877bd9d7a490a283d349bacf35a


### PR DESCRIPTION
Updated the plugin to remove all tiles on the ground, it only highlights helpful jugs and does not show the player where to stand or move. As per Jagex's guidelines here: https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1