### PR TITLE
log-adviser: bump to 84a0c37 (v1.1.10)

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=324f3733f294fae0715919dbb1c1be371532f7c4
+commit=84a0c373e281557e4b459ed69a0c10538bd2975c


### PR DESCRIPTION
Updates the pinned commit for **Log Adviser** to v1.1.10.

Changes since the last pin:
- Adds a "Membership" filter (F2P / P2P) that hides members-only collection-log slots. The free-to-play slot set is sourced from the OSRS Wiki's "Collection log/Free-to-play" page (bundled JSON). It defaults from the player's world type on first login (members world -> P2P, free world -> F2P) and is persisted per RuneLite profile, changeable from the panel like the existing Account mode dropdown.

This update references one new client API (`Client#getWorldType` / `WorldType`), so it is expected to route to maintainer review rather than auto-pass. The plugin makes no outbound HTTP calls.
