### PR TITLE
Update squeaky-toy 2.6

### DIFF
--- a/plugins/squeaky-toy
+++ b/plugins/squeaky-toy
@@ -1,2 +1,2 @@
 repository=https://github.com/H-Mill/Squeaky-Toy.git
-commit=d9707a06bb6726143acd38bbb966f20d99be6bfa
+commit=009794fe3b84860c5d170b0547f5ab28d609ee41


### PR DESCRIPTION
- Add NPC Exclusion user-defined options (npc id, npc name)
- Added path of het totem id's to be excluded from playing sfx (you damage them with a pickaxe while having another weapon equipped, confusing)