### PR TITLE
osrscn: update to 0.1.1

### DIFF
--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=56a56b70e2e7fb13a33bc45f02d919c89326b668
+commit=71782062ee253b33847618afaaeeee42e144c03e
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update osrscn to 0.1.1.

Changes since 0.1.0:
- Fix blank Simplified Chinese glyphs on macOS (Java2D antialiases even with the AA hint off, so small glyphs had no fully-opaque pixels for IndexedSprite to keep; the glyph coverage is now flattened to a 1-bit mask). No-op on Windows/Linux.
- Fix the Swing config panel rendering Chinese section titles as tofu on macOS (retarget UI fonts to a CJK-capable logical font on macOS only).
- Add in-client contact/feedback channels (QQ group + feedback form via LinkBrowser) and document them in the README.

repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
commit=71782062ee253b33847618afaaeeee42e144c03e