### PR TITLE
Add The Birdhouse plugin

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,2 +1,2 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=3636ef1d4376bbb8362bb9d0afc7adaa9863a75a
+commit=55c95997a15a1ca915800ba4ce86d2290975fa6d

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,2 +1,2 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=4c0a92b75674ecb121020da14062c10a9841b2a1
+commit=a67de7a74e1f9d56f3eae848c5d51275a323c1bb

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,2 +1,2 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=a67de7a74e1f9d56f3eae848c5d51275a323c1bb
+commit=4f48343e25cbc7c17d059ad963779abaeda59fb5

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,0 +1,2 @@
+repository=https://github.com/birdandworm/Birdhouse.git
+commit=7909917f7c19445441757e2a4fa1fb8a639c747c

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,2 +1,2 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=ff483de185bf833f6fdc8399dc7afe6337372bea
+commit=b7b904a469489cfc1e12721c2a47b84f6ae8614f

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,2 +1,2 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=55c95997a15a1ca915800ba4ce86d2290975fa6d
+commit=4c0a92b75674ecb121020da14062c10a9841b2a1

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,2 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
 commit=b7b904a469489cfc1e12721c2a47b84f6ae8614f
+warning=This plugin submits your IP address, RSN, and in-game screenshots to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,2 +1,2 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=7909917f7c19445441757e2a4fa1fb8a639c747c
+commit=3636ef1d4376bbb8362bb9d0afc7adaa9863a75a

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,2 +1,2 @@
-repository=https://github.com/birdandworm/Birdhouse.git
+repository=https://github.com/birdandworm/TheBirdhouse.git
 commit=7909917f7c19445441757e2a4fa1fb8a639c747c

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,2 +1,2 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=4f48343e25cbc7c17d059ad963779abaeda59fb5
+commit=ff483de185bf833f6fdc8399dc7afe6337372bea


### PR DESCRIPTION
## The Birdhouse

A companion plugin for [The Birdhouse](https://thebirdhouse.games) — a web platform for running OSRS bingo, tile races, and other clan events.

**Features:**
- Auto-submits drop proofs when loot matches a tile on the player's active board
- Tracks collection log entries, quest completions, and level-ups
- Includes screenshot capture with each submission
- In-game overlay showing tile progress
- Sidebar panel with full board status
- Session/activity tracking for event hosts

**How it works:**
Players link their account via an auth token from the website. The plugin fetches their active game board and matches incoming drops against tile names. When a match is found, it auto-submits proof (with optional screenshot) to the backend API.

No automation of gameplay — it only observes and reports.