### PR TITLE
Add Nightmare Prayer Shuffle Indicator

### DIFF
--- a/plugins/nightmareprayershuffled
+++ b/plugins/nightmareprayershuffled
@@ -1,0 +1,2 @@
+repository=https://github.com/iiceJ/nightmare-prayer-shuffle-indicator
+commit=2410d4dfcee6f95598487923ecbcd270486d8ff0


### PR DESCRIPTION
Adds a plugin that indicates when The Nightmare or Phosani's Nightmare shuffles your protection prayers. Well within the Jagex rules.