### PR TITLE
Add wilderness-teleport-blocker plugin

### DIFF
--- a/plugins/wilderness-teleport-blocker
+++ b/plugins/wilderness-teleport-blocker
@@ -1,0 +1,2 @@
+repository=https://github.com/Aiyasei/wilderness-teleport-blocker
+commit=2cdaaa4


### PR DESCRIPTION
Adds the Wilderness Teleport Blocker plugin.

Prevents accidental casting of wilderness teleport spells  (Ancient, Arceuus Cemetery, Lunar Ice Plateau) by removing  their menu entries while keeping the spells visible on the  spellbook. Does not rearrange or reorder spells in the spellbook to do so. Has options to toggle off and on. Useful for players who want safety against misclicks from going into the wilderness.