### PR TITLE
Add Clog Hunter Exporter

### DIFF
--- a/plugins/clog-hunter-exporter
+++ b/plugins/clog-hunter-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/MariuszSzafr/clog-hunter-exporter.git
-commit=4496e7884020884b124e7ad88967f081f4139fcc
+commit=8788b32041fa35d48f5b89f23fbb1dc56c94f500

--- a/plugins/clog-hunter-exporter
+++ b/plugins/clog-hunter-exporter
@@ -1,0 +1,2 @@
+repository=https://github.com/MariuszSzafr/clog-hunter-exporter.git
+commit=4496e7884020884b124e7ad88967f081f4139fcc


### PR DESCRIPTION
Adds Clog Hunter Exporter to the RuneLite Plugin Hub.

Clog Hunter Exporter records Collection Log pages as they are opened and exports progress to JSON for use with the Clog Hunter desktop application.

Features:
- Collection Log export
- Missing page tracking
- Incremental scanning
- Export folder access

Repository:
https://github.com/MariuszSzafr/clog-hunter-exporter