### PR TITLE
clan-management: item icons in member drops list

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=faba14b4e4b0b75af9a1c6f57d3877199b881083
+commit=1efeb319337ea0d901ed1b9cf136d866761b8484
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Small follow-up to the previous update.

- Show item icons alongside item names in the member "Recent Drops" list
  (uses the drop's item id from the plugin's own API, itemManager for the
  local icon).

Compliance unchanged: only contacts the plugin's hardcoded host
(https://api.solusosrs.com); no response-derived URLs; icon rendering is
local; warning= line unchanged.
