### PR TITLE
Update real-loot-key-value to 1.0.0 version

### DIFF
--- a/plugins/real-loot-key-value
+++ b/plugins/real-loot-key-value
@@ -1,2 +1,2 @@
 repository=https://github.com/pk-enjoyer/real-loot-key-value.git
-commit=d4252ab40e5d258ffeceb13e798aa55ffb68d031
+commit=2428504eb7e8096aa09ba9a28eb6c79144f70e4c


### PR DESCRIPTION
The plugin now makes beter use of the runelite API, the compact keys no longer overlays the loot chest UI at the top. It instead just calls the API and changes the value (It also saves the original displayed osrs value, so it can be reverted when the plugin is switched off). 

This also fixes an issue with other plugins that change the UI, our overlay would just overlay 'ugly' brown Runescape background over the no longer brown UI. 

That said, the "top right" version of the plugin still does this... not sure if ill ever make this pretty.

~- [ ] Fix the pictures in the README, as the old repo was deleted, meaning that the pictures url are now broken : (~