### PR TITLE
Update sound-swapper

### DIFF
--- a/plugins/sound-swapper
+++ b/plugins/sound-swapper
@@ -1,3 +1,3 @@
 repository=https://github.com/petertalbanese/SoundSwapper.git
-commit=15e4657d2e27531b3e984e35b1ac56f690ce215f
-authors=petertalbanese,riktenx
+commit=80d620b7de98e93f98e1869569bc8d4a08880ab0
+authors=petertalbanese,damencs


### PR DESCRIPTION
* fixes: blacklisted regions superseding consumed/whitelisted sounds
  * sound replacement is still blocked in blacklisted regions per Jagex ruling, this just allows for silencing annoying/distracting sounds
* adds: blacklisted region debug overlay indications
* adds: blacklisted region notices to README and plugin description
* adds: failure messages for file exceptions (unable to locate file, invalid format, etc.)
* adds: additional trigger points for resetting loaded sounds
* adds: "{}.wav.wav" file support (assists with the inquiries where a user names a .wav file with .wav in it)
* adds: @damencs to author list (plugin co-owner)