### PR TITLE
Update configurable-slayer-task-overlay

### DIFF
--- a/plugins/configurable-slayer-task-overlay
+++ b/plugins/configurable-slayer-task-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/configurable-slayer-task-overlay.git
-commit=bb733292dfef62a170335c7fbb349f8ef1d78956
+commit=ac6b8c10a957dce52518f774a4b6274d77fa3da2


### PR DESCRIPTION
Bumps the plugin to the latest release.

Fixes [NathanVegetable/configurable-slayer-task-overlay#3](https://github.com/NathanVegetable/configurable-slayer-task-overlay/issues/3): the overlay was not showing for Fleshcrawlers and other multi-NPC slayer tasks. Tasks are now matched against RuneLite's maintained task -> target-name table instead of fragile string matching, and dead NPC-id tracking code was removed.