### PR TITLE
Add Double Max

### DIFF
--- a/plugins/double-max
+++ b/plugins/double-max
@@ -1,2 +1,2 @@
 repository=https://github.com/rsvaultpudgy-create/double-max.git
-commit=a6da4a6b53a21c3bdf9885643d5ed74f24179dff
+commit=ae45a40cfaccee774b5da7735565da62d79ebcbd

--- a/plugins/double-max
+++ b/plugins/double-max
@@ -1,2 +1,2 @@
 repository=https://github.com/rsvaultpudgy-create/double-max.git
-commit=ae45a40cfaccee774b5da7735565da62d79ebcbd
+commit=54c3647813300070cba6758029fd2f695dcc557c

--- a/plugins/double-max
+++ b/plugins/double-max
@@ -1,0 +1,2 @@
+repository=https://github.com/rsvaultpudgy-create/double-max.git
+commit=a6da4a6b53a21c3bdf9885643d5ed74f24179dff


### PR DESCRIPTION
Adds Double Max — a cosmetic plugin that displays every skill as if one max (level 99's worth of XP, 13,034,431) were subtracted, so a maxed account can chase a second max. It rewrites the skills-tab numbers, hover tooltips, and skill total, adds an overlay (total + recalculated combat), and fires local level-up pop-ups. No automation or input and no real XP is changed — it uses the same client hooks as the built-in Virtual Levels plugin.