### PR TITLE
compatibility fix: static default tab positions instead of lazy capture

### DIFF
--- a/plugins/better-resizable-chat
+++ b/plugins/better-resizable-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/shanktank/better-resizable-chat.git
-commit=dcb2a8317cc06e79c864a1b2246e62be011b6072
+commit=6b6de68fdafd8d4ab63c13810d7ad62c0f955353


### PR DESCRIPTION
bug fix: static default tab positions instead of lazy capture to avoid capturing other plugins' moved positions as defaults