### PR TITLE
Add Item Lookup plugin

### DIFF
--- a/plugins/item-lookup
+++ b/plugins/item-lookup
@@ -1,2 +1,3 @@
 repository=https://github.com/faybii/Item-Lookup.git
-commit=39b6bb9dff4ccbcccb1129fd4cd9105e4b81eb2e
+commit=baf15d16afdaa8d3145b53158bf9553f37256e31
+build-standard=

--- a/plugins/item-lookup
+++ b/plugins/item-lookup
@@ -1,3 +1,2 @@
 repository=https://github.com/faybii/Item-Lookup.git
-commit=baf15d16afdaa8d3145b53158bf9553f37256e31
-build-standard=
+commit=bdf1f3fadae78179c056be0d2f2e9914ed04dd36

--- a/plugins/item-lookup
+++ b/plugins/item-lookup
@@ -1,0 +1,2 @@
+repository=https://github.com/faybii/Item-Lookup.git
+commit=5b49e04cf3478ad35cfeb1c0bfebbea2669637c2

--- a/plugins/item-lookup
+++ b/plugins/item-lookup
@@ -1,2 +1,2 @@
 repository=https://github.com/faybii/Item-Lookup.git
-commit=5b49e04cf3478ad35cfeb1c0bfebbea2669637c2
+commit=39b6bb9dff4ccbcccb1129fd4cd9105e4b81eb2e


### PR DESCRIPTION
Adds Item Lookup, an informational RuneLite plugin for quickly looking up OSRS item acquisition information using the Old School RuneScape Wiki.

Features include item-only search, crafting/materials info, best source summaries, drops, shops, source locations, wiki map popups where available, pinned items, recent searches, and Ironman mode.

The plugin does not automate gameplay. It sends user-entered search terms and clicked item/source names to the OSRS Wiki API for lookup.