### PR TITLE
Update Overhead Overload to latest commit

### DIFF
--- a/plugins/overhead-overload
+++ b/plugins/overhead-overload
@@ -1,2 +1,2 @@
 repository=https://github.com/brodloy/overhead-overload.git
-commit=b2d59eb4e4592b91ed7af7531d9ee4b78a408ef5
+commit=46c50c76e7422ab7cfd7a56ca3d6a09c28f220c6


### PR DESCRIPTION
Updates **Overhead Overload** to the latest commit (`46c50c7`).

Documentation-only changes since the last accepted commit (README wording). No source or behaviour changes.

Source: https://github.com/brodloy/overhead-overload