### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=bb4042aded60c0b7ffed85888633a4a8402bf03d
+commit=07171c64c2f401ebf521f553d4856306ce779243
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=07171c64c2f401ebf521f553d4856306ce779243
+commit=d5454e3afc6036b3447bf8ca838beb5bff196fe1
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
- Removed the 60s polling loop for Message of the Day, it now is just checked once upon login.
- Flip style (item image + context) is now sent alongside adjustment requests for the 12-hour sell ladder.
- GE transaction records now carry an offerId field, linking fills to their originating offer for accurate duplicate detection on the backend.
- Offline fill handling and GE-History backfill prompt has been improved to not fire every time a user logs in.
- Added a guard for StaleOfferQueue for the empty-queue edge case.