### PR TITLE
Update Boss Helper Bank Sync

### DIFF
--- a/plugins/boss-helper-bank-sync
+++ b/plugins/boss-helper-bank-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/ENiceApps/boss-helper-bank-sync.git
-commit=1534fd142fa4f3de1a61c14b7b39d9b32d3ba933
+commit=1167044c6abfa83ab9c55169fa3f53e4016ccbd9


### PR DESCRIPTION
Updates **Boss Helper Bank Sync** to a newer commit of the same repo.

Changes since the merged version:
- Simplified the config panel to a single opt-in toggle ("Save my bank & gear for the web app"). Removed two settings that weren't needed — the write throttle is now a fixed 2s, and the companion web-app URL is fixed.
- New plugin icon.
- Minor git history cleanup (no functional change).

Behavior is unchanged: read-only, **no network requests**, writes only a local file in the RuneLite directory, opt-in and disabled by default. BSD-2-Clause.
