### PR TITLE
update tree-despawn-timer to 1.5.2

### DIFF
--- a/plugins/tree-despawn-timer
+++ b/plugins/tree-despawn-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/tree-despawn-timer.git
-commit=de38ac7d9e2f886602c76debcfb469e4d0e15b68
+commit=7feb8e168dd627f9f3bc5facb5c1f98a30373233

--- a/plugins/tree-despawn-timer
+++ b/plugins/tree-despawn-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/CreativeTechGuy/tree-despawn-timer.git
-commit=7feb8e168dd627f9f3bc5facb5c1f98a30373233
+commit=9f9eb2b35db64cb6032d9d3e713afb2a3bd89176


### PR DESCRIPTION
Players now chop trees facing the SW tile of the tree. This affects the detection for which tree is being chopped. This version works around that issue with player rotation while chopping.