### PR TITLE
Update pvp-performance-tracker to v1.7.4

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=ae0e3020a15a5f99ad68923d96a9ae8d22e3a4e9
+commit=ad8bf72b1907593dcda08860132c93223ebc76cf


### PR DESCRIPTION
New opt-in feature which automatically uploads all of your fights to the PvP-Hub website, where it can be publicly viewed by anyone. This is disabled by default. When 2 of the same fight is uploaded, fight data is merged for more accurate results.

This properly includes the warning attribute on the config, which clearly states: "This feature will submit your RSN, fight logs, and IP address to a 3rd-party server not controlled or verified by Runelite developers."

More discussion, including links to the website itself + its github repo can be found here: https://github.com/Matsyir/pvp-performance-tracker/pull/78

Many thanks to @LogicalSoIutions for creating this feature and hosting the website!

Edit:
1) The initial commit had a build error due to `new okHttpClient()`, it's been replaced with an Inject and re-tested
2) Then I had to add the build=standard parameter to the plugin.properties. I'm honestly not too sure if I should use standard or gradle, but I don't think I have any fancy build steps in neither build.gradle, or settings.gradle, so standard should be fine