### PR TITLE
Rancour pvm update

### DIFF
--- a/plugins/rancour-pvm
+++ b/plugins/rancour-pvm
@@ -1,3 +1,3 @@
 repository=https://github.com/DaleW-Cyber/RancourClanPlugin.git
-commit=caf696e9bec1937f48074db596b170eaa2bb76b1
+commit=ed17f3aa2274b6e06c9d3b6b2dc1af29a8502731
 warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update the Rancour PvM Plugin Hub manifest to the latest plugin commit.

Changes included in this plugin update:

- bug fix: Shows Team Finder notes in the RuneLite team list.
- bug fix: new-team in-game notification handling for eligible users.
- Adds tests for fresh eligible Team Finder notifications.