### PR TITLE
Update 07flip to 5b00341

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=58992d3e9c5991807ffffae27c4fb11cb3ea5baa
+commit=5b003413d8cb7797f5f630fda171a559ebef7d24
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Update 07flip plugin to commit 5b00341.

This release fixes flip-plan progress tracking (progress could show 0 if trades completed before the sidebar finished loading, and sell listings were not reflected on plan cards), simplifies the Plan tab, and adds user settings for the gp-drop animation (position, font, colours, duration). No new dependencies and no new API endpoints.