### PR TITLE
update voiced-dialogue

### DIFF
--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=1d716b68906583a851ae6a3b7e030b92f84defba
+commit=e7ed97ff52c6790468304220bad338871103256c
 authors=grabartley
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates voiced-dialogue to [v0.2.0](https://github.com/grabartley/runelite-voiced-dialogue/releases/tag/v0.2.0). The pinned commit is the `v0.2.0` release tag commit.

Highlights since v0.1.0:

- Voice profiles for all NPCs in the new The Blood Moon Rises quest, so the latest story content is fully voiced.
- Smoother client performance: replaying already-heard lines now reads the audio cache off the game thread.
- Friendlier in-game guidance when an OpenRouter account runs out of credits, pointing players straight to topping up.
- Easier onboarding with a step-by-step OpenRouter setup guide in the README and clearer, more concise config descriptions.
