### PR TITLE
Add OSRSFliAdd OSRSFlipper Telemetrypper Telemetry

### DIFF
--- a/plugins/osrsflipper-telemetry
+++ b/plugins/osrsflipper-telemetry
@@ -1,0 +1,2 @@
+repository=https://github.com/DeadArrow4/osrsflipper-telemetry-plugin.git
+commit=889eeec2557eb76cb99da60f88127942036a764d

--- a/plugins/osrsflipper-telemetry
+++ b/plugins/osrsflipper-telemetry
@@ -1,2 +1,2 @@
 repository=https://github.com/DeadArrow4/osrsflipper-telemetry-plugin.git
-commit=9128858e05b9a71bdaa5d78fe03188c5216b0c12
+commit=dddb81459560b22b712e7680671aedd663709592

--- a/plugins/osrsflipper-telemetry
+++ b/plugins/osrsflipper-telemetry
@@ -1,2 +1,2 @@
 repository=https://github.com/DeadArrow4/osrsflipper-telemetry-plugin.git
-commit=889eeec2557eb76cb99da60f88127942036a764d
+commit=9128858e05b9a71bdaa5d78fe03188c5216b0c12


### PR DESCRIPTION
Adds OSRSFlipper Telemetry, a read-only local telemetry exporter for OSRSFlipper.

The plugin does not click, buy, sell, cancel, reprice, automate trading, or send data to a remote server. It only writes local RuneLite telemetry JSON for OSRSFlipper to read.