### PR TITLE
better-goldsmithing: re-point to current commit

### DIFF
--- a/plugins/better-goldsmithing
+++ b/plugins/better-goldsmithing
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/better-goldsmithing.git
-commit=a10b3804a4c615df8665b857f4071b8e17ab945d
+commit=f9b74fca2d6f568abac2ae353454d625f8741658

--- a/plugins/better-goldsmithing
+++ b/plugins/better-goldsmithing
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/better-goldsmithing.git
-commit=f9b74fca2d6f568abac2ae353454d625f8741658
+commit=d1a46fb75ff77a8481010e5fbf9c26d029606237

--- a/plugins/better-goldsmithing
+++ b/plugins/better-goldsmithing
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/better-goldsmithing.git
-commit=d1a46fb75ff77a8481010e5fbf9c26d029606237
+commit=6ae4ff6dd7dac99e91b29e6ba8bfea36ba089e5a


### PR DESCRIPTION
Re-points better-goldsmithing from `a10b3804a4c615df8665b857f4071b8e17ab945d` to `f9b74fca2d6f568abac2ae353454d625f8741658`.

Same version; the built tree is identical (a file was removed from older history only, not from the built commit's tree). The previous commit was orphaned during a git history tidy on my repo, so this updates the manifest to the equivalent reachable commit.