### PR TITLE
clan-management: loot-based drops, activity feed, announcements

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=0ebb60afc297379a8c2379b2926592138c7ad308
+commit=27fa0a60fe6f9f8f8c4ef9c0d893bafd854d51d2

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=4303b15896c581d37ba9d31d118ba10d154dad76
+commit=df712fccaa26032a7ff771f627ced5491dfcc0fb

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=8fdf94a5b415972fbc98449a3eb960ff954befb6
+commit=7e2bea6d33bdac6313047cdec8c71c525d7ad549

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=27fa0a60fe6f9f8f8c4ef9c0d893bafd854d51d2
+commit=b29903e7668b00085c2fe0ead8a8c7c5b000a1ed

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,0 +1,2 @@
+repository=https://github.com/WoodyCode23/clan-management-plugin.git
+commit=8fdf94a5b415972fbc98449a3eb960ff954befb6

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=ee67735e3988eda4a52fb146cec3c1c4d42b3403
+commit=57747f9c3fcc80254b8353e8fe762fabdc641752

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=e0c5088d3b2ad9851b365aba3400f485b0313c14
+commit=7290a82de1353295c8a0f88f7941fc4b0096a09a

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=b29903e7668b00085c2fe0ead8a8c7c5b000a1ed
+commit=4303b15896c581d37ba9d31d118ba10d154dad76

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=57747f9c3fcc80254b8353e8fe762fabdc641752
+commit=9bae5239b66b4d8e9b5b52e14e1170b26ed9befb

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=7e2bea6d33bdac6313047cdec8c71c525d7ad549
+commit=0ebb60afc297379a8c2379b2926592138c7ad308

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=df712fccaa26032a7ff771f627ced5491dfcc0fb
+commit=ee67735e3988eda4a52fb146cec3c1c4d42b3403

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=9bae5239b66b4d8e9b5b52e14e1170b26ed9befb
+commit=e0c5088d3b2ad9851b365aba3400f485b0313c14

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
 commit=58de87c596df3b4964f3108961e972936ee31111
+warning=This plugin submits your IP address, RSN, in-game location, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
 commit=e3f236b5f594a30466159cf69b9d0e9b1137cb3a
+warning=This plugin submits your IP address, RSN, in-game location, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=793dcd2b2d4e482f4333cbedb728daa0f2fc4c98
+commit=e3f236b5f594a30466159cf69b9d0e9b1137cb3a

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=24adf147c9aeff7c0319cb69035aab39ad3f0ca5
+commit=5a79199673ca3ab370ddf7aafeb0b21dbd76ee23

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=7290a82de1353295c8a0f88f7941fc4b0096a09a
+commit=24adf147c9aeff7c0319cb69035aab39ad3f0ca5

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=e3f236b5f594a30466159cf69b9d0e9b1137cb3a
+commit=9c3bb2b81eab0d17250aa09fc3d6ea2c9bcdfb14
 warning=This plugin submits your IP address, RSN, in-game location, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=f82bfb700a9a212199e01b7106101e017cbd8e64
+commit=58de87c596df3b4964f3108961e972936ee31111

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=74ffb30120e98eb13a0aeaed136e251d88b312c9
+commit=1bc1de309c60bc89c51f732e3faf31e39263ee00

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
 commit=ccd25070a0b0aa5928e4bb346a58337ed2e77c7f
-warning=This plugin submits your IP address, RSN, in-game location, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.
+warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=b81a61c6f2f5c208634d70220f89f755149363e8
+commit=74ffb30120e98eb13a0aeaed136e251d88b312c9

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=b59896dbeaa10715b6bc3811a5e21031ce8a6df0
+commit=c1d8e9720e2463d477224a4f57cfdb684c54b6ca

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=9c3bb2b81eab0d17250aa09fc3d6ea2c9bcdfb14
+commit=ccd25070a0b0aa5928e4bb346a58337ed2e77c7f
 warning=This plugin submits your IP address, RSN, in-game location, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=5a79199673ca3ab370ddf7aafeb0b21dbd76ee23
+commit=b59896dbeaa10715b6bc3811a5e21031ce8a6df0

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=1bc1de309c60bc89c51f732e3faf31e39263ee00
+commit=f82bfb700a9a212199e01b7106101e017cbd8e64

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=58de87c596df3b4964f3108961e972936ee31111
-warning=This plugin submits your IP address, RSN, in-game location, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.
+commit=793dcd2b2d4e482f4333cbedb728daa0f2fc4c98

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=ccd25070a0b0aa5928e4bb346a58337ed2e77c7f
+commit=20cfb379aea03b81ceb28c67e658ae50b6199671
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=c1d8e9720e2463d477224a4f57cfdb684c54b6ca
+commit=b81a61c6f2f5c208634d70220f89f755149363e8


### PR DESCRIPTION
Bumps clan-management to 20cfb37.
- Drop logging moved to the `LootReceived` event (correct NPC + item IDs); posts only collection-log/whitelisted items.
- Activity tab + announcements; speed-times clan/all toggle; drop/PB screenshots (event-driven, no `Thread.sleep`).

Still only calls the hardcoded `https://api.solusosrs.com` — no fetched URLs, no Discord calls from the plugin. `warning=` preserved.