### PR TITLE
Update Lucky Log to provide option to include unknown KC collection log items

### DIFF
--- a/plugins/lucky-log
+++ b/plugins/lucky-log
@@ -1,2 +1,2 @@
 repository=https://github.com/rsvaultpudgy-create/lucky-log.git
-commit=fc1e1d59cb49aa907e389a583a5cdd108a3da81d
+commit=17a86daba53b1510da374d51d17784dda86a631b

--- a/plugins/lucky-log
+++ b/plugins/lucky-log
@@ -1,2 +1,2 @@
 repository=https://github.com/rsvaultpudgy-create/lucky-log.git
-commit=c8da26184a4832728fbc6fc5a32e0509721b1845
+commit=f3e8f65859500acca5415f156d98401df843bdf3

--- a/plugins/lucky-log
+++ b/plugins/lucky-log
@@ -1,2 +1,2 @@
 repository=https://github.com/rsvaultpudgy-create/lucky-log.git
-commit=f3e8f65859500acca5415f156d98401df843bdf3
+commit=fc1e1d59cb49aa907e389a583a5cdd108a3da81d


### PR DESCRIPTION
Update to the Lucky Log plugin (com.pudgy.droptracker). Changes since the merged version:

- Import from Collection Log – reads your in-game collection log to fill in uniques obtained before installing the plugin (shown as "unknown KC"). Optional via a settings toggle, and the relevant collection-log pages are marked with an asterisk that clears as you open each one.
- Per-boss reset – right-click a boss's "Total loot" header to clear that boss's tracked loot/KC, behind a confirmation prompt.
- Total Loot sorted by value** – highest-value stacks first, untradeables last.
- Pet star marker** now drawn as an image instead of a font glyph (fixes a missing-glyph box on macOS).
- Fixed placeholder text colour that rendered as unreadable dark blue on some clients.