### PR TITLE
bank-templates: 1.5.2

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=1fc4de76c74b7facc083fdb017979cbd2a4e9cbf
+commit=f58c82b310f3883f98ee7590f23d80af529ee4a4


### PR DESCRIPTION
Updates bank-templates from 1.5.1 to 1.5.2 (commit f58c82b310f3883f98ee7590f23d80af529ee4a4).

- Custom per-tab icons: a bank tab can be given a chosen icon instead of defaulting to its first item, set via a right-click "Set icon" option (RuneLite chatbox item search) in the editor or in-bank.
- The plugin's overlay-drawn "virtual" tabs (template tabs the bank doesn't have yet) now expose a full right-click menu (View tab, Set icon, Collapse tab, Remove placeholders) and a hover action, matching real tabs; and they show their value in the bank title.
- Fixed the overlay's extra tab buttons disappearing while a selected numbered tab collapsed the tab spacing.

No new external requests or permissions.