### PR TITLE
Add the Prayer Metronome plugin

### DIFF
--- a/plugins/prayer-metronome
+++ b/plugins/prayer-metronome
@@ -1,2 +1,2 @@
 repository=https://github.com/its-edalo/prayer-metronome.git
-commit=7b24fb61fe88b2555fb8c6765868b98b451082b9
+commit=5713eee3eacca02875141dcecc310c266484b660

--- a/plugins/prayer-metronome
+++ b/plugins/prayer-metronome
@@ -1,0 +1,2 @@
+repository=https://github.com/its-edalo/prayer-metronome.git
+commit=7b24fb61fe88b2555fb8c6765868b98b451082b9

--- a/plugins/prayer-metronome
+++ b/plugins/prayer-metronome
@@ -1,2 +1,2 @@
 repository=https://github.com/its-edalo/prayer-metronome.git
-commit=5713eee3eacca02875141dcecc310c266484b660
+commit=2adac4f2a4562d7a535b990936ca03427f293304


### PR DESCRIPTION
The Prayer Metronome plugin is a customized metronome plugin that changes the tick sound based on the active protection prayer at the start of the tick.