### PR TITLE
flip-finder-sync: update to v1.0.4

### DIFF
--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=47a1478fe6a70989ea76f0b219a9025adba6aadf
+commit=f836132491d6158f57a0844f6fdc13888d3a55a9
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=f836132491d6158f57a0844f6fdc13888d3a55a9
+commit=d9e8bb8665b29914c8948ca7894f29732800f2e2
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/flip-finder-sync
+++ b/plugins/flip-finder-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/betmodejoe/osrsflipfinder.com.git
-commit=d9e8bb8665b29914c8948ca7894f29732800f2e2
+commit=f24323d740dcd2952e83772ed5148aa85250e443
 warning=This plugin sends your Grand Exchange transactions and IP address to OSRS Flip Finder, a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates **Flip Finder Sync** to v1.0.2.

New: the plugin now uses the same API key it already syncs with to pull OSRS Flip Finder's suggested buy/sell prices for the items in the player's live GE slots, shown in a new "Live offers" panel section — your price vs the model's suggestion (over/under-pay delta), projected margin/profit, fill probability + a rough ETA, and a stale/price-drift warning. Adds `Show price suggestions` + `Risk` config options. Read-only; no change to the existing trade-sync behaviour or the data sent.

Source commit: betmodejoe/osrsflipfinder.com@f836132491d6158f57a0844f6fdc13888d3a55a9

🤖 Generated with [Claude Code](https://claude.com/claude-code)