### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=9c08d94780573fe096be1f6827e186b97f2f4327
+commit=375b791d121657792ca21cfbb3ff1489988f864e
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
- Auto mode keeps focus locked on the item you're listing while the GE offer-setup screen is open (no mid-setup switching)
- Standardized the plugin name to "FlipSmart"
- Auto mode now drops a stale recommendation when Flip Finder refreshes its pool and surfaces a fresh one