### PR TITLE
Add veges-pk-guide

### DIFF
--- a/plugins/veges-pk-guide
+++ b/plugins/veges-pk-guide
@@ -1,0 +1,2 @@
+repository=https://github.com/Damms/veges-group-bronzeman.git
+commit=6e98ccb887ad1420508a4bcc458d1e285560d79d


### PR DESCRIPTION
**Veges PK Guide** — a read-only sidebar guide for the Veges Group Bronzeman.

It shows the main PK build paths (1 Def Pure, 40 Def, Zerker, Med, plus a pivot guide), each with a tickable quest checklist and progress bar. The checklist auto-ticks quests you have completed by reading in-game quest state, and shows each quest's skill-level requirements coloured met/unmet against your real skill levels.

No gameplay automation, no input injection, no network/HTTP, and no crowdsourcing — it only reads the local player's own quest and skill state to drive the display.