### PR TITLE
ge-offer-timer: fix broken README screenshot link

### DIFF
--- a/plugins/ge-offer-timer
+++ b/plugins/ge-offer-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/MRiJax/ge-offer-timer.git
-commit=b9b56b3798ae90860632bf5886bdb374f82e872c
+commit=3b2104ebd8b82782a2ff62cf693b50bc12ed17e8


### PR DESCRIPTION
Bumps ge-offer-timer to 3b2104e, which fixes the README screenshot image URL — the previously listed commit used a relative path that didn't resolve, so the screenshot rendered as a broken image. No code change.