### PR TITLE
FIXED play-music v1.1.2

### DIFF
--- a/plugins/play-music
+++ b/plugins/play-music
@@ -1,0 +1,2 @@
+repository=https://github.com/VitaMors/play-music.git
+commit=a79adc16f97c968d094bc859bb71c989de28f01b


### PR DESCRIPTION
♫ play music ♫
A RuneLite external plugin that lets chat control music playback with commands like: !!play never gonna give you up rick astley
!!stop
The plugin listens to public chat, finds the requested track with a bundled Java audio library, and plays it through the user's speakers. Requirements
Java 11 or newer. If dependency downloads fail with TLS handshake errors, update Java; very old Java 11 builds can no longer talk to modern Maven repositories cleanly. Commands
!!play song name artist - searches YouTube and starts the best audio result !!stop - stops the currently playing song
Notes
The development sidebar can be used on the login screen to test commands before logging into an account.