### PR TITLE
Add Veil Flipper plugin

### DIFF
--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=490dcecac6b223de32974a5d7261a6220cce4ea1
+commit=650988ce15362ba3b6f55bce43d668178ed23cdc

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=4078b1cfb76582c7390a1d96a5c10ef31390aa20
+commit=1b60f3bf9dc7dce68ce876e45e96b10ae13c1d26

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=0ee8592358fa0cf5a2d8d5a743201eab11a96013
+commit=2d76214f07daaaa5a03857ce5e354672a61b6710

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=d41c0c2578cdfbf0a6298c940c2ae1d018126a73
+commit=86b653d0aee58711ee5676b03fdadf2cf762e85f

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
--e repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=32f09a5cb6c87c949435d347777aaf424c1db875
+repository=https://github.com/MisTAiM/veil-rl-plugin.git
+commit=5244a8e5aa2db473e4aeb5252307b82dbe6cce7c

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=fb2fbcd511466f3a5efc1da289306a969ca41465
+commit=4078b1cfb76582c7390a1d96a5c10ef31390aa20

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
-repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=bf2d35ba4870c43862bb00c1da1abac9bbdf5b27
+-e repository=https://github.com/MisTAiM/veil-rl-plugin.git
+commit=32f09a5cb6c87c949435d347777aaf424c1db875

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=afca7d9b9178807ddfe625c9dbdcfb30f30246c9
+commit=28ed71966c88879fdf79a474a1abad517fbf5c0d

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=c3de204b4cda045619e6c0e639b536ad8d980afb
+commit=04bb83f41a7cc0fae5bf6d9869cb2f98f2419727

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=1b60f3bf9dc7dce68ce876e45e96b10ae13c1d26
+commit=490dcecac6b223de32974a5d7261a6220cce4ea1

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=5244a8e5aa2db473e4aeb5252307b82dbe6cce7c
+commit=0ee8592358fa0cf5a2d8d5a743201eab11a96013

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=04bb83f41a7cc0fae5bf6d9869cb2f98f2419727
+commit=d8ba4888c2f76e454edce49bd37a77110a60d34b

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,0 +1,2 @@
+repository=https://github.com/MisTAiM/veil-rl-plugin.git
+commit=bf2d35ba4870c43862bb00c1da1abac9bbdf5b27

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=2d76214f07daaaa5a03857ce5e354672a61b6710
+commit=7211a2c1ba2a28dec12e02ba4bbcca60a1df57ec

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=86b653d0aee58711ee5676b03fdadf2cf762e85f
+commit=fb2fbcd511466f3a5efc1da289306a969ca41465

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=650988ce15362ba3b6f55bce43d668178ed23cdc
+commit=84c6cfd81e43838c8aae34cc62daf23ee5203acc

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=84c6cfd81e43838c8aae34cc62daf23ee5203acc
+commit=c3de204b4cda045619e6c0e639b536ad8d980afb

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=7211a2c1ba2a28dec12e02ba4bbcca60a1df57ec
+commit=afca7d9b9178807ddfe625c9dbdcfb30f30246c9

--- a/plugins/veil-flipper
+++ b/plugins/veil-flipper
@@ -1,2 +1,2 @@
 repository=https://github.com/MisTAiM/veil-rl-plugin.git
-commit=28ed71966c88879fdf79a474a1abad517fbf5c0d
+commit=d41c0c2578cdfbf0a6298c940c2ae1d018126a73


### PR DESCRIPTION
## Veil Flipper

GE tracking, loot tracker, slayer sync, quest tracking, weapon charges, drop probability calculator, XP sync. Serves a local HTTP API so the Veil Android companion app can display live data without any external servers.

### Features
- Tracks all 8 GE slots via `GrandExchangeOfferChanged` — fill %, post-tax profit calc
- Loot tracking via `ItemContainerChanged` inventory diff — zero manual entry
- Slayer task/KC/points/streak via `VarPlayerID.SLAYER_*` varbits
- Quest state for all quests via `Quest.getState(client)` on GameTick
- Weapon charges via `VarbitID.CHARGES_*` (blowpipe, trident, Sanguinesti, Tumekens) with low-charge alerts
- Equipment death risk via WORN container (ID 94)
- Real-time XP per skill via `StatChanged`
- GE search overlay via `GrandExchangeSearched` — shows flip score on item search
- Flip scores from OSRS Wiki public prices API (same source as other hub plugins)
- Local HTTP server on port 7337 — all data stays on the player's machine

### No external data transmission
The sync server is local-only (`0.0.0.0` bind, LAN only). No data leaves the machine. The wiki API calls are read-only fetches of public data.

### Repository
https://github.com/MisTAiM/veil-rl-plugin