### PR TITLE
Update Loot Table Viewer drop parsing

### DIFF
--- a/plugins/loot-table-viewer
+++ b/plugins/loot-table-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/Oufqt/Loot-Table-Viewer.git
-commit=c31b32e45035454399fd7e9530caee48453995ab
+commit=32df1c41b81ed31a7905a72ac052422be03bc2d4


### PR DESCRIPTION
Updates Loot Table Viewer to commit 32df1c41b81ed31a7905a72ac052422be03bc2d4.

Fixes missing late wiki drop rows, including Sarachnis tertiary drops, and normalizes unsimplified wiki rarity fractions.