### PR TITLE
Update ping-check

### DIFF
--- a/plugins/ping-check
+++ b/plugins/ping-check
@@ -1,2 +1,2 @@
 repository=https://github.com/jaesicc/ping-check.git
-commit=4dc45c0ed32448181f7f032b382f796150c42595
+commit=68dd3b4928cb3e0ea967a2eca5874f9404cbc26f


### PR DESCRIPTION
## Summary
Many users did not expect to have to configure the ping threshold out of the box, and were confused why it wasn't alerting with pings they felt were high, but lower than the default threshold. Let's lower the default threshold to prioritize working out-of-the-box.