### PR TITLE
Update Better Goldsmithing to 1.2

### DIFF
--- a/plugins/better-goldsmithing
+++ b/plugins/better-goldsmithing
@@ -1,2 +1,2 @@
 repository=https://github.com/Krisisonfire/better-goldsmithing.git
-commit=ea55cad87dfb8322944981777d279c1828584468
+commit=b970d820f3bd2dc7494cf844fc8b3bfdc8c557a4


### PR DESCRIPTION
Updates **Better Goldsmithing** to 1.2.

Repository: https://github.com/Krisisonfire/better-goldsmithing

**Change**
- Fixes an intermittent case where the glove lock would occasionally not arm after a deposit. The lock previously relied solely on catching the deposit click; it now also arms from a self-contained game-state signal (the furnace's gold-ore count rising while the gauntlets are equipped), so a missed click/flag handoff no longer leaves the gloves unlocked.

Same rule compliance as before: every feature is toggleable, it only blocks/redirects the player's own clicks, no input injection, no automation, no external dependencies, BSD 2-Clause.