### PR TITLE
Update Skilling Toolkit to 0.2.0

### DIFF
--- a/plugins/skilling-toolkit
+++ b/plugins/skilling-toolkit
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/skilling-toolkit.git
-commit=b2bd24601789ddab3f8386e39419e8dfc97491c0
+commit=65b011770d270588bbd972cbfc253015c663335b


### PR DESCRIPTION
## What changed

- lets players click the All chat tab to switch between Skilling Toolkit and PvM Toolkit trackers when both plugins are enabled
- keeps automatic activity-based switching so skilling and combat can still take ownership naturally
- fixes protection-payment markers for all three Fossil Island hardwood patches by resolving the paid squirrel to the nearest patch

## Why

The two toolkits share the same chat-tab and inventory surfaces. A manual switch provides a reliable fallback while preserving automatic handoff, and the Fossil Island squirrel NPCs needed location-aware patch resolution.

## Validation

- `gradlew test shadowJar` with Java 11
- 6 Skilling Toolkit tests passing
- full developer client started with both toolkits loaded

Companion PvM Toolkit update: https://github.com/runelite/plugin-hub/pull/12694