### PR TITLE
Update 07flip to 8bcdcd0

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=d5315439903e6a3172a185280bcae89f6819c838
+commit=2cdc4121452d5f2f2475e85d71f1acd0dd3c6088
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Update 07flip plugin to commit 8bcdcd0.

This update adds a couple of new tabs and polishes the item view:

- **News tab** - shows OSRS game-update and blog posts with a short summary, the items each post is likely to affect, and a link to the full article.
- **Price alerts** - set a target buy or sell price on any item from the item view, and manage your alerts in one place.
- **Two new screeners** - "Band Flip" and "Event Recovery" for finding range-trade and post-event recovery opportunities.
- **Item view improvements** - shorter 2h/4h price-chart timeframes, a hover readout showing the exact price and time on the chart, a configurable default timeframe, and options to show or hide individual sections.
- **Grand Exchange helpers** - the recommended buy price now auto-fills when setting up a buy, and the item view opens automatically for whatever item you're trading, then returns you to your previous tab afterwards.