### PR TITLE
Add Better Goldsmithing

### DIFF
--- a/plugins/better-goldsmithing
+++ b/plugins/better-goldsmithing
@@ -1,0 +1,2 @@
+repository=https://github.com/Krisisonfire/better-goldsmithing.git
+commit=6d2c05a891efdde92c1ccf8ee9a3aa9d01d89262


### PR DESCRIPTION
Submitting **Better Goldsmithing**, a Blast Furnace helper that protects the Gauntlets of goldsmithing bonus XP on gold bars.

Repository: https://github.com/Krisisonfire/better-goldsmithing

**What it does**
- Removes the conveyor's deposit option while gold ore is held without the gauntlets equipped (a click then just walks you there).
- Locks the glove slot from when a deposit completes until the Smithing XP for it is credited, so the gauntlets aren't swapped off early.
- Hides the bar dispenser's "Check" option while it's empty, to avoid wasted clicks.

**Rule compliance**
- Every feature is individually toggleable.
- It only ever blocks or redirects the player's own clicks. It never injects input, never automates, and never sends any action to the server on the player's behalf.
- No reflection, no external dependencies, no crowdsourcing or HTTP.
- Licensed BSD 2-Clause.