### PR TITLE
update better-goldsmithing

### DIFF
--- a/plugins/better-goldsmithing
+++ b/plugins/better-goldsmithing
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/better-goldsmithing.git
-commit=cf0e9770f032ae949eafe3dcc8655e7f7668c298
+commit=1b13b683a7290784b442f47848ebbaf108adc4cd


### PR DESCRIPTION
Update better-goldsmithing to a new commit. Only change is setting the plugin author to Spryt in runelite-plugin.properties.