### PR TITLE
Update heal-indicators to 1a0e432

### DIFF
--- a/plugins/heal-indicators
+++ b/plugins/heal-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Necrotress/heal-indicators.git
-commit=02e7f111b7bee7745eb7ebc50adca677bacbc8e2
+commit=1a0e432452289a2e053e6847dbf999835f8d7419


### PR DESCRIPTION
### Fixed
- Prayer Splats settings section now expands by default instead of starting collapsed.
- Fixed inconsistent centering of heal/prayer splat numbers — text is now centered using the actual rendered glyph bounds instead of approximate font metrics, so it stays centered regardless of the number's digit count or shape.

### Changed
- Updated heal/prayer splat icon artwork.