### PR TITLE
Add Boss Helper Bank Sync

### DIFF
--- a/plugins/boss-helper-bank-sync
+++ b/plugins/boss-helper-bank-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/ENiceApps/boss-helper-bank-sync.git
-commit=7e13d5da30a3460b0ccda24f3d6a6d1ddc9c63a0
+commit=1534fd142fa4f3de1a61c14b7b39d9b32d3ba933

--- a/plugins/boss-helper-bank-sync
+++ b/plugins/boss-helper-bank-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/ENiceApps/boss-helper-bank-sync.git
+commit=7e13d5da30a3460b0ccda24f3d6a6d1ddc9c63a0


### PR DESCRIPTION
Adds **Boss Helper Bank Sync**, a companion plugin for the open-source [OSRS Boss Helper](https://osrsbosshelper.com) web app.

**What it does:** when the opt-in (default-off) toggle is enabled, it writes the player's own bank + inventory + worn equipment + combat levels + GP to a local JSON file in the RuneLite directory. The web app reads that file in the browser to recommend gear and compute DPS from what the player actually owns.

**Privacy & safety by design:**
- **Read-only** — only reads game state; it never modifies the bank, inventory, or any interface.
- **No network requests** — it writes a local file only; nothing leaves the user's machine. No HTTP exposure of player info, no crowdsourcing of other players' data.
- **Opt-in**, disabled by default. File I/O is confined to the RuneLite directory; disk writes run off the client thread with an atomic temp-file swap.
- BSD-2-Clause licensed. It is a data-export plugin, **not** a boss overlay — it adds no combat/PvP indicators or any other restricted feature.

Source: https://github.com/ENiceApps/boss-helper-bank-sync

Thanks for reviewing!
