### PR TITLE
clan-management: clan rank system + live requirement evaluation

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=5369207caf378bd8a3324a700282ce7c1002a2f0
+commit=faba14b4e4b0b75af9a1c6f57d3877199b881083
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates the clan-management plugin (commit → faba14b).

Changes:
- New "Ranks" panel: evaluates each clan rank's requirements locally
  (skills, total level & XP, Combat Achievement tiers and named tasks,
  Achievement Diaries, boss KC, and owned items) and lets a member
  request a rank.
- Boss KC and Combat Achievement completion are read from the plugin's
  own API (data it already syncs), not scraped from any third party.
- New-boss grouping (Maggot King).
- Panel item-icon, layout, and kill-count attribution fixes.

Compliance:
- Only contacts the plugin's hardcoded host (https://api.solusosrs.com);
  no URLs are derived from server responses.
- All network requests run off the client thread; game state is read on
  the client thread.
- No Discord/webhook requests from the client.
- warning= line unchanged.
