### PR TITLE
disable nh-input-tweaks

### DIFF
--- a/plugins/nh-input-tweaks
+++ b/plugins/nh-input-tweaks
@@ -1,2 +1,3 @@
 repository=https://github.com/NotCoco/nh-input-tweaks.git
 commit=ca3884bdedbf8c07784333e36cd3ddd563f7d833
+disabled=automates input


### PR DESCRIPTION
plugin automates input by invoking the client script that triggers tab switches