### PR TITLE
Update Team Kindling Tracker

### DIFF
--- a/plugins/team-kindling-tracker
+++ b/plugins/team-kindling-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/brodloy/team-kindling-tracker.git
-commit=990f53fc56ab8c8ea858a5e0a917c53fad2cb020
+commit=fdb32d62b842fe35a0e9ab5e55009030dd93cc8a


### PR DESCRIPTION
Bug-fix update for **Team Kindling Tracker**.

The brazier overlay was only torn down when leaving the whole raid, so after the Ice Demon was killed the overlay held stale brazier object references and re-projected them into later raid rooms on each scene reload (numbers floating in e.g. the thieving room). The room state is now cleared on the demon's death, and stale brazier references are dropped on every scene reload as a safety net. Also reframed the banner to match my other plugins.

- Repo: https://github.com/brodloy/team-kindling-tracker
- Diff: https://github.com/brodloy/team-kindling-tracker/compare/990f53f...fdb32d6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
