### PR TITLE
update osparty to 1.0.8

### DIFF
--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,3 +1,3 @@
 repository=https://github.com/iodrareg/osparty.git
-commit=04c2e4e2ed6f6978447c344497839643ce6d106d
+commit=f3cf2d8ff97dabbe50ccadd1f5c9f3b209e88fd3
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,3 +1,3 @@
 repository=https://github.com/iodrareg/osparty.git
-commit=43d5f4cc01bdb721112d6f7ee02dd8a739506edb
+commit=04c2e4e2ed6f6978447c344497839643ce6d106d
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,3 +1,3 @@
 repository=https://github.com/iodrareg/osparty.git
-commit=11cfb0d1c4fa21c40257fcc6415483065a45ce15
+commit=43d5f4cc01bdb721112d6f7ee02dd8a739506edb
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds the possibility to add players to a blocklist based on the player-hash instead of username.

- players blocked will not show up in the list of the owner of the blocklist
- if a blocked player tries to apply for a hosts' party, the host will be able to set different behaviors in their settings
- favorites now also use the player hash instead of a plain username
- local H2 database to handle and store client acquired player hashes
- more UX changes
- show current amount of users currently in the plugin
- better readability of the party panel
- add "Create voice channel" and "Join voice" with deeplink to discord
- add linking of discord account to the plugin for better control over channel management from the plugin