### PR TITLE
Update Enchanted Symbol Protector

### DIFF
--- a/plugins/enchanted-symbol-protector
+++ b/plugins/enchanted-symbol-protector
@@ -1,2 +1,2 @@
 repository=https://github.com/ZacharyHJacobson/enchanted-symbol-protector.git
-commit=4b06876d17aea22103421840e0da1ef6fe2f2e4d
+commit=5d3cfa33bbcdfc8b2353d303b44b060c827439ef


### PR DESCRIPTION
1.2 release

Version updated to 1.2. Symbol click is consumed if Redemption or Vindication are active and the setting is enabled. Message is displayed in chat if errors are enabled and this new setting is activated.