### PR TITLE
osrs-invest: add plugin

### DIFF
--- a/plugins/osrs-invest
+++ b/plugins/osrs-invest
@@ -1,0 +1,2 @@
+repository=https://github.com/TheSpryt/osrs-invest-plugin.git
+commit=0962f7beb7f9a165292ee9aa61fd54c1e372ae99


### PR DESCRIPTION
Adds the **OSRS Invest** plugin.

Companion plugin for the OSRS Invest dashboard: it streams the wearer's own Grand Exchange fills (and an optional, revision-gated datamine) to a user-configured dashboard URL, authenticated with a user-supplied token. Nothing is sent until both the URL and token are set; there is no third-party telemetry.

- Repository: https://github.com/TheSpryt/osrs-invest-plugin
- Builds against `latest.release`; `build=standard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)