### PR TITLE
Insert Tangle Crew Plugin File

### DIFF
--- a/plugins/Tangle Crew Plugin
+++ b/plugins/Tangle Crew Plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/ZH-Systems/DinkClanPlugin.git
+commit=941b78ea777d9e873c400a92666cd1b07ffa0440


### PR DESCRIPTION
This is a plugin based on the Dink plugin, it is forked off of the most recent Dink Plugin. Essentially it expands capabilities to the plugin to allow for a JSON payload to be synced from a web server to update specific fields within the plugin during clan events, and disabled and reverted to clan standards when event ends.