### PR TITLE
flip-finder-sync: 1.0.1 (auto-connect on load)

### DIFF
--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=14188a618ff5388e37df0b28bec7303954365985
+commit=cbc92590be89ab02683e31ee3b79810aaa45b0a1
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates **Flip Finder Sync** to 1.0.1.

- Pins to commit `cbc92590be89ab02683e31ee3b79810aaa45b0a1`.
- Change since the currently-pinned build: the plugin now auto-connects (verifies the configured API key) when it loads and re-verifies when the key changes, so the side panel shows live connection status without a manual "Test connection" click.

Source repo: https://github.com/betmodejoe/osrsflipfinder.com
