### PR TITLE
Update and rename corp-boosting-qol to pet-boosting-qol

### DIFF
--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,0 @@
-repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=4e8cc792bedb5431f825f1f25f0c698b7ae4dbfe

--- a/plugins/pet-boosting-qol
+++ b/plugins/pet-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/pet-boosting-qol.git
-commit=89e67c465250b6024d67fb4bf11ccf3d3e718d25
+commit=d53e138244a53e849182da7e056f9df0d527be90

--- a/plugins/pet-boosting-qol
+++ b/plugins/pet-boosting-qol
@@ -1,0 +1,2 @@
+repository=https://github.com/BPM-OSRS/pet-boosting-qol.git
+commit=89e67c465250b6024d67fb4bf11ccf3d3e718d25


### PR DESCRIPTION
Renaming plugin from "Corp Boosting QOL" to "Pet Boosting QOL" and expanding scope to cover Kalphite Queen, Giant Mole, and King Black Dragon in addition to Corporeal Beast. Updated repository URL to reflect the renamed repo. All original Corp features are preserved unchanged.