### PR TITLE
Update chat-item-pricer-and-tooltips

### DIFF
--- a/plugins/chat-item-pricer-and-tooltips
+++ b/plugins/chat-item-pricer-and-tooltips
@@ -1,2 +1,2 @@
 repository=https://github.com/RagnaJDC/OSRS-Runelite-Chat-Item.git
-commit=0a96c7b45d1840e29459a4b9f630f2a7bcc525bb
+commit=ea512e056eccea8fa2865b1de1a1eade7fdebc2c


### PR DESCRIPTION
Fixed compatibility with other plugins that use chat text colours where item hover tooltips broke on messages with nested colour tags ([Chat-Item Issue #1](https://github.com/RagnaJDC/OSRS-Runelite-Chat-Item/issues/1)).

- Replaced regex `<col>` parsing with a nested tag parser for safer hover detection alongside other chat plugins
- Lowered chat message handler priority so other plugins apply colours first
- Item spans are matched by this plugin’s rarity colours only
