### PR TITLE
Add slayer-setup-prompt

### DIFF
--- a/plugins/slayer-setup-prompt
+++ b/plugins/slayer-setup-prompt
@@ -1,2 +1,2 @@
 repository=https://github.com/andrewhathaway/slayer-setup-prompt-runelite-plugin.git
-commit=cfe3aa3eb3fa5ae54c9ec4925bf16af15faac4f3
+commit=550efff07bdb4b74a6db60fba21c296809aa3612

--- a/plugins/slayer-setup-prompt
+++ b/plugins/slayer-setup-prompt
@@ -1,0 +1,2 @@
+repository=https://github.com/andrewhathaway/slayer-setup-prompt-runelite-plugin.git
+commit=cfe3aa3eb3fa5ae54c9ec4925bf16af15faac4f3


### PR DESCRIPTION
Adds Slayer Setup Prompt, a local-only plugin that builds a copyable AI prompt from the player's selected slayer task, visible account stats, inventory, worn equipment, bank contents, and completed quests.

The plugin does not automate gameplay and does not send data to any external service. Prompt text is copied only when the user clicks Copy prompt.