### PR TITLE
Update loot-lookup to v1.2.2 - fix broken icons

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,3 +1,3 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=f267c38c900d6bd58a53e690d8c26756a5f00030
-authors=donth77,riktenx,iProdigy
+commit=283a82dadfa2e8e68034a2fbab0353a9eeb0fcfa
+authors=donth77,riktenx


### PR DESCRIPTION
- Fix item icons never loading: [https://github.com/donth77/loot-lookup-plugin/issues/50](https://github.com/donth77/loot-lookup-plugin/issues/50)
     - The OSRS Wiki began returning WebP for .png URLs, which Java's ImageIO can't decode - so most item icons were broken and loading animations spiked CPU. The image request now advertises only formats ImageIO supports.