### PR TITLE
log-adviser: bump to 57799a4

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=7602f97e401f201252f57324c1a83c2b4676b35e
+commit=57799a4407ae79207754ad68e6d4240a3c506460


### PR DESCRIPTION
Updates **Log Adviser** to v1.1.8.

Pins `commit=57799a4407ae79207754ad68e6d4240a3c506460` (was `7602f97`); `repository=` unchanged.

Changes in this release:
- **Fix:** the in-interface "Log Sync" button could be hidden when another collection-log plugin (e.g. Temple-OSRS) rebuilds the collection-log interface and clears its child widgets. The button now re-attaches reliably — a deferred re-attach after the collection-log setup script plus a per-tick watchdog — so it coexists with other plugins' buttons regardless of event ordering.
- Rename the button to "Log Sync" and tighten its size/padding to use less header space.
- Add a settings-page section and a sidebar hint explaining the Log Sync button.

No new external/client API surface beyond the existing collection-log Sync feature, and no outbound network calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
