### PR TITLE
disable disable-cancel

### DIFF
--- a/plugins/disable-cancel
+++ b/plugins/disable-cancel
@@ -1,3 +1,4 @@
 repository=https://github.com/AmeliaXT/disable-cancel.git
 commit=13a177a0d2852bcd8cd856e021ce686a6cfa6193
 authors=AmeliaXT,idyet
+disabled=violates 3pc guidelines


### PR DESCRIPTION
Plugin violates 3rd-party client guideline by removing the cancel option for spellcasts, allowing you to spam click a target without risk of missing:

> Makes it easier to target 3D entities with a spell by removing some options

https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1