### PR TITLE
log-adviser: bump to 3fb663a

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=2c47277904c497e674dff477673a65f323be5ac8
+commit=3fb663abf6faa44550beeb679b5871ea8ac8b365


### PR DESCRIPTION
Bug fix: the activity headline now shows the slot the time estimate is for.

Previously the icon/name showed the lowest-difficulty slot while the displayed time is the combined time to obtain any next slot (driven by the fastest/near-guaranteed slot), so a non-guaranteed slot (e.g. Araxxor's Noxious point) could appear next to an ~89s estimate that actually belongs to the near-guaranteed drop. The engine now headlines the slot that drives the estimate, so the icon always matches the time.

No new client-API surface; pure ranking/UI logic change. v1.1.5.