### PR TITLE
 Add OSRS Best in Slot

### DIFF
--- a/plugins/osrs-best-in-slot
+++ b/plugins/osrs-best-in-slot
@@ -1,4 +1,4 @@
 repository=https://github.com/osrsbis/account-connect.git
 commit=74b0c77b5a50318ef130c9f07a39c7933c998a28
 authors=osrsbis
-warning=This plugin uploads your account data (skills, quests, achievement diaries, equipment, inventory and bank contents) to osrsbestinslot.com to auto-fill its calculators, keyed by a link token you paste. Only enable it if you are comfortable with that data being uploaded.
+warning=This plugin submits your IP address and uploads your account data (skills, quests, achievement diaries, equipment, inventory and bank contents) to osrsbestinslot.com to auto-fill its calculators, keyed by a link token you paste. Only enable it if you are comfortable with that data being uploaded.

--- a/plugins/osrs-best-in-slot
+++ b/plugins/osrs-best-in-slot
@@ -1,0 +1,2 @@
+repository=https://github.com/osrsbis/account-connect.git
+commit=18d9d7fc45e5b94d42f7e21a5f12767fd5cb7b5a

--- a/plugins/osrs-best-in-slot
+++ b/plugins/osrs-best-in-slot
@@ -1,2 +1,4 @@
 repository=https://github.com/osrsbis/account-connect.git
-commit=18d9d7fc45e5b94d42f7e21a5f12767fd5cb7b5a
+commit=74b0c77b5a50318ef130c9f07a39c7933c998a28
+authors=osrsbis
+warning=This plugin uploads your account data (skills, quests, achievement diaries, equipment, inventory and bank contents) to osrsbestinslot.com to auto-fill its calculators, keyed by a link token you paste. Only enable it if you are comfortable with that data being uploaded.


### PR DESCRIPTION
 Lets a player connect their account to osrsbestinslot.com to auto-fill its OSRS calculators (skill/XP, BiS, DPS, drop-rate) from their real stats and gear. Modeled on WikiSync (credited). The player generates a one-time link token on the site, pastes it into the plugin's Link token field, and the plugin uploads game-account state only — skills/XP, quests, diaries, combat achievements, slayer, worn gear, inventory, bank, GE offers, rune pouch, collection log — keyed by that token. No password, email, payment, or Jagex credentials are sent. Upload is user-initiated; read-only export (no automation/input). Open source BSD-2, build=standard, no new third-party deps. Plugin repo: https://github.com/osrsbis/account-connect