### PR TITLE
Disable nex-swedish-voiceover plugin

### DIFF
--- a/plugins/nex-swedish-voiceover
+++ b/plugins/nex-swedish-voiceover
@@ -1,2 +1,3 @@
 repository=https://github.com/mattiasen1/nex-swedish-voiceover.git
 commit=26e081a8af29f8b624ee165a40ba5bd576ddfc71
+disabled=violates 3pc guidelines


### PR DESCRIPTION
Disabled the plugin due to violation of 3rd party guidelines.