### PR TITLE
flip-finder-sync: add plugin icon and refresh listing metadata

### DIFF
--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=cbc92590be89ab02683e31ee3b79810aaa45b0a1
+commit=47a1478fe6a70989ea76f0b219a9025adba6aadf
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates **flip-finder-sync** to the latest commit on the plugin repo.

Changes since the currently-listed commit:

- Adds an `icon.png` (48×48, within the 48×72 spec) so the plugin shows an icon in the Plugin Hub instead of a blank tile.
- Front-loads the `description` and broadens the search `tags` so the plugin is easier to find.
- Carries the plugin's own `1.0.1` changes that hadn't been re-submitted yet (auto-connect on load, transient-failure retries, hardcoded production endpoint).

No new third-party dependencies. Build type remains `standard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
