### PR TITLE
Update Kill Clog to 1.5.0

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=a0db47d7c8fec097436945bc441198d1b0933b49
+commit=f5c06e736fb768c3bf9bf539d4f643b7ebbf2eab
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Kill Clog to 1.5.0.

- Adds support for Defense Pures and Skillers.
- Adds boss Wiki page links to boss names in collection log tooltips.

Local gate:
`./gradlew.bat compileJava checkstyleMain checkstyleTest test`