### PR TITLE
bank-templates: 1.5.2

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=1fc4de76c74b7facc083fdb017979cbd2a4e9cbf
+commit=7ad93a925818d0f71772aab0ba2306249f8e34fc


### PR DESCRIPTION
Updates bank-templates from 1.5.1 to 1.5.2 (commit 7ad93a925818d0f71772aab0ba2306249f8e34fc).

- Template tabs the player's bank doesn't have yet (rendered as extra "virtual" tabs) now show their value in the bank title, matching real tabs.
- Fixed the extra tab buttons disappearing while certain numbered tabs were selected (a selected tab's duplicate background collapsed the computed tab spacing).

No new external requests or permissions.