### PR TITLE
Update drop-history to 237dd10

### DIFF
--- a/plugins/drop-history
+++ b/plugins/drop-history
@@ -1,2 +1,2 @@
 repository=https://github.com/markuskkramer/drop-history.git
-commit=82a5ddbd44f6ac8ead53126e5e2dab351befdc95
+commit=237dd10b991a4069bfae65ec048b53f3167adca0


### PR DESCRIPTION
Updates Drop History to 237dd10b991a4069bfae65ec048b53f3167adca0.

Performance fix: drop history was serialized and written to disk synchronously on the game thread on every NPC loot drop (once per item), causing a noticeable stutter on each kill that grew worse as the dataset got larger. Persistence now updates an in-memory cache on the game thread and writes to disk on a background thread, debounced/coalesced into a single atomic write, with a flush on plugin shutdown so nothing is lost.

No behavior or config changes.