### PR TITLE
Drop Rate: collection log drop-rate tooltip, clue data, new icon

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=187025320e4849040b82be95e5acf4d9c8b756a0
+commit=bdcd4c9bcd94b88c57392002e35bf4213a42eb4a


### PR DESCRIPTION
Updates drop-rate-properties to Pluckss/DropRatePluginFinal@bdcd4c9bcd94b88c57392002e35bf4213a42eb4a.

- New: hovering an item in the Collection Log shows every source that drops it, with rates grouped by rate
- New data: clue casket rewards (all six tiers), Grotesque Guardians, and Abyssal Sire's Unsired rewards
- New plugin icon (purple rare-drop droplet)