### PR TITLE
drop-rates-clog: ID-keyed lookup

### DIFF
--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=2f9362ad8d366d17dc4f97743b989b82a2dec798
+commit=01170366e7c6a5562b2236282e08062913138ec5


### PR DESCRIPTION
Switch the lookup chain to use item IDs directly, eliminating string-key mismatches (Decorative gold/magic items, all three Graceful variants, etc.). Also drops the bundled clog_items.json — ~245KB off the jar.