### PR TITLE
Update inferno-stats to v2.1.9

### DIFF
--- a/plugins/inferno-stats
+++ b/plugins/inferno-stats
@@ -1,2 +1,2 @@
 repository=https://github.com/InfernoStats/InfernoStats.git
-commit=1c232bcdca30bda76825fcee6df9e72c1c194940
+commit=0efd7441d0a33486bbf2f13fd54cea846f426ee8


### PR DESCRIPTION
Fixes a NullPointerException seen in `RedrawWaveSpawn` by requiring spawned NPCs to map to the new `InfernoNpc` class:

```
java.lang.NullPointerException: null
at view.RedrawWaveSpawn (WaveStatsPanel.java:217)
at view.WaveStatsPanel.update (WaveStatsPanel.java:300)
at InfernoStatsPanel.lambda$UpdateWave$1 (InfernoStatsPanel.java:54)
```