### PR TITLE
Update Stockpile to 1.3

### DIFF
--- a/plugins/stockpile
+++ b/plugins/stockpile
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Stockpile-Plugin.git
-commit=f33c1d34f9136c66b553c9d3d67431675d0708b3
+commit=cd187d3bcaa5f0447cb8d3528a85be57f33c886a

--- a/plugins/stockpile
+++ b/plugins/stockpile
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Stockpile-Plugin.git
-commit=790c964c01a5c10709ef08f8f102a5a1b42a1c51
+commit=f33c1d34f9136c66b553c9d3d67431675d0708b3


### PR DESCRIPTION
Updates Stockpile to Release 1.3 (R-1.3): live examine text from the wiki mapping (drops the 247 KB bundled dataset), GE-button cleanup on shutdown/config change, a full codebase style/documentation pass, and new unit tests with CI.

Release notes: https://github.com/Oveduumnakal/Stockpile-Plugin/releases/tag/R-1.3