### PR TITLE
Update better-goldsmithing

### DIFF
--- a/plugins/better-goldsmithing
+++ b/plugins/better-goldsmithing
@@ -1,2 +1,2 @@
-repository=https://github.com/Krisisonfire/better-goldsmithing.git
+repository=https://github.com/TheSpryt/better-goldsmithing.git
 commit=b970d820f3bd2dc7494cf844fc8b3bfdc8c557a4


### PR DESCRIPTION
The owner account was renamed from Krisisonfire to TheSpryt. Updating the repository URL in the manifest so it points at the canonical owner instead of relying on GitHub's username redirect (which would break if the old username is re-registered). Same commit, no plugin code change.