### PR TITLE
clan-management: Combat Achievements browser, Speed Times & whitelist polish

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=711e938d94d33bfb2e5f6824ac6a5bc3c9c50f5c
+commit=5369207caf378bd8a3324a700282ce7c1002a2f0
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update to the clan-management plugin. Changes:

- Combat Achievements: explore any member's CAs in the Members tab — by tier → boss → individual task (done/missing), with a search box.
- Member Speed Times: organized by boss group with boss icons; scaled raids (CoX/ToB/ToA group sizes) now collapse to a single best time labelled by size bucket (Duo/Trio/6+/Group) instead of a row per exact party size.
- Whitelist browser: shows each item's clan points, filterable by boss group and searchable by item or boss.
- Activity feed: cleaner scrollable layout with aligned rows, and now includes Combat Achievement completions.

The client only ever calls the project's own hardcoded API (https://api.solusosrs.com); all blocking HTTP runs off the client thread and item icons render locally via ItemManager. No user- or response-controlled URLs.
