### PR TITLE
Add RuneBound plugin

### DIFF
--- a/plugins/runebound
+++ b/plugins/runebound
@@ -1,2 +1,3 @@
 repository=https://github.com/Hxzardous/runebound-runelite-plugin.git
 commit=ce9f8052fcd9959e8661639d81aff4d81d6d4a00
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/runebound
+++ b/plugins/runebound
@@ -1,0 +1,2 @@
+repository=https://github.com/Hxzardous/runebound-runelite-plugin
+commit=e5a51087d6132c5a5c954a23ed63e8172e4890e9

--- a/plugins/runebound
+++ b/plugins/runebound
@@ -1,2 +1,2 @@
 repository=https://github.com/Hxzardous/runebound-runelite-plugin.git
-commit=e5a51087d6132c5a5c954a23ed63e8172e4890e9
+commit=ce9f8052fcd9959e8661639d81aff4d81d6d4a00

--- a/plugins/runebound
+++ b/plugins/runebound
@@ -1,2 +1,2 @@
-repository=https://github.com/Hxzardous/runebound-runelite-plugin
+repository=https://github.com/Hxzardous/runebound-runelite-plugin.git
 commit=e5a51087d6132c5a5c954a23ed63e8172e4890e9


### PR DESCRIPTION
Adds RuneBound, a display-only RuneLite plugin for viewing cached RuneBound profile summaries.

The plugin:

* Displays a RuneBound side panel.
* Opens rune-bound.net profile/search pages in the browser.
* Uses an opt-in GET request to the RuneBound read-only summary endpoint.
* Does not automate gameplay or game input.
* Does not call update endpoints.
* Does not store credentials or account data.

Testing:

* ./gradlew build
* ./gradlew test
* ./gradlew check
* Source scans for forbidden network/update/admin markers
* Credential and privacy scans

Reviewer notes:

* Network lookups are disabled by default and use RuneLite’s third-party warning.
* Browser actions are limited to rune-bound.net.
* No gameplay automation, input automation, packet modification, or update endpoint calls.
* V1 displays cached summaries only; missing summaries direct users to RuneBound.
