### PR TITLE
add music-cape-helper

### DIFF
--- a/plugins/music-cape-helper
+++ b/plugins/music-cape-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-music-cape-helper.git
-commit=8cb209de7c7f6ca085f649d7e3e6b0f5e73f1ef6
+commit=8cb209d8779913873a2efff81326cf44041d97ff
 authors=robisa693

--- a/plugins/music-cape-helper
+++ b/plugins/music-cape-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-music-cape-helper.git
-commit=8cb209d8779913873a2efff81326cf44041d97ff
+commit=692804594fde11d5c5bfd623b925798bdc697f22
 authors=robisa693

--- a/plugins/music-cape-helper
+++ b/plugins/music-cape-helper
@@ -1,0 +1,3 @@
+repository=https://github.com/robisa693/runelite-music-cape-helper.git
+commit=8cb209de7c7f6ca085f649d7e3e6b0f5e73f1ef6
+authors=robisa693


### PR DESCRIPTION
Plugin name: Music Cape Helper  

Repo: https://github.com/robisa693/runelite-music-cape-helper

Description: Helps you complete the music log and unlock the music cape. Shows all music tracks grouped by area, their unlock hints, and which are still missing. Track your progress, search by name, and click any track to open its OSRS Wiki page.

Disclosure: This plugin sends a request to oldschool.runescape.wiki when clicking a track to resolve the correct wiki URL (configurable via the "Wiki lookup on click" setting). Uses RuneLite's injected OkHttpClient.