### PR TITLE
Add veges-pk-guide

### DIFF
--- a/plugins/veges-pk-guide
+++ b/plugins/veges-pk-guide
@@ -1,0 +1,2 @@
+repository=https://github.com/Damms/veges-group-bronzeman.git
+commit=268c414d76dcf1042fa74be8e19ffb542286c1aa


### PR DESCRIPTION
**Veges PK Guide** — a read-only sidebar guide for the Veges Group Bronzeman.

It shows the main PK build paths (1 Def Pure, 40 Def, Zerker, Med, plus a pivot guide) and a per-build quest checklist. The checklist auto-ticks quests you have completed by reading in-game quest state, and shows each quest's skill-level requirements coloured met/unmet against your real skill levels.

No gameplay automation, no input injection, no network/HTTP, and no crowdsourcing — it only reads the local player's own quest and skill state to drive the display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)