### PR TITLE
update squeaky-toy 2.5

### DIFF
--- a/plugins/squeaky-toy
+++ b/plugins/squeaky-toy
@@ -1,2 +1,2 @@
 repository=https://github.com/H-Mill/Squeaky-Toy.git
-commit=f492a3490760ddb472a906484612e403055c3313
+commit=d9707a06bb6726143acd38bbb966f20d99be6bfa


### PR DESCRIPTION
- Add ability to rename Sound Groups
- Fix bug with unequipping weapons manually continuing to play previously equipped sfx