### PR TITLE
Update Loot Logger (v4.5.1)

### DIFF
--- a/plugins/loot-logger
+++ b/plugins/loot-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/Loot-Logger.git
-commit=6d7648229ddce3b05ed0e98cd0e5049380f3fcfc
+commit=89343b984426f6beddafb38c766469b6972e1ebd


### PR DESCRIPTION
* Removed the playback functionality
  * This was a mostly unused feature and is now preventing the bot from auto merging these PRs so bye
* Fixed `Kills Logged` text never showing up
* Removed custom Abyssal Sire font reclamation tracking
  * This seems to be tracked natively, either through a RL change or jagex sending this data to the client
