### PR TITLE
Add Tekton Reset Tracker

### DIFF
--- a/plugins/tekton-reset-tracker
+++ b/plugins/tekton-reset-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/brodloy/tekton-reset-tracker.git
+commit=5e6c45204c34a0efe8f07b57647e3fba9285d74d


### PR DESCRIPTION
## Tekton Reset Tracker

Adds [Tekton Reset Tracker](https://github.com/brodloy/tekton-reset-tracker), a lightweight side-panel plugin that counts how many Chambers of Xeric **Challenge Mode** raids you reset at Tekton without killing him — and the total time wasted doing it.

- Tracks **lifetime** and **per-session** resets and time wasted (lifetime persists across client restarts).
- **CM-only** — Normal raids are ignored.
- Live "current raid" status in the panel. No overlay or infobox.
- Optional chat message on each reset, plus Reset / Copy stats buttons.

Repository: https://github.com/brodloy/tekton-reset-tracker
License: BSD 2-Clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
