### PR TITLE
Add Green Log Reorder

### DIFF
--- a/plugins/green-log-reorder
+++ b/plugins/green-log-reorder
@@ -1,0 +1,2 @@
+repository=https://github.com/SFranciscoSouza/GreenLogReorder.git
+commit=9cf879144d3048138de0e3b388155c5635a657d3


### PR DESCRIPTION
## Green Log Reorder

New plugin (version 1.0.0) that reorders the in-game Collection Log so the entries you still need float to the top, while keeping every record visible (nothing is hidden):

- **Items** — on each page, un-obtained (faded) items are kept first and obtained items are moved to the bottom of the grid.
- **Categories** — in each tab's left-side list, pages with pending items are kept first and fully-completed ("green") pages are moved to the bottom.

It reads the game's own widget state (item opacity and the completed-page green text colour) on each Collection Log draw, so there is no syncing, no network requests and no stored data.

Repository: https://github.com/SFranciscoSouza/GreenLogReorder
Licensed under BSD 2-Clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
