### PR TITLE
Add Player Circles plugin

### DIFF
--- a/plugins/playercircles
+++ b/plugins/playercircles
@@ -1,2 +1,2 @@
-repository=https://github.com/iiceJ/player-circles
-commit=e50555cf6868857d7dc8b490ea98b9a2b0a4e72b
+repository=https://github.com/iiceJ/player-circles.git
+commit=720d579b4fdd878b397809307f57a066008a4f20

--- a/plugins/playercircles
+++ b/plugins/playercircles
@@ -1,0 +1,2 @@
+repository=https://github.com/iiceJ/player-circles
+commit=e50555cf6868857d7dc8b490ea98b9a2b0a4e72b

--- a/plugins/playercircles
+++ b/plugins/playercircles
@@ -1,2 +1,2 @@
 repository=https://github.com/iiceJ/player-circles.git
-commit=720d579b4fdd878b397809307f57a066008a4f20
+commit=d6879bc3af474429bff6e1aa984cb9867e22efe0


### PR DESCRIPTION
Draws a configurable circle or ring under players.

- 3D disc rendered in-world (occluded by models naturally)
- 2D overlay ring with solid or dashed outline
- Per-type colors for self, friends, clan, team, and PVP
- True tile support for own player