### PR TITLE
feat: add OSRS Bank Sync

### DIFF
--- a/plugins/osrs-bank-sync
+++ b/plugins/osrs-bank-sync
@@ -1,4 +1,4 @@
 repository=https://github.com/kyleamielke/osrs-bank-sync.git
-commit=29b473c9e87e6a38c20a6e0cfb98446676659e6f
+commit=42e00ad456f2a9cce03f4c2a81dbfc89b8694a59
 warning=This plugin sends your full bank contents (item IDs and quantities), your display name, account hash, and account type to whatever server URL you configure. By default the URL is http://127.0.0.1:8484 (localhost only). If you change the URL to a remote server, your bank data will be sent there in plaintext unless the URL uses https://.
 authors=kyleamielke

--- a/plugins/osrs-bank-sync
+++ b/plugins/osrs-bank-sync
@@ -1,0 +1,4 @@
+repository=https://github.com/kyleamielke/osrs-bank-sync.git
+commit=29b473c9e87e6a38c20a6e0cfb98446676659e6f
+warning=This plugin sends your full bank contents (item IDs and quantities), your display name, account hash, and account type to whatever server URL you configure. By default the URL is http://127.0.0.1:8484 (localhost only). If you change the URL to a remote server, your bank data will be sent there in plaintext unless the URL uses https://.
+authors=kyleamielke

--- a/plugins/osrs-bank-sync
+++ b/plugins/osrs-bank-sync
@@ -1,4 +1,4 @@
 repository=https://github.com/kyleamielke/osrs-bank-sync.git
-commit=42e00ad456f2a9cce03f4c2a81dbfc89b8694a59
+commit=da233f8b63ae04c7531652607588589192b5f8c6
 warning=This plugin sends your full bank contents (item IDs and quantities), your display name, account hash, and account type to whatever server URL you configure. By default the URL is http://127.0.0.1:8484 (localhost only). If you change the URL to a remote server, your bank data will be sent there in plaintext unless the URL uses https://.
 authors=kyleamielke

--- a/plugins/osrs-bank-sync
+++ b/plugins/osrs-bank-sync
@@ -1,4 +1,4 @@
 repository=https://github.com/kyleamielke/osrs-bank-sync.git
-commit=da233f8b63ae04c7531652607588589192b5f8c6
+commit=36a8d489ae02b83f213257df69f5e84f6bc46dae
 warning=This plugin sends your full bank contents (item IDs and quantities), your display name, account hash, and account type to whatever server URL you configure. By default the URL is http://127.0.0.1:8484 (localhost only). If you change the URL to a remote server, your bank data will be sent there in plaintext unless the URL uses https://.
 authors=kyleamielke


### PR DESCRIPTION
## Summary
Adds Plugin Hub manifest `plugins/osrs-bank-sync` for OSRS Bank Sync.

## Pinned commit
- `29b473c9e87e6a38c20a6e0cfb98446676659e6f`

## Trust model / data flow
This plugin follows the same trust model used by sync-oriented plugins such as WikiSync: users explicitly configure a destination endpoint, and data is sent only to that configured URL. To make that risk explicit, the manifest includes a warning line describing the exact payload (bank item IDs/quantities, display name, account hash, account type) and transport caveat when using non-HTTPS remote URLs.

For reviewer convenience, this PR pins release commit `29b473c9e87e6a38c20a6e0cfb98446676659e6f`.