### PR TITLE
Update Lootlette to 1.0.1

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=2e2823daed84c60d08e51b4e4ad1b10b6e7e5dcf
+commit=816cc66b51ee469f5bb4c3f2cff793a729140cf7


### PR DESCRIPTION
Bumps Lootlette to 1.0.1.

Suppresses the slot reel for monsters whose drop table is entirely guaranteed ("Always") drops — e.g. the Theatre of Blood Maiden of Sugadinti, whose only line is Serafina's diary. Nothing is actually rolled for such tables, so the reel landing on "Nothing" was meaningless.