### PR TITLE
update nex-leech-utility

### DIFF
--- a/plugins/nex-leech-utility
+++ b/plugins/nex-leech-utility
@@ -1,2 +1,2 @@
 repository=https://github.com/jakevollkommer/nex-leech-utility.git
-commit=baf77e870f4181fcc711367fd3b5cd42ebb70dc3
+commit=abbd95e5f13cfbc4bd7dd94dcf42d2e96f7b2db7


### PR DESCRIPTION
Update of an existing hub plugin (`nex-leech-utility`).

Adds an opt-in **blood reaver spawn predictor**: during Nex's blood phase it paints the most-likely blood-reaver spawn tiles (2x2 outlines labelled "Blood Reaver", nearest one highlighted), anchored to Nex's live position and clipped to the open walkable directions from her. Off by default, in its own "Blood reaver predictor" config section. Also includes a behaviour-neutral readability refactor.

No change to existing behaviour unless the new toggle is enabled.