### PR TITLE
log-adviser: bump to b6da3a0 (v1.1.1)

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=cebe88681deda18a3187223d77daf26c8cdd1bce
+commit=b6da3a0dbf94b8d88c03645c4bb9eff39154767d


### PR DESCRIPTION
Updates Log Adviser to the latest master.

New since the previously pinned commit (cebe886):
- Sailing Changes June 03
- Default display mode is now the info box instead of the overlay box
- Set plugin version to 1.1.1