### PR TITLE
Add OSRS Algo (GE log)

### DIFF
--- a/plugins/osrs-algo-ge-log
+++ b/plugins/osrs-algo-ge-log
@@ -1,3 +1,3 @@
 repository=https://github.com/RichardLechko/osrs-algo-ge-log.git
-commit=00a95d21bbc0dfe1e78864cdd1af080c766c3a67
+commit=4588406160271d8f34fbd00301a33663e9162bcf
 warning=This plugin sends Grand Exchange offer events to a user-configured URL (default http://127.0.0.1:5000, localhost only). No data leaves your machine unless you change the URL.

--- a/plugins/osrs-algo-ge-log
+++ b/plugins/osrs-algo-ge-log
@@ -1,3 +1,3 @@
 repository=https://github.com/RichardLechko/osrs-algo-ge-log.git
-commit=cd0979aa700ccf0ef1c0979a25f1610813b158bb
+commit=00a95d21bbc0dfe1e78864cdd1af080c766c3a67
 warning=This plugin sends Grand Exchange offer events to a user-configured URL (default http://127.0.0.1:5000, localhost only). No data leaves your machine unless you change the URL.

--- a/plugins/osrs-algo-ge-log
+++ b/plugins/osrs-algo-ge-log
@@ -1,3 +1,3 @@
 repository=https://github.com/RichardLechko/osrs-algo-ge-log.git
-commit=4588406160271d8f34fbd00301a33663e9162bcf
+commit=fe82e314ef7ca8410601f300c169c9c74c737130
 warning=This plugin sends Grand Exchange offer events to a user-configured URL (default http://127.0.0.1:5000, localhost only). No data leaves your machine unless you change the URL.

--- a/plugins/osrs-algo-ge-log
+++ b/plugins/osrs-algo-ge-log
@@ -1,0 +1,3 @@
+repository=https://github.com/RichardLechko/osrs-algo-ge-log.git
+commit=cd0979aa700ccf0ef1c0979a25f1610813b158bb
+warning=This plugin sends Grand Exchange offer events to a user-configured URL (default http://127.0.0.1:5000, localhost only). No data leaves your machine unless you change the URL.


### PR DESCRIPTION
Adds OSRS Algo (GE log). A plugin that auto-logs Grand Exchange offer state (place / partial / fill / cancel) to a user-configured URL, defaulting to http://127.0.0.1:5000 (localhost). Intended to pair with a personal local backend for flip/arbitrage tracking; the `warning=` field discloses the external POST behavior.

  Source: https://github.com/RichardLechko/osrs-algo-ge-log