### PR TITLE
Update commit reference in mokha-tracker

### DIFF
--- a/plugins/mokha-tracker
+++ b/plugins/mokha-tracker
@@ -1,2 +1,2 @@
-repository=https://github.com/camjewell11/Mokha-Loot-Tracker.git
-commit=ca3726b3947da020b33c3a5f4525c1cd3bc6bea0
+repository=https://github.com/camjewell11/Doom-Loot-Tracker.git
+commit=ee9e4e8c3fe9bf1f05c56bcc2ac03962a0bb1a3e

--- a/plugins/mokha-tracker
+++ b/plugins/mokha-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/camjewell11/Mokha-Loot-Tracker.git
-commit=39b8ef96bd21c404e4110024b769573292d11c8d
+commit=ca3726b3947da020b33c3a5f4525c1cd3bc6bea0

--- a/plugins/mokha-tracker
+++ b/plugins/mokha-tracker
@@ -1,2 +1,2 @@
-repository=https://github.com/camjewell11/Doom-Loot-Tracker.git
+repository=https://github.com/camjewell11/Mokha-Loot-Tracker.git
 commit=ee9e4e8c3fe9bf1f05c56bcc2ac03962a0bb1a3e

--- a/plugins/mokha-tracker
+++ b/plugins/mokha-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/camjewell11/Mokha-Loot-Tracker.git
-commit=24f926a746f7b458513f64db5eacb0b64a27086e
+commit=39b8ef96bd21c404e4110024b769573292d11c8d

--- a/plugins/mokha-tracker
+++ b/plugins/mokha-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/camjewell11/Mokha-Loot-Tracker.git
-commit=f07c6d9d9dede5be04a7e1fe447fcfe037a9bbf4
+commit=24f926a746f7b458513f64db5eacb0b64a27086e


### PR DESCRIPTION
## Summary

- **Claim routing**: `Claim and Leave` is now the authoritative claim event. Any exit that follows it — Leave button, teleport, logout, world hop, or forced arena exit — routes the run to claimed. Previously only the Leave button triggered the claimed path; teleporting or logging out after clicking `Claim and Leave` would incorrectly log the run as unclaimed.
- **Wave counter double-increment**: A tick guard on the Descend handler prevents two `onMenuOptionClicked` events firing in the same game tick (fast double-click) from incrementing `currentWaveNumber` twice. Combined with a loot-window widget parse failure, this could store loot under the wrong wave key and produce gaps in the current-run wave list.
- **Loot capture reliability**: `LootTrackingService` now retries loot parsing on the next tick if the widget's item children are null when the window first becomes visible, preventing missed loot when the player clicks through quickly. Wave-change detection was also added alongside the existing visibility-based rising edge, so a game engine in-place widget refresh between waves doesn't silently skip loot capture.