### PR TITLE
Add NPC Tracker

### DIFF
--- a/plugins/npc-tracker
+++ b/plugins/npc-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/calleb23/npc-tracker.git
+commit=f45c437eeea5def45d8ceed6fd9d27a672a35589


### PR DESCRIPTION
New plugin submission: **NPC Tracker** — https://github.com/calleb23/npc-tracker

Right-click **Track wander** on an NPC and the plugin infers, purely from watching it move:

- its walked-tiles trail (shown by default),
- its estimated spawn tile, and
- its wander radius, drawn as a square outline.

Each tracked NPC is drawn in its own colour, and the tracked NPCs plus everything learned persist across logouts/world hops/restarts.