### PR TITLE
Add overheal-save plugin

### DIFF
--- a/plugins/overheal-save
+++ b/plugins/overheal-save
@@ -1,3 +1,2 @@
 repository=https://github.com/idyet/overheal-save.git
 commit=676baa82c2fc756cc04a9e451161e84ae65195e2
-build=standard

--- a/plugins/overheal-save
+++ b/plugins/overheal-save
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/overheal-save.git
-commit=c6c9449aa5e8659207fdcb029f1d93c06f39f737
+commit=e1ead15f53f0c6e7d4d7dcfb85395c547e57617d

--- a/plugins/overheal-save
+++ b/plugins/overheal-save
@@ -1,0 +1,2 @@
+repository=https://github.com/idyet/overheal-save.git
+commit=fdd363cf1f92dbe60e690082981591605026f055

--- a/plugins/overheal-save
+++ b/plugins/overheal-save
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/overheal-save.git
-commit=e1ead15f53f0c6e7d4d7dcfb85395c547e57617d
+commit=704016aa226480531af2b1d615e251bb9208078b

--- a/plugins/overheal-save
+++ b/plugins/overheal-save
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/overheal-save.git
-commit=fdd363cf1f92dbe60e690082981591605026f055
+commit=676baa82c2fc756cc04a9e451161e84ae65195e2

--- a/plugins/overheal-save
+++ b/plugins/overheal-save
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/overheal-save.git
-commit=676baa82c2fc756cc04a9e451161e84ae65195e2
+commit=c6c9449aa5e8659207fdcb029f1d93c06f39f737

--- a/plugins/overheal-save
+++ b/plugins/overheal-save
@@ -1,2 +1,3 @@
 repository=https://github.com/idyet/overheal-save.git
 commit=676baa82c2fc756cc04a9e451161e84ae65195e2
+build=standard


### PR DESCRIPTION
# Summary

Overheal Save alerts the player when their overheal is about to decay. Can be alerted via HP orb arc, rapid heal prayer arc, and notification. The progress arc rendered over the HP orb and the rapid heal prayer matches the one used by Regeneration Meter, but flashes when within the warning window.

<img width="2110" height="1024" alt="2026-06-15_23-27-27" src="https://github.com/user-attachments/assets/1d9e98c3-783f-4316-b630-1ba88d00141a" />