### PR TITLE
herblorerecipes: bump to v1.7.8

### DIFF
--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,2 +1,2 @@
 repository=https://github.com/climbridecode/herblore-recipes.git
-commit=a83fff50f2dc752f31ad141ff59b10fdd99bc478
+commit=4e9f27099f60916c910a1a1acf5a30dade3fb99c

--- a/plugins/herblorerecipes
+++ b/plugins/herblorerecipes
@@ -1,2 +1,2 @@
 repository=https://github.com/climbridecode/herblore-recipes.git
-commit=4e9f27099f60916c910a1a1acf5a30dade3fb99c
+commit=e1c05904ec3b2199ea0976c4a29f9d9bb100cd56


### PR DESCRIPTION
Updates the herblorerecipes plugin to v1.7.8.

  Source commit: https://github.com/climbridecode/herblore-recipes/commit/4e9f27099f60916c910a1a1acf5a30dade3fb99c