### PR TITLE
Add Rune Loot plugin

### DIFF
--- a/plugins/rune-loot
+++ b/plugins/rune-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/PtrStruct/rune-loot.git
-commit=92e600242fe0af9adad6d2f05def611b3febd80b
+commit=4298697cdf97d72ce55332a62da4b1a71bb16b45

--- a/plugins/rune-loot
+++ b/plugins/rune-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/PtrStruct/rune-loot.git
-commit=0a28b7975309fcdc5a69b92bc0863293d3f37d06
+commit=af8c680faec72ac2a0504df94e44c5ec8a8d316f

--- a/plugins/rune-loot
+++ b/plugins/rune-loot
@@ -1,0 +1,2 @@
+repository=https://github.com/PtrStruct/rune-loot.git
+commit=27b1fcaa03e48e9d874f30a9c3efc99cf5618644

--- a/plugins/rune-loot
+++ b/plugins/rune-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/PtrStruct/rune-loot.git
-commit=c95d88fad81e3bb59c272bdb25fd5cae481083dc
+commit=0a28b7975309fcdc5a69b92bc0863293d3f37d06

--- a/plugins/rune-loot
+++ b/plugins/rune-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/PtrStruct/rune-loot.git
-commit=af8c680faec72ac2a0504df94e44c5ec8a8d316f
+commit=92e600242fe0af9adad6d2f05def611b3febd80b

--- a/plugins/rune-loot
+++ b/plugins/rune-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/PtrStruct/rune-loot.git
-commit=27b1fcaa03e48e9d874f30a9c3efc99cf5618644
+commit=c95d88fad81e3bb59c272bdb25fd5cae481083dc


### PR DESCRIPTION
Shows an animated popup at the top of the screen when you receive a drop at or above a configurable GP threshold.
Displays the item icon, name, and GE value. Supports NPC drops, PvP, raids, clue scrolls, and other loot events.