### PR TITLE
Update enchanted-symbol-protector

### DIFF
--- a/plugins/enchanted-symbol-protector
+++ b/plugins/enchanted-symbol-protector
@@ -1,2 +1,2 @@
 repository=https://github.com/ZacharyHJacobson/enchanted-symbol-protector.git
-commit=c10d28b65802715cfffc2aba44f11a40877a93ec
+commit=4b06876d17aea22103421840e0da1ef6fe2f2e4d


### PR DESCRIPTION
1.1 release

Version updated to 1.1. Dizana's Quiver ammo is only counted if the Quiver is in the inventory or equipped.  An optional chat message is displayed when too many items are present to use the Symbol.