### PR TITLE
Update Better Goldsmithing (icon + re-pin)

### DIFF
--- a/plugins/better-goldsmithing
+++ b/plugins/better-goldsmithing
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/better-goldsmithing.git
-commit=1b13b683a7290784b442f47848ebbaf108adc4cd
+commit=a10b3804a4c615df8665b857f4071b8e17ab945d


### PR DESCRIPTION
Adds an icon.png (Gauntlets of goldsmithing) for the hub listing, and re-points the manifest to the current HEAD after a repo history cleanup. Same v1.3 plugin code, no functional change.