### PR TITLE
Update 07flip to 3ab47d6

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=650760ff059d49778e202cd82392128e75cd31c4
+commit=3ab47d6f33c8dc8175120ce8d8e218ea2548d9b1
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=3ab47d6f33c8dc8175120ce8d8e218ea2548d9b1
+commit=cef246f365fc75f991247508f557582a94fded70
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates the 07Flip - GE Flip Finder plugin. This release: fixes the Item insights tab sometimes failing to open or showing a stale/wrong item; makes the Grand Exchange price overlay's trend chart follow the timeframe selected on the Item tab; shows buying and selling progress together on optimizer slots and keeps the Stop buying option available once selling has started; fixes the optimizer refresh icons not rendering on macOS (Windows unchanged); improves trade-tracking accuracy so partially-filled offers report their full final quantity; and removes unused code. No new dependencies.