### PR TITLE
Update RuneBound plugin

### DIFF
--- a/plugins/runebound
+++ b/plugins/runebound
@@ -1,3 +1,3 @@
 repository=https://github.com/Hxzardous/runebound-runelite-plugin.git
-commit=38b6195f4b116a2550b3e994ff9c6a9d280ec488
+commit=d875dbbfe4ee141df800f994c354a30451ae9861
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates RuneBound to the final approved public plugin commit.

Plugin commit:
d875dbbfe4ee141df800f994c354a30451ae9861

This update includes:
- Final RB crest root icon.png for Plugin Hub listing.
- Summary refresh URL cache-bypass marker for the read-only endpoint.
- Parser hardening for the live summary contract.
- Preservation of valid displayed data after transient refresh failures.

Testing completed in the plugin repo:
- Icon verification: PNG, 48x48, 5,761 bytes.
- Live endpoint probes for Broxklyn, BloodSlyther, uncached, and invalid username.
- ./gradlew clean build test check
- git diff --check
- Forbidden marker scan
- Credential/privacy scan

Safety notes:
- Still GET-only and read-only.
- No direct update POST calls.
- No WOM/admin calls.
- No logout auto-update.
- No gameplay or input automation.
- Browser action remains limited to opening the selected RuneBound profile.