### PR TITLE
update ring-menu

### DIFF
--- a/plugins/ring-menu
+++ b/plugins/ring-menu
@@ -1,2 +1,2 @@
 repository=https://github.com/mepatrick73/ring-menu-plugin.git
-commit=11b22dd63cb85be268a81a42807e2143fc9d89f1
+commit=f7f480f04ba57612e0742631f025acfe2bab5390


### PR DESCRIPTION
## Changes in 1.0.3

- **Suppress the ring hotkey while typing.** The ring no longer opens (and the key still types) when a text input is active: focused input fields (GE quantity, fairy ring), bank/GE search and private-message prompts (MESLAYERMODE), and regular chatbox typing. The typing context is computed on the client thread (ClientTick) and cached for the AWT key listener to avoid cross-thread staleness.
- **"Press Enter to Chat" support.** Detects KeyRemapping's chat lock so plain letter hotkeys still open the ring while chat is idle.
- **Custom key listener.** Replaces HotkeyListener, which always consumes a matching key; the ring now only consumes the keypress when it actually opens, so a hotkey key still types in chat when appropriate.
- **Configurable label font and size.** New config panel with RuneScape fonts plus common system fonts (Arial, Cambria, Rockwell, Segoe UI, Times New Roman, Verdana) and an adjustable font size.
- **Fix.** Single-entry sub-rings no longer always render as an ellipsis (the n == 1 chord width was zero).