### PR TITLE
Update iron-value plugin to 1.3 (ores, nature runes prices)

### DIFF
--- a/plugins/iron-value
+++ b/plugins/iron-value
@@ -1,2 +1,2 @@
 repository=https://github.com/hawkins/hawkins-external-plugins.git
-commit=6e699c20cad9f0383957daa2daf4f7108fc7acc3
+commit=4ffcf6da09495b86efe6aded7fb4d93c4d686fbb


### PR DESCRIPTION
Adds ore prices and nature rune prices thanks to @Diapolo10.

Also updates the plugin structure with new changes to `example-plugin` since I haven't contributed this plugin in several years