### PR TITLE
Update lobster-pot

### DIFF
--- a/plugins/lobster-pot
+++ b/plugins/lobster-pot
@@ -1,3 +1,3 @@
 repository=https://github.com/datlalo/The-Lobster-Pot---Clan-Plugin.git
-commit=45ad19ba70c45f2c2127681db69ef581feb2c861
+commit=33493b704286b004191df92b4b3c61cdb3fcc33d
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates The Lobster Pot plugin to add clan world map member locations.

Changes:
- Adds clan member markers to the world map
- Shows member name, world, rank icon, and detected activity
- Adds Hop-to support from map markers
- Adds a config toggle for sharing world map location
- Uses a deployed LobsterPot positions backend

Privacy note:
This feature submits IP address, RSN, world, in-game location, and detected activity to a third-party server for the clan map.

Tested:
- ./gradlew.bat test --offline
- node --check backend/worker.js
- In-game smoke test with deployed backend