### PR TITLE
Update commit reference in stymphike-hunter

### DIFF
--- a/plugins/stymphike-hunter
+++ b/plugins/stymphike-hunter
@@ -1,2 +1,2 @@
 repository=https://github.com/JoadsV/Stymphike.git
-commit=7db98b2bf7ae1bf9226fe514371d0331e7c5331e
+commit=5829dbea7ee28bc5ca27ff7c0baabaa1f752c137


### PR DESCRIPTION
- Hiding status and baited-tree markers are now read directly from the game's state (varbits) instead of being inferred from clicks and movement, so they always match reality.
- Catches are detected by the bird dying; a failed spear (under 10 damage) is correctly reported as the stymphike fleeing rather than as a catch.
- Recognises all five stymphike tree variants.
- Outlines the stymphike bird when it appears (toggleable).
- Trees are marked with a centre circle, like Hunter trap markers.
- The status box only shows inside the hunting area.
- Added a changelog.