### PR TITLE
Update All Skills Calculator to 1.0.0

### DIFF
--- a/plugins/all-skills-calculator
+++ b/plugins/all-skills-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/all-skills-calculator.git
-commit=a4b1135056e6864264d613c6a44f930fcaabf9d4
+commit=7efa8b465673aaf37812e4f9599f5018c8573b44

--- a/plugins/all-skills-calculator
+++ b/plugins/all-skills-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/all-skills-calculator.git
-commit=1d99ff9ba361329705193820ce96b85c88b1b3cf
+commit=a4b1135056e6864264d613c6a44f930fcaabf9d4

--- a/plugins/all-skills-calculator
+++ b/plugins/all-skills-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/all-skills-calculator.git
-commit=7efa8b465673aaf37812e4f9599f5018c8573b44
+commit=a56ffac592e07a0276e074064431a14af012e307


### PR DESCRIPTION
Sets the plugin author to Reasel and adds a proper version (1.0.0) so the install page shows a version instead of a commit hash.