### PR TITLE
Add Item Exceptions

### DIFF
--- a/plugins/shop-block
+++ b/plugins/shop-block
@@ -1,2 +1,2 @@
 repository=https://github.com/LogicalSoIutions/Shop-Block.git
-commit=a21992b2bb733eeef73f99b17a732f600de7694c
+commit=61515469994fa37fd08387c0519264f802bec383

--- a/plugins/shop-block
+++ b/plugins/shop-block
@@ -1,2 +1,2 @@
 repository=https://github.com/LogicalSoIutions/Shop-Block.git
-commit=be97e3102e3cba107902ff34087cc2fb7fd906db
+commit=a21992b2bb733eeef73f99b17a732f600de7694c


### PR DESCRIPTION
Per user request, added Item Exceptions. Allows users to let items they set be excluded from the Shop Block so they can sell them without toggling plugin on/off every time. 