### PR TITLE
Add Prayer Sound Swapper plugin

### DIFF
--- a/plugins/prayer-sound-swapper
+++ b/plugins/prayer-sound-swapper
@@ -1,0 +1,2 @@
+repository=https://github.com/aaronenberg/PrayerSoundSwapper.git
+commit=d69e607abd63dcb4d556bb9ebcf7f0270c7eeda5


### PR DESCRIPTION
Allows the user to replace prayer-related sound effects.

Unlike the original Sound Swapper plugin, Prayer Sound Swapper only replaces prayer sound IDs from a static allowlist of prayer sound IDs. This is to allow this plugin to be compliant when enabled in areas where the original SoundSwapper plugin cannot be due to RuneLite guidelines around swapping arbitrary sounds.