### PR TITLE
Update AFK Stats Tracker

### DIFF
--- a/plugins/afk-stats-tracker
+++ b/plugins/afk-stats-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/AfkTracker.git
-commit=7d260df4f316098fc50e1a9dea74c1c253da9850
+commit=7ef588122f59e1658c1e8379f0031d859124ac9c


### PR DESCRIPTION
Adds a new **Avg Click Distance** stat — how far the mouse moves between clicks on average, as a % of the canvas diagonal. Shows live next to Consistency and Avg Click Interval, and saves per session.

Also fixes a bug where the mouse listener got registered twice, so clicks were double-counted during a session.

![AFK Stats Tracker panel](https://raw.githubusercontent.com/Reasel/AFK-Stats-Tracker/7ef588122f59e1658c1e8379f0031d859124ac9c/panel-preview.png)
