### PR TITLE
Update ZMI Rune Tracker - XP tracking, GP/hour modes, login fix

### DIFF
--- a/plugins/zmi-rune-tracker
+++ b/plugins/zmi-rune-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CalabiOSRS/zmi-rune-tracker.git
-commit=ac99bbff46a0bff7388b5028436b690cf7020a79
+commit=dc333011d0aaaa1c5b4d608032df7c01f83d6d4c


### PR DESCRIPTION
- Fixed rune pouch login bug (existing pouch runes were counted on login)
- Added XP last lap display (configurable)
- Added XP/hour display (configurable)  
- Added GP/hour mode option: last 10 laps, full session, or hidden
- Tested in developer mode