### PR TITLE
Add Mahogany Homes Highlighter plugin

### DIFF
--- a/plugins/mahogany-homes-highlighter
+++ b/plugins/mahogany-homes-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/youncc/MahoganyHomesHighlighter.git
+commit=db0ec69f5daf5ee5104d85b04c0f82aa042b82ff


### PR DESCRIPTION
## Summary
- Adds **Mahogany Homes Highlighter**, an overlay-only plugin that highlights Mahogany Homes contract objects with configurable colors for remove, build, and repair tasks.
- Complements the existing [Mahogany Homes](https://runelite.net/plugin-hub/show/mahogany-homes) plugin without duplicating contract tracking, supplies, or teleports.

## Test plan
- [ ] Enable plugin from Plugin Hub after merge
- [ ] Start a Mahogany Homes contract and verify hotspots highlight in the correct colors
- [ ] Confirm remove/build/repair colors match varb state as tasks are completed
- [ ] Toggle hull and clickbox render options in config