### PR TITLE
update 2.7

### DIFF
--- a/plugins/squeaky-toy
+++ b/plugins/squeaky-toy
@@ -1,2 +1,2 @@
 repository=https://github.com/H-Mill/Squeaky-Toy.git
-commit=2391643fb8060701766e9a66fe9832791742831e
+commit=4b06c4401641110c94824436b7b94f8b2ccdf41e


### PR DESCRIPTION
- Fix the wrong sound playing on a ranged/magic hit when you switch weapons right after attacking. The hit now plays the sound of the weapon you actually attacked with.