### PR TITLE
Add Kaisham's Exhumed Markers plugin

### DIFF
--- a/plugins/kaishams-exhumed-markers.properties
+++ b/plugins/kaishams-exhumed-markers.properties
@@ -1,0 +1,2 @@
+repository=https://github.com/KaishamRL/kaishams-exhumed-markers.git
+commit=118b166

--- a/plugins/kaishams-exhumed-markers.properties
+++ b/plugins/kaishams-exhumed-markers.properties
@@ -1,2 +1,2 @@
 repository=https://github.com/KaishamRL/kaishams-exhumed-markers.git
-commit=118b166
+commit=2a0396d


### PR DESCRIPTION
This plugin automatically populates tile markers for the Xarpus exhumed grid layout in the Theatre of Blood (Plane 1) using the native Object Indicators plugin configurations