### PR TITLE
Update Better Goldsmithing to 1.1

### DIFF
--- a/plugins/better-goldsmithing
+++ b/plugins/better-goldsmithing
@@ -1,2 +1,2 @@
 repository=https://github.com/Krisisonfire/better-goldsmithing.git
-commit=6d2c05a891efdde92c1ccf8ee9a3aa9d01d89262
+commit=ea55cad87dfb8322944981777d279c1828584468


### PR DESCRIPTION
Updates **Better Goldsmithing** to 1.1.

Repository: https://github.com/Krisisonfire/better-goldsmithing

**Changes**
- The glove lock now holds until the whole deposited batch has finished smelting (tracked via the in-game gold-ore furnace count) instead of releasing on the first XP drop, so the goldsmith bonus is no longer lost on bars that are still smelting.
- The safety auto-unlock now resets while bars are smelting, so it only triggers when genuinely stuck.
- Added a configurable, semi-transparent "no entry" icon drawn on gloves in the inventory while the slot is locked.

Same rule compliance as the original submission: every feature is toggleable, it only blocks/redirects the player's own clicks, no input injection, no automation, no external dependencies, BSD 2-Clause.