### PR TITLE
Update to BankTabNames

### DIFF
--- a/plugins/bank-tab-names
+++ b/plugins/bank-tab-names
@@ -1,2 +1,2 @@
 repository=https://github.com/Psyda/bank-tab-names.git
-commit=c21369dd1f55e90f6316e25b95b30aa8637dd42a
+commit=f9d94c35ae6078dc1df9e2028926d81501dccaf1

--- a/plugins/bank-tab-names
+++ b/plugins/bank-tab-names
@@ -1,2 +1,2 @@
 repository=https://github.com/Psyda/bank-tab-names.git
-commit=b83653b9a20f381954b73e56aa74887656954bf5
+commit=c21369dd1f55e90f6316e25b95b30aa8637dd42a

--- a/plugins/bank-tab-names
+++ b/plugins/bank-tab-names
@@ -1,2 +1,2 @@
 repository=https://github.com/Psyda/bank-tab-names.git
-commit=b8c6ad04c2a7220035384356d24157be1e08f908
+commit=225a94164b5ce9af2463425be2a3562897b43feb

--- a/plugins/bank-tab-names
+++ b/plugins/bank-tab-names
@@ -1,2 +1,2 @@
 repository=https://github.com/Psyda/bank-tab-names.git
-commit=4e610a93dca9efb98322c1c30f29b0688cb51bbb
+commit=b8c6ad04c2a7220035384356d24157be1e08f908

--- a/plugins/bank-tab-names
+++ b/plugins/bank-tab-names
@@ -1,2 +1,2 @@
 repository=https://github.com/Psyda/bank-tab-names.git
-commit=daad23fb9c02328a8794ed4e233e6db24a29e027
+commit=4e610a93dca9efb98322c1c30f29b0688cb51bbb

--- a/plugins/bank-tab-names
+++ b/plugins/bank-tab-names
@@ -1,2 +1,2 @@
 repository=https://github.com/Psyda/bank-tab-names.git
-commit=f9d94c35ae6078dc1df9e2028926d81501dccaf1
+commit=daad23fb9c02328a8794ed4e233e6db24a29e027


### PR DESCRIPTION
Reopening #11105 

It has been reviewed here: https://github.com/runelite/plugin-hub/pull/11105, but I was unavailable for the last month to provide an update. Sorry for the delay, work has been rough, and the changes were implemented.

I removed the images I didn't create, so it now only includes my work. I also swappedthe awt.Desktop usage.

---

This replaces the single-icon sprite editor with a multi-icon system and overhauls how tab overlays are rendered.

Why: The old editor had a persistent issue where sprite IDs shuffled whenever the icon list updated, breaking user configs. The rendering was also clipped to the tab bar boundaries, limiting what users could do with custom icons and offsets. Both problems required a ground-up rethink rather than incremental patches .I held off on shipping incremental fixes because most of the reported problems shared root causes in the rendering and sprite ID systems. Fixing them properly meant reworking both at the same time.

What changed:
Tabs now support multiple icons (items, skills, game sprites, custom PNGs) with per-icon size, offset, z-index, and aspect-ratio-locked resizing. Icons and text render on Bankmain.INFINITE instead of Bankmain.TABS, removing the clipping limitation. Game sprite dimensions are resolved from SpritePixels.getMaxWidth/getMaxHeight rather than the trimmed BufferedImage from SpriteManager.getSprite(), which was causing sprites to render at wrong sizes.

The side panel got a scrollable icon editor, curated sprite category browser, fit toggle for stacking/overlay designs, config presets with import/export (versioned JSON), and panel visibility options.

See the updated README for full feature documentation.

Testing: Tested across all three tab display modes (item, digit, roman numeral), with bank settings page open/closed, with 1-8+ icons per tab, with custom user PNGs, and with various game sprites including non-square and padded sprites. Config migration from old single-icon format verified.

<img width="748" height="326" alt="image" src="https://github.com/user-attachments/assets/12f01ff3-985f-49da-a6a9-2f99837c97ef" />


<img width="2233" height="1207" alt="image" src="https://github.com/user-attachments/assets/5ab22863-aef2-4994-aee4-36b59883c873" />

<img width="1084" height="132" alt="image" src="https://github.com/user-attachments/assets/ad2542fa-2af2-4e6e-ac31-8bda302323e4" />

