### PR TITLE
Update slayer-task-logger

### DIFF
--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=fbf7dbe298b383f8c7bafbe3d175eb4db1a52f0e
+commit=59e5bb220c30aa890ec21ec6ca37d84778ea486e
 warning=This plugin can send slayer event data to an external webhook URL configured by the user. The webhook is disabled by default.


### PR DESCRIPTION
Updates slayer-task-logger to the latest commit.

## Changes
- Move log file to plugin-specific subdirectory (`~/.runelite/slayer-task-logger/slayer-log.txt`)
- Fix TzHaar task assignment always reading live varbits instead of stale cache
- Fix new task point total reading live from varbit instead of cached value
- Add TzHaar/Jad/Zuk upgrade handling
- Add superior spawn logging
- Add task skip logging with full varbit state
- Add Konar task message format support
- Add cape perk proc logging for standard and Konar masters
- Add webhook URL validation