### PR TITLE
Add Team Kindling Tracker

### DIFF
--- a/plugins/team-kindling-tracker
+++ b/plugins/team-kindling-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/brodloy/team-kindling-tracker.git
-commit=e5fc543c066f5f3e7b8d11b50617c198d1424b61
+commit=59b04641628545052e08a19aa60d4389a6c62d53

--- a/plugins/team-kindling-tracker
+++ b/plugins/team-kindling-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/brodloy/team-kindling-tracker.git
+commit=e5fc543c066f5f3e7b8d11b50617c198d1424b61


### PR DESCRIPTION
Adds **Team Kindling Tracker**, a Chambers of Xeric plugin for the Ice Demon room.

It shows the party-wide total of kindling fed into each of the four braziers (drawn above each brazier), and optionally each party member's kindling-in-inventory in an overlay box and/or above their head. Adds are counted locally and shared cumulatively over the Party API; nothing uses hard-coded IDs (room/brazier detection is NPC/name based).

- Repository: https://github.com/brodloy/team-kindling-tracker
- License: BSD 2-Clause
- Builds against the RuneLite client on JDK 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
