### PR TITLE
Update lootlette to 1.0.3

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=bd65a6690051d0b7fa1730b7180be6ded71dca3b
+commit=0c19d788ef42b1cf7a9d01b553c43c2d095b14fe


### PR DESCRIPTION
Bumps Lootlette to 1.0.3.

- Multi-phase bosses (Nightmare/Phosani's/Verzik/KQ) only pre-spin on the real death, not on a phase/shield HP-zero.
- ToA/ToB reward chest reel is persistent, re-anchors onto the player's own chest, and is pinned vertical.
- Optional right-click ignore for NPCs (persisted); CoX Scavenger beasts ignored by default.
- Doom of Mokhaiotl golden-hole anticipation.