### PR TITLE
Add Learner ToB plugin

### DIFF
--- a/plugins/learner-tob
+++ b/plugins/learner-tob
@@ -1,0 +1,2 @@
+repository=https://github.com/macflag/learner-tob.git
+commit=2f17e7cca611b960a01633cef74072b5ed4236d6

--- a/plugins/learner-tob
+++ b/plugins/learner-tob
@@ -1,2 +1,2 @@
 repository=https://github.com/macflag/learner-tob.git
-commit=2f17e7cca611b960a01633cef74072b5ed4236d6
+commit=a886d5662bcf1affce2baf25007d6b4716ad1ba0

--- a/plugins/learner-tob
+++ b/plugins/learner-tob
@@ -1,2 +1,2 @@
 repository=https://github.com/macflag/learner-tob.git
-commit=a886d5662bcf1affce2baf25007d6b4716ad1ba0
+commit=f33fe95316c707ec60d6cb21d1dbd29675bf2e3b


### PR DESCRIPTION
Bank-driven gear checker for Theatre of Blood learners, built for the Rancour PvM clan.

The plugin reads the player's bank, equipment, and inventory, auto-detects whether they're running a Scythe or No-Scythe MDPS setup, and shows a colour-coded sidebar loadout (green = ready, yellow = in bank, red = missing). A "Run Gear Check" button (or ::tobcheck) validates worn and inventory items against the loadout and shows a pass/fail popup. The check accepts any valid substitute per slot, so cosmetic variants and alternative items all pass.

Planned future improvements:
- Loadouts for every role (Ranged DPS, North Freeze, South Freeze) in addition to the current Melee DPS setups
- Room-by-room guidance and checks for each Theatre encounter (Maiden, Bloat, Nylocas, Sotetseg, Xarpus, Verzik)

Repository: https://github.com/macflag/learner-tob