### PR TITLE
Update Team Kindling Tracker

### DIFF
--- a/plugins/team-kindling-tracker
+++ b/plugins/team-kindling-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/brodloy/team-kindling-tracker.git
-commit=59b04641628545052e08a19aa60d4389a6c62d53
+commit=112fcdf078fcd4a79600c7d2977cf4a8d851fa9c

--- a/plugins/team-kindling-tracker
+++ b/plugins/team-kindling-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/brodloy/team-kindling-tracker.git
-commit=112fcdf078fcd4a79600c7d2977cf4a8d851fa9c
+commit=990f53fc56ab8c8ea858a5e0a917c53fad2cb020


### PR DESCRIPTION
Bug-fix update for **Team Kindling Tracker**.

Dropping kindling on the ground lowered inventory the same way feeding a brazier does, so a drop was being miscounted toward the nearest brazier. In CM teams it's common for one player to drop kindling and another to pick it up / telegrab and dump it themselves, which made counts wrong. The plugin now ignores inventory decreases caused by a "Drop" on kindling; the player who actually feeds it still counts it on their own client.

- Repo: https://github.com/brodloy/team-kindling-tracker
- Diff: https://github.com/brodloy/team-kindling-tracker/compare/59b0464...112fcdf

🤖 Generated with [Claude Code](https://claude.com/claude-code)
