### PR TITLE
feat: Add Session Tracker Plugin

### DIFF
--- a/plugins/session-tracker
+++ b/plugins/session-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/samnooby/SessionTracker.git
-commit=d99ad0bde6fbd381a9a786e9176534ec9ee99aa7
+commit=2d7ed72d087ee32106957b25962a17aad095a743
 authors=mrnooby

--- a/plugins/session-tracker
+++ b/plugins/session-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/samnooby/SessionTracker.git
+commit=d99ad0bde6fbd381a9a786e9176534ec9ee99aa7
+authors=mrnooby

--- a/plugins/session-tracker
+++ b/plugins/session-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/samnooby/SessionTracker.git
-commit=2d7ed72d087ee32106957b25962a17aad095a743
+commit=84e11a9b13a9f8d8c4076786bee00aee1f7c1d8f
 authors=mrnooby


### PR DESCRIPTION
Session Tracker is a passive trip- and session-tracker for combat and skilling. It observes loot, XP, and inventory changes and shows what you gained and spent.

**Features**

Per-trip tracking: loot picked up vs. left on the ground, resources gathered, supplies used, items consumed, net GP, and XP.
Session roll-ups with GP/hr and XP/hr, plus per-trip averages.
Per-category stats, auto-named after the first monster killed or first item gathered, with per-item and per-skill breakdowns.
Live Grand Exchange valuation; each trip is stored with the prices captured when it ended.

**How it's different from the existing trackers**

RuneLite's Loot Tracker, XP tracker, and GP/value tools each surface one metric on its own. Session Tracker's focus is the trip: it ties kills, XP, GP, supplies, and loot together into a single per-trip and per-session view, so you can see everything a trip earned and cost in one place instead of cross-referencing several panels. As far as I can tell there isn't a consistent way to see your kills, XP, GP, and loot together for a given trip — that's the gap this fills, with the emphasis on per-trip and per-session stats rather than lifetime totals.

**Review notes**

Read-only: no automation, no input, no network calls.
Sessions are persisted locally under the RuneLite directory; nothing is sent anywhere.
Licensed BSD 2-Clause.
Source: https://github.com/samnooby/GoodRuneTracker

**Screenshots**
<img width="2968" height="1838" alt="image" src="https://github.com/user-attachments/assets/ea2b74ce-c18d-4a98-ad70-664e5a5b5756" />
<img width="2968" height="1838" alt="image" src="https://github.com/user-attachments/assets/c2cd3747-c50b-44dc-b3df-8616234bd362" />
<img width="2968" height="1838" alt="image" src="https://github.com/user-attachments/assets/925076f5-ada8-4550-9910-fcddf47d7d07" />
<img width="2968" height="1838" alt="image" src="https://github.com/user-attachments/assets/04b59a66-4f41-4d1f-ac4d-fee1140057b7" />
<img width="2968" height="1838" alt="image" src="https://github.com/user-attachments/assets/17c81dc0-1707-4972-a4fd-ce60e641cdbc" />

