### PR TITLE
Add Bank Highlight Search

### DIFF
--- a/plugins/bank-highlight-search
+++ b/plugins/bank-highlight-search
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/Highlight-Search.git
-commit=763c1acb3068e0abc4268a09f51a5d1c7feceac3
+commit=e7d4c1dc3b8d760b47545e8b372b6f99f4c3dc06

--- a/plugins/bank-highlight-search
+++ b/plugins/bank-highlight-search
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/Highlight-Search.git
-commit=e7d4c1dc3b8d760b47545e8b372b6f99f4c3dc06
+commit=316e035322fc8744355882015658104539bbbd5e

--- a/plugins/bank-highlight-search
+++ b/plugins/bank-highlight-search
@@ -1,0 +1,2 @@
+repository=https://github.com/Reasel/Highlight-Search.git
+commit=763c1acb3068e0abc4268a09f51a5d1c7feceac3


### PR DESCRIPTION
Adds Bank Highlight Search: search the bank with a hotkey and highlight matching
items (blinking/feathered outline) instead of filtering them out; Enter
switches to the ALL tab and scrolls to where the most matches are visible.

Repository: https://github.com/Reasel/Highlight-Search