### PR TITLE
Update drop-history

### DIFF
--- a/plugins/drop-history
+++ b/plugins/drop-history
@@ -1,2 +1,2 @@
 repository=https://github.com/markuskkramer/drop-history.git
-commit=39c44230ce79fc849b2369a959b7c7f1f4c4c8fc
+commit=82a5ddbd44f6ac8ead53126e5e2dab351befdc95


### PR DESCRIPTION
Updates Drop History to 65d762df2ec808908c9a9b63f13f6eb4508b60e0.

Changes since the published version:
- Fix the historical loot tracker import silently failing for users without local loot data (no longer writes the import-done flag when nothing was found; retries on startup)
- Import loot records missing a kill count as "KC unknown" instead of discarding them
- Add screenshot-based historical import (collection log entry screenshots, plus exact KCs from boss kill screenshot filenames)
- Add optional Wise Old Man KC estimation for drops where only the date is known (config-toggleable, lazy, one request per record)
- Show a compact summary for items with very many recorded drops
- Show source and obtained date in tooltips