### PR TITLE
Update drop rate properties

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=4e59de440ced999480f85da52eed5f895e5fe157
+commit=ad775170c907ce8fa0d3a295ac813ae399bc3c61


### PR DESCRIPTION
Changes:
- Fixed drop rates that were stored as unevaluated wiki templates, which made
  some boss uniques (e.g. Alchemical Hydra's claw) show no rate message at all
- Recovered herb/seed drops that were missing for several monsters
  (demonic gorillas, drakes, wyverns, hydras, kraken family)
- Fixed multi-roll drop rates (e.g. "2 × 6/101") displaying twice as rare as
  they actually are
- Refreshed all drop data from the OSRS Wiki (608 NPCs)