### PR TITLE
update squeaky-toy

### DIFF
--- a/plugins/squeaky-toy
+++ b/plugins/squeaky-toy
@@ -1,2 +1,2 @@
 repository=https://github.com/H-Mill/Squeaky-Toy.git
-commit=4b06c4401641110c94824436b7b94f8b2ccdf41e
+commit=55346844e7baa0fe6089619c1399bf5180b7100e


### PR DESCRIPTION
- Add a **Side Panel Priority** setting (in the plugin's config cog) to control where the Custom Weapon SFX icon sits in the RuneLite sidebar. Lower numbers sit higher; changes apply instantly without a restart.
- Small UI updates