### PR TITLE
update attacktimer

### DIFF
--- a/plugins/attacktimer
+++ b/plugins/attacktimer
@@ -1,3 +1,3 @@
 repository=https://github.com/ngraves95/attacktimer.git
-commit=fce3366e9183bc3d2a38de21a796c4e09c26b0b1
+commit=c7d68925e97b707422caa99b6d4765537f0d6dd8
 authors=ngraves95,Lexer747


### PR DESCRIPTION
Fixes https://github.com/ngraves95/attacktimer/issues/154 (PR https://github.com/ngraves95/attacktimer/pull/155)

TL:DR Dragon Cbow in LMS was broken, for some reason `itemManager.getItemStats(33460).getEquipment().getAspeed()` throws NPE so added to the workaround map in the plugin.