### PR TITLE
log-basket: bump commit for version display

### DIFF
--- a/plugins/log-basket
+++ b/plugins/log-basket
@@ -1,2 +1,2 @@
 repository=https://github.com/aidanmastro/log-basket-plugin.git
-commit=2990a00c2a52d1d4eea106dd6043fdaec2d2fce2
+commit=d5cd7622384ac0d21c037d1f08880223def787cb

--- a/plugins/log-basket
+++ b/plugins/log-basket
@@ -1,2 +1,2 @@
 repository=https://github.com/aidanmastro/log-basket-plugin.git
-commit=d5cd7622384ac0d21c037d1f08880223def787cb
+commit=e1f5694788027291f11f3cdc493f322649023b23


### PR DESCRIPTION
Adds version=1.0.1 to runelite-plugin.properties so the hub shows a version string instead of the commit hash, and documents the beehive Forestry event as a known limitation in the README. No code changes...