### PR TITLE
Update 07flip to b060ced

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=08a3f8006b1c663949dd61d0ce6a5b2d2a47fe7b
+commit=d5315439903e6a3172a185280bcae89f6819c838
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Update 07flip plugin to commit b060ced.

Summary of changes in this update:
- The plugin's Item tab can now open automatically showing details for the item the player is setting up a GE buy or sell offer for (optional, can be turned off in settings).
- Friendlier handling when item data fails to load - a retry button and suggested items instead of a bare error message.
- The Item tab shows more market detail: longer price-chart periods (7d/30d), price ranges, volume, and additional stats for subscribed users.
- New settings to show/hide each section of the Item tab individually.