### PR TITLE
Update gim hub to 1.6.0

### DIFF
--- a/plugins/gim-hub
+++ b/plugins/gim-hub
@@ -1,4 +1,4 @@
 repository=https://github.com/wouterrutgers/gim-hub-plugin.git
-commit=72e694a477f309547b330863a515d827daa9a280
+commit=8d72aeb5b5a163556fb80b8f2478ff67f256adaf
 authors=wouterrutgers,EllarBooher
 warning=This plugin sends your player data (including your items, world map location, xp values, collection log information), and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/gim-hub
+++ b/plugins/gim-hub
@@ -1,4 +1,4 @@
 repository=https://github.com/wouterrutgers/gim-hub-plugin.git
-commit=394302f052b5a459a3a189ce16d992deb19032fd
+commit=72e694a477f309547b330863a515d827daa9a280
 authors=wouterrutgers,EllarBooher
 warning=This plugin sends your player data (including your items, world map location, xp values, collection log information), and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
* Sends the timezone to the server so we can show the player's local time on the dashboard.
* Fixes an issue where data would be sent even when there were no changes.
