### PR TITLE
Add Bank Assistant

### DIFF
--- a/plugins/bank-assistant
+++ b/plugins/bank-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/jamesjmurtagh/runelite-bank-organiser-plugin.git
-commit=66631c11817ef4a208ce4433fbdaa93c7feb577c
+commit=e775a51d7908e08d862bc1abca5ec872714a2374

--- a/plugins/bank-assistant
+++ b/plugins/bank-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/jamesjmurtagh/runelite-bank-organiser-plugin.git
-commit=07a93975ed4bd910861a10ef68dbeb220d0a8ac4
+commit=508d67346cdc9c161caec956c0478d4d302f47b0

--- a/plugins/bank-assistant
+++ b/plugins/bank-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/jamesjmurtagh/runelite-bank-organiser-plugin.git
-commit=2527be9ae68bb523d12876cd54a85d8980565b10
+commit=07a93975ed4bd910861a10ef68dbeb220d0a8ac4

--- a/plugins/bank-assistant
+++ b/plugins/bank-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/jamesjmurtagh/runelite-bank-organiser-plugin.git
-commit=e775a51d7908e08d862bc1abca5ec872714a2374
+commit=2527be9ae68bb523d12876cd54a85d8980565b10

--- a/plugins/bank-assistant
+++ b/plugins/bank-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/jamesjmurtagh/runelite-bank-organiser-plugin.git
-commit=334829ff8dc0c01a37c1f4679e6e6fd1a0798793
+commit=66631c11817ef4a208ce4433fbdaa93c7feb577c

--- a/plugins/bank-assistant
+++ b/plugins/bank-assistant
@@ -1,0 +1,2 @@
+repository=https://github.com/jamesjmurtagh/runelite-bank-organiser-plugin.git
+commit=334829ff8dc0c01a37c1f4679e6e6fd1a0798793


### PR DESCRIPTION
Adds **Bank Assistant**, a bank-organisation plugin.

It re-lays-out the bank's all-items view into skill and combat-style category sections (Melee/Ranged/Mage Equipment, the gathering skills, consumables, teleports, etc.), with user-defined category overrides and Quest-Helper-style loadout checklists (placeholder items with have/need indicators).

It uses the same bank widget-layout and withdraw menu-remap technique as Quest Helper and Bank Tags. There is no automation — it only lays out widgets and corrects the slot index for user-initiated clicks.

Repo: https://github.com/jamesjmurtagh/runelite-bank-organiser-plugin

<img width="1552" height="902" alt="image" src="https://github.com/user-attachments/assets/ef51b452-1ccd-4b23-8d23-ef0e19b70f18" />


