### PR TITLE
Update 07flip to 58992d3

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=5e5da18cf9fba2e2c334d6fafa75c84ecc8b9dc6
+commit=58992d3e9c5991807ffffae27c4fb11cb3ea5baa
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates 07flip to 58992d3.

Changes:
- Bidirectional optimiser plan sync between 07flip.com and the plugin: version-gated structural adoption keyed on a monotonic generated_at, with the live fill ledger re-attached across re-plans.
- Plan-capped optimiser fill tracking: the optimiser counts up to the planned quantity; full quantities and profit remain in the local trade history.
- Site-authoritative plan structure: removed plugin-side auto-recycle; added a Regenerate action and a site Reconfigure link.
- Grand Exchange buy/sell progress UI on the optimiser cards.
- HTTP transport hardening: global 429 backoff honouring Retry-After (jitter/escalation), 503 retry handling, panel-visibility-gated polling.

No new dependencies (OkHttp/Gson remain transitive RuneLite deps). BSD-2-Clause. The plugin sends only the user's own GE/optimiser data to 07flip.com; the IP-disclosure warning line is retained.