### PR TITLE
disable sound-swapper

### DIFF
--- a/plugins/sound-swapper
+++ b/plugins/sound-swapper
@@ -1,2 +1,3 @@
 repository=https://github.com/petertalbanese/SoundSwapper.git
 commit=527f5faee6aeb2cf923029dd0bce16268fd27b43
+disabled=violates 3pc guidelines


### PR DESCRIPTION
We are disabling sound-swapper because arbitrary replacement of sound effects by ID can be abused to provide additional / clearer auditory indicators of boss mechanics.

In order for this plugin to be re-enabled, it **MUST** be updated to disable the entirety of its functionality in all of the same map regions that the Watchdog plugin does.