### PR TITLE
feat: update overheal-save v1.1.0

### DIFF
--- a/plugins/overheal-save
+++ b/plugins/overheal-save
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/overheal-save.git
-commit=704016aa226480531af2b1d615e251bb9208078b
+commit=0f3af5a99984605aca23371219ae25a74b69c476


### PR DESCRIPTION
new configs
- show hp orb ring at full hp to avoid overhealing right before a regen tick
- prayer ring only within configured lead window

new features
- notification sound is suppressed in LMS (rapid heal is not available)
- set higher overlay priority to guarantee rendering above Regeneration Meter
- handle indeterminate state when plugin is enabled while logged in
  - enabled rings remain full and flashing
  - full hp ring is not displayed