### PR TITLE
Update ZMI Rune Tracker - fix detection logic

### DIFF
--- a/plugins/zmi-rune-tracker
+++ b/plugins/zmi-rune-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CalabiOSRS/zmi-rune-tracker.git
-commit=cba17c01e1d42b257042ebe09551f528f590ddf3
+commit=ad05f8bcb953f2213d8139026519d98ffdc9fe07


### PR DESCRIPTION
Fixes rune detection - the original Ourania region ID check was unverified and never matched, so the plugin never tracked anything. Now triggers on the rune-crafting animation directly instead.