### PR TITLE
log-adviser: bump to 17b88a2

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=7602f97e401f201252f57324c1a83c2b4676b35e
+commit=17b88a2d6ca4cb3c64376bc6b1fa08e39bacd38b


### PR DESCRIPTION
Updates Log Adviser to v1.1.8.

Pins `commit=17b88a2d6ca4cb3c64376bc6b1fa08e39bacd38b` (was `7602f97`); `repository=` unchanged.

Config-only change: adds a notice on the plugin's settings page asking users to temporarily disable the Temple OSRS plugin in order to see Log Adviser's collection-log Sync button, while a fix for the conflict between the two plugins is prepared.
