### PR TITLE
Add NPC Location Logger

### DIFF
--- a/plugins/npc-location-logger
+++ b/plugins/npc-location-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/JensDevWoW/npc-location-logger.git
+commit=af461de1e2c2ebfd6ddb6914c1588a2693a18924


### PR DESCRIPTION
Adds the NPC Location Logger plugin.

Tracks NPCs in the loaded scene and exports their world coordinates and screen positions to a JSON file at configurable intervals. Supports filtering by NPC name, append mode for historical snapshots, and optional chat message on export.

**Checklist:**
- [x] I have read [the contribution guide](https://github.com/runelite/plugin-hub/blob/master/CONTRIBUTING.md)
- [x] My plugin does not use any prohibited APIs or packages
- [x] My plugin does not use any Jagex code