### PR TITLE
Update mahogany-homes-highlighter to 1bc7495

### DIFF
--- a/plugins/mahogany-homes-highlighter
+++ b/plugins/mahogany-homes-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/youncc/MahoganyHomesHighlighter.git
-commit=a3dcc145f09d4cd84b8a683cf9e98b2021ab2ce2
+commit=1bc74954816a075d46d6ee44024764dbea1aff56


### PR DESCRIPTION
## Summary
- Updates mahogany-homes-highlighter to commit 1bc74954816a075d46d6ee44024764dbea1aff56
- Adds door highlighting with open/closed colors and optional status text
- Adds stair/ladder highlighting with floor-aware task counts and turn-in hints
- Adds homeowner highlighting when the contract is complete
- Adds render options (outline, tile, border width, feather, fill opacity, clickbox colors, status text position)
- Adds optional Remove/Build/Repair labels on furniture
- Adds plugin icon with upstream attribution in LICENSE
- Updates README with full feature documentation

## Test plan
- [ ] Plugin Hub CI build passes
- [ ] Plugin loads in RuneLite with an active Mahogany Homes contract
- [ ] Furniture, door, stair, and homeowner highlights render as expected
- [ ] Plugin icon displays correctly in the plugin list