### PR TITLE
Add Prayer Audio Cues

### DIFF
--- a/plugins/prayer-audio-cues
+++ b/plugins/prayer-audio-cues
@@ -1,2 +1,2 @@
 repository=https://github.com/rvisek/runeliteplugin.git
-commit=32bd27549e6ab7949f1bc373218df9cc873b2169
+commit=f62ff997e42d50faa5a13d71d3fbacbe54ee4e58

--- a/plugins/prayer-audio-cues
+++ b/plugins/prayer-audio-cues
@@ -1,0 +1,2 @@
+repository=https://github.com/rvisek/runeliteplugin.git
+commit=7a7c1fd24c40b88785ac09fd42a451269f979770

--- a/plugins/prayer-audio-cues
+++ b/plugins/prayer-audio-cues
@@ -1,2 +1,2 @@
 repository=https://github.com/rvisek/runeliteplugin.git
-commit=2c8eb9eece459e76d0861abe9f0f30178c86aab9
+commit=32bd27549e6ab7949f1bc373218df9cc873b2169

--- a/plugins/prayer-audio-cues
+++ b/plugins/prayer-audio-cues
@@ -1,2 +1,2 @@
 repository=https://github.com/rvisek/runeliteplugin.git
-commit=7a7c1fd24c40b88785ac09fd42a451269f979770
+commit=2c8eb9eece459e76d0861abe9f0f30178c86aab9


### PR DESCRIPTION
### Prayer Audio Cues

An accessibility plugin that announces, by sound, which protection prayer to use as a boss attacks — turning visual-only attack tells into clear audio cues.

**Why / who it helps:** boss attack styles are normally signalled only visually (projectile colour, a brief animation, flame vs. shadow). That's a barrier for players who are blind/low-vision, colour blind, have visual-processing or reaction-time differences, or simply need to look away from a busy screen. The plugin maps each incoming attack to a distinct spoken cue.

**Informational only:** it plays a sound (and an optional chat line). It never activates prayers or takes any action for the player — it's an assistive cue, not automation.

**Details:**
- Cues are driven by the game's underlying attack data (animation / projectile / NPC ids), not on-screen colour, so they work regardless of colour vision.
- Bosses covered: Yama, TzTok-Jad, Hunllef (Gauntlet), Cerberus, Vorkath, Zulrah, Great Olm, and all Tombs of Amascut bosses (Akkha, Zebak, Kephri, Ba-Ba, Wardens). Each has its own toggle.
- Options: "only when a prayer switch is needed" (reduces noise), volume control, two bundled voice packs, and a test hotkey to learn/preview cues outside a fight.
- All bundled audio is original/self-made and licensed under the repo's BSD 2-Clause license.

Repo: https://github.com/rvisek/runeliteplugin