### PR TITLE
lootlette: update to 1.0.2

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=816cc66b51ee469f5bb4c3f2cff793a729140cf7
+commit=bd65a6690051d0b7fa1730b7180be6ded71dca3b


### PR DESCRIPTION
Update Lootlette to 1.0.2.

Changes since 1.0.1:
- Hide the shared rare/gem/mega drop table from the reel by default (new config toggle), detected per-row so a monster's own drops are kept.
- Bundle in-game item ids so untradeable drops (pets, clue scrolls, boss uniques) render in the reel instead of being dropped by the GE-tradeable-only item search.
- Suppress the HP-zero pre-spin for multi-phase bosses (The Nightmare, Phosani's Nightmare, Verzik Vitur, Kalphite Queen) that empty their HP bar between phases.
- Don't roll for Theatre of Blood room bosses whose loot comes from the reward chest.
- Raids reward chest: anticipation reel on entering the reward room; purple chests roll only the unique table, white chests roll only the supplies (CoX/ToB/ToA).