### PR TITLE
Update one-tick-flick to v1.5.0

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,3 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=ef8dd1b79d68941806ee398ab41174c0d6f4ddf7
+commit=95714a3c383113b66ed5e74083f3fc98a245e7c3
+warning=When live logging is enabled, this plugin sends your IP address, RSN, and detailed combat log data to a third-party server not controlled or verified by RuneLite developers.

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=95714a3c383113b66ed5e74083f3fc98a245e7c3
+commit=4284a4ad8fee52056550f32affb17ee51317c128
 warning=When live logging is enabled, this plugin sends your IP address, RSN, and detailed combat log data to a third-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
- Fix issue where death event logged before final damage on the same tick caused the killing blow to start a new fight
- Add Runelogs.com live logging functionality