### PR TITLE
Revert "update terpinheimercc (#12894)"

### DIFF
--- a/plugins/terpinheimercc
+++ b/plugins/terpinheimercc
@@ -1,4 +1,4 @@
 repository=https://github.com/FadedOSRS/terpinheimerccplugin.git
-commit=9bafb15f04dc0ecbab06b24e5c38bfa5b1087710
+commit=a9b95938887f066cf91ed5d5d4bc7ed66d699630
 authors=FadedOSRS
 warning=Terpinheimer can send your IP address and game client data to services you enable: Wise Old Man, TerpinheimerCC (calendar, live map, collection log, roster, attendance), party loot via RuneLite party, Discord webhooks, and GETs to terpinheimercc.com for clan settings (cached; no player data).<br>Some of that may be visible to others depending on those services. Not recommended for PvP-locked HCIM where sharing location or progress could hurt you.


### PR DESCRIPTION
This reverts commit b83187faedfbcc085b5badbea20eb0959f6f4ebf.

@FadedOSRS you can't make some network request to a server to then receive another URL(s) to make requests to in your plugin, that is a security risk.

every URL that the plugin talks to either needs to be user-configured or hardcoded.

it looks like that's what you had before so you'll just need to go back to that.