### PR TITLE
drop-rates-clog: hotfix, forgot to uncomment the network refresh

### DIFF
--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=7770d4974e38b66c56e621f0384ad4833b390076
+commit=f5d3b9f50ceea24a1b087da9056f89703f8e96b0

--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=f5d3b9f50ceea24a1b087da9056f89703f8e96b0
+commit=2f9362ad8d366d17dc4f97743b989b82a2dec798


### PR DESCRIPTION
hotfix - forgot to uncomment the network refresh for drop_rates.json and clog_items.json