### PR TITLE
feat: pvp-arena add saved loadouts

### DIFF
--- a/plugins/pvp-arena
+++ b/plugins/pvp-arena
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/pvp-arena.git
-commit=d8f957915712657c7acb99ae34e5d88ba0d9990e
+commit=64b5bf15c83cebe0ca2a7b078e7727e6181780de

--- a/plugins/pvp-arena
+++ b/plugins/pvp-arena
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/pvp-arena.git
-commit=9e4ec9088510e41f4669445e3f836fdc2cf010bb
+commit=d8f957915712657c7acb99ae34e5d88ba0d9990e

--- a/plugins/pvp-arena
+++ b/plugins/pvp-arena
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/pvp-arena.git
-commit=64b5bf15c83cebe0ca2a7b078e7727e6181780de
+commit=ffe70fabc407a5f449b0fbfa9a5ddcf1651e2a1c


### PR DESCRIPTION
- enables saving a PvP Arena loadout (equipment, inventory, spellbook)
- selecting a saved loadout:
  - highlights items in the catalog
  - toggleable filtering of the catalog
  - highlights excess items not matching the loadout
  - highlights spellbook mismatch from the loadout
- loadouts can be shared and imported

<img width="720" height="285" alt="loadout" src="https://github.com/user-attachments/assets/39f7f0c7-b035-4c8c-bbf3-cb8c901791e2" />
