### PR TITLE
update fashionscape to 1.4.6

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=95af6ab48148749137d1a573bc0a85b5567fe25d
+commit=58d7f549532c74e03f0fc6a94b833f403ff41ea3


### PR DESCRIPTION
big LoC numbers but it's entirely from adding unit tests, and some new test-only adjustments to build.gradle. figured I would add the tests all in one swoop without making changes to the plugin