### PR TITLE
Add osrscn (Simplified Chinese translation)

### DIFF
--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,2 +1,2 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=0f59163a014e3b5dba7e7431524c82f3eb9d0fbc
+commit=56a56b70e2e7fb13a33bc45f02d919c89326b668

--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,2 +1,2 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=b4283d9dc3cd466b7cb3494cdeae4bd3071291d7
+commit=4606b150367676e59b1b9dda9646ac1cba8cbf4b

--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,2 +1,2 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=3c24e0a116f015059e9a149ca44c6c604b2b549f
+commit=0f59163a014e3b5dba7e7431524c82f3eb9d0fbc

--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,2 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
 commit=56a56b70e2e7fb13a33bc45f02d919c89326b668
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,2 +1,2 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=4606b150367676e59b1b9dda9646ac1cba8cbf4b
+commit=646ae5eb84fc7abc0107510ce472b82ba68c30a9

--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,2 +1,2 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=646ae5eb84fc7abc0107510ce472b82ba68c30a9
+commit=3c24e0a116f015059e9a149ca44c6c604b2b549f

--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,0 +1,2 @@
+repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
+commit=b4283d9dc3cd466b7cb3494cdeae4bd3071291d7


### PR DESCRIPTION
﻿Adds OSRSCN Chinese, a clean-room Simplified Chinese translation plugin (package com.osrscn).

It translates game text (menus, chat, dialogue, overhead text, interfaces) into Simplified Chinese from local lookup tables. OSRS's native UI cannot render Chinese, so the plugin rasterizes each glyph and shows it inline via ChatIconManager.

In case you are wondering about the plugin size and the AI option:

- Plugin size (~6 MB): it bundles the Source Han Sans SC font (SIL OFL 1.1), loaded via getResourceAsStream. Runtime rasterization of arbitrary characters is required because the optional AI translation can output any character, so a pre-rendered glyph atlas would not cover them. The OFL license text is in the repo and inside the JAR, with attribution in NOTICE.
- AI translation is off by default and, when enabled, calls a local Ollama instance (localhost) only. Nothing is sent to any third-party server by default. This is documented in the README and config descriptions.

License: BSD 2-Clause. 