### PR TITLE
create player-interpolation plugin

### DIFF
--- a/plugins/player-interpolation
+++ b/plugins/player-interpolation
@@ -1,0 +1,2 @@
+repository=https://github.com/JarateKing/player-interpolation.git
+commit=1b2c006d5f4a094d237829b329bcac6843190f0c

--- a/plugins/player-interpolation
+++ b/plugins/player-interpolation
@@ -1,2 +1,2 @@
 repository=https://github.com/JarateKing/player-interpolation.git
-commit=1b2c006d5f4a094d237829b329bcac6843190f0c
+commit=871dc387e99ee6598144f0b02d8be8f90af96776


### PR DESCRIPTION
Adds `Player Interpolation`, a plugin for tightening up player movement to align with the true tile.

When the player moves, this plugin hides the default player model and creates a new player model that the plugin repositions. It will lerp between the true tile on the last tick and the current tick, ensuring that it always ends up at the true tile by the end of the tick.

This should be fine with Jagex's third party client guidelines. This doesn't reposition the camera, or NPCs / other players, or any click zones. It's essentially just a complicated true tile plugin.

Repo: https://github.com/JarateKing/player-interpolation