### PR TITLE
Add Stockpile

### DIFF
--- a/plugins/stockpile
+++ b/plugins/stockpile
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Stockpile-Plugin.git
-commit=cc1c4b3dd6c4a1a9587abe1547ead0e82b03b8af
+commit=790c964c01a5c10709ef08f8f102a5a1b42a1c51

--- a/plugins/stockpile
+++ b/plugins/stockpile
@@ -1,0 +1,2 @@
+repository=https://github.com/Oveduumnakal/Stockpile-Plugin.git
+commit=cc1c4b3dd6c4a1a9587abe1547ead0e82b03b8af


### PR DESCRIPTION
### Stockpile

Adds **Stockpile**, a plugin for tracking the quantity, value, and cost-basis profit of items you gather, produce, or trade, with live Grand Exchange / wiki pricing, in-panel charts, and price alerts.

**Highlights**
- Track item quantities (manual or auto-add) with collection-log reconciliation.
- Live GE/wiki prices with time-window breakdowns and market-state stats.
- Cost-basis profit model (per-item and portfolio-wide).
- Per-item detail view with price/volume graphs and pop-out charts.
- Configurable price/percent/volume notifications.

**Data sources / network**
- The only network access is to the **official OSRS Wiki prices API** (`prices.runescape.wiki` — `/latest`, `/mapping`, `/timeseries`), the same source RuneLite's own price tooling uses.
- A small bundled `examines.json.gz` (~240 KB) provides item examine text for the detail view. It's a static map of item id → examine text, generated from a public OSRS item dump; the generator script (`tools/generate-examines.py`) is included in the repo for provenance. No network call is made for it.

**Rules**
- No automation or input simulation — the plugin is read-only/UI: it displays data, highlights tracked items, and reacts to game events. Nothing clicks or plays for you.
- Open source under the BSD 2-Clause license.

Repo: https://github.com/Oveduumnakal/Stockpile-Plugin