### PR TITLE
Add scapestack-sync

### DIFF
--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
+commit=39931dc965e4e9f01bf549bdc192b85c4cd6c1fc

--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,2 +1,3 @@
 repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
 commit=5244bfe92e22143a0546144f213e9b174e4aafd5
+warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
-commit=39931dc965e4e9f01bf549bdc192b85c4cd6c1fc
+commit=5244bfe92e22143a0546144f213e9b174e4aafd5


### PR DESCRIPTION
Adds Scapestack Sync v0.2.0, a RuneLite plugin that syncs opt-in account-progress signals to Scapestack so /next can stop guessing from public Hiscores alone.

## Current review state
- Plugin Hub PR: #12536
- Status: Plugin Hub PR #12536 open
- Detail: Awaiting RuneLite maintainer review. Use developer install while the Plugin Hub submission is pending.
- Review decision: No RuneLite reviews recorded yet. Keep the PR body, pinned commit and reviewer packet ready before a maintainer starts review.
- Checks: Build is passing; RuneLite Plugin Hub Checks is the maintainer review gate.
- Pin: Plugin Hub pin matches standalone repo head 5244bfe.
- PR body copy: Live PR body appears aligned with current consent, token, data and web-handoff wording.
- Plugin Hub pin: 5244bfe92e22143a0546144f213e9b174e4aafd5
- Standalone repo head: 5244bfe92e22143a0546144f213e9b174e4aafd5

## What it captures after player opt-in
- RSN used for the claim
- Plugin version and sync status
- Quest and diary completion
- Loaded collection-log item IDs
- Slayer task, points, streak and block-list state
- Local install token only as Authorization bearer on claim/sync requests

## What it never captures
- RuneScape password or account login
- bank, inventory, equipment or GE offers
- chat messages, friends list or private messages
- mouse clicks, key presses or gameplay inputs
- screenshots, client files, config folders, IP or machine fingerprint

## Game integrity
- Read-only plugin: it reads RuneLite client state and never clicks, types, swaps menus, changes prayers, moves the player or performs game actions.
- No overlays, alerts or in-client recommendations that could automate gameplay decisions; recommendations live in the external web app after opt-in sync.
- No item, inventory, equipment, bank, trade, GE offer or wealth data is collected by the plugin.

## Consent defaults
- Auto-sync on login defaults off.
- Sync on quest complete defaults off.
- Quest-complete sync is also gated behind Auto-sync on login; enabling the quest-complete setting alone never sends a payload.
- No progress POST happens until the player enables Auto-sync on login from RuneLite settings.
- Show chat feedback defaults on so players see when sync starts, succeeds, fails, or needs a fresh claim.

## Network and auth
- Default endpoint: `https://www.scapestack.org/api/sync`.
- The claim endpoint is derived as `/api/sync/claim` from the configured sync URL.
- The raw local install token is sent only as an `Authorization: Bearer <token>` for claim/sync requests.
- Scapestack stores `sha256(token)` for the RSN claim; it does not store the raw token.
- HTTP claim/readiness/sync work runs on a background Thread, not RuneLite's client thread.
- Shutdown cancels the active OkHttp call and suppresses further chat feedback while the background worker returns normally.

## Web-app merge behavior
- Successful sync chat includes the verified `/next?rsn=...&source=plugin-sync&bank=none` link for that RSN.
- `bank=none` is intentional: RuneLite sync does not send bank, inventory, equipment, GE offers or wealth.
- Players can still paste a bank into the web app separately; that browser-only bank context is never sent to the plugin.
- While Plugin Hub review is pending, Scapestack still works with Hiscores, bank paste, TempleOSRS, WOM and collectionlog.net.

## Web-app merge contract
- The plugin is an account-progress verifier, not a bank uploader.
- Successful sync chat links to `/next?rsn=...&source=plugin-sync&bank=none` so the web app treats RuneLite payloads as bankless by default.
- `source=plugin-sync` tells Scapestack to load the verified account payload for coverage labels; it does not remove bank, gear or tracker caveats by itself.
- `bank=none` prevents stale browser bank context from being silently reused after a plugin-only sync.
- Players who want gear-aware advice paste Bank Memory or Bank Tags into the web app separately; that browser-only bank context is never sent back to RuneLite.
- /next, /slayer, /dps, /goals and player profiles all show readiness rails so players can see Bank, RSN and RuneLite sync as separate evidence signals.
