### PR TITLE
anvil: collection-log tab, clan Discord notifications & OBS replay clips

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=c695554f3e56b37014201d349c7f92319ba08202
+commit=b8c972d41d46e2f725136625f320676478b02164
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=8e9fc6355af01cab4accb5cb5aadd80f58a450dc
+commit=e5093960ced5a346e88d2966f86a6fd1defcc8dc
 warning=This plugin submits your IP address and gameplay screenshots (bingo drops, deaths, PvP kills, rare drops, combat achievements) to a 3rd-party server (your configured Anvil site) and to Discord, not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=62daf217d1e3f19ebba5ae84604cb61395dd6e47
+commit=8e9fc6355af01cab4accb5cb5aadd80f58a450dc
 warning=This plugin submits your IP address and gameplay screenshots (bingo drops, deaths, PvP kills, rare drops, combat achievements) to a 3rd-party server (your configured Anvil site) and to Discord, not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=35be150f61e4fafab97f81704591e0acb999ad2d
+commit=c695554f3e56b37014201d349c7f92319ba08202
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=b8c972d41d46e2f725136625f320676478b02164
+commit=f0d35342327e20b8e926148707538a15b1f2736d
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
 commit=e5093960ced5a346e88d2966f86a6fd1defcc8dc
-warning=This plugin submits your IP address and gameplay screenshots (bingo drops, deaths, PvP kills, rare drops, combat achievements) to a 3rd-party server (your configured Anvil site) and to Discord, not controlled or verified by RuneLite developers.
+warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=e5093960ced5a346e88d2966f86a6fd1defcc8dc
+commit=d79ffdd8b4d2397052dbb16c46fcadf68ec458da
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=7fc4440eaf5d5ee3bf88118cc3b826fcadbf213f
+commit=83835785f6f1bac1368bc578d8896909f7b2aa6b
 warning=This plugin submits your IP address, RSN, and gameplay screenshots/clips (bingo drops, deaths, PvP kills, rare drops, combat achievements) to a 3rd-party server (your configured Anvil site) and to Discord webhooks you configure, and can control a local OBS instance to record and upload replay clips. These services are not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=83835785f6f1bac1368bc578d8896909f7b2aa6b
+commit=62daf217d1e3f19ebba5ae84604cb61395dd6e47
 warning=This plugin submits your IP address, RSN, and gameplay screenshots/clips (bingo drops, deaths, PvP kills, rare drops, combat achievements) to a 3rd-party server (your configured Anvil site) and to Discord webhooks you configure, and can control a local OBS instance to record and upload replay clips. These services are not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
 commit=62daf217d1e3f19ebba5ae84604cb61395dd6e47
-warning=This plugin submits your IP address, RSN, and gameplay screenshots/clips (bingo drops, deaths, PvP kills, rare drops, combat achievements) to a 3rd-party server (your configured Anvil site) and to Discord webhooks you configure, and can control a local OBS instance to record and upload replay clips. These services are not controlled or verified by RuneLite developers.
+warning=This plugin submits your IP address and gameplay screenshots (bingo drops, deaths, PvP kills, rare drops, combat achievements) to a 3rd-party server (your configured Anvil site) and to Discord, not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=f0d35342327e20b8e926148707538a15b1f2736d
-warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.
+commit=7fc4440eaf5d5ee3bf88118cc3b826fcadbf213f
+warning=This plugin submits your IP address, RSN, and gameplay screenshots/clips (bingo drops, deaths, PvP kills, rare drops, combat achievements) to a 3rd-party server (your configured Anvil site) and to Discord webhooks you configure, and can control a local OBS instance to record and upload replay clips. These services are not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Update of the **Anvil** plugin (companion for the Anvil clan-events / bingo platform).

This update brings the in-game side of the platform:

**Collection Log "Anvil" tab**
- Schedule view: your active event plus live / upcoming competitions.
- Bingo board rendered as a square grid, a Leagues-style points accordion, or a tile-race track (per event type), with a per-tile detail page.
- Weekly SOTW / BOTW leaderboards, plus read-only previews of events you're not competing in.

**In-game popups**
- A Collection-log-style unlock banner for bingo drops / tile completions.
- Optional banner sound (bundled clips, or a user-supplied `.wav` from the RuneLite directory).

**More auto-tracked tile types** — the existing "Auto Submit Drops" now also handles:
- NPC kill-count tiles (for mobs that aren't on the hiscores).
- Timed-clear tiles: times an activity (Inferno, CoX / ToB / ToA, Colosseum, Gauntlet, Nightmare, …) and submits the clear time when it's under the tile's threshold. The parsing is isolated and unit-tested against real chat formats.
- (Alongside the existing item-drop, collection-set, skill-XP and boss-KC tiles.)

**Clan notifications** — each individually toggleable, and they only fire when the clan has configured the matching Discord webhook on the Anvil site:
- Deaths, PvP kills, rare drops, pets, and combat-achievement tier clears → Discord webhooks. Deaths / rare-drops / pets / CAs default on; PvP kills default off.

**OBS replay clips** (opt-in, off by default)
- Connects to a local OBS via obs-websocket to save a replay clip on a hotkey and, when it's under the size limit, posts it to a configured Discord clips channel.

**Data / external services** (mirrored in the manifest `warning`)
- The Anvil-site submission (your IP, RSN, and screenshots) is unchanged from the original plugin. New in this update are the optional Discord-webhook posts and local OBS control described above. None of these destinations are controlled or verified by RuneLite.

Builds with the standard plugin-hub packager; `./gradlew test` passes.
