### PR TITLE
Update PvM Toolkit to 3.4.0

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=c20409af73426655083224b903237d4dc715f1d4
+commit=1dbc26746cedcd6928c40365735c3a81126790a3

--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=1dbc26746cedcd6928c40365735c3a81126790a3
+commit=52c80ed12ce7aa7eede8d9f45715f2a13f6e63e4

--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=a5d801ffa1ba8a12c4a294ec71646cbca798d288
+commit=84d0180688ddbecc6edfc4a2ee244498df102ff7

--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=52c80ed12ce7aa7eede8d9f45715f2a13f6e63e4
+commit=a5d801ffa1ba8a12c4a294ec71646cbca798d288


### PR DESCRIPTION
## What changed

- restores automatic PvM ownership of the shared chat-tab trackers when combat starts
- lets players click the All chat tab to switch manually between PvM Toolkit and Skilling Toolkit trackers
- keeps PvM Toolkit fully functional when Skilling Toolkit is not installed or is disabled

## Why

Both toolkits can use the same chat-tab and inventory surfaces. This update coordinates ownership explicitly so the active toolkit is shown without resetting either toolkit's accumulated tracker values.

## Validation

- `gradlew test shadowJar` with Java 11
- 2 PvM Toolkit tests passing
- full developer client started with both toolkits loaded

Companion Skilling Toolkit update: https://github.com/runelite/plugin-hub/pull/12822