### PR TITLE
Update ZMI Rune Tracker - pause timer on logout, rolling GP/hour

### DIFF
--- a/plugins/zmi-rune-tracker
+++ b/plugins/zmi-rune-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CalabiOSRS/zmi-rune-tracker.git
-commit=9422dfbb5dd33648a9e281a13d8e05ada43582f5
+commit=abdd0f5ab95f8d8af2e4f8210adf0e489358e2ec


### PR DESCRIPTION
- Lap timer now pauses when logged out and resumes on login
- GP/hour now shows rolling average of last 10 laps instead of session average (won't drop when AFK)