### PR TITLE
Update combat-logger to v1.6.4

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=0869b39429b3755d327a3092ba4e51b8fffe07e9
+commit=47cb2523b1dcd2093f272ebd36a10a2bf0358508


### PR DESCRIPTION
- Pass currentLogId on live log commands.