### PR TITLE
Add Flip Finder Sync

### DIFF
--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=7c2b04804c297894a1e0d5552c8bceb3e7596ba5
+commit=b275f7eeddff9e8e1f402eec486f08568b8889c0
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=1bf748fe1a44b8d18c94cf7170c27a0f6c1c4cab
+commit=7c2b04804c297894a1e0d5552c8bceb3e7596ba5
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=1f99e460d9ff299db2da74a1af1aa5818546ba96
+commit=14188a618ff5388e37df0b28bec7303954365985
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=c621c19d144c342eaca49155cb1195a607e3d541
+commit=43d84af0540643561c683fe9657e287963725e25
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=43d84af0540643561c683fe9657e287963725e25
+commit=1bf748fe1a44b8d18c94cf7170c27a0f6c1c4cab
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=66f361e2d9386c73fdb066c0a936a59ee85835de
+commit=1f99e460d9ff299db2da74a1af1aa5818546ba96
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=14b93eeee9352597194c0f37c8f280582310419b
+commit=2f777d83d6f4c707ce33da545511bb9dfa2cf75b
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=2f777d83d6f4c707ce33da545511bb9dfa2cf75b
+commit=c621c19d144c342eaca49155cb1195a607e3d541
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=b275f7eeddff9e8e1f402eec486f08568b8889c0
+commit=66f361e2d9386c73fdb066c0a936a59ee85835de
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,0 +1,3 @@
+repository=https://github.com/betmodejoe/osrsflipfinder.com.git
+commit=14b93eeee9352597194c0f37c8f280582310419b
+warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Adds **Flip Finder Sync**, a companion plugin for [OSRS Flip Finder](https://osrsflipfinder.com).

### What it does
Listens for `GrandExchangeOfferChanged` and syncs completed Grand Exchange buys/sells to the user's OSRS Flip Finder trade journal over HTTPS, authenticated with a per-user API key generated on the website. Each fill is sent as a delta (newly-filled quantity + average price) with a deterministic id so re-logs never double-count. Only filled buy/sell quantities are sent — no inventory, location, or other data.

### Details
- **Source:** https://github.com/betmodejoe/osrsflipfinder.com — BSD 2-Clause licensed
- **3rd-party server:** the plugin sends data to the user's own OSRS Flip Finder account, so a `warning=` line is included in the manifest.
- **Opt-in:** Base URL and API key are user-configured; nothing is sent until a key is entered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
