### PR TITLE
log-adviser: bump to 2c47277

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=b6da3a0dbf94b8d88c03645c4bb9eff39154767d
+commit=2c47277904c497e674dff477673a65f323be5ac8


### PR DESCRIPTION
Bump Log Adviser to v1.1.2.

Changes since the previously pinned commit:
- Added popup list for activities
- Add hover preview popup for activity log slots
- Image refresh fix