### PR TITLE
Add camera-locks

### DIFF
--- a/plugins/camera-locks
+++ b/plugins/camera-locks
@@ -1,0 +1,2 @@
+repository=https://github.com/Varzeki/camera-locks.git
+commit=5d37f7e84551d6731f694761678494e48db38cb6

--- a/plugins/camera-locks
+++ b/plugins/camera-locks
@@ -1,2 +1,2 @@
 repository=https://github.com/Varzeki/camera-locks.git
-commit=6f271b9b590dc772549e5ba2ca2d7aadea582854
+commit=473c92042937d2e1184af2262b701c5291fd0c49

--- a/plugins/camera-locks
+++ b/plugins/camera-locks
@@ -1,2 +1,2 @@
 repository=https://github.com/Varzeki/camera-locks.git
-commit=25c69edcb080a816f12c4732230ca7f6c51261ee
+commit=6f271b9b590dc772549e5ba2ca2d7aadea582854

--- a/plugins/camera-locks
+++ b/plugins/camera-locks
@@ -1,2 +1,2 @@
 repository=https://github.com/Varzeki/camera-locks.git
-commit=5d37f7e84551d6731f694761678494e48db38cb6
+commit=25c69edcb080a816f12c4732230ca7f6c51261ee


### PR DESCRIPTION
Allows locking the camera so it doesn't move by accident.
Allows saving presets of camera positions and provides on screen guidance to manually return the camera to that position later.