### PR TITLE
Update barracuda-trials-pathfinder

### DIFF
--- a/plugins/barracuda-trials-pathfinder
+++ b/plugins/barracuda-trials-pathfinder
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/barracuda-trial.git
-commit=78f3041e33781b467c392bb237ec03ff4165d66f
+commit=6734e68437c1248827f04e12f4813dec2d02504c

--- a/plugins/barracuda-trials-pathfinder
+++ b/plugins/barracuda-trials-pathfinder
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/barracuda-trial.git
-commit=4604dc97c4ade00fcc0c1b0a04c8207d984bfca3
+commit=78f3041e33781b467c392bb237ec03ff4165d66f


### PR DESCRIPTION
Bumps the plugin to the latest release, which fixes Jubbly Jive markers and pathing breaking on Marlin difficulty.

Fixes NathanVegetable/barracuda-trial#11