### PR TITLE
veges-pk-guide: prerequisite trees and collapsing completed quests

### DIFF
--- a/plugins/veges-pk-guide
+++ b/plugins/veges-pk-guide
@@ -1,2 +1,2 @@
 repository=https://github.com/Damms/veges-group-bronzeman.git
-commit=6e98ccb887ad1420508a4bcc458d1e285560d79d
+commit=2f6395eaaafc02ba4269b2cf43ea998ecc77c263


### PR DESCRIPTION
Updates the Veges PK Guide plugin to the latest commit.

Changes since the last release:
- Adds a recursive prerequisite-quest tree under each quest, showing required quests and their transitive prerequisites with per-level skill requirements marked met/unmet, plus a "Show all prerequisites" toggle.
- Completed quests in the checklist now collapse to a single struck-through line, with an optional "Hide completed quests" toggle.

No new permissions or external requests; the plugin remains read-only over the local player's own quest and skill state.