### PR TITLE
Add Tile Marker Symbols

### DIFF
--- a/plugins/tile-marker-symbols
+++ b/plugins/tile-marker-symbols
@@ -1,2 +1,2 @@
-repository=https://github.com/mostpalone9/Tile-Marker-Symbols
+repository=https://github.com/mostpalone9/Tile-Marker-Symbols.git
 commit=9c6e39bd5672a7587e0c149cbc0003f6710efa76

--- a/plugins/tile-marker-symbols
+++ b/plugins/tile-marker-symbols
@@ -1,2 +1,2 @@
 repository=https://github.com/mostpalone9/Tile-Marker-Symbols.git
-commit=9c6e39bd5672a7587e0c149cbc0003f6710efa76
+commit=2839aeac209cc1e951b4892c9dba9b948e19a293

--- a/plugins/tile-marker-symbols
+++ b/plugins/tile-marker-symbols
@@ -1,0 +1,2 @@
+repository=https://github.com/mostpalone9/Tile-Marker-Symbols
+commit=9c6e39bd5672a7587e0c149cbc0003f6710efa76

--- a/plugins/tile-marker-symbols
+++ b/plugins/tile-marker-symbols
@@ -1,2 +1,2 @@
 repository=https://github.com/mostpalone9/Tile-Marker-Symbols.git
-commit=2839aeac209cc1e951b4892c9dba9b948e19a293
+commit=a3a60c180ae0ea10421f8d2dfb5206d6aaadf180


### PR DESCRIPTION
Adds Tile Marker Symbols, a plugin for quickly marking tiles with Unicode symbols and custom labels.

Features:
- Configurable sidebar symbol palette
- Right-click or shift-right-click tile marking
- Custom labels and per-marker colors
- Ground Markers-style rendering
- Inherits Ground Markers color, border width, and fill opacity settings
- Undo last marker and confirmed clear-all action

Repository:
https://github.com/mostpalone9/Tile-Marker-Symbols