### PR TITLE
drop-rates-clog: fix client freeze, re-enable

### DIFF
--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=01170366e7c6a5562b2236282e08062913138ec5
+commit=a5ee28c5dd1ecb348dc709f94412472f2bba3741


### PR DESCRIPTION
Re-enables `drop-rates-clog` with the freeze fixed.

The plugin was disabled for an `IllegalAccessError` that froze the client on every collection-log hover. Cause: the config-referenced `MultiRollMethod` enum was package-private, so RuneLite's generated config proxy couldn't access it. Fix makes it `public`.

Diff is just the commit bump + removing the `disabled` line.