### PR TITLE
disable boss-voicer

### DIFF
--- a/plugins/boss-voicer
+++ b/plugins/boss-voicer
@@ -1,3 +1,4 @@
 repository=https://github.com/Endrit-alt/boss_voicer.git
 commit=acdaab9f0e3066a5e6546a88f341ca81b506d8e8
 authors=Endrit
+disabled=violates 3pc guidelines


### PR DESCRIPTION
We are disabling boss-voicer because the sound effects it adds can be abused to provide additional auditory indicators of boss mechanics.

We will not be entertaining the addition of any "moderating" patches to this plugin to bring it back within guidelines, because we do not believe it is possible to do so effectively, thus it will remain disabled.