### PR TITLE
update compass-camera-control to 1.2.5

### DIFF
--- a/plugins/compass-camera-control
+++ b/plugins/compass-camera-control
@@ -1,2 +1,2 @@
 repository=https://github.com/RaazKH/CompassCameraControl.git
-commit=6c1892ca83b75e0a60c8fa3f1b87503527ce0886
+commit=4fba2cc3e3e431e1d110d6334a29d1dfd8ce20a1


### PR DESCRIPTION
Jagex increased the camera yaw range from 2048 to 16384, this plugin needed a patch so it would work with the new range.

Users reported the issue here: https://github.com/RaazKH/CompassCameraControl/issues/31
Patch applied here: https://github.com/RaazKH/CompassCameraControl/pull/32