### PR TITLE
Add Doom Unique Colors

### DIFF
--- a/plugins/doom-unique
+++ b/plugins/doom-unique
@@ -1,0 +1,3 @@
+repository=https://github.com/PattyRich/doom-unique.git
+commit=26a500de13548cbabe4b1a60162b704e1f7c442f
+


### PR DESCRIPTION
Adds Doom Unique Colors, a plugin that lets players customize the color of Doom of Mokhaiotl's special-loot.