### PR TITLE
Add PB Tracker Sync

### DIFF
--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/0xJeu/pb-tracker-sync.git
-commit=f692afbb45e07977634ba5a4b82863c765d054e8
+commit=68b4ffca6d8d1512a53e0c7783ee3077571cd79b

--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/0xJeu/pb-tracker-sync.git
-commit=8ef61fbdf035f83c5e65e89662e6c1cf91637902
+commit=f692afbb45e07977634ba5a4b82863c765d054e8

--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/0xJeu/pb-tracker-sync.git
-commit=68b4ffca6d8d1512a53e0c7783ee3077571cd79b
+commit=8206dd6895019ed16576c274007d5de169694b1d

--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/0xJeu/pb-tracker-sync.git
+commit=8ef61fbdf035f83c5e65e89662e6c1cf91637902


### PR DESCRIPTION
Adds PB Tracker Sync, a RuneLite plugin that syncs boss personal best times to a configurable PB leaderboard backend.\n\nPlugin repository: https://github.com/0xJeu/pb-tracker-sync\nPlugin commit: 8ef61fbdf035f83c5e65e89662e6c1cf91637902