### PR TITLE
Add Vetion Pipe Alert

### DIFF
--- a/plugins/vetion-pipe-alert
+++ b/plugins/vetion-pipe-alert
@@ -1,0 +1,2 @@
+repository=https://github.com/ChaseErrorin/vetion-pipe-alert.git
+commit=a69b4f17219755c5b510cd33ec87f26270439e73

--- a/plugins/vetion-pipe-alert
+++ b/plugins/vetion-pipe-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/ChaseErrorin/vetion-pipe-alert.git
-commit=a69b4f17219755c5b510cd33ec87f26270439e73
+commit=120c7c1937d4e7fde18c09e97169785ff5fd1d0c


### PR DESCRIPTION
Plays a pipe banging sound when a player drops into the Calvar'ion or Vet'ion lair while you are already in there. Has a volume slider, options to ignore friends, clan members/ friend chat members. This is a reference to the 2026 Deadman Allstars when the Dino Nuggets dropped in on Purpp Rebels while they were killing Vet'ion.