### PR TITLE
Revert "update fate-locked-ironman"

### DIFF
--- a/plugins/fate-locked-ironman
+++ b/plugins/fate-locked-ironman
@@ -1,2 +1,2 @@
 repository=https://github.com/Nubles/RS3-Fate-Locked-Runelite.git
-commit=2bd1f792d4ff5a14e451ad100e66fffe4734e622
+commit=eabdeb2ec17e9d3968ab2cb64b7bc6dc99663f34


### PR DESCRIPTION
This reverts commit 79ccb042be59d0b6a79c5060b0df8e965d36360b.

@Nubles since you're adding it after the initial release of the plugin, all your networking calls to your custom domain MUST be opt-in through an explicit boolean config, with its `@ConfigItem::warning` field set to "This feature submits your IP address to a 3rd-party server not controlled or verified by Runelite developers". Methods that make API calls to this domain should have a clear check for this config at the top, which either returns early or throws an exception if false, so we can exhaustively verify that you're not making these calls without user consent.