### PR TITLE
Add Slayer Drop Prioritizer

### DIFF
--- a/plugins/slayer-drop-prioritizer
+++ b/plugins/slayer-drop-prioritizer
@@ -1,0 +1,3 @@
+repository=https://github.com/hamilton-junior/SlayerDropPrioritizer.git
+commit=1f59189cd250753a7259c7a554e0d287c3b62838
+authors=hamilton-junior

--- a/plugins/slayer-drop-prioritizer
+++ b/plugins/slayer-drop-prioritizer
@@ -1,3 +1,3 @@
 repository=https://github.com/hamilton-junior/SlayerDropPrioritizer.git
-commit=1f59189cd250753a7259c7a554e0d287c3b62838
+commit=c621b8e1b832281dd1909dc3577d3dea9f760c49
 authors=hamilton-junior


### PR DESCRIPTION
Adds the **Slayer Drop Prioritizer** plugin.

It reorganizes the ground-item right-click menu around the current Slayer task's drop table (resolved from the OSRS Wiki): prioritize, deprioritize, or hide non-task drops, with value/rarity filtering, optional highlight colors and markers, and priority-drop notifications.

Repository: https://github.com/hamilton-junior/SlayerDropPrioritizer