### PR TITLE
Add idle-familiar plugin

### DIFF
--- a/plugins/idle-familiar
+++ b/plugins/idle-familiar
@@ -1,2 +1,2 @@
 repository=https://github.com/mackenzie0cameron0/idle-familiar.git
-commit=a54df8cc030103dbe96da6aa2e1550c373813b16
+commit=f2566a1c57b3e16684a5ab57b3d6edffc71ed171

--- a/plugins/idle-familiar
+++ b/plugins/idle-familiar
@@ -1,2 +1,2 @@
 repository=https://github.com/mackenzie0cameron0/idle-familiar.git
-commit=445ea92a11132ffd491879fd475dd5142f0de5b0
+commit=7901bfc612997c5f8b9e8c04ebfebe9c62979f33

--- a/plugins/idle-familiar
+++ b/plugins/idle-familiar
@@ -1,2 +1,2 @@
 repository=https://github.com/mackenzie0cameron0/idle-familiar.git
-commit=7901bfc612997c5f8b9e8c04ebfebe9c62979f33
+commit=a54df8cc030103dbe96da6aa2e1550c373813b16

--- a/plugins/idle-familiar
+++ b/plugins/idle-familiar
@@ -1,2 +1,2 @@
 repository=https://github.com/mackenzie0cameron0/idle-familiar.git
-commit=80e41ae82ac23d80e703d9faabe9c1e142b1ed11
+commit=445ea92a11132ffd491879fd475dd5142f0de5b0

--- a/plugins/idle-familiar
+++ b/plugins/idle-familiar
@@ -1,0 +1,2 @@
+repository=https://github.com/mackenzie0cameron0/idle-familiar.git
+commit=80e41ae82ac23d80e703d9faabe9c1e142b1ed11


### PR DESCRIPTION
The idle familiar plugin is a pop-out, always on-top, widget. It reads a players in-game state and plays a corresponding animation. This is intended to act as an idle notifier while the client is minimized. 
It's a status display only: no game input, automation, or interaction with the client. The README has previews and full feature list.