### PR TITLE
Add Rivalry plugin

### DIFF
--- a/plugins/rivalry
+++ b/plugins/rivalry
@@ -1,0 +1,2 @@
+repository=https://github.com/samwise0101/rivalry.git
+commit=3f91fc10e4bbdfe2169b9e303d355d185762b5b5

--- a/plugins/rivalry
+++ b/plugins/rivalry
@@ -1,2 +1,2 @@
 repository=https://github.com/samwise0101/rivalry.git
-commit=3f91fc10e4bbdfe2169b9e303d355d185762b5b5
+commit=be330a06a2d68a5729ba5407fa17ad62cc59f8b6


### PR DESCRIPTION
Adding the Rivalry plugin, which tracks the player and their chosen rivals across the official OSRS hiscores and awards "crowns" for leading in skills, boss KC, and clue counts.

All hiscore lookups are for user-entered names against the official Jagex hiscores endpoint. No crowdsourcing or redistribution of other players' data, and nothing is queried automatically without the user adding a name.