### PR TITLE
drop-rates-clog: fix client freeze, re-enable

### DIFF
--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,3 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=4dff08c7f22d4dc5a51ac7cf21761fd0834c7311
-disabled=freezes the client
+commit=4af663785280f68d8979b2eecb3d42e547bfb035


### PR DESCRIPTION
Re-enables `drop-rates-clog` with the freeze fixed.

It was disabled for an `IllegalAccessError` that froze the client on every collection-log hover (and the same cause NPE'd the settings panel). A config-referenced enum was package-private, so RuneLite's generated config proxy couldn't access it; replaced it with a boolean.

Diff: commit bump + remove `disabled`.