### PR TITLE
Update Traducao OSRS BR commit

### DIFF
--- a/plugins/traducao-osrs-br
+++ b/plugins/traducao-osrs-br
@@ -1,2 +1,2 @@
 repository=https://github.com/walterrezende12-tech/Traducao-OSRS-BR.git
-commit=018a9462ca535be36ee0fba9da7c26794c9569fa
+commit=27cd5e2ba1a679f2eabaf5ec5b8afae3612c3b74


### PR DESCRIPTION
Atualiza o `commit=` do plugin Traducao OSRS BR para o hash publicado com as novas traducoes de `translations.json` e `translations_overhead.json`.