### PR TITLE
Update clog hunter exporter

### DIFF
--- a/plugins/clog-hunter-exporter
+++ b/plugins/clog-hunter-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/MariuszSzafr/clog-hunter-exporter.git
-commit=117c62b415d6f11399bb13b40912e223a41ab34f
+commit=f2e79a8d0c8af3b89c96f3fdfacc1c7c43dad547

--- a/plugins/clog-hunter-exporter
+++ b/plugins/clog-hunter-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/MariuszSzafr/clog-hunter-exporter.git
-commit=4496e7884020884b124e7ad88967f081f4139fcc
+commit=8788b32041fa35d48f5b89f23fbb1dc56c94f500

--- a/plugins/clog-hunter-exporter
+++ b/plugins/clog-hunter-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/MariuszSzafr/clog-hunter-exporter.git
-commit=a98848fb4c821701a72d0fcc3df44fff74b6a962
+commit=db90a900e41562d188011fdeb34630886808efa2

--- a/plugins/clog-hunter-exporter
+++ b/plugins/clog-hunter-exporter
@@ -1,0 +1,2 @@
+repository=https://github.com/MariuszSzafr/clog-hunter-exporter.git
+commit=4496e7884020884b124e7ad88967f081f4139fcc

--- a/plugins/clog-hunter-exporter
+++ b/plugins/clog-hunter-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/MariuszSzafr/clog-hunter-exporter.git
-commit=8788b32041fa35d48f5b89f23fbb1dc56c94f500
+commit=de78bd0b6e36136903cda5f1da8750291e21d291

--- a/plugins/clog-hunter-exporter
+++ b/plugins/clog-hunter-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/MariuszSzafr/clog-hunter-exporter.git
-commit=de78bd0b6e36136903cda5f1da8750291e21d291
+commit=117c62b415d6f11399bb13b40912e223a41ab34f

--- a/plugins/clog-hunter-exporter
+++ b/plugins/clog-hunter-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/MariuszSzafr/clog-hunter-exporter.git
-commit=f2e79a8d0c8af3b89c96f3fdfacc1c7c43dad547
+commit=a98848fb4c821701a72d0fcc3df44fff74b6a962


### PR DESCRIPTION
Updates Clog Hunter Exporter to the latest release commit.

This update keeps the plugin passive and includes the polished UI, wanted-item overlay, manual scan helper, passive collection-log page export, and chat unlock sync.