### PR TITLE
Update Loot Table Viewer Barrows lookup

### DIFF
--- a/plugins/loot-table-viewer
+++ b/plugins/loot-table-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/Oufqt/Loot-Table-Viewer.git
-commit=30279ff3c7caa29502d1895a867a0e9d016610d4
+commit=5f840d4f6789ffb471bcaffe19d598940381ae81


### PR DESCRIPTION
Updates Loot Table Viewer to commit 5f840d4f6789ffb471bcaffe19d598940381ae81.

Fixes Barrows chest lookup so Barrows loot resolves to Chest (Barrows) instead of the generic Chest page, allowing Barrows reward drop rates to display.