### PR TITLE
Update Overhead Overload to latest commit

### DIFF
--- a/plugins/overhead-overload
+++ b/plugins/overhead-overload
@@ -1,2 +1,2 @@
 repository=https://github.com/brodloy/overhead-overload.git
-commit=46c50c76e7422ab7cfd7a56ca3d6a09c28f220c6
+commit=aa5464f22cf1fd8a6ae60381fe3f3995ee5d4b73


### PR DESCRIPTION
Updates **Overhead Overload** to the latest commit (`aa5464f`).

Documentation and asset only since the last accepted commit: adds a README banner image and rewrites the README. No source, config or behaviour changes.

Source: https://github.com/brodloy/overhead-overload