### PR TITLE
Update commit reference in trueclueareas

### DIFF
--- a/plugins/trueclueareas
+++ b/plugins/trueclueareas
@@ -1,2 +1,2 @@
 repository=https://github.com/Daniel-Tudose/True-Clue-Dig-Locations.git
-commit=bab5e5d3eae3f7392713a3638d80b1c9725da503
+commit=8b622e0641255c09048a4cff34b47e3f5db06401


### PR DESCRIPTION
Quick bugfix of some emote clue steps. There were inverted coordinates and some abberant ones. My bad. I didn't check them thoroughly 