### PR TITLE
Add Alch Assistant

### DIFF
--- a/plugins/alch-assistant
+++ b/plugins/alch-assistant
@@ -1,0 +1,2 @@
+repository=https://github.com/tucker-green/alch-assistant.git
+commit=57fb1e45a4a46592eb7ba5e00cc1b46347c76913


### PR DESCRIPTION
Adds Alch Assistant, a plugin that tracks the profit of items bought on the Grand Exchange and then high alched, including the cost of nature runes.

Features:
- Auto-tracks GE buy offers to record the average price paid per item.
- Counts high alch casts from the Magic XP gained per cast (so fast alching is captured fully).
- Subtracts the (live or fixed) nature rune price from each cast.
- Side panel with profit per cast, totals, a Magic level/XP-to-next progress tracker, and an "alch only" mode that hides GE flips.

Repository: https://github.com/tucker-green/alch-assistant