### PR TITLE
Update Key Remapping Plus - Add Shift Remapping

### DIFF
--- a/plugins/key-remapping-plus
+++ b/plugins/key-remapping-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/macica2/key-remapping-plus.git
-commit=c8194f894a6aba284b07ea2463bcba5ee8143328
+commit=e80e7628ec89d07aec076e513cf5969629d6a1ce

--- a/plugins/key-remapping-plus
+++ b/plugins/key-remapping-plus
@@ -1,2 +1,3 @@
 repository=https://github.com/macica2/key-remapping-plus.git
 commit=da4b410c212542cddea1de398d0b73f919c39f6c
+authors=LeoDrennan

--- a/plugins/key-remapping-plus
+++ b/plugins/key-remapping-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/macica2/key-remapping-plus.git
-commit=e80e7628ec89d07aec076e513cf5969629d6a1ce
+commit=da4b410c212542cddea1de398d0b73f919c39f6c


### PR DESCRIPTION
Added shift remapping in line with logic for other keys.

There is a dedicated plugin for shift functionality that can be found at https://runelite.net/plugin-hub/show/shift-remapping but this causes users to be unable to start chatting when using "Press Enter to Chat..." when run at the same time as either this plugin or the RuneLite base "key-remapping" plugin.

This PR moves the shift remap functionality under one umbrella and in doing so allows users to rebind shift while preserving "Press Enter to Chat...".