### PR TITLE
Add Maggot King Acid Recolor

### DIFF
--- a/plugins/maggot-acid-recolor
+++ b/plugins/maggot-acid-recolor
@@ -1,0 +1,2 @@
+repository=https://github.com/carutherstyler-png/maggot-acid-recolor.git
+commit=ecc80682a0a00524a62e1a1144608f3cba7a7303


### PR DESCRIPTION
Recolors the Maggot King's green (poison) and yellow (attack delay) spit pools to user-configurable colors for better visibility against the arena floor, with an optional tile outline/fill highlight.

Unlike the existing maggot-king plugin (fight overlays/mechanics helpers), this plugin does true model recoloring of the pool graphics: face colors are hue-swapped with shading preserved, and textured faces are painted flat in the target color. All changes are purely visual and reversible; original colors/textures are restored when the plugin is disabled.

Repository: https://github.com/carutherstyler-png/maggot-acid-recolor