### PR TITLE
Update Tekton Reset Tracker

### DIFF
--- a/plugins/tekton-reset-tracker
+++ b/plugins/tekton-reset-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/brodloy/tekton-reset-tracker.git
-commit=8984b49a0f61750f8b5177343e2f6ccc20a05b0f
+commit=a1541c37c133addff3f32e33bad131409e2a08fa

--- a/plugins/tekton-reset-tracker
+++ b/plugins/tekton-reset-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/brodloy/tekton-reset-tracker.git
-commit=5e6c45204c34a0efe8f07b57647e3fba9285d74d
+commit=8984b49a0f61750f8b5177343e2f6ccc20a05b0f


### PR DESCRIPTION
## Update Tekton Reset Tracker

Bumps [Tekton Reset Tracker](https://github.com/brodloy/tekton-reset-tracker) to its latest commit.

Changes since the initial release:

- A reset now counts whenever you reach Tekton in a CM raid and leave (or log out) without progressing past him - including the common case of killing Tekton, seeing a slow time, and re-rolling. Previously only no-kill leaves were counted.
- Progressing to the next room (combat or puzzle) or completing the raid never counts.
- Panel shows live status: "Completed Tekton" while you can still re-roll, then green "Moved past Tekton" once you commit to the raid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
