### PR TITLE
Bump embargo to 1.6.1

### DIFF
--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,4 +1,4 @@
 repository=https://github.com/EmbargoOSRS/Embargo-Plugin.git
-commit=ffe3ef3cc401cbb69c810fb231df7cfec5f194ea
+commit=cdd945b44aeaf39a6201ad8e8e7dbd5af8e90a26
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github
 authors=Sharpienero,cnyms,CMjones5,jacobDM

--- a/plugins/embargo-clan-plugin
+++ b/plugins/embargo-clan-plugin
@@ -1,4 +1,4 @@
 repository=https://github.com/EmbargoOSRS/Embargo-Plugin.git
-commit=cdd945b44aeaf39a6201ad8e8e7dbd5af8e90a26
+commit=4ad31967f03998273b0397d160bf777149b2446a
 warning=This plugin sends player data (including IP address) to a 3rd party server not controlled by RuneLite or Jagex. To see the full list of data this plugin collects, check out project's README on Github
 authors=Sharpienero,cnyms,CMjones5,jacobDM


### PR DESCRIPTION
- Fix bank widget
- Add local client override for testing
- Consolidate BASE_URL across 7 files
- Add new config option to prevent "untrackable" items from syncing automatically on bank scan
- Move raid board stuff to constants
- Fix bug with panel resetting after transient payload errors
- Add case insensitive dedupe + id first ordering
- add npe guard for missing gear requirements