### PR TITLE
Update tyrs-guard-clan

### DIFF
--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,3 +1,3 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
-commit=447a70f10597c08090afe681964ba9e1f386e4d1
+commit=63bf39230c82ba78cfcb45a18c36e5fab24f90cd
 warning=This plugin submits your IP address, RSN, game screenshots, and clan chat messages to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Fixed GE clan listing sync — the overlay and panel now correctly update in real time for all clan members simultaneously. Previously only one plugin client could be connected at a time, causing broadcasts to only reach the most recently logged in member. Multiple clients can now stay connected at once. The "I Listed It!" button is now disabled and labelled "Already Listed" when another member has the clan listed, and automatically re-enables for everyone when the lister logs out or hops worlds.