### PR TITLE
Add Overhead Overload plugin

### DIFF
--- a/plugins/overhead-overload
+++ b/plugins/overhead-overload
@@ -1,0 +1,2 @@
+repository=https://github.com/brodloy/overhead-overload.git
+commit=b2d59eb4e4592b91ed7af7531d9ee4b78a408ef5


### PR DESCRIPTION
Adds **Overhead Overload**.

It displays the Chambers of Xeric overload refresh timer (varbit `5418`, `COX_OVERLOAD_REFRESHES_REMAINING`) as a small tick countdown above the player, rather than as a corner infobox, with an optional text label on the refresh tick. It is purely a visual readout of information already present on screen and only renders while the player is overloaded in the Chambers.

- Source: https://github.com/brodloy/overhead-overload
- Builds with `./gradlew build` (compile + checkstyle pass)
- Icon included (`icon.png`, 48x71)