### PR TITLE
Update kill-clog to 1.4.2

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=f4ee7cfadc187f55cb82a9116371427d001ad36f
+commit=a19045b4e947dc05082378d035bc9891d40c07b4
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Kill Clog to 1.4.2.

Changes since 1.4.1:
- fixes ironmen with unsynced collection logs being shown as 0% profiles
- fixes rare clue bucket data for `!kclog` / `!missing`, and includes boss kc in command headers
- keeps the search-icon self lookup active after comparison-mode state changes
- tightens summary tooltip sizing so long ranks and values fit without border clipping
- uses quieter no-sync/no-data tooltip states, including dim player-colored dashes in comparison mode

Tested:
- `.\gradlew.bat compileJava checkstyleMain checkstyleTest test --rerun-tasks`

No new dependencies.