### PR TITLE
Update ZMI Rune Tracker - add rune pouch tracking

### DIFF
--- a/plugins/zmi-rune-tracker
+++ b/plugins/zmi-rune-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CalabiOSRS/zmi-rune-tracker.git
-commit=abdd0f5ab95f8d8af2e4f8210adf0e489358e2ec
+commit=ac99bbff46a0bff7388b5028436b690cf7020a79


### PR DESCRIPTION
- Added rune pouch tracking using game enum for correct rune type mapping
- Pouch gains are only tracked when bank is not open (prevents bank withdrawal false positives)
- Added config option to show/hide pouch warning message
- Fixed startup crash (snapshotPouch called on client thread)
- tested in developper mode