### PR TITLE
herblorerecipes: bump to v1.7.7

### DIFF
--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,2 +1,2 @@
 repository=https://github.com/climbridecode/herblore-recipes.git
-commit=a83fff50f2dc752f31ad141ff59b10fdd99bc478
+commit=0ab7898e91b13ee2dd09758ef08dd015e43c6bfa


### PR DESCRIPTION
Updates the herblorerecipes plugin to v1.7.7.

  Source commit: https://github.com/climbridecode/herblore-recipes/commit/0ab7898e91b13ee2dd09758ef08dd015e43c6bfa