### PR TITLE
Update RuneBound plugin

### DIFF
--- a/plugins/runebound
+++ b/plugins/runebound
@@ -1,3 +1,3 @@
 repository=https://github.com/Hxzardous/runebound-runelite-plugin.git
-commit=ce9f8052fcd9959e8661639d81aff4d81d6d4a00
+commit=38b6195f4b116a2550b3e994ff9c6a9d280ec488
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates RuneBound to the latest public plugin commit with final UI polish and functional cooldown/last-lookup fixes.

Plugin commit:
38b6195f4b116a2550b3e994ff9c6a9d280ec488

Testing completed in the plugin repo:
- ./gradlew build
- ./gradlew test
- ./gradlew check
- git diff --check
- Forbidden network/update/admin marker scan
- Credential/privacy scan

Safety notes:
- Still GET-only and read-only.
- No direct update POST calls.
- No WOM/admin calls.
- No gameplay or input automation.
- Browser action remains limited to opening the selected RuneBound profile.