### PR TITLE
bank-templates: update to 1.4

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=c42b69df632fbbe31b4a55d5bc34b066ed6d3b4b
+commit=7b0d380d017b4daed7331827ca6738de1f7d171f

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=7b0d380d017b4daed7331827ca6738de1f7d171f
+commit=2b8823dc9f8a307a4bca17cdf1a54fc2f5d4e9cb


### PR DESCRIPTION
Updates the Bank Templates plugin to 1.4.

Highlights:
- My Templates and Browse cards show how much of each template you own ("x / y items"); the count is cached per account so it shows before the bank loads, then updates live.
- New "Items owned" Browse sort (client-side; the server never receives your bank).
- Colour-coding is now its own combinable reorganise display option, with per-tab colours configurable in settings.
- Reorganise step-by-step reworked into a single forward pass (creates tabs inline, no backtracking/looping); labels moved bottom-right with a green tick for placed items.
- Preview/editor windows sized consistently; editor description is editable; layout-editor swap is a toggle.

Full notes are in the in-plugin Updates tab / changelog.json.