### PR TITLE
clan-management: Discord-integrated ranks, feed polish, and rank-item coverage

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=061013d0b821a8d36493f4fdcbe5d976712103a5
+commit=2601f82f65f70d178baaf50918a222186d7e34d0
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=faba14b4e4b0b75af9a1c6f57d3877199b881083
+commit=061013d0b821a8d36493f4fdcbe5d976712103a5
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates the clan-management plugin.

- Ranks: a member's current clan rank (from the clan's own API) auto-checks
  and collapses the ranks they already hold; rank icons render beside player
  names across the panel feeds.
- Rank requirements: many item-variant resolutions (ornament kits, recolours,
  opened storage bags, combined items) and collection-log-based checks for
  consumed uniques — all evaluated locally, as before.
- Speed times: clan-verified times are the default view (toggle for all PBs),
  recent list is newest-first, team submissions no longer depend on a single
  designated submitter, 6+ mass categories.
- Drops/Activity: item + boss icons, wrapped text, clan-record highlighting,
  readable player detail view, search-only trackable-drops browser.
- Removed the legacy shared admin key — admin unlocks by role only.

Compliance: only contacts the hardcoded https://api.solusosrs.com; no
response-derived URLs; network off the client thread; file writes confined
to RUNELITE_DIR/clan-management; warning= line unchanged.
