### PR TITLE
P1770 plugin

### DIFF
--- a/plugins/p1770
+++ b/plugins/p1770
@@ -1,0 +1,2 @@
+repository=https://github.com/septemgeminus/p1770.git
+commit=3d028d759f73a0a5ec55827d0f7b4f2ead3e700b


### PR DESCRIPTION
A simple kill-count/item-count tracker for item-grinds based indirectly on killing NPCs, that also provides some feedback as to how lucky one is on one's grind, based on grind-specific probabilities that users can specify.

The personal motivation is to have a tracker that offers some feedback per kill for a purely Bryophyta-based essence grind. It comes pre-configured for an Obor-based Giant Club grind as well as the Bryophyta-based essence grind; but the plugin intentionally tries to be dumb, simple, and universal.

The plugin is general enough that I believe to have been able to test it sufficiently on different mobs around Lumbridge.

I have tried to write a decent README, please refer to it for further information.