### PR TITLE
Add Object Name Markers

### DIFF
--- a/plugins/object-name-markers
+++ b/plugins/object-name-markers
@@ -1,0 +1,2 @@
+repository=https://github.com/jtclowner/object-name-markers.git
+commit=e5be0018cdbbd5a6a0002636c70aaacdfe66bed7


### PR DESCRIPTION
Object Name Marker allows objects to be highlighted directly by object name, without first marking them in-game.

**Features**
Highlight objects using configurable object names
Object hull/outline highlights
Tile highlights for tiles occupied by objects
Optional tile highlight expansion radius (name:radius)

**Compliance**
No automation or input modification
No external communication or data transmission
Java 11, no reflection, JNI, native libraries, external dependencies, or classloader modification

_Note: Unlike other Object Markers, which marks **specific** object instances at specific locations, Object Name Marker highlights **all** game, wall, decorative, and ground objects matching the configured list of object names._