### PR TITLE
clan-management: loot-based drops, activity feed, announcements

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=ccd25070a0b0aa5928e4bb346a58337ed2e77c7f
+commit=20cfb379aea03b81ceb28c67e658ae50b6199671
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps clan-management to 20cfb37.
- Drop logging moved to the `LootReceived` event (correct NPC + item IDs); posts only collection-log/whitelisted items.
- Activity tab + announcements; speed-times clan/all toggle; drop/PB screenshots (event-driven, no `Thread.sleep`).

Still only calls the hardcoded `https://api.solusosrs.com` — no fetched URLs, no Discord calls from the plugin. `warning=` preserved.