### PR TITLE
Update OSParty to 1.0.3

### DIFF
--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,3 +1,3 @@
 repository=https://github.com/iodrareg/osparty.git
-commit=9ce2e9a224c9d90e36a11d770ec818e142da5c8a
+commit=f0c674d13b5f3d13399bdb3bf3cc0ee6b2316168
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Add host key for authorizing host-only operations so that any PATCH/POST/DELETE call cannot just be executed from any rest client, but only the host/creator of the party can execute these calls by sending a key in the headers on every modifying call.