### PR TITLE
Update Bank Wealth Dashboard

### DIFF
--- a/plugins/persistent-bank
+++ b/plugins/persistent-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/rsvaultpudgy-create/persistent-bank-plugin.git
-commit=d2a09f080cdee2a3d9c98eb435b54fbcd6e3114f
+commit=61118ee18661d1d9f0b76a3ead4f91e741443d23


### PR DESCRIPTION
Bank Wealth Dashboard (update to Persistent Bank)

-Renamed to "Bank Wealth Dashboard" to reflect the new in-panel view.
-Added a wealth-over-time chart: per-account or combined-total line, period selector (1D/1W/1M/6M/1Y/All) on a fixed UTC-day axis, green/red by net change.
-Grand Exchange value is now included in account totals (coins committed to offers + items/coins awaiting collection).
-Accuracy fixes: bank/seed-vault/GE are restored from the last snapshot on login so a write can't drop a section to zero; GE captured up front; Refresh now force-captures the live account on demand.
-Minor: support/contact buttons on the panel; chart anchors to the live displayed total.