### PR TITLE
Update 07flip to 77defa4

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=650760ff059d49778e202cd82392128e75cd31c4
+commit=77defa4c61416acf1f5c9da242a6057990926417
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
This update adds a quick price helper to the Grand Exchange Set-a-price screen: a row of one-click suggested prices (the 07Flip recommended price, plus quicker-filling and more-patient options and the live market price), a Clear button, and the item last traded price, so offers can be priced faster without leaving the GE. It also adds settings to choose the overlay font and the tooltip background colour, shows the buy limit on the quantity screen, and keeps the per-slot timers visible while hovering an offer. No new dependencies.