### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=b48c345f8bf036a8317a74f900b7a895bcb8430f
+commit=1820c527357ed815f9006d90ad931f8aae2198f3
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
- Cut down how often the plugin re-sends your account-linking info to the server on every world hop, since it rarely changes.
- Stopped re-checking webhook notification settings every few minutes when they almost never change.
- The Active Flips panel now updates instantly when a flip fills instead of waiting on a full refresh, and rapid refresh triggers are batched together instead of firing repeatedly.
- Bank snapshot uploads now back off properly after a failure instead of retrying on every tick, and a redundant status-check call was removed in favor of a single call.
- Consolidated retry/backoff handling for server requests so hiccups and rate limits are handled more gracefully instead of retrying aggressively.
- Item analysis data (buy limits, liquidity, risk info) that rarely changes is now cached for longer, and duplicate in-flight requests for the same item are shared instead of being sent twice.

This is mostly performance improvements to scale with our amount of users.
