### PR TITLE
Update ClanFinder plugin commit

### DIFF
--- a/plugins/clanfinder
+++ b/plugins/clanfinder
@@ -1,3 +1,3 @@
 repository=https://github.com/OSRSClanFinder/clanfinder-runelite-plugin.git
-commit=9a420be702b6b692c231bac6e345280561801d0f
+commit=0bdf38963c90aff34254508efac743b2c19767cf
 warning=This plugin makes JSON listing requests, banner image requests, and event data requests to osrsclanfinder.com. Listed member totals are site listing data from Wise Old Man group stats or manual counts, not live online status. These external requests expose your IP address to that service, which is not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Updates ClanFinder to OSRSClanFinder/clanfinder-runelite-plugin@0bdf38963c90aff34254508efac743b2c19767cf.

  Changes included:
- Redesigns the Plugin Hub side panel layout with clearer clan cards, fixed width content, improved spacing, status text, and a visible "Clan Finder" header.
- Adds an "Add Clan" flow inside the panel with buttons to open the Clan Finder clan registration page and support Discord invite, both only after explicit user action.
- Improves clan detail display with richer requirements and upcoming-event sections.
- Displays additional requirement fields from the API, including application instructions and requirement notes.
- Improves display of clan-provided text by normalizing HTML snippets/entities, preserving multiline spacing, and handling emoji rendering more reliably in Swing.
- Makes the copied clan chat confirmation less noisy by no longer echoing the clan chat name into the RuneLite chat message.
- Adds regression tests for text normalization, requirement notes, emoji/font fallback behavior, and the new display parsing behavior.