### PR TITLE
Update Purple Box trigger filtering

### DIFF
--- a/plugins/purple-box
+++ b/plugins/purple-box
@@ -1,3 +1,3 @@
 repository=https://github.com/TheRinky/purple-box.git
-commit=341804f57f6b6e4b9233ce9daa80b296febbffcb
+commit=8cb70642396ff605c36d97058c3ebfa55660d544
 


### PR DESCRIPTION
Updates Purple Box so automatic rolls only trigger from loot/reward-style messages, preventing false activations during raid boss fights. Manual ::purplebox and !purplebox tests are unchanged.