### PR TITLE
Update to seca-tears

### DIFF
--- a/plugins/seca-tears
+++ b/plugins/seca-tears
@@ -1,2 +1,2 @@
 repository=https://github.com/STRIKERnz/Seca-Tears.git
-commit=3454fd670ebb9f1cbeb93aa6f5d7d4edc803b200
+commit=cdff58c9720549a448eda82b8e91f11be02033d1

--- a/plugins/seca-tears
+++ b/plugins/seca-tears
@@ -1,2 +1,2 @@
 repository=https://github.com/STRIKERnz/Seca-Tears.git
-commit=cdff58c9720549a448eda82b8e91f11be02033d1
+commit=8705fd299d0420954a17f2dddb47bd7ea3ca50c7


### PR DESCRIPTION
### 1.0.4 - 2026-06-17

- Fixed herb patch matching after Jagex changed grown herb object names from generic `Herb` labels to specific herb names.