### PR TITLE
anvil: token-based admin, achievement notifications, kill-count on drops

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=d79ffdd8b4d2397052dbb16c46fcadf68ec458da
+commit=9b4e9899beafbc59eafe67205bd546a1954673d4
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Update for the Anvil plugin.

- Renamed the source package `com.osrsbingo` → `com.anvil` to match the plugin name (config group key unchanged, so existing settings are preserved).
- Removed the admin link-code flow and the admin-only side panel. Admin status is now a once-per-login check against the user's own account token; the "Sync clan roster" action lives in the in-game collection-log tab for admins only.
- Renamed the "Player Token" config to "Account Token" (one token works across every event) and cleared the hardcoded default site URL so self-hosters set their own.
- Added clan-channel notifications for level 99s, high total-level milestones, and maxing (new toggle, default on); fixed combat-achievement posts to handle multiple tasks completed in one tick.
- Show boss/raid kill count on rare-drop and valuable-loot posts.
- Guard against a second RuneLite client sharing one OBS instance uploading a clip it didn't trigger.
