### PR TITLE
Add OSRS Best in Slot (account connect for osrsbestinslot.com calculators)

### DIFF
--- a/plugins/osrs-best-in-slot
+++ b/plugins/osrs-best-in-slot
@@ -1,0 +1,2 @@
+repository=https://github.com/osrsbis/account-connect.git
+commit=74b0c77b5a50318ef130c9f07a39c7933c998a28


### PR DESCRIPTION
## OSRS Best in Slot — account connect

Lets a player connect their account to **osrsbestinslot.com** to auto-fill its OSRS calculators (skill/XP, best-in-slot, DPS, drop-rate) from their real stats, gear and progress, instead of entering everything by hand.

**How it works** — modeled on WikiSync (credited in the repo):
1. The player generates a one-time link token on the site's Connect page.
2. They paste it into the plugin's **Link token** config field.
3. The plugin uploads game-account state, keyed by that token: skills/XP, total & combat level, quest / achievement-diary / combat-achievement progress, slayer task & points, worn equipment, inventory, bank, GE offers, rune pouch, and collection-log entries.

**Data & safety:**
- **No** password, email, payment info, or Jagex credentials are ever sent — game-account state only.
- Upload is **user-initiated**: nothing is sent until the player generates a token and pastes it in.
- **Read-only export** — the plugin does not automate, click, send input, or modify the game in any way.
- Open source, BSD-2-Clause. One config group, `build=standard`, **no new third-party dependencies** (okhttp/gson come via runelite-client; lombok is compile-only).

Plugin repo: https://github.com/osrsbis/account-connect
