### PR TITLE
Add Mouse Wheel plugin

### DIFF
--- a/plugins/mouse-wheel
+++ b/plugins/mouse-wheel
@@ -1,2 +1,2 @@
 repository=https://github.com/Largemann/mouse-wheel.git
-commit=d64f1c77aadb970a4e2a2f68f0db1afbbe5fc2eb
+commit=d9912f09e5d2d9d9f62f48e236e8d5e3f16e7b64

--- a/plugins/mouse-wheel
+++ b/plugins/mouse-wheel
@@ -1,0 +1,2 @@
+repository=https://github.com/Largemann/mouse-wheel.git
+commit=d64f1c77aadb970a4e2a2f68f0db1afbbe5fc2eb


### PR DESCRIPTION
Certain window sizes in combination with high mouse wheel scroll speed settings in the OS can cause the bank and chat interfaces to scroll too far with a single wheel click, sometimes further than a visible page.

This plugin allows adjustment of how many pixels an interface should scroll for each mouse wheel click.