### PR TITLE
Add Lootlette

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,0 +1,2 @@
+repository=https://github.com/Diogo-G-Dias/lootlette.git
+commit=1e9bc2f8f1b83dd3032b9535a9ddf152d94988aa

--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=1e9bc2f8f1b83dd3032b9535a9ddf152d94988aa
+commit=2e2823daed84c60d08e51b4e4ad1b10b6e7e5dcf


### PR DESCRIPTION
Adds **Lootlette** — a fun plugin that turns every kill (and Sailing creature harvest) into a CS:GO-style slot-machine reel of the monster's drop table, landing on what you actually got, with rarity-coloured cells, roll counts, always-drop filtering and "Nothing" results.

Source: https://github.com/Diogo-G-Dias/lootlette

Notes for review:
- Drop tables ship **bundled** with the plugin (a trimmed snapshot of the OSRS Wiki `dropsline` bucket, ~180 KB gzipped), so it works fully offline with **no third-party request by default**.
- An optional "Live wiki fallback" setting (for monsters missing from the snapshot) makes requests to the OSRS Wiki; it is **off by default** and carries the standard IP-disclosure warning.
- Drop-table data is © the OSRS Wiki contributors (CC BY-NC-SA), attributed in the README.
