### PR TITLE
Update Purple Sweet Tracker

### DIFF
--- a/plugins/purple-sweet-tracker
+++ b/plugins/purple-sweet-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/brodloy/purple-sweet-tracker.git
-commit=ff8c6ffd329f62efc63583aa16be454cccc28cd9
+commit=19f1900d2c745def6943a86fc1c56d9002de4daa


### PR DESCRIPTION
Updates Purple Sweet Tracker to commit `19f1900`.

Removes the volume slider, which was non-functional: `playSoundEffect(id, volume)` only honours the passed volume when the player's in-game sound effects are muted, so the slider had no effect for normal users. The eat sound now plays at the player's in-game sound-effects volume.

Builds with `gradlew build`; no external network calls.
