### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=375b791d121657792ca21cfbb3ff1489988f864e
+commit=d2cd3066d3d27ede908cac9af839a843eef810f5
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
- Fixed a performance issue where the plugin repeatedly requested daily-volume data every render frame while a Grand Exchange offer screen was open
- Auto mode now reliably surfaces a fresh recommendation when a GE slot frees up after collecting or cancelling, and partial-buy and sell cancels now prompt you to collect and re-sell the items instead of stalling
- The "Collect profit" and "Open GE History" prompts no longer overlay the buy/sell offer screens; while you're placing an order the item you're setting up is shown instead, and the prompts return when you leave the offer screen