### PR TITLE
Update lobster-pot plugin

### DIFF
--- a/plugins/lobster-pot
+++ b/plugins/lobster-pot
@@ -1,3 +1,3 @@
 repository=https://github.com/datlalo/The-Lobster-Pot---Clan-Plugin.git
-commit=26c8488ae49b1f295d7ff54cc8c35114eaef40fe
+commit=45ad19ba70c45f2c2127681db69ef581feb2c861
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates lobster-pot to datlalo/The-Lobster-Pot---Clan-Plugin@45ad19ba70c45f2c2127681db69ef581feb2c861.

Changes include in-game checks for Diamond, Dragonstone, Onyx, Zenyte, and Legacy Veteran rank requirements.