### PR TITLE
Update compact-orbs to v1.8.1

### DIFF
--- a/plugins/compact-orbs
+++ b/plugins/compact-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/its-cue/compact-orbs.git
-commit=f3203837a6d890f3107cab84e6ed50ebc5fc0bb9
+commit=0c6f07c9eb998acba9ba4eea5a4997611e1e6c46


### PR DESCRIPTION
- add noClickThrough support for non-compact layouts
- add a menu op to the minimap button that can hide/show the detached minimap (only visible in compact view, and can be disabled via config)
- add additional reordering conditions for Horizontal / Horizontal (wide) layouts

bugfixes
- fix obscured compass toggle button in the Horizontal layout if the compass & wiki banner were hidden
- fix possible stale hover state for an orb frame (edge-case, due to orb swapping)
- fix incorrect activity orb position on shutdown when the store orb is disabled via settings
- fix missing compass when turning the plugin off in fixed mode, and switching to another display mode