### PR TITLE
Update Blert to 0.9.13

### DIFF
--- a/plugins/blert
+++ b/plugins/blert
@@ -1,4 +1,4 @@
 repository=https://github.com/blert-io/plugin.git
-commit=1d1d6ee01ffd22ec6b295351fc68d6bf30be0d98
+commit=ba5b86e587f4476b280929dbf6347e8eaa60cbd1
 authors=frolv
 warning=This plugin submits your IP address, RSN, and data about your raids to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Fixes phantom nylo stalls by only sending events at room cap.

Also contains a reformat pass over the codebase.