### PR TITLE
Add PvP Profit Tracker

### DIFF
--- a/plugins/pvp-profit-tracker
+++ b/plugins/pvp-profit-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/anonyser/runelite-profit-tracker.git
+commit=c36b3ac13b1bb3b1994d495c06c5080847c80117


### PR DESCRIPTION
Tracks real PvP profit at Bounty Hunter and in the Wilderness — loot key gains and crate rewards minus deaths and consumables — plus K/D, live risk and net worth.

Repo: https://github.com/anonyser/runelite-profit-tracker

Display-only: reads containers, varps and widgets and draws an overlay and side panel; it never sends input.