### PR TITLE
Update lootlette to 1.0.4

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=0c19d788ef42b1cf7a9d01b553c43c2d095b14fe
+commit=0f4935ff905d5919319f38d8ff10f64fd0da84d7


### PR DESCRIPTION
Bumps Lootlette to 1.0.4.

- Fix Theatre of Blood reward-chest detection (per-seat multilocs 33086-33090 resolved via getImpostor; anchor only on the player's own chest).
- Tombs of Amascut reward reel anchored on the shared sarcophagus and purple/white resolved from the tomb varbits.
- Reward reels narrow while spinning: white -> supplies, purple -> uniques.
- Fix an IllegalAccessError crash (config enum must be public).
- Optional unique-drop sound (raid purples / very rare hits).
- Configurable fade-out for the landed result.
- Untradeable drops (clue scrolls/caskets, pets) no longer filtered out by the min-item-value setting.
- Vertical reel anchor option; config reorganised.