### PR TITLE
bank-templates: 1.5.1

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=2edcdcf2189e9170831cc51f224352d9fb7b93cb
+commit=1fc4de76c74b7facc083fdb017979cbd2a4e9cbf


### PR DESCRIPTION
Updates bank-templates from 1.5 to 1.5.1 (commit 1fc4de76c74b7facc083fdb017979cbd2a4e9cbf).

Bug fix: the plugin now steps aside for Quest Helper's "show quest items" bank view, which retitles the bank and rebuilds its item widgets like a Bank Tags tag tab. Previously the layout applied on top of it and withdrawals in that view didn't work. Foreign/filtered bank views are now detected with an allow-list (normal bank, numbered tabs, and the plugin's own editing view) instead of a per-plugin block-list.

No new external requests or permissions.