### PR TITLE
Add Loot Notifier plugin

### DIFF
--- a/plugins/loot-notifier
+++ b/plugins/loot-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/biscuitbob59/loot-notifier.git
-commit=d8f9a8f83dfcc95344640c7d8e74613dd32b7a42
+commit=7e38be60adaec795f249a68f2ebb3fc99563fd45

--- a/plugins/loot-notifier
+++ b/plugins/loot-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/biscuitbob59/loot-notifier.git
-commit=7e38be60adaec795f249a68f2ebb3fc99563fd45
+commit=00a854c34ef081e79f23a63e3bc74dedd1ce2a45

--- a/plugins/loot-notifier
+++ b/plugins/loot-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/biscuitbob59/loot-notifier.git
+commit=d8f9a8f83dfcc95344640c7d8e74613dd32b7a42


### PR DESCRIPTION
A plugin that displays a collection log style popup when you receive a valuable drop. 
Supports 4 configurable tiers (Low, Medium, High, Insane) each with a custom GP 
threshold, header text and border colour.