### PR TITLE
Update commit hash for True Clue Dig Locations

### DIFF
--- a/plugins/trueclueareas
+++ b/plugins/trueclueareas
@@ -1,2 +1,2 @@
 repository=https://github.com/Daniel-Tudose/True-Clue-Dig-Locations.git
-commit=d02522c5f391bcd374da9ec4c6ebb4a61c974cf1
+commit=d197d65c6c11ec812474f30e56994ed6c04411d1


### PR DESCRIPTION
Version 1.3.3: Added a few more emote steps and Three part master cryptic steps should display the overlay correctly now, if there is a step which requires digging