### PR TITLE
bank-templates: 1.4.1

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=b2959fc95d2215bc7bdb821a962feff4e989eee9
+commit=e3cd25d9321a4a81f4366358ff943672fda54c91

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=2e5ea5fb6c91f53b8b16035ad53582d7491b35c7
+commit=2347a1349cbfdc99ea748ccd8ed66fb590a66432

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=2347a1349cbfdc99ea748ccd8ed66fb590a66432
+commit=b2959fc95d2215bc7bdb821a962feff4e989eee9

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=2b8823dc9f8a307a4bca17cdf1a54fc2f5d4e9cb
+commit=2e5ea5fb6c91f53b8b16035ad53582d7491b35c7

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=e3cd25d9321a4a81f4366358ff943672fda54c91
+commit=41b78e140fca8795a7716794c36b68b163e359a2


### PR DESCRIPTION
Updates bank-templates to 1.4.1.

- My Templates: 'Capture current bank' and 'New empty template' buttons moved to the top of the tab (under the search box); 'New empty layout' renamed to 'New empty template'.