### PR TITLE
fishing-spot-tracker: update to latest (lantern harpooning + startup crash fixes)

### DIFF
--- a/plugins/fishing-spot-tracker
+++ b/plugins/fishing-spot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CharlesLillo/fishing-spot-tracker.git
-commit=01efd287737d787384d13c6ce5a7f198887455a4
+commit=c3912d8f5220394fe369525543be164a0abe87ed


### PR DESCRIPTION
Updates Fishing Spot Tracker to the latest commit.

Fixes:

- Fix lantern harpooning spots not tracking correctly. The squid fishing spot entry now lists both catchable fish with correct Fishing levels and item IDs Swordtip squid (52) and Jumbo squid (69) instead of a single incorrect "Squid" entry.
- Fix startup crash when enabling the plugin near a fishing spot. The initial scan of existing spots now runs on the client thread, since `getWorldLocation()` should not be called from the AWT thread