### PR TITLE
squeaky-toy 2.9 update

### DIFF
--- a/plugins/squeaky-toy
+++ b/plugins/squeaky-toy
@@ -1,2 +1,2 @@
 repository=https://github.com/H-Mill/Squeaky-Toy.git
-commit=55346844e7baa0fe6089619c1399bf5180b7100e
+commit=21856f32517ea41936b3eead236caa41316711e6


### PR DESCRIPTION
- Add a Weight control to each sound in a group with multiple sounds. Set how likely each sound is to play relative to the others, the % beside it shows the resulting chance. Existing groups keep an even random pick.
- Add a test button to each sound group header that rolls the group's chance and plays a weighted sound at its volume, so you can preview chance, weights, and volume together. The per-sound preview button now uses the same icon in place of the previous Unicode glyph.
- Each sound now sits in its own box in the panel to make multi-sound groups easier to read.