### PR TITLE
update special-attack-timers

### DIFF
--- a/plugins/special-attack-timers
+++ b/plugins/special-attack-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/AnuVen/special-attack-timers.git
-commit=37707829d8878c3386ee37ee6189570f8b206cd0
+commit=12c7a4912f01fb089a349e896774b9990507272a


### PR DESCRIPTION
Adds an optional 'Time to full' tooltip on the spec orb