### PR TITLE
flip-exporter: 0.2.0

### DIFF
--- a/plugins/flip-exporter
+++ b/plugins/flip-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/vriken/flip-exporter.git
-commit=e270f08259526d2915d6b91254991ec076ae52be
+commit=bdc1de361ed52432429e656eae0bc653463ce0b0


### PR DESCRIPTION
Update [Flip Exporter](https://github.com/vriken/flip-exporter) to 0.2.0.

Changes since 0.1.0:
- Each exported GE offer now carries a `placementObserved` boolean. RuneLite exposes no real GE placement timestamp, so `placedAt` is stamped when the plugin first sees an offer; for an offer already open at login that is not a real placement time. The flag is `true` only when the plugin actually witnessed the offer appear (past the login-settle window, nothing yet bought/sold), so consumers can tell a real age from a first-seen guess. Persisted in slot state.

No new permissions or network access — still writes local JSON only.