### PR TITLE
Update slayer-streak

### DIFF
--- a/plugins/slayer-streak
+++ b/plugins/slayer-streak
@@ -1,2 +1,2 @@
 repository=https://github.com/nw51/slayer-streak-plugin.git
-commit=25ffc45e71fb77a40378d402ceb394d73d47c521
+commit=0a28a135adde7341f8f550f815723f2662709e6a


### PR DESCRIPTION
Streak tracking now reads directly from games varbit instead of piggybacking on the built-in Slayer plugin's stored config.

Added config to choose milestone interval: every 10th, 50th, 100th or 250th (previously only every 50th)

Added to the hiding of NPC Contact Slayer Masters (except Konar) with removing talk-to and get assignment from other masters.