### PR TITLE
ge-offer-timer: fix timers wiped on login/hop & reset on restart

### DIFF
--- a/plugins/ge-offer-timer
+++ b/plugins/ge-offer-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/MRiJax/ge-offer-timer.git
-commit=bb70b297685e7759b0aad73b390a36db91b3fe18
+commit=b9b56b3798ae90860632bf5886bdb374f82e872c


### PR DESCRIPTION
Bumps ge-offer-timer to b9b56b3798ae90860632bf5886bdb374f82e872c.

Fixes:
- GE offer timers wiped on logout → login and on world hop
- overlay returning blank after a full client restart

The overlay now renders from the live GE offers (no destructive clearing), reloads saved timers when the RS profile resolves, and tracks the item id per active offer so a reused slot starts fresh. Verified in a dev client across relog, hop, and full restart.