### PR TITLE
Add next-star plugin for shooting star data

### DIFF
--- a/plugins/next-star
+++ b/plugins/next-star
@@ -1,0 +1,3 @@
+repository=https://github.com/keebleton/next-star.git
+commit=81510b85d5a65937783cb3708603fafbe70fef72
+warning=This plugin fetches shooting star data from a 3rd party website not controlled or verified by the RuneLite Developers, which exposes your IP address to that website.


### PR DESCRIPTION
next star reads the star miners shooting-star feed, ranks active stars by tier and easiest teleport, and draws a route to the best one through the shortest path plugin. read-only and informational, no input automation.