### PR TITLE
Add Lost Property Diary Tiers Plugin

### DIFF
--- a/plugins/lost-property-diary-tiers
+++ b/plugins/lost-property-diary-tiers
@@ -1,2 +1,2 @@
 repository=https://github.com/N1ck/lost-property-diary-tiers.git
-commit=ad5166e915378a1361f35a54ec12533822ceba44
+commit=265b0fb668c5a198d4384640cfa506a199f93818

--- a/plugins/lost-property-diary-tiers
+++ b/plugins/lost-property-diary-tiers
@@ -1,0 +1,2 @@
+repository=https://github.com/N1ck/lost-property-diary-tiers.git
+commit=ad5166e915378a1361f35a54ec12533822ceba44

--- a/plugins/lost-property-diary-tiers
+++ b/plugins/lost-property-diary-tiers
@@ -1,2 +1,2 @@
 repository=https://github.com/N1ck/lost-property-diary-tiers.git
-commit=265b0fb668c5a198d4384640cfa506a199f93818
+commit=8d29a292b80b5e6f06fd2239a950ee8ff07399a4


### PR DESCRIPTION
The Lost Property shop (Perdu/Chris) always shows the easy-tier icon for diary rewards, even when you've completed a higher tier. This plugin shows the tier you've actually earned instead, e.g. Karamja gloves 4 rather than the base gloves.

It's cosmetic, just changes the icon and name shown in the shop.

| Before | After |
|:------:|:-----:|
| <img width="505" height="329" alt="before" src="https://github.com/user-attachments/assets/d9767f7e-6cbd-4b7d-9064-7e6c6ca60595" /> | <img width="505" height="329" alt="Screenshot 2026-06-18 at 2 10 08 pm" src="https://github.com/user-attachments/assets/410569df-96b5-4cbd-94db-929d42ede923" />

