### PR TITLE
Add MMO HUD and Loot Chat

### DIFF
--- a/plugins/loot-chat
+++ b/plugins/loot-chat
@@ -1,0 +1,2 @@
+repository=https://github.com/jaydog990/loot-chat.git
+commit=c921dc34c3393e9589cab80a76c2a0c5d620ad66

--- a/plugins/mmo-hud
+++ b/plugins/mmo-hud
@@ -1,0 +1,2 @@
+repository=https://github.com/jaydog990/mmo-hud.git
+commit=8c2dd2eed93b8886ccedc721e182e64b9cd06f26


### PR DESCRIPTION
Adds two external plugins:

- MMO HUD: MMO-style player, target, and RuneLite party HUD frames. Known issue documented in the plugin README: after hopping worlds, the player portrait orb can appear blank until the player changes equipment; HUD bars continue to update.
- Loot Chat: colored NPC drop chat messages with configurable value tiers and saved kill count context.

Both plugin repositories are public and use build=standard with no third-party dependencies.