### PR TITLE
clan-management: Members tab, Combat Achievements, drop & PB improvements

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=20cfb379aea03b81ceb28c67e658ae50b6199671
+commit=711e938d94d33bfb2e5f6824ac6a5bc3c9c50f5c
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update to the clan-management plugin. Changes:

- Members tab: browse other clan members' collection logs (overview + item-grid drill-down), combat achievements, personal bests, and recent drops.
- Combat Achievements: tracked from the in-game CA interface, grouped by tier.
- Speed Times: searchable player filter; clan-verified team times now list every teammate (e.g. a duo best shows both names).
- Drops: post only notable items — collection-log uniques on first unlock, pets, or items above a value threshold — instead of every drop, removing per-kill feed spam.
- Role-based admin: a member's personal key inherits their Discord-role permissions, so the separate admin key is no longer required.
- Clan announcements shown on the Home tab.
- Readability/styling pass for consistent theming, plus an onboarding screen when no API key is configured.

The client only ever calls the project's own hardcoded API (https://api.solusosrs.com); all blocking HTTP runs off the client thread and item icons render locally via ItemManager. No user- or response-controlled URLs.
