### PR TITLE
hotfix: update `collection-log-master` to v2.0.1

### DIFF
--- a/plugins/collection-log-master
+++ b/plugins/collection-log-master
@@ -1,4 +1,4 @@
 repository=https://github.com/OSRS-Taskman/collection-log-master.git
-commit=d122b39b071d2ec4d1d6d205973b06f47ccc758d
+commit=7eaa5aed1a1ddff031006068422ac4d167908439
 authors=ImTedious,rmobis
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Just a tiny update to remove some testing code I'd forgotten.