### PR TITLE
Update Alch Assistant

### DIFF
--- a/plugins/alch-assistant
+++ b/plugins/alch-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/tucker-green/alch-assistant.git
-commit=57fb1e45a4a46592eb7ba5e00cc1b46347c76913
+commit=415bd0280b0a95e860ef967ad5377d2bd8c2360e


### PR DESCRIPTION
Updates the pinned commit to a clean build with a user-facing README (removes the developer-mode build instructions that were showing on the plugin's page). No code changes versus the published version.