### PR TITLE
Update Hub Party Panel (v3.7)

### DIFF
--- a/plugins/party-panel
+++ b/plugins/party-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/TheStonedTurtle/party-panel.git
-commit=78487832b5ace8d9865aacb75a1a0769dcdefc5d
+commit=18ec11939ff783550cb192d6a0b6715a0229988b


### PR DESCRIPTION
* Fixes some references to deprecated APIs
* Adds a reminder overlay telling you that you aren't in a party
  * The config option controlling this defaults to off
* Adds a icon under the toggle icon indicating which spellbook you are on