### PR TITLE
Update 07flip to 43392f7

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=d5315439903e6a3172a185280bcae89f6819c838
+commit=5132f8613f38daa3c63a5c4bf96b8d015e3fb5bd
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
This update is a maintenance and polish pass for the 07Flip plugin. It trims unused code to keep the plugin lightweight, fixes item search so it returns all matching results instead of only the first few, and adds a small show/hide toggle to the My Trades stats box. No existing features were changed or removed.