### PR TITLE
Update protect-item-notifier to 1.0.1

### DIFF
--- a/plugins/protect-item-notifier
+++ b/plugins/protect-item-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/cubeee/protect-item-notify.git
-commit=20271a6fa8c5e4750654adf0932251a706c988c3
+commit=302770a3fe4d374ff504f68b8e3d11f0179e750d


### PR DESCRIPTION
Use normal checks for LMS worlds instead of marking the whole world type safe