### PR TITLE
disable sound-triggers

### DIFF
--- a/plugins/sound-triggers
+++ b/plugins/sound-triggers
@@ -1,2 +1,3 @@
 repository=https://github.com/tylanphear/runelite-sound-triggers.git
 commit=580a1bd9e93233840314f596e0e6efba104037b6
+disabled=pending changes from author


### PR DESCRIPTION
Hello @tylanphear - this plugin needs some changes to be re-enabled.

1) It needs restrictions in areas where it can be abused. See Watchdog's list of regions here: https://github.com/adamk33n3r/runelite-watchdog/blob/9087cd85bf090397b0a3150475e861000219d4d9/src/main/java/com/adamk33n3r/runelite/watchdog/Region.java  
   Additionally, since the list of regions is bound to change, please join the Discord's #development channel so we can notify you of this in real-time.
2) You need to remove the "Player Seen" trigger.
