### PR TITLE
Update dynamic-inventory-tags

### DIFF
--- a/plugins/dynamic-inventory-tags
+++ b/plugins/dynamic-inventory-tags
@@ -1,3 +1,3 @@
 repository=https://github.com/BraveH/gear-switch-alert.git
-commit=8ae6e9511354b4df7f14bdf9f467027a7747cb3d
+commit=32065d9b0465a75f43b3785ffe5ebc3fd7f3f234
 authors=braveh,daltonpearson,tenaibms


### PR DESCRIPTION
Add special attack gear tag support

- Add Special gear tag with configurable purple highlight colour 
- Add Special tag option to inventory and profile panel menus 
- Show Special tag icon in the profile panel
- Use Special-tagged equipped weapons to activate Special mode
- Keep existing melee, ranged, and magic tag behaviour unchanged