### PR TITLE
bank-templates: 1.5

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=41b78e140fca8795a7716794c36b68b163e359a2
+commit=2edcdcf2189e9170831cc51f224352d9fb7b93cb


### PR DESCRIPTION
Updates bank-templates from 1.4.1 to 1.5 (commit 2edcdcf2189e9170831cc51f224352d9fb7b93cb).

Changes since 1.4.1:
- Reorder a template's tabs and move items between tabs, in the editor and in-bank; extra tab buttons in-bank for template tabs your bank doesn't have yet, with a + to add new tabs.
- Rename a template from the layout editor, and an option to push edits to your shared community copy (only new imports adopt the changes; existing imports are untouched).
- Import a single tab from a template's preview into one of your templates, to mix and match tabs.

No new external requests or permissions beyond the existing (opt-in) community repository feature.