### PR TITLE
add aim-trainer

### DIFF
--- a/plugins/aim-trainer
+++ b/plugins/aim-trainer
@@ -1,0 +1,2 @@
+repository=https://github.com/NotCoco/nh-input-tweaks.git
+commit=4e2ef00dbaf84196ce054356fd236d23d54b3f97


### PR DESCRIPTION
﻿Adds the Aim Trainer plugin to Plugin Hub.

This is submitted as a separate `aim-trainer` entry rather than updating the disabled `nh-input-tweaks` entry. The referenced plugin commit is an Aim Trainer-only submission: it removes the old input-tweaks plugin source from the public submission branch and exposes only `com.nhtrainer.inputtweaks.NhAimTrainerPlugin` in `runelite-plugin.properties`.

Validation:
- `./gradlew.bat test` passed in the plugin repository submission worktree.
