### PR TITLE
Add bank-templates

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,0 +1,2 @@
+repository=https://github.com/TheSpryt/bank-templates.git
+commit=5367f3ece2fe133b577abbb8bc9de90bcdec29dc


### PR DESCRIPTION
Adds **Bank Templates** - saved, shareable bank layout templates rendered **virtually** over the bank (client-side widget repositioning only, the same technique as RuneLite's built-in Bank Tag Layouts). It never moves real items, never injects input, and never adds menu entries that send actions to the server.

Features:
- Per-tab templates (main view + numbered tabs), applied to whichever tab you're viewing
- Capture your current bank as a template
- Faded placeholders for items you don't own yet; filler (no-symbol) reserved slots
- A guided reorganise helper that outlines mismatched slots - the user drags items manually
- Optional, opt-in community repository (browse / search / import / share) with the required IP-address warning; off by default

Repository: https://github.com/TheSpryt/bank-templates