### PR TITLE
Update ping-grapher to 1.7.1

### DIFF
--- a/plugins/ping-grapher
+++ b/plugins/ping-grapher
@@ -1,2 +1,2 @@
 repository=https://github.com/yuh25/Ping-Grapher.git
-commit=692ea88c86495d30fb11dcea79990c43496cbdc9
+commit=a625219c12ac4cb813b0e2afd6f7c71540025fa9

--- a/plugins/ping-grapher
+++ b/plugins/ping-grapher
@@ -1,2 +1,2 @@
 repository=https://github.com/yuh25/Ping-Grapher.git
-commit=a625219c12ac4cb813b0e2afd6f7c71540025fa9
+commit=d3ff074ffc15009671679bf65dc7e4c6c25aca1d


### PR DESCRIPTION
From [Ned-57/fix/brazil-worlds-ipv6-ping](https://github.com/Ned-57/Ping-Grapher/tree/fix/brazil-worlds-ipv6-ping)

"Replace the Ping.ping() call with a local pingWorld() helper that uses getAllByName() to prefer IPv4 when available. If only IPv6 is returned, falls back to a direct TCP connect on port 43594, which Socket.connect() handles natively on all platforms."