### PR TITLE
combo-tags: update to 1.1.0

### DIFF
--- a/plugins/combo-tags
+++ b/plugins/combo-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/HydraTal/combo-tags.git
-commit=ba1fd39bb09338fdccfd662fbb6121b6a731f5f1
+commit=f9632b8c76df142e7c50e88740b49f4d14675dfe


### PR DESCRIPTION
Updates **Combo Tags** to 1.1.0.

New in this release:
- **Replace in all tabs** for a combo or a whole group — consolidates its loose items into a cell in every layout-enabled tab at once.
- Non-modal **toast** confirmations for copy-to-clipboard (no more blocking dialogs).
- Deleting a combo/group now **restores the best item you own** (or the goal placeholder) into the freed cells; group delete offers "Group" vs "Group with contents".
- Multi-import **skips** combos whose names already exist instead of auto-renaming.
- README usage guide refresh + ready-made combo sets.

Plugin repo: https://github.com/HydraTal/combo-tags
Commit: f9632b8c76df142e7c50e88740b49f4d14675dfe