### PR TITLE
Add Shortest Path ALT

### DIFF
--- a/plugins/shortest-path-alt
+++ b/plugins/shortest-path-alt
@@ -1,0 +1,3 @@
+repository=https://github.com/PauloAguiar/shortest-path-alt.git
+commit=f1f1f8ef266eaab6da9e92c488c2876ad62297e3
+authors=PauloAguiar

--- a/plugins/shortest-path-alt
+++ b/plugins/shortest-path-alt
@@ -1,3 +1,3 @@
 repository=https://github.com/PauloAguiar/shortest-path-alt.git
-commit=f1f1f8ef266eaab6da9e92c488c2876ad62297e3
+commit=dab37e815a5d3e4042fd32f091f008b0e2083bce
 authors=PauloAguiar


### PR DESCRIPTION
Shortest Path ALT is a fork of Shortest Path that adds an alternative-routes explorer: a side panel listing alternative teleport routes to your destination, a browsable teleport-method catalog with include/exclude toggles and availability markers. All pathfinding/collision/transport data is from the original Shortest Path.


The plugin diverges enough from the original Shortest Path that instead of trying to push it on top of the existing plugin, which could break integration with other plugins that already use it, I decided to create an ALT version of it for new players that prefer a list of routes available so they can learn the alternatives.