### PR TITLE
Update mahogany-homes-highlighter to 65b77e9

### DIFF
--- a/plugins/mahogany-homes-highlighter
+++ b/plugins/mahogany-homes-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/youncc/MahoganyHomesHighlighter.git
-commit=db0ec69f5daf5ee5104d85b04c0f82aa042b82ff
+commit=65b77e9020aeb78f8d0071d3a7bbdfd13b084a0f

--- a/plugins/mahogany-homes-highlighter
+++ b/plugins/mahogany-homes-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/youncc/MahoganyHomesHighlighter.git
-commit=65b77e9020aeb78f8d0071d3a7bbdfd13b084a0f
+commit=a3dcc145f09d4cd84b8a683cf9e98b2021ab2ce2


### PR DESCRIPTION
Bumps the plugin commit to include startup and contract highlighting fixes.