### PR TITLE
Add OSRS Trade Tracker

### DIFF
--- a/plugins/osrs-trade-tracker
+++ b/plugins/osrs-trade-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/StefanMikael/osrs-trade-tracker.git
+commit=0748407eb6540ee861ee97317c39e5ffc8647b28


### PR DESCRIPTION
Adds OSRS Trade Tracker, a RuneLite plugin that records Grand Exchange offer creation, fills, completion, cancellation, and modifications to local JSON files. Trading data remains local and is separated by character.