### PR TITLE
Update ultimate-stat-tracker

### DIFF
--- a/plugins/ultimate-stat-tracker
+++ b/plugins/ultimate-stat-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/cabrilliant/UltimateStatTracker.git
-commit=5e990581345fb794821a6edb02d6d34d4d623077
+commit=e93bf5c73ede58f5a1ee737c5dae172317c087a3


### PR DESCRIPTION
Ultimate Stat Tracker Release Notes for v1.1.2
                "Fix a bug preventing scrolling in the main stat view
                "Add milestone messages for certain stat milestones(can be disabled in config)"