### PR TITLE
Update ZMI Rune Tracker - rune pouch tracking and bank-to-bank timer

### DIFF
--- a/plugins/zmi-rune-tracker
+++ b/plugins/zmi-rune-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CalabiOSRS/zmi-rune-tracker.git
-commit=9422dfbb5dd33648a9e281a13d8e05ada43582f5
+commit=b50b01b5b2177df9ad597a54eed952e3a89fed32


### PR DESCRIPTION
- Track runes that go directly into the rune pouch
- Full bank-to-bank lap timer (banking time now included)
- Option to hide body and mind runes separately from breakdown