### PR TITLE
Update combat-logger to v1.5.0

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,3 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
 commit=4284a4ad8fee52056550f32affb17ee51317c128
-warning=When live logging is enabled, this plugin sends your IP address, RSN, and detailed combat log data to a third-party server not controlled or verified by RuneLite developers.

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=4284a4ad8fee52056550f32affb17ee51317c128
+commit=bfdfb2bb5560cb90e8d74f90e02b7db6bcc273d3

--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,3 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=ef8dd1b79d68941806ee398ab41174c0d6f4ddf7
+commit=4284a4ad8fee52056550f32affb17ee51317c128
+warning=When live logging is enabled, this plugin sends your IP address, RSN, and detailed combat log data to a third-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
- Fix issue where death event logged before final damage on the same tick caused the killing blow to start a new fight
- Add Runelogs.com live logging functionality