### PR TITLE
ge-offer-timer: add README screenshot

### DIFF
--- a/plugins/ge-offer-timer
+++ b/plugins/ge-offer-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/MRiJax/ge-offer-timer.git
-commit=b9b56b3798ae90860632bf5886bdb374f82e872c
+commit=dc8c40254120dedac388155c520656c1b7194db8


### PR DESCRIPTION
Bumps ge-offer-timer to dc8c402, which adds a Screenshots section and overlay screenshot to the README. No code change from the currently-listed b9b56b3 — README/asset only.