### PR TITLE
update brimhaven-agility to 1.4.1

### DIFF
--- a/plugins/brimhaven-agility
+++ b/plugins/brimhaven-agility
@@ -1,2 +1,2 @@
 repository=https://github.com/kagof/rl-plugin-brimhaven-agility.git
-commit=ef961b044c94888595c85edc70d8c0c37631a305
+commit=dc80c9a2d3d16d1147ec51985fac9304e37b4963


### PR DESCRIPTION
Not much that's really visible to end users in this update, mainly just some internal improvements.

The most visible change is removing some times when the path in the Brimhaven agility arena would be recalculated unnecessarily which was wasteful and could sometimes lead to a different path showing up (if they have the same end weight).

Other than that
* simplifies the layout file from double-entry to single-entry
* adds some better debug logging & logback configuration when running in dev mode