### PR TITLE
update ring-menu

### DIFF
--- a/plugins/ring-menu
+++ b/plugins/ring-menu
@@ -1,2 +1,2 @@
 repository=https://github.com/mepatrick73/ring-menu-plugin.git
-commit=16451b1e9ded427297d2986b25c9fbaa1bbf59c8
+commit=11b22dd63cb85be268a81a42807e2143fc9d89f1


### PR DESCRIPTION
## Changes in 1.0.2

- **Ring toggle**: each ring in the editor now has an enable/disable checkbox; disabled rings keep their hotkey registered but don't open
- **Combination hotkeys**: the hotkey capture now waits for a non-modifier key, so Ctrl/Shift/Alt combos (e.g. Ctrl+F9) are captured correctly
- **Label truncation**: long ring entry names are truncated with `…` to prevent overflow outside the ring boundary
- **Cancel action fix**: clicking the centre X of the ring now correctly closes an active bank tag or inventory setup display (`clientThread.invoke` from the mouse listener)
- **Startup race fix**: `navButton` is now `volatile` and removal is dispatched via `invokeLater` so enable→disable cycles can't leak the nav button