### PR TITLE
Update pvp-performance-tracker to v1.7.6

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=8d9c17aabe40268097bced4aaa9eab525f2133f4
+commit=41ea76caed232876d6e388de9912a013b7a4cd60


### PR DESCRIPTION
Fix attack timings in fight logs to allow fight merges on PvP-Hub to work properly, also sort same-tick attack fight logs by attacker name for visual consistency between 2 clients. Thanks to @LogicalSoIutions for figuring out the issue causing tick delays, and thanks to Pan1c & Lagunarium for noticing these issues.

Bit of a weird bug to explain, here is a screenshot of pan1c & lagunarium's fights side by side (sorry for shit quality, screenshot of a recording of 2 discord streams)
<img width="2550" height="723" alt="image" src="https://github.com/user-attachments/assets/a669da76-01bc-4ede-a2af-6ee092026b22" />

Essentially, the attacks are all the same, but:
1) There is a seemingly random tick offset on certain attacks. For the 2nd attack, on the left side it's 4th tick, but right side is 6th tick. This shouldn't really happen, and should hopefully be fixed now
2) They are visually different due to how it prioritizes the client player on same-tick attacks, now it will sort the attacker name alphabetically for same-tick attacks, for consistency.
