### PR TITLE
Add object id marker

### DIFF
--- a/plugins/object-id-marker
+++ b/plugins/object-id-marker
@@ -1,2 +1,2 @@
 repository=https://github.com/jtclowner/object-id-marker.git
-commit=b1f9f5f11c0bd42656386c32623c0b508aac0841
+commit=1bfb6961a51c436f89b4f601db3906cc41107ccf

--- a/plugins/object-id-marker
+++ b/plugins/object-id-marker
@@ -1,0 +1,2 @@
+repository=https://github.com/jtclowner/object-id-marker.git
+commit=b1f9f5f11c0bd42656386c32623c0b508aac0841


### PR DESCRIPTION
Object ID Marker allows objects to be highlighted directly by object ID, without first marking them in-game.

## Features
Highlight objects using configurable object IDs
Object hull/outline highlights
Tile highlights for tiles occupied by objects
Optional tile highlight expansion radius (id:radius)

### Compliance
No automation or input modification
No external communication or data transmission
Java 11, no reflection, JNI, native libraries, external dependencies, or classloader modification

_Note: Unlike the built-in Object Markers plugin, which marks individual object instances at specific locations, Object ID Marker highlights all game, wall, decorative, and ground objects matching the configured object IDs._