### PR TITLE
Takeover impling-finder - real-time Supabase backend replacement

### DIFF
--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=a418c3fc99928b8b7a1185ff0d3e71a462a934c7
+commit=375835e
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings to a 3rd party database not controlled or verified by the RuneLite Developers.

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=375835e921ad20c5ac34cf6932e6e17ff1ca6163
+commit=294d193371c3645636b6a176e736654064d1177d
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings to a 3rd party database not controlled or verified by the RuneLite Developers.

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=294d193371c3645636b6a176e736654064d1177d
+commit=a418c3fc99928b8b7a1185ff0d3e71a462a934c7
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings to a 3rd party database not controlled or verified by the RuneLite Developers.

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,5 +1,4 @@
-repository=https://github.com/Hablapatabla/ImplingFinder.git
+repository=https://github.com/Koopy98/ImplingFinderRT.git
 commit=a418c3fc99928b8b7a1185ff0d3e71a462a934c7
-authors=Hablapatabla,Elvonia
-warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
-
+authors=Hablapatabla,Elvonia,Koopy98
+warning=This plugin submits the location and time of found implings to a 3rd party database not controlled or verified by the RuneLite Developers.

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=375835e
+commit=375835e921ad20c5ac34cf6932e6e17ff1ca6163
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings to a 3rd party database not controlled or verified by the RuneLite Developers.

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=a418c3fc99928b8b7a1185ff0d3e71a462a934c7
+commit=944ad27c281c8395df2cec989efb7d5bb1d3dffb
 authors=Hablapatabla,Elvonia,Koopy98
-warning=This plugin submits the location and time of found implings to a 3rd party database not controlled or verified by the RuneLite Developers.
+warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Requesting plugin takeover of impling-finder per the plugin takeover policy.

The original Oracle Cloud backend has been non-functional (~2 minute delays) 
for an extended period, rendering the plugin essentially broken for its 
intended purpose. The last commit to the repository was March 10, 2025 — 
over 15 months ago with no development activity.

I have built a complete replacement using a Supabase real-time backend, 
reducing data delay from ~2 minutes to 2-5 seconds. Additional improvements:
- All 14 impling types tracked (original only tracked 5)
- Batch posting replaces one-request-per-impling
- Fully automatic operation, no user configuration required
- Per-type display filters in the config panel
- Jar NPC IDs properly tracked and normalized

I contacted the original author via GitHub issues on June 11, 2026 and have 
not received a response. The plugin qualifies for immediate takeover as it 
has been incompatible/non-functional for more than 60 days.

New repository: https://github.com/Koopy98/ImplingFinderRT
Original author contact: https://github.com/Hablapatabla/ImplingFinder/issues