### PR TITLE
Update kill-clog to 1.4.3

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=a19045b4e947dc05082378d035bc9891d40c07b4
+commit=46e128183ac3e6d6b39e87582feb0cf90f2e8c19
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Kill Clog to 1.4.3.

User-facing changes:
- Collection-log item sprites in tooltips now show the item name on hover and can open the OSRS Wiki when clicked.
- Added a `Wiki Item Links` config toggle, on by default.
- Added a single `Autosync chat messages` config toggle for local clog sync notices.
- Comparison clog totals now use the same hover/underline affordance as player names.
- `!3a` now matches the panel bucket: 3rd age ring stays under Mimic and no longer counts toward the 3rd age `/23` total.
- Quieter rare-bucket zero states for synced players with no 3rd age or gilded items.

Maintenance:
- Refactored large chunks of panel/plugin logic into focused helpers for search row state, panel icons, account badges, tooltip item hover/link behavior, manual/live clog sync, and visible clog category parsing.
- No client-to-server Kill Clog sync/upload code is included in this release.

Tested:
- `./gradlew compileJava checkstyleMain checkstyleTest test`
- Real-client smoke for tooltip spacing, resource-pack tooltip theming, wiki item hover/click behavior, comparison mode, and `!3a` ring behavior.