### PR TITLE
Update corp-boosting-qol

### DIFF
--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/pet-boosting-qol.git
-commit=76ffb8421f77f65210b70351c1f9dbc1a3826445
+commit=75604f9000843eddd3d045cc08cd6ddd5f255974


### PR DESCRIPTION
Updated commit — fixes an issue where the movement lock keybind defaulted to 0 and consumed all numpad/keyboard 0 keypresses anywhere in the game even when movement lock was disabled or the feature wasn't in use. The keybind now only activates when movement lock is actually enabled for Corp or KQ, and the default has been changed to unbound. Also changed the combat idle overlay to a more subtle default colour.