### PR TITLE
Add maggot-king

### DIFF
--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/maggot-king.git
-commit=8a010fd198856ed88c3220c30c6f11824df4683f
+commit=0f30d49f7128be5acb2105565a4622c0189f3eff

--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,0 +1,2 @@
+repository=https://github.com/randytkrx/maggot-king.git
+commit=3d3f682b819cf1cb2ad1b31efcbff1f30bdb31d8

--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/maggot-king.git
-commit=3d3f682b819cf1cb2ad1b31efcbff1f30bdb31d8
+commit=8a010fd198856ed88c3220c30c6f11824df4683f


### PR DESCRIPTION
Adds Maggot King, a helper plugin for the Maggot King boss.

Features:
- Reactive callouts for the boss's telegraphed mechanics: screech (configurable text), slam and airborne larvae. All react to visible animations only, nothing is predicted.
- Attack style indicator showing the last style observed from the boss. It starts empty each kill and only ever reports what has already happened.
- Larvae highlighting with a separate color for airborne larvae, boss true tile colored by phase, and a corpse highlight labelled with the user's preferred loot interaction.
- Boss health with phase thresholds, an optional burn damage counter, and a session panel with kills, deaths, kill times, personal best per profile, loot value and egg breakdown.
- Optional cosmetic toggles to hide the post screech rock litter and the darkwood trees around the arena, off by default. Interactable objects and hazards are never hidden.

The plugin deliberately omits hazard tile marking, projectile landing tiles and any prayer or next attack indication per the third party client guidelines.