### PR TITLE
osrs-best-in-slot: one panel + two opt-in off-by-default media captures

### DIFF
--- a/plugins/osrs-best-in-slot
+++ b/plugins/osrs-best-in-slot
@@ -1,4 +1,4 @@
 repository=https://github.com/osrsbis/account-connect.git
-commit=74b0c77b5a50318ef130c9f07a39c7933c998a28
+commit=246e2b7f86b80aebf461aae9b6377040f0d2d473
 authors=osrsbis
 warning=This plugin submits your IP address and uploads your account data (skills, quests, achievement diaries, equipment, inventory and bank contents) to osrsbestinslot.com to auto-fill its calculators, keyed by a link token you paste. Only enable it if you are comfortable with that data being uploaded.


### PR DESCRIPTION
**What changed since the last approved commit (`74b0c77`)**

- **One plugin, one panel.** The two previously separate plugin classes are merged into a single `AccountConnectPlugin` with one config panel and one `@PluginDescriptor` (verified: exactly one descriptor in `src/main`). No change to what the base feature uploads.
- **Opt-in trade screenshot (off by default).** When the user explicitly enables it, a screenshot of the trade-confirmation window is uploaded as delivery proof on trade completion. In-config disclosure (verbatim): *"When enabled, this captures a screenshot of your trade confirmation window — which shows the other player's name and the items traded — when a trade completes, and uploads it with your osrsbestinslot.com link token to osrsbestinslot.com's servers as delivery proof. Nothing else is sent, and nothing is captured while this is off."* The toggle also carries a RuneLite `warning=`: *"This uploads a screenshot of your trade window (which includes the other player's name and the traded items) to osrsbestinslot.com. Only enable it if you agree to that."* Default: **false**.
- **Opt-in general-store clip (off by default).** When enabled, a short muted video clip (default 6 s @ 10 fps) of the game screen while a shop interface is open is uploaded as delivery proof. In-config disclosure (verbatim): *"When enabled, this records a short muted video clip of your game screen while a shop is open and uploads it, together with your osrsbestinslot.com link token, to osrsbestinslot.com's servers as delivery proof. Only the rendered game frames are captured — no keyboard, mouse, password or other data is sent. Off by default."* Encoded in pure Java (jcodec) — no native code, no subprocess. Default: **false**.
- **Change-gated uploads.** The account snapshot now uploads only when the account state actually changes (previously a fixed 30 s cadence), cutting request volume to osrsbestinslot.com by ~95%, and backs off on HTTP 429.

**Privacy stance**

- Both media features are **opt-in and off by default** — nothing is captured or uploaded unless the user turns the toggle on.
- Each toggle shows a plain-language disclosure of exactly what is captured and where it goes, in the config panel, at the point of enabling.
- Captures are **passive** — only rendered game frames / the trade window are read. No keyboard, mouse, password, email, payment, or Jagex-account credentials are read or sent (RuneLite does not expose those to plugins).
- The base account-data upload is unchanged from the approved `74b0c77`; the hub `warning=` is updated to disclose the two new optional media features.

**Build**: `./gradlew clean build` green on the exported public tree (JDK 11); tests + `check` pass.