### PR TITLE
Update Hallowed Sepulchre Tracker

### DIFF
--- a/plugins/hallowed-sepulchre-tracker
+++ b/plugins/hallowed-sepulchre-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/aliomran93/hallowed-sepulchre-tracker.git
-commit=56001b18b02b109ead7a309c216bf2fd809aee34
+commit=2455328073f3e774fe9ffbef16a3d24c6475a8fe


### PR DESCRIPTION
This updates Hallowed Sepulchre Tracker to the latest version.

The main user-facing change is that goal projections now learn from the highest Sepulchre floor the player actually reaches, instead of assuming fixed floor unlock levels. That should make the "runs to next level" estimate behave correctly after moving from floor 4 to floor 5.

This update also includes the earlier tracker improvements: session-scoped run stats, more reliable daily stat persistence, fail counting, clearer panel labels.

