### PR TITLE
Add silly-specs plugin repository information

### DIFF
--- a/plugins/silly-specs
+++ b/plugins/silly-specs
@@ -1,2 +1,2 @@
-repository=https://github.com/Inzomniakk/silly-specs.git
-commit=007f66a1ef52b001540e0896f19a7a8e1ca5aee3
+ repository=https://github.com/Inzomniakk/silly-specs.git
+commit=a615a601d09bc433054b5355938477534576fb90

--- a/plugins/silly-specs
+++ b/plugins/silly-specs
@@ -1,0 +1,2 @@
+repository=https://github.com/Inzomniakk/silly-specs.git
+commit=007f66a1ef52b001540e0896f19a7a8e1ca5aee3

--- a/plugins/silly-specs
+++ b/plugins/silly-specs
@@ -1,2 +1,2 @@
  repository=https://github.com/Inzomniakk/silly-specs.git
-commit=a615a601d09bc433054b5355938477534576fb90
+commit=28766dd15e693b884009c9fbd46d3eff9e3606d4


### PR DESCRIPTION
Changes the sound effect played when speccing with certain weapons. Currently supports Fang, D Baxe, and D Claws.