### PR TITLE
Add farming-profit plugin

### DIFF
--- a/plugins/farming-profit
+++ b/plugins/farming-profit
@@ -1,0 +1,3 @@
+repository=https://github.com/JaredEzz/farming-profit-plugin.git
+commit=95820f7cb23bec5ee29d7200d9565575c3bff254
+warning=This plugin can optionally (off by default) send a short status message over HTTPS to a user-configured ntfy notification URL, which may be a third-party server.


### PR DESCRIPTION
## Farming Profit

Tracks farm-run profit or Farming XP and ranks the most profitable herbs to plant.

- **Tracker**: groups herb-patch harvests into runs, shows a cumulative expected-vs-actual graph per run, live progress while harvesting, and persists history across restarts. GE profit for mains, Farming XP for ironmen (auto-detected, overridable).
- **Herb-run helper**: all 10 herb patches with live ready/growing state, a "next run in mm:ss" countdown, configurable location icons, and a bottomless compost bucket use counter.
- **Planner**: ranks every plantable herb by profit or XP per run using your live level/gear/compost, plus a Mastering Mixology section (reads your resin balances and, if the Mastering Mixology or Easy Mixology plugin is installed, your reward goal) showing herbs needed to reach it.
- Optional (off by default) ntfy push notification when your herb run is ready — see the `warning=` line in the manifest.

Repo: https://github.com/JaredEzz/farming-profit-plugin

This is the externalized version of the original [RuneLite PR #6585](https://github.com/runelite/runelite/pull/6585) by Mika Kuijpers, closed with `should-be-external`, with substantial features added on top (see the repo README for the full attribution/changelog).

`build=standard`, no new third-party dependencies beyond what's already bundled with runelite-client.