### PR TITLE
log-adviser: bump to 91ae7e5 (v1.1.6)

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=3fb663abf6faa44550beeb679b5871ea8ac8b365
+commit=91ae7e5e16a387cc09a1cf04b2ea0b7d39e202cb


### PR DESCRIPTION
Bumps the pinned commit for **Log Adviser** to the latest `master`.

- repository unchanged: https://github.com/SFranciscoSouza/LogAdviser.git
- commit: `3fb663a` → `91ae7e5e16a387cc09a1cf04b2ea0b7d39e202cb`
- version: 1.1.5 → **1.1.6** (PATCH)

### What changed since the pinned commit
**"Pets Only" filter** — a new option in the sidebar **Show:** dropdown that re-frames the ranking around remaining pets.

- Lists only activities that still drop an uncollected pet, ranked by time-to-pet (the pet treated as the only possible drop, ignoring the other items on the table).
- One row per pet: a pet with several sources collapses to its fastest unlocked source; a pet whose every source is locked is still shown once, demoted to the locked section. Dagannoth Kings shows the combined shared rate for its three pets.
- Each row shows the pet's icon and time with no slot `x/x` count; a separate, separately-persisted skip list applies in this mode.
- New bundled `pets.json` enumerating the 68 collection-log pets.

### Notes for review
- No external/network behavior — no outbound HTTP calls; no new third-party dependencies.
- `build` check passes; `./gradlew build` (incl. tests) green locally.
- Independent of #12484 (collection log auto-sync), which remains under review; this bump does not include that change.