### PR TITLE
Update Blert to 0.9.11

### DIFF
--- a/plugins/blert
+++ b/plugins/blert
@@ -1,4 +1,4 @@
 repository=https://github.com/blert-io/plugin.git
-commit=6cbc286b3cb9600cb3f4b094e9fb1cfe78c6c991
+commit=965d03eedd8a179c51a8b3723222ca53501372f2
 authors=frolv
 warning=This plugin submits your IP address, RSN, and data about your raids to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/blert
+++ b/plugins/blert
@@ -1,4 +1,4 @@
 repository=https://github.com/blert-io/plugin.git
-commit=cd590459fd99a27f1960f273c39f9870f21c463f
+commit=6cbc286b3cb9600cb3f4b094e9fb1cfe78c6c991
 authors=frolv
 warning=This plugin submits your IP address, RSN, and data about your raids to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Fixes spurious spawn/death events with Verzik tornadoes and Sotetseg.