### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=d2cd3066d3d27ede908cac9af839a843eef810f5
+commit=341d8d3cee3b3647a8d206143c0d68c9f2bd3bf8
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
- Added Active-mode stale-offer advisor that polls the backend offer-action endpoint and surfaces wait, cancel, move-down, and exit recommendations on the flip panel, GE slot overlay, and main overlay
- Advisor price changes can be accepted via hotkey; overlay prompts show the full target price and a colored net profit/loss estimate
- Batched advisor requests into a single poll per cycle with per-offer fallback to reduce network overhead
- Fixed concurrent modification safety on the stale-offer collection and ensured slot highlights clear correctly when advice retracts or the queue drains
- Suppressed the collect prompt when the GE has nothing to collect
- Guarded the overlay renderer against a race between focus events and surface clears

<img width="960" height="400" alt="image" src="https://github.com/user-attachments/assets/e8092a5c-179a-43c3-bd6f-116c6b1442df" />


