### PR TITLE
osrscn: update to 0.1.2

### DIFF
--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=b18edcd067ae11931376241e6078e2e80e8e2684
+commit=bd9c432c06f9c5dbaf9842b1b3bcc1b4ebd9d2cb
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=71782062ee253b33847618afaaeeee42e144c03e
+commit=b18edcd067ae11931376241e6078e2e80e8e2684
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates OSRSCN Chinese to 0.1.2.

- ~1,600 more translations (item names/examines, skill-unlock messages, NPC dialogue)
- more robust lookup: folds typographic quotes/dashes and non-breaking / full-width
  spaces, and falls back across translation categories, so fewer lines stay English
- new opt-in toggle (default off) that writes untranslated game text to a local file
  the user can choose to share; nothing is uploaded automatically
