### PR TITLE
Add Revenant Ether Loot Tracker Plugin

### DIFF
--- a/plugins/revenant-ether-loot-tracker
+++ b/plugins/revenant-ether-loot-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/lps-dot-dev/revenant-ether-loot-tracker.git
+commit=a6ed43c13a18e8b10f491e26f13f404679d141df


### PR DESCRIPTION
# Revenant Ether Loot Tracker

A RuneLite plugin designed to track and display how much **Revenant Ether** the player has received as loot well after the official limit of `65535` is exceeded.

#### But Why Tho?

This plugin was made for people like me who just like seeing number go up. Also I participate in bingo events where revenant ether is a form of contribution, so this plugin will make it easier for me and others with max revenant ether on their collection logs to contribute.

<img width="694" height="614" alt="revenant-ether-loot-tracker-example" src="https://github.com/user-attachments/assets/a3efd3db-0683-4894-a028-a21180a8e17d" />