### PR TITLE
Add Particles plugin

### DIFF
--- a/plugins/particles
+++ b/plugins/particles
@@ -1,2 +1,2 @@
-repository=https://github.com/cnnnr/particles
+repository=https://github.com/cnnnr/particles.git
 commit=795a5d29ccf7bf581e54b14fadc902e14ef1d165

--- a/plugins/particles
+++ b/plugins/particles
@@ -1,2 +1,2 @@
 repository=https://github.com/cnnnr/particles.git
-commit=795a5d29ccf7bf581e54b14fadc902e14ef1d165
+commit=bf9f15fe1ea5e8d1614acfb555634f261a55a736

--- a/plugins/particles
+++ b/plugins/particles
@@ -1,0 +1,2 @@
+repository=https://github.com/cnnnr/particles
+commit=795a5d29ccf7bf581e54b14fadc902e14ef1d165


### PR DESCRIPTION
# Particles

**Version 1.0.0**

## What it does

Cosmetic 3D particle effects for your gear.

Effects are predefined per item rather than user-customized, so particles stay cohesive and consistent for everyone.

## Supported gear

The plugin includes a preset pack covering popular items, including:

- Max capes
- All halos
- Crystal crowns
- Ancient sceptres
- Scythe of vitur ornament kits, Tumeken's shadow, nightmare staves, dragonfire shield

Each preset can be toggled individually.

## Settings

- **Just me** — only your own character emits particles.
- **Particle density** — Normal, Low, or Very low; scales every effect's emission rate.
- **Effect radius** — only players within this many tiles of you emit particles.
- **Max live particles** — the total particle budget across all effects. Lower it if you want to trade density for frames.
- **Hide Side Panel** — removes the sidebar icon for a clean layout; effects keep working.

![Particle effects preview](https://i.imgur.com/BwqYvnv.gif)