### PR TITLE
Update Purple Sweet Tracker

### DIFF
--- a/plugins/purple-sweet-tracker
+++ b/plugins/purple-sweet-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/brodloy/purple-sweet-tracker.git
-commit=b520a8d0982138983fc535834719c6db37cddb05
+commit=cdb57d8156d4668e3ccb67911a54b858c26aa025


### PR DESCRIPTION
Updates Purple Sweet Tracker to commit `cdb57d8`.

Changes since the live version:

- **Fix:** spam-clicking a sweet no longer over-counts. Counting (and the sound) now happen on a valid Eat click, then lock out for the 3-tick food eat delay, so only actual consumption is counted.
- **New:** a Copy stats button in the side panel copies your all-time / session / per-hour stats to the clipboard.

Builds with `gradlew build`; no external network calls.
