### PR TITLE
Add Interaction Cue

### DIFF
--- a/plugins/interaction-cue
+++ b/plugins/interaction-cue
@@ -1,0 +1,2 @@
+repository=https://github.com/nanopink/InteractionCue.git
+commit=2b95e111db72e870d49657a2506ce2d88ca9fd92


### PR DESCRIPTION
Adds Interaction Cue to the Plugin Hub.

Interaction Cue shows selected spell and Use item cues near the cursor, plus pending markers on inventory slots clicked with selected spell or item-use actions.

Plugin repository: https://github.com/nanopink/InteractionCue
Commit: 2b95e111db72e870d49657a2506ce2d88ca9fd92