### PR TITLE
Add proximity-tags

### DIFF
--- a/plugins/proximity-tags
+++ b/plugins/proximity-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/richardverheyen/proximity-tags.git
-commit=7f6d544190e05780c332220fcece27b698843d67
+commit=afb179cee624da9e19e2b33724918f79a229bf61

--- a/plugins/proximity-tags
+++ b/plugins/proximity-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/richardverheyen/proximity-tags.git
-commit=afb179cee624da9e19e2b33724918f79a229bf61
+commit=a517d6895b0375504d2934739dceb34ec44ce4a8

--- a/plugins/proximity-tags
+++ b/plugins/proximity-tags
@@ -1,0 +1,2 @@
+repository=https://github.com/richardverheyen/proximity-tags.git
+commit=7f6d544190e05780c332220fcece27b698843d67


### PR DESCRIPTION
## What it does

Proximity Tags lets you add monsters by name from a sidebar panel and sets per-monster Danger/Warn/Safe distance thresholds (via a dual-thumb slider), each with its own fill/border RGBA colour. The monster's true tiles are outlined live based on current distance to the player.

Source: https://github.com/richardverheyen/proximity-tags