### PR TITLE
Zmi rune tracker update

### DIFF
--- a/plugins/zmi-rune-tracker
+++ b/plugins/zmi-rune-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CalabiOSRS/zmi-rune-tracker.git
-commit=cba17c01e1d42b257042ebe09551f528f590ddf3
+commit=ad05f8bcb953f2213d8139026519d98ffdc9fe07

--- a/plugins/zmi-rune-tracker
+++ b/plugins/zmi-rune-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CalabiOSRS/zmi-rune-tracker.git
-commit=ad05f8bcb953f2213d8139026519d98ffdc9fe07
+commit=0c567071cadc129db3787f318897c03dd2d7967d


### PR DESCRIPTION
Fixes multi-batch rune tracking at the Ourania Altar.

Previously only the first craft per lap was tracked because the detection relied on the runecrafting animation, which only fires once even when clicking the altar multiple times (e.g. after emptying pouches).

Now uses inventory change detection instead, which correctly captures all batches in a lap. Also adds lap timing and average trip time display.