### PR TITLE
Update corp-boosting-qol

### DIFF
--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/pet-boosting-qol.git
-commit=fec614159ea1a055a9445cbf52810b7ed5018d9b
+commit=76ffb8421f77f65210b70351c1f9dbc1a3826445

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/pet-boosting-qol.git
-commit=76ffb8421f77f65210b70351c1f9dbc1a3826445
+commit=4e8cc792bedb5431f825f1f25f0c698b7ae4dbfe

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
-repository=https://github.com/BPM-OSRS/corp-boosting-qol.git
-commit=4e8cc792bedb5431f825f1f25f0c698b7ae4dbfe
+repository=https://github.com/BPM-OSRS/pet-boosting-qol.git
+commit=d53e138244a53e849182da7e056f9df0d527be90

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/pet-boosting-qol.git
-commit=4517cec87b588ed6143a66dbcf943e5b4d630077
+commit=fec614159ea1a055a9445cbf52810b7ed5018d9b

--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/pet-boosting-qol.git
-commit=d53e138244a53e849182da7e056f9df0d527be90
+commit=4517cec87b588ed6143a66dbcf943e5b4d630077


### PR DESCRIPTION
Updating repository URL and commit hash for corp-boosting-qol. The plugin has been expanded to cover Kalphite Queen, Giant Mole, and King Black Dragon in addition to Corporeal Beast. The display name has been updated to "Pet Boosting QOL" to reflect the broader scope. All original Corp features are preserved unchanged.