### PR TITLE
Add Tormented Demon Effects Hider

### DIFF
--- a/plugins/tormented-demon-effects-hider
+++ b/plugins/tormented-demon-effects-hider
@@ -1,0 +1,3 @@
+repository=https://github.com/psihosrs/tormented-demon-effects-hider.git
+commit=194b521d3975133e06925999fbe588ec87c70a59
+authors=psih


### PR DESCRIPTION
Adds **Tormented Demon Effects Hider**.

A cosmetic client-side plugin that hides the eye-straining fire spot animations on Tormented Demons — the swirling fire shield vortex (on by default), plus optional per-effect toggles for the melee swipe, death burn, fireball-cast flash and spawn fire.

It removes the demon's `ActorSpotAnim`s each client tick, so it only stops drawing effects that are already on screen. It sends nothing to the server and gives no gameplay advantage. The model-baked body flames that indicate the shield/accuracy state are intentionally left visible.

Source: https://github.com/psihosrs/tormented-demon-effects-hider

🤖 Generated with [Claude Code](https://claude.com/claude-code)