### PR TITLE
Add Maggot King Helper

### DIFF
--- a/plugins/maggot-king-helper
+++ b/plugins/maggot-king-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/itsdukey/Maggot-King-Helper.git
+commit=563702689ded1c1eb39b2f913d5e7ce7e3fdbcc6


### PR DESCRIPTION
Summary

Maggot King Helper hides three specific scenery objects inside the Maggot King boss arena instance Darkwood trees, the exit door (visual only, and optionally its left-click action), and Carrion so the arena is easier to see during the fight. Includes a debug chat command (::mdb) used during development to discover the arena's object IDs; it has no gameplay effect.

Why this doesn't add capability beyond what's already possible

This plugin doesn't let a player do anything they couldn't already do with a general-purpose object hider (e.g. Object Hider) you could already right-click each of these objects and hide them one at a time. This plugin only:

- Bundles the specific objects that clutter this one fight into single-click toggles, instead of hiding them individually.
- Scopes the hiding to the Maggot King arena's region ID specifically, so the same trees/scenery elsewhere in the game world are left untouched.

No new information is exposed, and no interaction that wasn't already available to any RuneLite user is added.