### PR TITLE
bank-templates: update to 1.2

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=436b839a071fefd13d9fff4f13535a1cb69c293d
+commit=dcb60e5879d09a5443e5188035fc94927a2a2bad

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=dcb60e5879d09a5443e5188035fc94927a2a2bad
+commit=5b52700fc60e1331a03266a06f54eb334da7e2dc

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=5b52700fc60e1331a03266a06f54eb334da7e2dc
+commit=b12293599daa7edc1616a1ef94423fd1c756579c


### PR DESCRIPTION
Update of the existing **Bank Templates** plugin to v1.2 - `TheSpryt/bank-templates@f5b9cd2bec768e74000a10b82996af4f0cc299d4`.

Highlights:
- Inventory Setups compatibility: items are positioned by identity (each keeps its own bank slot), so slot-based plugins target the right items.
- Live editing now uses the game's native bank drag (fixes a post-drag click stealing a withdraw, and a placeholder-look glitch); drag onto the + for a new tab; edge auto-scroll.
- Reorganise helper: step prompts shown in the bank title bar, bank-filler reservation guidance, per-tab sorting.
- Sharing: optional description; anonymous shares no longer send the RuneScape name.
- Browse: result count and a "Page X of N" pager.
- Cleanup: removed developer diagnostics, thread-safe editor listeners, dead-code/imports removed.

No new permissions. The community-repository feature remains opt-in with the IP-address warning.