### PR TITLE
feat: add pvp-overheads plugin

### DIFF
--- a/plugins/pvp-overheads
+++ b/plugins/pvp-overheads
@@ -1,0 +1,2 @@
+repository=https://github.com/idyet/pvp-overheads.git
+commit=c17ba215b26e4b0d42c499021268476c26f5efdf


### PR DESCRIPTION
# PvP Overheads

<img width="640" height="321" alt="clip" src="https://github.com/user-attachments/assets/bcd46824-66be-49e9-b021-2082587166fe" />

Coaches overhead-prayer play in PvP by alerting you the moment you make one of two prayer mistakes:

  - Off-prayer hit received - an opponent attacked with a style your overhead didn't protect against.
  - Wrong style given - you attacked into the opponent's overhead.

Each case alerts independently via any combination of a chat message, a full-screen flash, and a sound, all configurable (colour, opacity, duration, sound ID, volume) and separately for received vs given.

It's stateless and reacts to attack animations after the fact, purely as feedback. It only reads the overhead prayer icon (getOverheadIcon()), which is already visible in the vanilla client, so it exposes no hidden information. No automation, no input, no menu manipulation. Alerts are suppressed in multi-combat by default (toggleable). All data comes through the public RuneLite API.

The animation-classification table (AnimationData) is adapted near-verbatim from PvP Performance Tracker under BSD 2-Clause; attribution is in the file header and LICENSE.

Repo: https://github.com/idyet/pvp-overheads