### PR TITLE
Update Bank Highlight Search to 1.0.0

### DIFF
--- a/plugins/bank-highlight-search
+++ b/plugins/bank-highlight-search
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/Highlight-Search.git
-commit=32ca65bdbefbba4a711ecca6df13841e583cad1c
+commit=cd7eaf52c3e4c2152cdd8f6cc1566a8fe05f76d5

--- a/plugins/bank-highlight-search
+++ b/plugins/bank-highlight-search
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/Highlight-Search.git
-commit=cd7eaf52c3e4c2152cdd8f6cc1566a8fe05f76d5
+commit=f2165ad9bf3b49ac75b393d185256281c1925e6e


### PR DESCRIPTION
Bumping the version to 1.0.0 so it shows in the download.