### PR TITLE
Update who-can-craft

### DIFF
--- a/plugins/who-can-craft
+++ b/plugins/who-can-craft
@@ -1,2 +1,2 @@
 repository=https://github.com/visagex/Who-Can-Craft-Group-Ironman-Crafting-Helper.git
-commit=6ee31510d1f773e8418079ddd209e2b527ef5628
+commit=b9ccaa2325e4ba5eb3836f6fe3577f6f0ab7e32c


### PR DESCRIPTION
update plugin to 1.1, fixing search issues where items didnt show up properly, adding hyperlinks to the wiki for items and non craftable materials.