### PR TITLE
update bank-tab-names -fixes heavy performance issue

### DIFF
--- a/plugins/bank-tab-names
+++ b/plugins/bank-tab-names
@@ -1,2 +1,2 @@
 repository=https://github.com/Psyda/bank-tab-names.git
-commit=225a94164b5ce9af2463425be2a3562897b43feb
+commit=dee7759d9323adfb1aa53989a6b2590ac4f97b96


### PR DESCRIPTION
## Performance fix

Multiple users reported FPS slowly dropping the longer they sat in the bank.
It resets to normal on closing the bank and only happened with the plugin enabled.

The cause was `createTextOverlay()`, it created a fresh text widget on Bankmain.INFINITE
every rebuild and only hid the previous one. The bank's redraw scripts fire
about 10 times a second, so hidden BTN_tabN_text widgets piled up without
bound until the bank closed, and the client walks hidden children every frame.
With ten text tabs that was roughly 100 leaked widgets a second.

The fix:
the text widget is now pooled and reused, the same way icon overlays
already were. It is only recreated when it is missing, stale after a
destructive rebuild, or pushed below the icons in z-order. INFINITE now holds
one text widget per tab instead of thousands, and the frame rate stays flat.

Tested by sitting in the bank with text tabs configured. Widget count holds
steady and FPS no longer bleeds down.

## Minor changes

- Disabled or emptied tabs now restore their default content immediately,
  instead of staying blank until the next natural bank rebuild. Turning the
  plugin off while in the bank cleans them up the same way. Both work by
  asking the bank to redraw itself, mirroring RuneLite's own bank relayout.
- The plugin's bank tab right-click actions moved into a "Bank Tab Names" submenu,
  so they are no longer adjacent to the game's easily-misclicked Collapse and
  Remove-placeholders options.
- New "Risky tab options" setting (Off / Show only on Shift / Hide) to keep
  those game options from being hit by accident.
- Fixed the side-panel text field caret jumping to the end on every keystroke,
  which made editing tab text awkward.