### PR TITLE
Add STASH Tracker

### DIFF
--- a/plugins/stash-tracker
+++ b/plugins/stash-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Nearvaas/S.T.A.S.H-Toolkit.git
+commit=600c17f0679a9859505631a77a71d5c18f77c029


### PR DESCRIPTION
Adds **STASH Tracker** — tracks which STASH units you have built and filled, grouped by clue tier.

Source: https://github.com/Nearvaas/S.T.A.S.H-Toolkit

Features:
- Auto-detects **built** state (a built STASH only renders for its owner, so its game-object spawn is the signal) and **filled / emptied** state (deposit/withdraw chat messages, attributed by the interacted object with a location fallback). State is persisted per account.
- Side-panel checklist of all 119 STASH units with per-tier progress and a "hide filled" filter.
- Lists the items each unfilled STASH still needs and **highlights those items in inventory / bank / equipment** so they aren't accidentally dropped or sold (variant-aware via ItemVariationMapping).
- World map markers at every STASH, coloured by state, with an "only unfilled" filter.
- Manual row toggle as a fallback for any missed auto-detection.