### PR TITLE
create ge-tax-helper

### DIFF
--- a/plugins/ge-tax-helper
+++ b/plugins/ge-tax-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/MRiJax/ge-tax-helper.git
+commit=237a5e99bbf79c8d2cd5535598de39f67e025af2

--- a/plugins/ge-tax-helper
+++ b/plugins/ge-tax-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/MRiJax/ge-tax-helper.git
-commit=237a5e99bbf79c8d2cd5535598de39f67e025af2
+commit=35106783652591bdd607c6526fbcc2ad0ad4f323


### PR DESCRIPTION
Adds GE Tax Helper, a lightweight plugin that shows the Grand Exchange 2% sell tax and the net coins you'll receive when selling, with optional loss coloring. Icon and BSD-2 license included.