### PR TITLE
Update current-spellbook

### DIFF
--- a/plugins/current-spellbook
+++ b/plugins/current-spellbook
@@ -1,2 +1,2 @@
 repository=https://github.com/PieOnRS/current-spellbook.git
-commit=37fa75deb350ac28b2dd9febc33311e8bf8d7732
+commit=d9b27e7b48896302db89fca12d1323cd502d4a08

--- a/plugins/current-spellbook
+++ b/plugins/current-spellbook
@@ -1,3 +1,2 @@
-repository=https://github.com/IceIceFuego/current-spellbook.git
-commit=da32be8dbcb88736e53ba6d9ddad934974853f4f
-disabled=true
+repository=https://github.com/PieOnRS/current-spellbook.git
+commit=37fa75deb350ac28b2dd9febc33311e8bf8d7732


### PR DESCRIPTION
Plugin takeover on the current spellbook plugin that was disabled and the repo was deleted by the original author.