### PR TITLE
disable yama-swedish-voiceover

### DIFF
--- a/plugins/yama-swedish-voiceover
+++ b/plugins/yama-swedish-voiceover
@@ -1,2 +1,3 @@
 repository=https://github.com/mattiasen1/yama-overhead-audio.git
 commit=e67a11945e8082e35d6f7016664722dedd184d35
+disabled=violates 3pc guidelines


### PR DESCRIPTION
We are disabling yama-swedish-voiceover because the sound effects it adds can be abused to provide additional auditory indicators of boss mechanics.

We will not be entertaining the addition of any "moderating" patches to this plugin to bring it back within guidelines, because we do not believe it is possible to do so effectively, thus it will remain disabled.