### PR TITLE
Update Better Goldsmithing to 1.3

### DIFF
--- a/plugins/better-goldsmithing
+++ b/plugins/better-goldsmithing
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/better-goldsmithing.git
-commit=b970d820f3bd2dc7494cf844fc8b3bfdc8c557a4
+commit=cf0e9770f032ae949eafe3dcc8655e7f7668c298


### PR DESCRIPTION
Fixes an occasional delay where the glove lock engaged a beat late after depositing gold ore. The lock now arms the instant the inventory empties at the furnace (tracking the conveyor's presence + a bank-open check to exclude banking) rather than depending on the deposit click being caught. No new permissions; same passive, single-player behaviour.