### PR TITLE
Add Reactive Menu Swapper plugin

### DIFF
--- a/plugins/reactive-menu-swapper
+++ b/plugins/reactive-menu-swapper
@@ -1,0 +1,2 @@
+repository=https://github.com/youncc/ReactiveMenuSwapper.git
+commit=c111cdfb88b2b7681c94979eb572a424f72a0087

--- a/plugins/reactive-menu-swapper
+++ b/plugins/reactive-menu-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/youncc/ReactiveMenuSwapper.git
-commit=c111cdfb88b2b7681c94979eb572a424f72a0087
+commit=6b7d56f5a9423690db8263a7326752667e2e8948


### PR DESCRIPTION
## Summary
- Adds Reactive Menu Swapper, a plugin that reorders right-click menu entries based on configurable game-state conditions
- Supports inventory, equipment, skill, region, widget, chat, varbit, and player state conditions with a sidebar rule editor
- Reorders menu options only — never automates clicks or sends actions to the server

## Test plan
- [ ] Plugin Hub CI build passes
- [ ] Plugin loads from Plugin Hub in RuneLite
- [ ] Example salvage cargo hold rule swaps Deposit-all when carrying salvage
- [ ] Rule editor can create, edit, import, and export rules