### PR TITLE
Update Kill Clog to 1.5.1

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=f5c06e736fb768c3bf9bf539d4f643b7ebbf2eab
+commit=4afd28860b6f520f742a8d1e65095fbdfbcd915e
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Kill Clog to 1.5.1.

Changes:
- renames regular 1-defence accounts from Defense Pure to Pure
- adds `:killclog:` and `:clog:` chat icons
- guards the new Maggot King hiscore row so later boss KC values stay aligned while RuneLite adds the official enum/sprite
- prepares an official-enum bridge so Maggot King can use RuneLite's sprite once the enum is available

Local gate:
- `./gradlew.bat compileJava checkstyleMain checkstyleTest test`