### PR TITLE
Add ClanSocket plugin

### DIFF
--- a/plugins/clansocket
+++ b/plugins/clansocket
@@ -1,0 +1,2 @@
+repository=https://github.com/osrs-clansocket/clansocket-plugin.git
+commit=af412f5ab6f323a2c538f268cdc4a8b7ed1a9cd5

--- a/plugins/clansocket
+++ b/plugins/clansocket
@@ -1,2 +1,2 @@
 repository=https://github.com/osrs-clansocket/clansocket-plugin.git
-commit=af412f5ab6f323a2c538f268cdc4a8b7ed1a9cd5
+commit=3c1e165d599489136e704c507f226d2e959f6c70

--- a/plugins/clansocket
+++ b/plugins/clansocket
@@ -1,3 +1,3 @@
 repository=https://github.com/osrs-clansocket/clansocket-plugin.git
-commit=1e7943ab1ddd1943af1ba52b6b13143f7283f302
+commit=fefd534d9766f459e3329be1abd9dfc4938b77c3
 authors=Varietyz

--- a/plugins/clansocket
+++ b/plugins/clansocket
@@ -1,2 +1,2 @@
 repository=https://github.com/osrs-clansocket/clansocket-plugin.git
-commit=3c1e165d599489136e704c507f226d2e959f6c70
+commit=1c10ad606058835cf3e9fff672817feaf039628b

--- a/plugins/clansocket
+++ b/plugins/clansocket
@@ -1,2 +1,2 @@
 repository=https://github.com/osrs-clansocket/clansocket-plugin.git
-commit=dec88605a8a997919d936715c74185acb4b5fcee
+commit=1e7943ab1ddd1943af1ba52b6b13143f7283f302

--- a/plugins/clansocket
+++ b/plugins/clansocket
@@ -1,2 +1,2 @@
 repository=https://github.com/osrs-clansocket/clansocket-plugin.git
-commit=7a5afc221f76815a511c418c0c390c271a63bfa5
+commit=dec88605a8a997919d936715c74185acb4b5fcee

--- a/plugins/clansocket
+++ b/plugins/clansocket
@@ -1,3 +1,4 @@
 repository=https://github.com/osrs-clansocket/clansocket-plugin.git
 commit=fefd534d9766f459e3329be1abd9dfc4938b77c3
 authors=Varietyz
+warning=This plugin submits your IP address, RSN, in-game location, and extensive account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clansocket
+++ b/plugins/clansocket
@@ -1,2 +1,2 @@
 repository=https://github.com/osrs-clansocket/clansocket-plugin.git
-commit=1c10ad606058835cf3e9fff672817feaf039628b
+commit=7a5afc221f76815a511c418c0c390c271a63bfa5

--- a/plugins/clansocket
+++ b/plugins/clansocket
@@ -1,2 +1,3 @@
 repository=https://github.com/osrs-clansocket/clansocket-plugin.git
 commit=1e7943ab1ddd1943af1ba52b6b13143f7283f302
+authors=Varietyz


### PR DESCRIPTION
Streams the player's own OSRS clan + gameplay telemetry over a single WebSocket to a clan-owned dashboard at clansocket.com. Endpoint is user-configurable (`wss://` only).

The server only persists data when the in-game clan has been claimed by an Owner / Deputy Owner; otherwise events are dropped silently.

24 per-stream toggles in the side panel. Full browse / export / wipe rights from clansocket.
Self-hostable web-platform.

Website: https://clansocket.com
Docs: https://github.com/osrs-clansocket/clansocket-plugin/wiki
Clansocket Web source code: https://github.com/osrs-clansocket/clansocket