### PR TITLE
Update nh-input-tweaks

### DIFF
--- a/plugins/nh-input-tweaks
+++ b/plugins/nh-input-tweaks
@@ -1,2 +1,2 @@
 repository=https://github.com/NotCoco/nh-input-tweaks.git
-commit=e984490f44801a624d592c9f14d44b1e56920daf
+commit=ca3884bdedbf8c07784333e36cd3ddd563f7d833


### PR DESCRIPTION
Updates nh-input-tweaks to the tested side-panel hotkey fix.

Root cause: the local client reported the resizable side-panel layout as layout key 1131, while the previous fix only respected the `HOTKEY_CANNOT_CLOSE_SIDEPANEL` setting for layout key 1130. The plugin now sends the no-close flag for both relevant resizable side-panel layout keys.

Validation:
- Tested locally by the user in RuneLite with modern resizable layout and the side-panel close-by-hotkey option disabled.
- Ran `./gradlew.bat clean check` in the plugin repository.
- Ran `git diff --check` in plugin-hub.