### PR TITLE
update bank-skill-sorting

### DIFF
--- a/plugins/bank-skill-sorting
+++ b/plugins/bank-skill-sorting
@@ -1,2 +1,2 @@
 repository=https://github.com/Frailrain/Bank-Skill-Sorting.git
-commit=9f400287bae2813b61b4de7ff411c2a9990f66dc
+commit=6aa9f293328698be30af86426fb441048ceb3f1c


### PR DESCRIPTION
Bumps the pinned commit for bank-skill-sorting.

Changes since the last pin:
- Classify separate-ID item variants so degraded/charge-depleted/trimmed gear no longer drops out of its tab (Barrows degradation states + ~80 charge/degrade/trim families, each mirroring its base's classification).
- Fix the collision-chooser dialog rendering (rows were collapsing to unusable slivers).

Builds clean against the pinned commit.
