### PR TITLE
update osparty to 1.0.4

### DIFF
--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,3 +1,3 @@
 repository=https://github.com/iodrareg/osparty.git
-commit=f0c674d13b5f3d13399bdb3bf3cc0ee6b2316168
+commit=cf824701a280380c2f35b3288a8145d5a06d30cf
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates OSParty to 1.0.4, using a websocket instead of REST to manage the party as a host for better updatability of the client (remove polling entirely). [Backend implemented with a Spring Websocket](https://github.com/iodrareg/ospartyapi/commit/4dbe4785dc5ce89ef2ad77831ca5cbbc7c8c301f). Also uses wss to improve security for users. 