### PR TITLE
log-adviser: bump to 97db160

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=7602f97e401f201252f57324c1a83c2b4676b35e
+commit=97db160cd5a556fc3f6317590a9ed694df477ace


### PR DESCRIPTION
Updates Log Adviser to v1.1.9.

Pins `commit=97db160cd5a556fc3f6317590a9ed694df477ace` (was `7602f97`); `repository=` unchanged.

Fixes the in-interface "Log Sync" button being hidden when another collection-log plugin (e.g. Temple-OSRS) rebuilds the collection-log interface and clears its child widgets. The button now re-attaches reliably — a deferred re-attach after the collection-log setup script plus a per-tick watchdog — so it coexists with other plugins' buttons regardless of event ordering.

Also renames the button to "Log Sync", tightens its size to use less header space, and adds a settings-page section and a sidebar hint explaining it.
