### PR TITLE
Add Combo Tags

### DIFF
--- a/plugins/combo-tags
+++ b/plugins/combo-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/HydraTal/combo-tags.git
-commit=f1d825a9640d35568fb828db1d4bd5029c4ce39c
+commit=ba1fd39bb09338fdccfd662fbb6121b6a731f5f1

--- a/plugins/combo-tags
+++ b/plugins/combo-tags
@@ -1,0 +1,2 @@
+repository=https://github.com/HydraTal/combo-tags.git
+commit=f1d825a9640d35568fb828db1d4bd5029c4ce39c


### PR DESCRIPTION
Adds **Combo Tags** — embeds smart "combo" cells in RuneLite's built-in bank tag layouts. Each cell stands in for an ordered group of items and renders the best item you currently own from that group (e.g. your highest melee helm), so one bank slot follows your gear progression. Members aren't individually tagged; membership is driven live from the group definition.

Repo: https://github.com/HydraTal/combo-tags