### PR TITLE
Update traducao-osrs-br to latest published translations

### DIFF
--- a/plugins/traducao-osrs-br
+++ b/plugins/traducao-osrs-br
@@ -1,2 +1,2 @@
 repository=https://github.com/walterrezende12-tech/Traducao-OSRS-BR.git
-commit=4e70f8b61dd1ad94ae1b31b99381af8ab0f68911
+commit=018a9462ca535be36ee0fba9da7c26794c9569fa


### PR DESCRIPTION
## Summary
- update `traducao-osrs-br` to published release commit `018a9462ca535be36ee0fba9da7c26794c9569fa`
- keep Plugin Hub diff limited to the `commit=` line

## Validation
- confirmed `release` HEAD is `018a9462ca535be36ee0fba9da7c26794c9569fa`
- confirmed Plugin Hub diff is only `commit=`