### PR TITLE
Add account-data-exporter

### DIFF
--- a/plugins/account-data-exporter
+++ b/plugins/account-data-exporter
@@ -1,0 +1,3 @@
+repository=https://github.com/A-Kimpton/account-data-exporter.git
+commit=1f10312ba54a9df8dc1ac101eef87279aeeb582e
+authors=A-Kimpton


### PR DESCRIPTION
Adds Account Data Exporter, a plugin that writes periodic JSON snapshots of the local account to `.runelite/account-data-exporter/` for use with spreadsheets, account tracking, and personal tooling. It covers skills, inventory, equipment, bank, Grand Exchange, quests, achievement diaries, combat achievements, slayer, hunter rumours, and current combat. Every section can be toggled on or off.

Repo: https://github.com/A-Kimpton/account-data-exporter

A few notes for review:

- It only writes local JSON files under `RUNELITE_DIR`. There is no network or HTTP, and it only reads the local player.
- For PvP, when the target is another player it records just `{"type":"player"}` with no name, level, or stats.
- There is no game var for hunter rumour state, so when that section is enabled it reads the saved config from the existing Hunter Rumours plugin and enriches it. It does nothing when that data is not present.
