### PR TITLE
New plugin: Bank Watcher

### DIFF
--- a/plugins/bank-watcher
+++ b/plugins/bank-watcher
@@ -1,2 +1,2 @@
 repository=https://github.com/Khaled2143/bank-watcher.git
-commit=a3ecddcb3c51044fa6faaecd8a962c02204fc359
+commit=633b93475edf42320caf589566175b3d182fd80f

--- a/plugins/bank-watcher
+++ b/plugins/bank-watcher
@@ -1,2 +1,2 @@
 repository=https://github.com/Khaled2143/bank-watcher.git
-commit=633b93475edf42320caf589566175b3d182fd80f
+commit=ce3f0d5bb99285034e9807439538b138b7733b1e

--- a/plugins/bank-watcher
+++ b/plugins/bank-watcher
@@ -1,0 +1,2 @@
+repository=https://github.com/Khaled2143/bank-watcher.git
+commit=a3ecddcb3c51044fa6faaecd8a962c02204fc359


### PR DESCRIPTION
Reopening as a fresh PR per the previous closure.

**Fix**: All network and price-fetch work, including the Thread.sleep rate-limiting now runs on a background thread via ScheduledExecutorService. The client thread is only used to read the bank container and item compositions; results are pushed back to the Swing UI via SwingUtilities.invokeLater.

**What it does**: Bank Watcher tracks your bank's total value and shows per-item price and quantity changes between scans, with daily-limited scans and gainer/loser/top-mover filtering.