### PR TITLE
Create penguin-crushers

### DIFF
--- a/plugins/penguin-crushers
+++ b/plugins/penguin-crushers
@@ -1,0 +1,2 @@
+repository=https://github.com/hyperslab/penguin-crushers.git
+commit=3de42d1763523960cc6cf1fa35d5b7901398e02b

--- a/plugins/penguin-crushers
+++ b/plugins/penguin-crushers
@@ -1,2 +1,2 @@
 repository=https://github.com/hyperslab/penguin-crushers.git
-commit=3de42d1763523960cc6cf1fa35d5b7901398e02b
+commit=5b53a5a5d052a87dcf7a7756b7f652dc3e63764c


### PR DESCRIPTION
To borrow from the readme:

Clicking on the stepping stone at the end of the penguin agility course crushers obstacle when the crushers have just finished moving will always allow you to cross without taking damage. However, this can be unintuitive and even when understood can be difficult to time correctly. The Penguin Crushers plugin helps you identify when the crushers are moving and when they are still alongside any other information you may need to make your journey through this obstacle a safe one.