### PR TITLE
Create nh-input-tweaks plugin

### DIFF
--- a/plugins/nh-input-tweaks
+++ b/plugins/nh-input-tweaks
@@ -1,2 +1,2 @@
 repository=https://github.com/NotCoco/nh-input-tweaks.git
-commit=1acaae35a5cfbde158e4f54ff9280a0486736c5c
+commit=e26f75750cf23907d7d8db0cb8c235f31ad97727

--- a/plugins/nh-input-tweaks
+++ b/plugins/nh-input-tweaks
@@ -1,2 +1,2 @@
 repository=https://github.com/NotCoco/nh-input-tweaks.git
-commit=95e11e0004f0e184d2388ae06c9ce2f5ab0439a6
+commit=1acaae35a5cfbde158e4f54ff9280a0486736c5c

--- a/plugins/nh-input-tweaks
+++ b/plugins/nh-input-tweaks
@@ -1,0 +1,2 @@
+repository=https://github.com/NotCoco/nh-input-tweaks.git
+commit=671014bc4609488ac2382c9d5197addb32757a03

--- a/plugins/nh-input-tweaks
+++ b/plugins/nh-input-tweaks
@@ -1,2 +1,2 @@
 repository=https://github.com/NotCoco/nh-input-tweaks.git
-commit=671014bc4609488ac2382c9d5197addb32757a03
+commit=95e11e0004f0e184d2388ae06c9ce2f5ab0439a6


### PR DESCRIPTION
Adds NH Input Tweaks, a small RuneLite plugin with two input-feel changes:

- fast F-key side-tab switching by invoking the game's top-level keypress script for F1-F12
- clicked inventory item visual feedback with configurable brightness

Validation:
- `./gradlew.bat clean check` passes in the plugin repository