### PR TITLE
Update Hiscore Notifications

### DIFF
--- a/plugins/hiscore-notifications
+++ b/plugins/hiscore-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/malafel-dev/hiscore-notifications.git
-commit=0c2b50d18cf870aead7f73afbf6ad228cccf6aff
+commit=c616ec1b858176fb9ac68080c281f6acec1ad684

--- a/plugins/hiscore-notifications
+++ b/plugins/hiscore-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/malafel-dev/hiscore-notifications.git
-commit=16dd61d58f37155cb516568a5f03b10b08dc323e
+commit=0c2b50d18cf870aead7f73afbf6ad228cccf6aff


### PR DESCRIPTION
Implements:
- Notify players when they gain boss hiscore ranks.
- More aggressively rate limit requests to the hiscore server.
- Allow players to completely disable notifications for rank ranges by setting the interval value to 0.