### PR TITLE
Add OSRS Preview

### DIFF
--- a/plugins/osrs-preview
+++ b/plugins/osrs-preview
@@ -1,0 +1,2 @@
+repository=https://github.com/sayuop/osrs-preview.git
+commit=a7d38ffe9e80117cdc216dc10a7db95c6c34c3cf


### PR DESCRIPTION
Adds OSRS Preview, a local-only multi-client preview and focus-switching plugin for RuneLite.

The plugin discovers other local RuneLite clients running the same plugin, displays live sidebar previews, and allows clicking a preview to focus that client. 
Communication is local-only over 127.0.0.1 and temporary heartbeat files.