### PR TITLE
Update arealoot v1.4.0

### DIFF
--- a/plugins/arealoot
+++ b/plugins/arealoot
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/AreaLoot.git
-commit=903e96bf36a2a5cbb2c133c303e1c78b613e9d43
+commit=851734a45dbdd33d9514818fd1366feaebfaa3d6


### PR DESCRIPTION
Fixed a major issue that didn't allow you to type using the letter assigned to the hotkey. Now it should let you type it. Must be using the "press enter to chat" function.

Made the overlay now behave like other runelite overlays. Can now be moved by Alt+dragging and removed the old way of moving it with X/Y coordinates. much cleaner way of moving it and positioning it where the user wants it.

Added a bit more space between the items and the footer text.

Fixed footer, if more items than your designated max items it would show the incorrect number of total items.

added a fixed minimum width for the overlay list mode.