### PR TITLE
Update Private message fade v1.1.2

### DIFF
--- a/plugins/privatemessagefade
+++ b/plugins/privatemessagefade
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/PrivateMessageFade.git
-commit=4015870a28f7acafa8103108515030c32538d639
+commit=05239f09e30cbfb1e77a3ad1b2249ce0d10e99f0

--- a/plugins/privatemessagefade
+++ b/plugins/privatemessagefade
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/PrivateMessageFade.git
-commit=05239f09e30cbfb1e77a3ad1b2249ce0d10e99f0
+commit=ca67477ea4869e85f83714518d8c183bc33619cb

--- a/plugins/privatemessagefade
+++ b/plugins/privatemessagefade
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/PrivateMessageFade.git
-commit=ca67477ea4869e85f83714518d8c183bc33619cb
+commit=6361f42b911decf100aaead8a00013e563f4ed16


### PR DESCRIPTION
Fixed a major issue that using the letter assigned to the hotkey would trigger even while typing. Now it should let you type the letter without triggering the toggle. must be using the "press enter to chat" function.