### PR TITLE
Add Exact Stacks plugin

### DIFF
--- a/plugins/exact-stacks
+++ b/plugins/exact-stacks
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-exact-stacks-plugin.git
-commit=4cd6e05a65104587097fb5bbe7b81407c22a13df
+commit=b4b4456dce5f45f881beec9993ede0830bbfd79a
 authors=robisa693

--- a/plugins/exact-stacks
+++ b/plugins/exact-stacks
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-exact-stacks-plugin.git
-commit=243d8c2d5f5afbdb5e44a2e7c5cb4fc6bdca5cc6
+commit=4cd6e05a65104587097fb5bbe7b81407c22a13df
 authors=robisa693

--- a/plugins/exact-stacks
+++ b/plugins/exact-stacks
@@ -1,0 +1,3 @@
+repository=https://github.com/robisa693/runelite-exact-stacks-plugin.git
+commit=243d8c2d5f5afbdb5e44a2e7c5cb4fc6bdca5cc6
+authors=robisa693

--- a/plugins/exact-stacks
+++ b/plugins/exact-stacks
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-exact-stacks-plugin.git
-commit=b4b4456dce5f45f881beec9993ede0830bbfd79a
+commit=c7f8897ec24ffd5e8da2d95205cba93ee09c326f
 authors=robisa693


### PR DESCRIPTION
Exact Stacks — Shows exact stackable item quantities broken down by denomination (K and individual units) on inventory/bank slot overlays. Works for coins and any stackable item.

Toggles for 

-  Show in inventory
-  Show in bank
-  Show individual units


<img width="48" height="49" alt="icon" src="https://github.com/user-attachments/assets/17fa37d9-2d80-4a66-91fb-035feec3f10a" />
