### PR TITLE
Update AFK Stats Tracker to 1.1.1

### DIFF
--- a/plugins/afk-stats-tracker
+++ b/plugins/afk-stats-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/AFK-Stats-Tracker.git
-commit=18a74e1b310ac3bf3bc126107147be76ac4e2279
+commit=52125d059359a1d1bfbbf8bcb812c61dc6817c75

--- a/plugins/afk-stats-tracker
+++ b/plugins/afk-stats-tracker
@@ -1,2 +1,2 @@
-repository=https://github.com/Reasel/AfkTracker.git
-commit=d5d4fd9b4b92696c5235db2d422e05a5d4fd6594
+repository=https://github.com/Reasel/AFK-Stats-Tracker.git
+commit=18a74e1b310ac3bf3bc126107147be76ac4e2279


### PR DESCRIPTION
Bumping the version to 1.1.1 so it shows in the download. Also updates the repository URL to the repo's new name (old URL redirects).