### PR TITLE
Update kill-clog to 1.4.4

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=46e128183ac3e6d6b39e87582feb0cf90f2e8c19
+commit=a0db47d7c8fec097436945bc441198d1b0933b49
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Kill Clog to 1.4.4.

Changes:
- colors tooltip item names by completion state: obtained names green, unobtained names red
- clears the PvP summary cell when starting a new lookup, so stale PvP data cannot linger during failed or pending searches
- deduplicates shared summary-tooltip painting/loading helpers across single and comparison tooltips

Local gate:
- .\gradlew.bat compileJava checkstyleMain checkstyleTest test