### PR TITLE
Update drop-rates-clog commit hash

### DIFF
--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=a5ee28c5dd1ecb348dc709f94412472f2bba3741
+commit=4dff08c7f22d4dc5a51ac7cf21761fd0834c7311


### PR DESCRIPTION
Bumps the Clog Drop Rates plugin to the latest commit.

Splits the single "Reduce fractions" option into separate, configurable controls (show-as-1/N with decimal precision, combine multi-roll rates, and a choice of combine method), addressing pairofcrocs/drop-rates-clog#3.