### PR TITLE
account-data-exporter: bump to 0.5.0

### DIFF
--- a/plugins/account-data-exporter
+++ b/plugins/account-data-exporter
@@ -1,3 +1,4 @@
 repository=https://github.com/A-Kimpton/account-data-exporter.git
-commit=1f10312ba54a9df8dc1ac101eef87279aeeb582e
+commit=38cbadb0275715fdeddf889227667447815b8b8b
+version=0.5.0
 authors=A-Kimpton

--- a/plugins/account-data-exporter
+++ b/plugins/account-data-exporter
@@ -1,4 +1,3 @@
 repository=https://github.com/A-Kimpton/account-data-exporter.git
 commit=38cbadb0275715fdeddf889227667447815b8b8b
-version=0.5.0
 authors=A-Kimpton


### PR DESCRIPTION
Bumps account-data-exporter to 0.5.0. It now decodes the human-readable names for Konar slayer areas (`areaName`) and boss-slayer tasks (`bossName`) alongside the raw ids, so consumers don't need the game cache to interpret them; the export `schemaVersion` also moves to semver (now `1.0.1`).