### PR TITLE
Update scapestack-sync endpoint migration

### DIFF
--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
-commit=5244bfe92e22143a0546144f213e9b174e4aafd5
+commit=5a6d11f2663f349ffa6f1baaf906edfef9207045
 warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates `scapestack-sync` to the latest standalone plugin commit.

Why:
- Existing early installs can have a persisted legacy `https://scapestack.app/api/sync` endpoint from pre-Plugin-Hub testing.
- `scapestack.app` no longer resolves; production sync lives at `https://www.scapestack.org/api/sync`.

What changed in the pinned plugin commit:
- Keeps the default sync endpoint on `https://www.scapestack.org/api/sync`.
- Migrates saved `scapestack.app` / `www.scapestack.app` sync endpoint config to `https://www.scapestack.org/api/sync` on plugin startup.
- Leaves current `.org` and self-hosted/local endpoints unchanged.
- Adds unit coverage for the endpoint migration.

Validation:
- `./gradlew test` in the standalone plugin repo.
- `npm run plugin:release-check` from the monorepo.
