### PR TITLE
Update dont-telegrab-npcs to v1.1.0

### DIFF
--- a/plugins/dont-telegrab-npcs
+++ b/plugins/dont-telegrab-npcs
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/dont-telekinetic-grab-npcs.git
-commit=46e89d45df48eb8a76c2d6f4fdb4cff4a22b6c68
+commit=17d85df423f17e51456df2516140696b285e7718


### PR DESCRIPTION
Refactor whitelist to include some pre-made toggles so NPC IDs can be used internally, particularly to only whitelist dead sailing creatures