### PR TITLE
Update helm-assist: fix domain + GE/shop price-check link (v2)

### DIFF
--- a/plugins/helm-assist
+++ b/plugins/helm-assist
@@ -1,2 +1,2 @@
 repository=https://github.com/MargoB2402/helm-assist.git
-commit=eb40cd98880809068a0f6bb60d71100cb87bd3de
+commit=0cdd59dcbb9a3b1fe6d0a72013bbb6c582af52f9


### PR DESCRIPTION
Updates the Helm Assist plugin to commit 0cdd59d:

- **Fix**: the price-check link pointed at the wrong domain (`osrstracker.sbs`, which does not resolve). Corrected to the live site, `osrstracker.app`.
- **v2**: the "View on OSRS Tracker" right-click price-check link now also works on the Grand Exchange search results / offer setup screen and on NPC shop interfaces (both the shop's stock and the player's inventory next to it). These widgets aren't backed by an `ItemContainer`, so the item id is read directly from the clicked widget's `getItemId()`.

No changes to the Reverse Sailing Alert feature or to network behaviour (still only `LinkBrowser.browse()` on explicit click).