### PR TITLE
Update soulreaper-axe-qol

### DIFF
--- a/plugins/soulreaper-axe-qol
+++ b/plugins/soulreaper-axe-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/seacelery/soulreaper-axe-qol.git
-commit=936f7ec032f6353fe8345cc1c13b84ef063c7d8e
+commit=56a2aefdaaca454efbb290d564df18d50985ca28

--- a/plugins/soulreaper-axe-qol
+++ b/plugins/soulreaper-axe-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/seacelery/soulreaper-axe-qol.git
-commit=ef912d324f6fe07697d834b75106eceaef455861
+commit=936f7ec032f6353fe8345cc1c13b84ef063c7d8e


### PR DESCRIPTION
Hiya, sorry I've got quite a few changes here. Mostly bugfixes but the main one is previously the only way I had it working was by turning off regenmeter's special attack timer which I realise I shouldn't have done, so I'm really sorry for any trouble, I know a few people turned up saying their timer disappeared 😭 I've made it so it doesn't do that, there are two separate overlays, one of which instead masks the regenmeter timer while the soulreaper orb is in that spot and shows the soulreaper stack timer on top. 

I've added "configManager.setConfiguration("regenmeter", "showSpecial", true);" to startup, just because if it gets updated now, because of my previous mistake then everyone with the plugin will suddenly have the regenmeter timer turned off and never turned back on. I wasn't sure how else to mitigate that so I was wondering how you'd like that handled. Again, sorry for the mess..

Changes:
- Remove dependence on disabling regenmeter's timer
- Allow negative offsets in the position config
- Fix the overlays not being visible on the more recent minimised minimap orbs
- Separate the overlay into two overlays, with the extra orb overlay being on a different layer in order for the "always on top" toggle to work properly
- Reset orb sprite changes on shutdown so the orb doesn't remain recoloured for the session