### PR TITLE
New plugin AlertBadOffers

### DIFF
--- a/plugins/alert-bad-offers
+++ b/plugins/alert-bad-offers
@@ -1,0 +1,2 @@
+repository=https://github.com/itssapir/AlertBadOffers.git
+commit=1e8e87600d2d611381a7acfdb5f2e093d76ca06a


### PR DESCRIPTION
This plugin aims to extend the built in OSRS functionality of warning for GE offers lower than 10% or higher than 10x the market price.

The plugin allows to manually set the % at which an alert will be presented to the user, at which point he would have to click confirm twice in order for the offer to be submitted, avoiding misclicks or momentary mistakes costing millions of GP.
