### PR TITLE
Update Clan Finder plugin v0.1.2.

### DIFF
--- a/plugins/clanfinder
+++ b/plugins/clanfinder
@@ -1,3 +1,3 @@
 repository=https://github.com/OSRSClanFinder/clanfinder-runelite-plugin.git
-commit=7c4465f2f15b70233f20ff55a0b9876ddcd180e0
+commit=4f271726da5c45ade43d311ae70cca5ad07e960a
 warning=This plugin makes JSON listing requests, banner image requests, and event data requests to osrsclanfinder.com. Listed member totals are site listing data from Wise Old Man group stats or manual counts, not live online status. These external requests expose your IP address to that service, which is not controlled or verified by the RuneLite Developers.

--- a/plugins/clanfinder
+++ b/plugins/clanfinder
@@ -1,3 +1,3 @@
 repository=https://github.com/OSRSClanFinder/clanfinder-runelite-plugin.git
-commit=0bdf38963c90aff34254508efac743b2c19767cf
+commit=7c4465f2f15b70233f20ff55a0b9876ddcd180e0
 warning=This plugin makes JSON listing requests, banner image requests, and event data requests to osrsclanfinder.com. Listed member totals are site listing data from Wise Old Man group stats or manual counts, not live online status. These external requests expose your IP address to that service, which is not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Updates Clan Finder to OSRSClanFinder/clanfinder-runelite-plugin@7c4465f2f15b70233f20ff55a0b9876ddcd180e0.

Changes included:
- Bumps the plugin version to 0.1.2.
- Adds a +/- toggle to collapse and expand the search/filter controls.
- Fixes the results panel jumping down on initial load by resetting fresh result scroll position and preventing embedded text caret auto scroll.
- Improves Clan Finder API reliability with longer bounded timeouts and retry handling for transient IO failures.
- Keeps the last successful search results visible when a same-query refresh fails instead of immediately blanking the panel.
- Updates visible wording from "ClanFinder" to "Clan Finder" where shown to users.
- Adds regression tests for retry behavior, scroll reset behavior, and the search controls toggle.

