### PR TITLE
lootlette 1.0.5

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=0f4935ff905d5919319f38d8ff10f64fd0da84d7
+commit=85eb000d71209834e29f85f692fb53a2a4d4a87c


### PR DESCRIPTION
Updates Lootlette to v1.0.5.

- Raid reward-chest reels (Theatre of Blood / Tombs of Amascut / Doom of Mokhaiotl) now render above the reward-chest interface instead of behind it.
- Repeated boss kills within a single instance (e.g. Phosani's Nightmare) now roll on every kill without needing to leave/reset the instance.

Repository: https://github.com/Diogo-G-Dias/lootlette
Commit: 85eb000d71209834e29f85f692fb53a2a4d4a87c

🤖 Generated with [Claude Code](https://claude.com/claude-code)