### PR TITLE
Add OSRS FlipHub plugin

### DIFF
--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,2 +1,2 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=1c3a4755ad795635cf38140c6dbec8909c106889
+commit=d9bb35dd5107da289cf1afd59441e3743b4b2910

--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,0 +1,2 @@
+repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
+commit=1c3a4755ad795635cf38140c6dbec8909c106889


### PR DESCRIPTION
Adds **OSRS FlipHub**, a Grand Exchange flip tracker.

### What it does
- Records GE offer history locally (buys/sells/completed/aborted)
- Shows per-flip and rolling profit/margins, GE buy-limit timers, and live OSRS Wiki prices
- Item bookmarks and price context in a side panel

### Read-only / no automation
The plugin only observes `GrandExchangeOfferChanged` and related client events. It performs no automation and sends no input to the game. No RuneScape/Jagex credentials are requested, read, or transmitted.

### Network / data handling (please note)
- **Default (not linked): local-only.** All trade data stays on the user's machine. The only network calls are read-only price lookups to the public OSRS Wiki price API (`prices.runescape.wiki`).
- **Optional account link:** if the user pastes a FlipHub license key in the plugin settings, their GE offer events (item, quantity, price, offer state, timestamps) are uploaded over HTTPS to FlipHub's servers (`osrsfliphub.com`) to power an online dashboard. This is **opt-in** - nothing is uploaded until the user links - and is disclosed both in the plugin description and in a dedicated config section. Clearing the key or clicking **Unlink** stops uploads immediately.

Source: https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public
Licensed BSD 2-Clause.
