### PR TITLE
Create bingo-discord-logger

### DIFF
--- a/plugins/bingo-discord-logger
+++ b/plugins/bingo-discord-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/Ronaldrc/bingo-discord-logger.git
-commit=5b840559007357ccd20b4ad9f8a7aacaffa7dc7d
+commit=d3c214de55ba308dacea26056c69ea2b767ba168

--- a/plugins/bingo-discord-logger
+++ b/plugins/bingo-discord-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/Ronaldrc/bingo-discord-logger.git
+commit=5b840559007357ccd20b4ad9f8a7aacaffa7dc7d


### PR DESCRIPTION
Sends bingo-relevant drops as a rich embed to a Discord channel via webhook with an optional screenshot.

Retrieves bingo list from a google sheet (CSV)