### PR TITLE
Add OmniPresence plugin

### DIFF
--- a/plugins/omnipresence
+++ b/plugins/omnipresence
@@ -1,2 +1,2 @@
 repository=https://github.com/jonathanavis96/omnipresence-runelite-plugin.git
-commit=b5f2ee8cc851fc0240494159c6b00e32e0c0271e
+commit=494837b5be2b724cc7b8747e930b38311b06ba12

--- a/plugins/omnipresence
+++ b/plugins/omnipresence
@@ -1,2 +1,2 @@
 repository=https://github.com/jonathanavis96/omnipresence-runelite-plugin.git
-commit=29051415d0f783182ef57c015d25ad3e922ebe66
+commit=b5f2ee8cc851fc0240494159c6b00e32e0c0271e

--- a/plugins/omnipresence
+++ b/plugins/omnipresence
@@ -1,2 +1,2 @@
 repository=https://github.com/jonathanavis96/omnipresence-runelite-plugin.git
-commit=494837b5be2b724cc7b8747e930b38311b06ba12
+commit=6ffd76e804562137c376fe723ffc8ed1b3b18ddc

--- a/plugins/omnipresence
+++ b/plugins/omnipresence
@@ -1,0 +1,2 @@
+repository=https://github.com/jonathanavis96/omnipresence-runelite-plugin.git
+commit=29051415d0f783182ef57c015d25ad3e922ebe66


### PR DESCRIPTION
Adds the **OmniPresence** plugin.

Source: https://github.com/jonathanavis96/omnipresence-runelite-plugin

**What it does:** reads the local player's in-game activity (current skill, boss/NPC, region, banking state) and POSTs a small JSON summary to the OmniPresence desktop companion app so it can show OSRS activity in Discord Rich Presence. It is conceptually the same as the built-in Discord plugin, but feeds a local companion app instead of Discord directly.

**Data / network:**
- Read-only observation of game state. No input is ever sent to the game; no new menu entries; no automation.
- Network egress is **loopback only** — the host is hard-coded to `127.0.0.1`; only the port is user-configurable, so it cannot be pointed at any remote/third-party server.
- Account name is **opt-in and off by default**; chat content is never forwarded.
- If the companion app is not running, the plugin silently no-ops.

**Dependencies:** only gson + okhttp, both transitive dependencies of `net.runelite:client` (no third-party deps requiring verification metadata).

Builds and tests pass under the standard build against `latest.release`.