### PR TITLE
Add flip-exporter

### DIFF
--- a/plugins/flip-exporter
+++ b/plugins/flip-exporter
@@ -1,0 +1,2 @@
+repository=https://github.com/vriken/flip-exporter.git
+commit=92c21b46ea21912e97e2e95aba4ae3223a393f47

--- a/plugins/flip-exporter
+++ b/plugins/flip-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/vriken/flip-exporter.git
-commit=92c21b46ea21912e97e2e95aba4ae3223a393f47
+commit=e270f08259526d2915d6b91254991ec076ae52be


### PR DESCRIPTION
Adds **flip-exporter**, a data-export plugin that writes flipping-relevant account state to local JSON for personal analysis.

**What it exports** (to `~/.runelite/flip-exporter/`):
- `latest.json` — coins + platinum cash, inventory (with noted items folded onto their tradeable id via `getLinkedNoteId`), live GE offers (real listed price, qty, per-slot placement time), optional bank.
- `history.json` — persisted, deduped log of completed/cancelled GE offers (for cost / P&L analysis).

**Guidelines:**
- Local files only — **no network connections**.
- **No game automation** of any kind; it reads account state and writes JSON. Same category as the existing data-exporter plugins.
- Atomic writes (temp file + rename).
- Compiles against the current client; includes a unit test for the noted-id resolution.

Source: https://github.com/vriken/flip-exporter