### PR TITLE
log-basket: bump to 1.0.1

### DIFF
--- a/plugins/log-basket
+++ b/plugins/log-basket
@@ -1,2 +1,2 @@
 repository=https://github.com/aidanmastro/log-basket-plugin.git
-commit=2990a00c2a52d1d4eea106dd6043fdaec2d2fce2
+commit=d5cd7622384ac0d21c037d1f08880223def787cb


### PR DESCRIPTION
Picks up handling for the bank "Empty containers" button (Forestry update) and the "Your containers are already empty." message. Fixes the basket overlay being stuck at 28 after bulk emptying via bank or deposit box.