### PR TITLE
update tyrs-guard-clan

### DIFF
--- a/plugins/tyrs-guard-clan
+++ b/plugins/tyrs-guard-clan
@@ -1,3 +1,3 @@
 repository=https://github.com/torlokt/TyrsGuardClan-Plugin.git
-commit=447a70f10597c08090afe681964ba9e1f386e4d1
+commit=63bf39230c82ba78cfcb45a18c36e5fab24f90cd
 warning=This plugin submits your IP address, RSN, game screenshots, and clan chat messages to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Fixes a sync issue where the plugin was incorrectly defaulting to every new member that logged in as having the clan listed on the Grand Exchange advertisement board, rather than correctly tracking who actually had it listed. The plugin now properly syncs the listing status and disables the advertisement buttons for other members while someone already has the clan listed, until they log out, world hop, or press the delist button.

please let this work I have no idea what I am doing....