### PR TITLE
drop-rates-clog: bump version

### DIFF
--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=4af663785280f68d8979b2eecb3d42e547bfb035
+commit=9a8cdaa851de0545c1bc32d497d46e10cc4e8a6c


### PR DESCRIPTION
Applies the "Show as 1/N" setting to multi-roll rates when "Combine multi-roll rates" is off (previously left verbatim).