### PR TITLE
Add Item Tracker plugin

### DIFF
--- a/plugins/item-tracker
+++ b/plugins/item-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/Oveduumnakal/Item-Tracker-Plugin.git
+commit=adfe9b0a30be09638da28c163222284cc1a03628
+authors=Oveduumnakal

--- a/plugins/item-tracker
+++ b/plugins/item-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Oveduumnakal/Item-Tracker-Plugin.git
-commit=adfe9b0a30be09638da28c163222284cc1a03628
+commit=047212359d47a377a6a9aed2b310f1f2f9b41b7b
 authors=Oveduumnakal


### PR DESCRIPTION
Adds the **Item Tracker** plugin.

Track the quantity and value of gathered or processed items, with a side panel, live wiki/GE prices, and tracked-item highlighting.

Repository: https://github.com/Oveduumnakal/Item-Tracker-Plugin