### PR TITLE
Fix ZMI Rune Tracker startup crash

### DIFF
--- a/plugins/zmi-rune-tracker
+++ b/plugins/zmi-rune-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CalabiOSRS/zmi-rune-tracker.git
-commit=abdd0f5ab95f8d8af2e4f8210adf0e489358e2ec
+commit=2daf7b7c384c7153aa5158257d3da98427697ce2


### PR DESCRIPTION
Fix startup crash: snapshotPouch() reads varbits which must be called 
on the client thread. Wrapped with clientThread.invokeLater() in startUp().