### PR TITLE
Update maggot-king

### DIFF
--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/maggot-king.git
-commit=fc4b2fe70e50d56aa152e1a85a2a7d4ea2219aca
+commit=5248a4f8ad830a189e58e9347f286d02027fdafb


### PR DESCRIPTION
Values coins at face value and untradeable items at their high alchemy value in the loot tracking; previously both counted as zero.