### PR TITLE
Update persistent-bank

### DIFF
--- a/plugins/persistent-bank
+++ b/plugins/persistent-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/rsvaultpudgy-create/persistent-bank-plugin.git
-commit=858374ba333f641319d8196f46c590136435a714
+commit=82749bd750d9cf6d6e9298fb1f04a1f1bb7a7bb1

--- a/plugins/persistent-bank
+++ b/plugins/persistent-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/rsvaultpudgy-create/persistent-bank-plugin.git
-commit=82749bd750d9cf6d6e9298fb1f04a1f1bb7a7bb1
+commit=61ceea97b011ac781ed6aef914e484a0da5ddd94


### PR DESCRIPTION
Item valuation was running on a
background thread, where ItemManager.getItemPrice() returns 0, so whole accounts were priced at ~0. Valuation now runs on the client thread.