### PR TITLE
update ring-menu

### DIFF
--- a/plugins/ring-menu
+++ b/plugins/ring-menu
@@ -1,2 +1,2 @@
 repository=https://github.com/mepatrick73/ring-menu-plugin.git
-commit=734bd5f39f74053680a82a50c65e5c9d215f3488
+commit=16451b1e9ded427297d2986b25c9fbaa1bbf59c8


### PR DESCRIPTION
Update ring-menu to 1.0.1 — fixes filter lag with large inventory setup lists and entries buttons being hidden when names are too long.