### PR TITLE
update squeaky-toy

### DIFF
--- a/plugins/squeaky-toy
+++ b/plugins/squeaky-toy
@@ -1,2 +1,2 @@
 repository=https://github.com/H-Mill/Squeaky-Toy.git
-commit=009794fe3b84860c5d170b0547f5ab28d609ee41
+commit=2391643fb8060701766e9a66fe9832791742831e


### PR DESCRIPTION
- Add Don't override Global option — when enabled, weapon-specific triggers no longer override the matching Global (All Weapons) triggers, so both sounds play. Disabled by default.
- Add more tooltips throughout the panel to better explain how things work.
- Replace the panel's collapse, rename, and delete buttons with PNG icons in place of the previous Unicode glyphs