### PR TITLE
Add voiced-dialogue

### DIFF
--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,0 +1,4 @@
+repository=https://github.com/grabartley/runelite-voiced-dialogue.git
+commit=52dc16bd473e00d13f19cdc5d8196f6addce9386
+authors=grabartley
+warning=With the Cloud (OpenRouter) voice backend selected, the dialogue text being spoken is sent to OpenRouter over HTTPS using your API key. The local backend stays fully offline and sends nothing off your machine.

--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=45f3adc69c2ec37b41e20da931ea37394238c336
+commit=40ae7cd7d55f29e27e576777dca1cac49c3376da
 authors=grabartley
 warning=With the Cloud (OpenRouter) voice backend selected, the dialogue text being spoken is sent to OpenRouter over HTTPS using your API key. The local backend stays fully offline and sends nothing off your machine.

--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=40ae7cd7d55f29e27e576777dca1cac49c3376da
+commit=1d716b68906583a851ae6a3b7e030b92f84defba
 authors=grabartley
-warning=With the Cloud (OpenRouter) voice backend selected, the dialogue text being spoken is sent to OpenRouter over HTTPS using your API key. The local backend stays fully offline and sends nothing off your machine.
+warning=This plugin sends the NPC and player dialogue text it voices to OpenRouter (a third-party service not controlled or verified by the RuneLite developers) over HTTPS, using your API key, to synthesize speech.

--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=a2f2ef404558170603b08c0095726f46ace9d351
+commit=45f3adc69c2ec37b41e20da931ea37394238c336
 authors=grabartley
 warning=With the Cloud (OpenRouter) voice backend selected, the dialogue text being spoken is sent to OpenRouter over HTTPS using your API key. The local backend stays fully offline and sends nothing off your machine.

--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=52dc16bd473e00d13f19cdc5d8196f6addce9386
+commit=a2f2ef404558170603b08c0095726f46ace9d351
 authors=grabartley
 warning=With the Cloud (OpenRouter) voice backend selected, the dialogue text being spoken is sent to OpenRouter over HTTPS using your API key. The local backend stays fully offline and sends nothing off your machine.

--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
 commit=1d716b68906583a851ae6a3b7e030b92f84defba
 authors=grabartley
-warning=This plugin sends the NPC and player dialogue text it voices to OpenRouter (a third-party service not controlled or verified by the RuneLite developers) over HTTPS, using your API key, to synthesize speech.
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Voiced Dialogue

Gielinor, out loud. **Voiced Dialogue** gives every NPC and your own adventurer a real, real-time AI voice, turning silent text boxes into a living world you can actually hear. Walk up, talk, listen, that's the whole setup.

### What makes it special

- **13,700+ NPCs already voiced.** The plugin knows who's speaking and picks the right voice from a bundled race/gender table, so there are no lookups or lag mid-conversation. Meet someone added in a later game update and an optional auto-learn quietly looks them up on the wiki once and remembers them.
- **Accents with real craft.** 12 races and 13 regional origins each map to their own accent, following the real-world cultures the lands are based on: Scottish dwarves, South London trolls, Irish leprechauns, Dracula-esque vampyres, Norse Fremennik raiders, the gothic dread of Morytania, and more.
- **6,400+ hand-written personalities.** On top of the accents, thousands of NPCs get a bespoke persona with its own delivery style and speaking pace, so the icons of Gielinor sound like themselves.
- **Real emotion.** Each line's delivery, happy, sad, angry, scared, or neutral, is read from the speaker's chat-head expression, so a furious dwarf actually sounds furious.
- **You star in it too.** Set your own hero's accent, persona, and pace: the dashing knight, the gruff mercenary, or the chaos goblin of your dreams.
- **Any language, any vibe.** Pipe dialogue through another language, or layer a speaking style over it (Gen Z slang, pirate speak, Shakespearean, and more).
- **Atmosphere on tap.** Lines spoken underground pick up a cave echo, so dungeons and sewers feel enclosed.
- **Friendly by default.** Built-in profanity filtering needs no setup.

Everything runs off the game thread and replays already-heard lines from a local cache, so the client stays snappy even when you mash through dialogue.

### Setup & privacy

Speech is synthesized by OpenRouter, so the plugin needs a free OpenRouter API key. Until one is set it stays silent with a one-time notice pointing you to the setting. While active, the dialogue text being voiced is sent to OpenRouter over HTTPS using your key (disclosed in the descriptor `warning=` and in-plugin before it does anything); nothing else leaves your machine. The API key is stored as a RuneLite secret, never logged, and sent only to OpenRouter.

### For reviewers

- All HTTP/JSON goes through RuneLite's injected `OkHttpClient` / `Gson` (no `new OkHttpClient()` / `new Gson()`).
- No third-party runtime dependencies are bundled; all bundled resources load via `getResourceAsStream`.
- Audio uses `javax.sound.sampled.SourceDataLine` to stream synthesized PCM at low latency and cut the current line off when the player advances dialogue, the same pattern as the merged [NaturalSpeech](https://github.com/phyce/rl-natural-speech) plugin; confirmed acceptable with the team for this use case.
- MIT licensed, public repo, README documents every feature.
