### PR TITLE
Update grand-flip-out

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=9fea2c43f4564433e7096f570591d1d7c575480f
+commit=875d4df980b9cd1294ef6d3b3a11e37d5d22d897


### PR DESCRIPTION
Update grand-flip-out to v1.0.1.

- Fix an expired Discord invite link.
- Point the panel's Upgrade button at the pricing page and add referral (`?ref`) params to the outbound website links.

Link-string changes only — no new APIs, dependencies, reflection, scripts/automation, or data egress. The optional server features remain off by default.