### PR TITLE
Update maggot-king

### DIFF
--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/maggot-king.git
-commit=5248a4f8ad830a189e58e9347f286d02027fdafb
+commit=aa6314f19627d7b9ecfd0ceed1a431f735fd0e4b


### PR DESCRIPTION
Adds an arena border outline option (useful when the hide trees option is on) and limits the tree and rock hiding to the Maggot King arena region so the shared scenery ids are untouched elsewhere in the game.