### PR TITLE
Update ZMI Rune Tracker - improvements

### DIFF
--- a/plugins/zmi-rune-tracker
+++ b/plugins/zmi-rune-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CalabiOSRS/zmi-rune-tracker.git
-commit=3c15a1ce26fd4993fd9a053909408acff9a8b995
+commit=9422dfbb5dd33648a9e281a13d8e05ada43582f5


### PR DESCRIPTION
- Add option to hide elemental runes (Air/Water/Earth/Fire) from breakdown while still counting their value
- Fix right-click reset (was just a text hint before, now properly wired up)
- Lap timer now starts when bank closes and ends when bank opens
- Remove craft time display
- Remove last lap rune breakdown
- Add configurable background opacity slider