### PR TITLE
Update grand-flip-out plugin

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=050659877072be2b7d8c07f0c9030f12dc95a4b2
+commit=9fea2c43f4564433e7096f570591d1d7c575480f


### PR DESCRIPTION
Bumps Grand Flip Out to the latest commit. This update adds spike detection/alerts, turns GE auto-fill on by default with a warning, fixes the User-Agent bug, and improves the JTabbedPane layout.