### PR TITLE
Update clogman-mode

### DIFF
--- a/plugins/clogman-mode
+++ b/plugins/clogman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/mozjay/clogman-mode.git
-commit=f04845be9027273e1dfd95e864bdc1f27c6951a9
+commit=3f37fcc73abe609129676a0816291ef0d319b16a


### PR DESCRIPTION
Refreshed clog_restrictions.json: 
- excludes non-obtainable wiki item duplicates (LMS, etc.), and various small fixes to item dependencies
- new items since last refresh e.g. oathplate slayer helm, etc.