### PR TITLE
Add Rancour pvm clan plugin

### DIFF
--- a/plugins/rancour-pvm
+++ b/plugins/rancour-pvm
@@ -1,2 +1,2 @@
 repository=https://github.com/DaleW-Cyber/RancourClanPlugin.git
-commit=5d500799b8ebb2834cd5fb17f46c4a85627d9510
+commit=e96c837301ce0447d49fb1ff832e638f6e74c08c

--- a/plugins/rancour-pvm
+++ b/plugins/rancour-pvm
@@ -1,0 +1,2 @@
+repository=https://github.com/DaleW-Cyber/RancourClanPlugin.git
+commit=5d500799b8ebb2834cd5fb17f46c4a85627d9510

--- a/plugins/rancour-pvm
+++ b/plugins/rancour-pvm
@@ -1,2 +1,3 @@
 repository=https://github.com/DaleW-Cyber/RancourClanPlugin.git
 commit=e96c837301ce0447d49fb1ff832e638f6e74c08c
+warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds the Rancour PvM external plugin.

Plugin repository:
https://github.com/DaleW-Cyber/RancourClanPlugin

Features:
- Rancour Discord verification
- Clan announcements
- Read-only events
- Team Finder
- Approved drop submission tools for Clan events