### PR TITLE
log-adviser: bump to 043bda1 (sidebar sync button)

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=2c47277904c497e674dff477673a65f323be5ac8
+commit=043bda1033665cdf765c24018fe2a61e8d88fca6


### PR DESCRIPTION
Bumps the pinned commit for **Log Adviser** to the latest code.

- repository unchanged: https://github.com/SFranciscoSouza/LogAdviser.git
- commit: `2c47277` -> `043bda1033665cdf765c24018fe2a61e8d88fca6`
- version: 1.1.2 -> **1.1.4**

### What changed
The collection-log **Sync** control was moved off the in-game collection-log interface and onto the **Log Adviser sidebar panel** ("Sync now" button). The in-game button widget (`CollectionLogSyncButton`) is removed entirely; the underlying full-sync logic is unchanged.

This drops all in-game widget-creation API usage (`WidgetType`, `JavaScriptCallback`, `WidgetPositionMode`, `WidgetTextAlignment`, `SpriteID`, `FontID`).

### Notes for review
- No external/network behavior — the plugin makes no outbound HTTP calls.
- No new third-party dependencies.
- `build` check passes; `./gradlew build` (incl. tests) green locally.