### PR TITLE
bank-templates: update to 1.3

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=b12293599daa7edc1616a1ef94423fd1c756579c
+commit=c42b69df632fbbe31b4a55d5bc34b066ed6d3b4b


### PR DESCRIPTION
Updates Bank Templates to 1.3.

Highlights:
- Reorganise helper: correct handling of kit/ornament item variants; the Skip button works on any single move step; guides you back to the normal bank view from a filtered (Inventory Setups / tag tab / search) view.
- Bank view: fixed the + add button covering (and blocking withdrawal of) an item while an Inventory Setups view was open.
- Fixed the community-template preview opening off-screen on maximised/fullscreen clients.
- Editor: swap/insert is drag-only now, and swaps/moves update only the changed slots.
- Add-item search now finds untradeable items (Barrows gloves, Arclight, Emberlight, ...).

Full notes: https://github.com/TheSpryt/bank-templates/releases/tag/v1.3