### PR TITLE
Update ZMI Rune Tracker - ZMI region check, XP tracking, GP/hour modes

### DIFF
--- a/plugins/zmi-rune-tracker
+++ b/plugins/zmi-rune-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/CalabiOSRS/zmi-rune-tracker.git
-commit=b50b01b5b2177df9ad597a54eed952e3a89fed32
+commit=a8abbc35dc00853b5a870e897877fbf50b9661b7


### PR DESCRIPTION
- Tracker now only activates inside the Ourania Cave
- Added XP per last lap display (configurable)
- Added XP/hour display (configurable)
- Added GP/hour mode option: last 10 laps, full session, or hidden
- Fixed rune pouch login bug
- Tested in developer mode