### PR TITLE
letterbox: update author

### DIFF
--- a/plugins/letterbox
+++ b/plugins/letterbox
@@ -1,2 +1,2 @@
 repository=https://github.com/randall-hash/letterbox.git
-commit=13f610b858529fc3ca9e0f7d815d1ac1617845e9
+commit=e257c644ab63cd3759efa5b6893ba08942d1cb65


### PR DESCRIPTION
Bumps the pinned commit for the existing `letterbox` plugin to update the `author` field in runelite-plugin.properties. No functional code changes.