### PR TITLE
Update penguin-crushers to 1.1

### DIFF
--- a/plugins/penguin-crushers
+++ b/plugins/penguin-crushers
@@ -1,2 +1,2 @@
 repository=https://github.com/hyperslab/penguin-crushers.git
-commit=5b53a5a5d052a87dcf7a7756b7f652dc3e63764c
+commit=540d736a094ebeb44cae46de474fdf5e0c1ae11c


### PR DESCRIPTION
Tracking of the stepping stone game object was occasionally bugging out where it would store an increasing number of copies of itself or draw on the wrong chunk. We already know the tile location so just get rid of all the object tracking and draw directly on the tile.