### PR TITLE
Add RtaTrueTick

### DIFF
--- a/plugins/rta-true-tick
+++ b/plugins/rta-true-tick
@@ -1,0 +1,2 @@
+repository=https://github.com/rsvaultpudgy-create/rta-true-tick.git
+commit=e280d548854ba4fa8d87b3f733828e0733142560


### PR DESCRIPTION
Adds RtaTrueTick

a game-tick metronome -> with hotkeys to switch between cycle-length presets on the fly (for swapping rhythms mid-fight, e.g. boss phases). Adjustable number size, color, and height. Cosmetic overlay + hotkeys only. no automation, no input sending, no external access.