### PR TITLE
Adds OSParty

### DIFF
--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,3 +1,3 @@
 repository=https://github.com/iodrareg/osparty.git
-commit=1a8367b34b12dc1f262b9b13821180ce97b9593a
+commit=6c79ad30122bfe646c6029a5d7d5cb8204febaae
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,0 +1,2 @@
+repository=https://github.com/iodrareg/osparty.git
+commit=00ab6cefbe41b91b28b56f89712e0497b6a8cced

--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,2 +1,2 @@
 repository=https://github.com/iodrareg/osparty.git
-commit=00ab6cefbe41b91b28b56f89712e0497b6a8cced
+commit=1a8367b34b12dc1f262b9b13821180ce97b9593a

--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,2 +1,3 @@
 repository=https://github.com/iodrareg/osparty.git
 commit=1a8367b34b12dc1f262b9b13821180ce97b9593a
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds the ability to search an open or private place for parties for various activities around the game. Makes it easy to find party members for raids, various Ironman activities or minigames. It's an extension on the current P2P party plugin that enriches the protocol with an actual host that can manage users within a party. These parties are formed off of an API that is publicly available (https://github.com/iodrareg/ospartyapi) using Spring boot and Redis as a semi-persistent way of storing parties and their respective owner. 