### PR TITLE
Update OSParty to 1.0.1

### DIFF
--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,3 +1,3 @@
 repository=https://github.com/iodrareg/osparty.git
-commit=e55b5cad0d66a59f91de943be8e625158d58e5dc
+commit=9f1adba105b490a216e42d389ab2a1f854328ba4
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,3 +1,3 @@
 repository=https://github.com/iodrareg/osparty.git
-commit=9f1adba105b490a216e42d389ab2a1f854328ba4
+commit=e7bafb08dd328e9380616d1a8ded4984436279eb
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,3 +1,3 @@
 repository=https://github.com/iodrareg/osparty.git
-commit=6c79ad30122bfe646c6029a5d7d5cb8204febaae
+commit=e55b5cad0d66a59f91de943be8e625158d58e5dc
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Learner/teacher raids
- Killcount requirements.
- CoX layout scouting. Layout is pushed to the api on the advertisement of the host so that it's clear for applicants which layout they'll be doing.
- Defence tracking and map pings with the in-game overlays that go with them
- A pile of smaller stuff: country flags next to host worlds, some icon updates, the API base URL is now overridable for local dev, and the heartbeat keeps the still-open roles up to date.
- Big comment cleanup generated by el claudio