### PR TITLE
Add Stat-Seer plugin

### DIFF
--- a/plugins/stat-seer
+++ b/plugins/stat-seer
@@ -1,0 +1,2 @@
+repository=https://github.com/STRIKERnz/Stat-Seer.git
+commit=494f32493baeff02fe01b8d1162175ec6eb49084


### PR DESCRIPTION
Stat Seer is a plugin for quickly checking equipment stats only when you need them.

Set a hotkey, hold it while hovering an equitable item, and Stat Seer shows the equipment stat tooltip using RuneLite's built-in Item Stats overlay. Release the hotkey and the extra tooltip disappears.
