### PR TITLE
log-adviser: bump to 324f373

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=97db160cd5a556fc3f6317590a9ed694df477ace
+commit=324f3733f294fae0715919dbb1c1be371532f7c4


### PR DESCRIPTION
Updates Log Adviser to v1.1.9.

Changes in this release:
- The sidebar "Show" filter is now multi-select: tick any combination of Combat / Minigame / Miscellaneous / Slayer (unioned). Previously it was single-select.
- New "Slayer" option covering activities that have a Slayer requirement (excluding boat-combat bounty tasks).
- "Pets Only" remains a separate, exclusive mode.
- Minor UI polish so the filter dropdown arrows render consistently.

No new outbound network calls. Bumps the pinned `commit=` to the new master HEAD of SFranciscoSouza/LogAdviser.