### PR TITLE
Update Interaction Cue

### DIFF
--- a/plugins/interaction-cue
+++ b/plugins/interaction-cue
@@ -1,2 +1,2 @@
 repository=https://github.com/nanopink/InteractionCue.git
-commit=2b95e111db72e870d49657a2506ce2d88ca9fd92
+commit=2937d498601a939ccf8733e221b01c3592c39630

--- a/plugins/interaction-cue
+++ b/plugins/interaction-cue
@@ -1,2 +1,2 @@
 repository=https://github.com/nanopink/InteractionCue.git
-commit=2937d498601a939ccf8733e221b01c3592c39630
+commit=994dd27af45cfdbce9e222774d7115a3aeaf83ec


### PR DESCRIPTION
Updates Interaction Cue to include a pending marker lifecycle fix.

The marker now stays active for queued or delayed item and spell interactions until a real resolution signal occurs, instead of clearing just because the next game tick did not expose a local animation/graphic/interacting change.

Plugin repository: https://github.com/nanopink/InteractionCue
Commit: 2937d498601a939ccf8733e221b01c3592c39630