### PR TITLE
Add bingo-discord-logger plugin repository details

### DIFF
--- a/plugins/bingo-discord-logger
+++ b/plugins/bingo-discord-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/Ronaldrc/bingo-discord-logger.git
+commit=91977bc815f3288b58126cde08885439454a0f53


### PR DESCRIPTION
Sends tracked item drops straight to a Discord channel via webhook.

Tracked item ID list is retrieved from google sheets (CSV). A screenshot of the next frame when a drop is logged and player information is sent to the discord webhook.