### PR TITLE
update ge-tax-helper

### DIFF
--- a/plugins/ge-tax-helper
+++ b/plugins/ge-tax-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/MRiJax/ge-tax-helper.git
-commit=35106783652591bdd607c6526fbcc2ad0ad4f323
+commit=a806b44ba81e06abd869d41b75c3a897cbce3ff0


### PR DESCRIPTION
Bumps the pinned commit to include README screenshots (profit/loss examples). No code changes.