### PR TITLE
Update Loot Table Viewer GWD drop rates

### DIFF
--- a/plugins/loot-table-viewer
+++ b/plugins/loot-table-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/Oufqt/Loot-Table-Viewer.git
-commit=32df1c41b81ed31a7905a72ac052422be03bc2d4
+commit=78df9e49af5455c8574f08d02ef8d95dab177a90

--- a/plugins/loot-table-viewer
+++ b/plugins/loot-table-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/Oufqt/Loot-Table-Viewer.git
-commit=78df9e49af5455c8574f08d02ef8d95dab177a90
+commit=78df9e45a3d947a44dd40dff81ab52d94d03bef3

--- a/plugins/loot-table-viewer
+++ b/plugins/loot-table-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/Oufqt/Loot-Table-Viewer.git
-commit=78df9e45a3d947a44dd40dff81ab52d94d03bef3
+commit=30279ff3c7caa29502d1895a867a0e9d016610d4


### PR DESCRIPTION
Updates Loot Table Viewer to commit 78df9e49af5455c8574f08d02ef8d95dab177a90.

Fixes God Wars Dungeon bodyguard source lookups so encounter uniques use the boss drop table rates, e.g. Bandos chestplate displays 1/381 from General Graardor instead of the bodyguard page rate 1/16256.