### PR TITLE
Update Bank Highlight Search to 1.0.1

### DIFF
--- a/plugins/bank-highlight-search
+++ b/plugins/bank-highlight-search
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/Highlight-Search.git
-commit=f2165ad9bf3b49ac75b393d185256281c1925e6e
+commit=24e6ab5e21e1b022d88e12f2c44ba3af83baff3e


### PR DESCRIPTION
Updates Bank Highlight Search to v1.0.1: https://github.com/Reasel/Highlight-Search/commit/24e6ab5e21e1b022d88e12f2c44ba3af83baff3e

Fixes highlight outlines on stackable items. Outlines now use the stack-size sprite variant the bank renders instead of the single-item model.