### PR TITLE
Add ImplingFinderRT plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -1,0 +1,1 @@
+https://github.com/Koopy98/ImplingFinderRT


### PR DESCRIPTION
Replaces the Oracle Cloud backend in the existing ImplingFinder plugin with 
Supabase for real-time impling location sharing. Data delay reduced from ~2 
minutes to 2-5 seconds. Adds jar NPC IDs and batch posting.