### PR TITLE
Updated Area loot v1.5.0

### DIFF
--- a/plugins/arealoot
+++ b/plugins/arealoot
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/AreaLoot.git
-commit=7c1e90099b52c30083623f6d2a4afbbcd1b38e81
+commit=16eb6647c62afb06bbfa4390bb686316f2ff9f0c

--- a/plugins/arealoot
+++ b/plugins/arealoot
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/AreaLoot.git
-commit=903e96bf36a2a5cbb2c133c303e1c78b613e9d43
+commit=851734a45dbdd33d9514818fd1366feaebfaa3d6

--- a/plugins/arealoot
+++ b/plugins/arealoot
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/AreaLoot.git
-commit=3a1b306d58486d732cebe7bf9256c618b3a41612
+commit=7c1e90099b52c30083623f6d2a4afbbcd1b38e81

--- a/plugins/arealoot
+++ b/plugins/arealoot
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/AreaLoot.git
-commit=851734a45dbdd33d9514818fd1366feaebfaa3d6
+commit=3a1b306d58486d732cebe7bf9256c618b3a41612


### PR DESCRIPTION
## 1.5.0 - 2026-07-1

### Added

- Added a `Keep overlay above game` setting so the overlay can render above in-game actors and scene elements.
- Added a `Show item delay` setting to wait up to 10 seconds before newly dropped items appear in the overlay.
- Added chat confirmations for Shift+right-click block, unblock, whitelist, and unwhitelist actions.
- Added README configuration screenshots.

### Changed

- Changed `List max items` default from 12 to 10.
- Changed `Show total loot count` to be enabled by default.
- Changed `Show total GE value` to default to long format.
- Changed default hotkeys to `Ctrl+X` for overlay toggle and `Ctrl+Z` for auto show/hide.
- Improved grid overlay sizing so cells stay stable as item GE values change.
- Improved grid auto-adjust so the overlay changes by grid rows/columns instead of fluctuating with GP text width.
- Improved overlay footer layout so total loot and total GE stack on narrow grid overlays.
- Hid total GE footer text when only one item is visible.
- Added temporary overlay title status text for toggle and auto show/hide mode changes, with smoother fade behavior.
- Changed config sections other than Overlay to start closed by default.
- Improved whitelist and blocklist config tooltips with exact-match and wildcard examples.
- Cleaned up Overlay List Settings labels and config section ordering.

### Fixed

- Fixed temporary auto-enabled title text popping back in after it faded out.
- Fixed GE and other text-entry fields triggering Area Loot hotkeys while typing.
- Fixed overlay visibility on login and click-to-enter screens by only rendering when the game viewport is visible.
- Fixed layer switching so disabling `Keep overlay above game` restores the original overlay layer behavior.
