### PR TITLE
Update AFK Stats Tracker

### DIFF
--- a/plugins/afk-stats-tracker
+++ b/plugins/afk-stats-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/AfkTracker.git
-commit=7ef588122f59e1658c1e8379f0031d859124ac9c
+commit=d5d4fd9b4b92696c5235db2d422e05a5d4fd6594


### PR DESCRIPTION
Bump to the latest commit. Only the session history list scrolls now, so the Start/Stop buttons stay in place.

![panel](https://raw.githubusercontent.com/Reasel/AFK-Stats-Tracker/d5d4fd9b4b92696c5235db2d422e05a5d4fd6594/panel-preview.png)