### PR TITLE
Add last-prayer plugin

### DIFF
--- a/plugins/last-prayer
+++ b/plugins/last-prayer
@@ -1,0 +1,2 @@
+repository=https://github.com/itsdukey/last-prayer.git
+commit=b7bfc9f5c75e192d7322e9a787be7ec850a5c59c


### PR DESCRIPTION
Last Prayer tracks the last overhead protection prayer (Protect from Melee/Missiles/Magic) you had active and keeps displaying it as an icon and/or colored text after it drops, so you can see at a glance what you last had on. Includes an optional in-combat reminder for when no overhead prayer is active, with per-attack-style gating.

Compliance notes:
- No opponent/boss/NPC data is read — every signal the plugin uses (current overhead prayer, combat status, attack style) reflects only the local player's own client-side state.

- Not a "prayer switching indicator": the plugin never recommends a prayer or predicts what an opponent will do next. It only reflects  a prayer you already activated yourself, after it's turned off, and optionally warns that no overhead prayer is active at all it never tells you which one to pick.

- No automation: no simulated clicks, no injected input, no menu entries that send actions to the server (the plugin adds none).

- No network requests of any kind fully offline, no third-party server involved.

- No boss-specific logic, timing, or mechanic awareness of any kind.