### PR TITLE
Add Ring Menu plugin

### DIFF
--- a/plugins/ring-menu
+++ b/plugins/ring-menu
@@ -1,0 +1,2 @@
+repository=https://github.com/mepatrick73/ring-menu-plugin.git
+commit=e272846a16db266a26d331fdea973aa6d8e35ca6

--- a/plugins/ring-menu
+++ b/plugins/ring-menu
@@ -1,2 +1,2 @@
 repository=https://github.com/mepatrick73/ring-menu-plugin.git
-commit=e272846a16db266a26d331fdea973aa6d8e35ca6
+commit=98c673bcd11e4e2ccc487d16636b655dd5e8302e


### PR DESCRIPTION
Adds the Ring Menu plugin, a radial hotkey menu for quickly accessing bank tags and inventory setups.

**Features:**
- Bind multiple rings to different hotkeys
- Mix bank tags and inventory setups in the same ring
- Nest rings inside rings with sub-rings
- Editor panel to create and modify rings