### PR TITLE
persistent-bank: read-path account-hash fix

### DIFF
--- a/plugins/persistent-bank
+++ b/plugins/persistent-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/rsvaultpudgy-create/persistent-bank-plugin.git
-commit=2278b9bcb3daea3804a8d8f6f47cc600ca0c9c7a
+commit=d2a09f080cdee2a3d9c98eb435b54fbcd6e3114f


### PR DESCRIPTION
Read-path counterpart to the merged #11993. SnapshotReader.readOne() had the same hash <= 0 gate as the write path, so the panel still dropped negative-signed accounts whose JSON files were on disk. Changes the read-side sentinel to hash == -1L. One-line change; build passes.