### PR TITLE
log-adviser: bump to 0a108dc (v1.2.0)

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=84a0c373e281557e4b459ed69a0c10538bd2975c
+commit=0a108dc1cd378724fb223eaeea5172cb25b746c4


### PR DESCRIPTION
Bumps the pinned commit for **Log Adviser** to `0a108dc` (v1.2.0).

Changes since the last release (ranking **data + tests only** — no `src/main` code and no new client-API surface):
- Adds two collection-log activities to the ranking data: **Killing Maggot King** and **Killing Venators (on task)**, and registers a new pet (Maggot marquess).
- Updates the JUnit row-count / pet-count asserts and adds quest-resolution guards.