### PR TITLE
Update Kill Clog to 1.6.0

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=4afd28860b6f520f742a8d1e65095fbdfbcd915e
+commit=ee38ad9b93ad398947c1be0e5021668b7aa9741a
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Kill Clog to 1.6.0.

Highlights:
- Adds skill-hover stats in solo and comparison Skill Summary tooltips, swapping the GOTR footer for rank and XP while hovering a skill.
- Reworks unsynced collection-log tooltips so public lookups without synced clog data still show useful native hiscore context, rank rows, and explorable dimmed item grids instead of dead/no-data states.
- Adds cold-panel collection-log previews before any lookup: boss/clue cells preview the catalog with `--/Y` slot counts, and Clue/PvP summaries render their ladders with dashes.
- Adds a Slayer row and Superiors section to PvM Summary, including synced collection-log progress and unsynced XP/rank context.
- Adds the same Slayer/Superiors PvM Summary support to comparison mode.
- Adds a Clog Summary trophy shelf for earned special items, currently Stale baguette and Helmet of the Moon.
- Adds obtained dates to Clog Summary recent items.
- Adds hover names and wiki links for Clog Summary Special/Recent item sprites and PvM Summary megarare/superior item sprites.
- Moves TempleOSRS/RuneProfile provenance into Clog Summary behind a compact hover badge instead of showing it across boss popups.
- Replaces the Clog Summary title with the source label while the provenance badge is hovered, preventing source text from clipping at narrow tooltip widths.
- Adds chat emoji aliases for `:green:`, `:rune:`, `:dragon:`, and `:gilded:`.
- Adds regression coverage for tier emoji rewrites, source-badge sizing, chat icon rendering, comparison sprite counts, tooltip-builder behavior, and tier ladder behavior.

Also includes internal tooltip/comparison cleanup for more consistent rendering, with no client-to-Kill-Clog server sync/upload path included in this release.
