### PR TITLE
log-adviser: bump to 7602f97

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=91ae7e5e16a387cc09a1cf04b2ea0b7d39e202cb
+commit=7602f97e401f201252f57324c1a83c2b4676b35e


### PR DESCRIPTION
Bumps the pinned commit for **Log Adviser** to the latest `master`.

- repository unchanged: https://github.com/SFranciscoSouza/LogAdviser.git
- commit: `2c47277` → `b40fc6dff552db1e4c0c403a54f73d87008fe489`
- version: 1.1.2 → **1.1.3** (PATCH)

### What changed since the pinned commit
**Collection log auto-sync** — the plugin now reads the player's collection log directly from the in-game collection log book widgets to keep its "obtained" state in sync, instead of the previous manual/overlay-based flow.

- New `sync/CollectionLogSyncButton` adds a Sync button on the collection log interface.
- `sync/CollectionLogTracker` reworked to parse the book's widgets and emit sync-status changes; drives the sidebar indicator and a one-shot per-login chat warning when the log isn't fully synced.
- Removed the now-unused `CollectionLogSyncState`, `CollectionLogWidgets`, and `CollectionLogSyncOverlay`.
- Panel shows a "Syncing…" state while the log redraws.

### Notes for review
- No external/network behavior — the plugin makes no outbound HTTP calls; sync reads in-game widgets only.
- No new third-party dependencies.
- `build` check passes; `./gradlew build` (incl. tests) green locally.