### PR TITLE
Update Hiscore Notifications to account for addition of Maggot King boss

### DIFF
--- a/plugins/hiscore-notifications
+++ b/plugins/hiscore-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/malafel-dev/hiscore-notifications.git
-commit=c616ec1b858176fb9ac68080c281f6acec1ad684
+commit=00928aab19163a5727ee6d8aae2aeee01ee0e652


### PR DESCRIPTION
Very tiny update to an enum that maps a few different pieces of data together, adding Maggot King to the list of bosses.