### PR TITLE
Add Letterbox plugin

### DIFF
--- a/plugins/letterbox
+++ b/plugins/letterbox
@@ -1,0 +1,2 @@
+repository=https://github.com/randall-hash/letterbox.git
+commit=13f610b858529fc3ca9e0f7d815d1ac1617845e9


### PR DESCRIPTION
Adds **Letterbox** — renders the game at a smaller, configurable size centered in black space for the Resizable - Classic layout (a compact play area floating in black on large/ultrawide monitors).

Source: https://github.com/randall-hash/letterbox

How it works: it resizes the game **engine** component inside `ClientPanel` (not the canvas) and lets the panel's existing black background show in the margins. Because the engine genuinely renders at the smaller size, the interface reflows and mouse hit-detection stays correct.

Compliance notes:
- No network/HTTP, no IP submission to any third party (so no `warning=` line), no file I/O.
- No input injection, no menu entries / server actions, no reflection, Java 11.
- Listeners/timer/layout are all torn down in `shutDown` (the game returns to filling the window).

One thing I want to flag proactively re: the *"no moving or resizing click zones for 3D components"* guideline: Letterbox resizes the **entire** viewport **uniformly** — click targets get *smaller*, never larger, so it confers no targeting advantage. The built-in Stretched Mode is the precedent for whole-viewport scaling. Happy to adjust if you'd prefer a different approach.