### PR TITLE
goalplanner: bump to 0.4.0

### DIFF
--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-goal-planner.git
-commit=3593bae5bcc989d31fd0befaa94cfb73b7877d1c
+commit=238f1a7f71c5c3fcb90f22719e8e40d85579cdf3


### PR DESCRIPTION
Updates the **Goal Planner** plugin to 0.4.0 (commit 238f1a7f71c5c3fcb90f22719e8e40d85579cdf3).

Highlights this release:
- Per-profile goal scoping (goals/sections/tags scoped to the active config profile, reload on profile switch)
- Degradable/charged-item goals count all item variants toward the target
- Collapsible nested view with persisted per-goal state; nested-view preference carried through share import/export
- Saved Plans library, section completion badges, configurable panel font (family + size scale)
- Various font-rendering and large-font layout fixes

Source builds clean and stays within the hub limits — `./gradlew preSubmit` (test + checkDocs + checkGlyphs + checkTokens) passes; main source is 177,073 / 200,000 tokens.