### PR TITLE
Add No-Drink-In-Bank

### DIFF
--- a/no-drink-in-bank/no-drink-in-bank.properties
+++ b/no-drink-in-bank/no-drink-in-bank.properties
@@ -1,5 +1,6 @@
 displayName=No Drink In Bank
 author=Welkon1
-description=Removes drink option from potions & foods (like wines) while bank is open
+description=Removes drink option from potions while bank is open
 tags=bank,potion,qol
 plugins=com.example.NoDrinkInBankPlugin
+repository=https://github.com/Welkon1/No-Drink-In-Bank

--- a/no-drink-in-bank/no-drink-in-bank.properties
+++ b/no-drink-in-bank/no-drink-in-bank.properties
@@ -1,0 +1,5 @@
+displayName=No Drink In Bank
+author=Welkon1
+description=Removes drink option from potions & foods (like wines) while bank is open
+tags=bank,potion,qol
+plugins=com.example.NoDrinkInBankPlugin

--- a/no-drink-in-bank/no-drink-in-bank.properties
+++ b/no-drink-in-bank/no-drink-in-bank.properties
@@ -4,3 +4,4 @@ description=Removes drink option from potions while bank is open
 tags=bank,potion,qol
 plugins=com.example.NoDrinkInBankPlugin
 repository=https://github.com/Welkon1/No-Drink-In-Bank
+commit=c6d20c1ffb8280aa962d34e20fefb349e6bc00cc

--- a/plugins/no-wield-no-wear-in-bank
+++ b/plugins/no-wield-no-wear-in-bank
@@ -1,2 +1,0 @@
-repository=https://github.com/Welkon1/No-Wield-No-Wear-In-Bank.git
-commit=c1578e1c53bd7a4c8549e847fb981bdc29a246c9

--- a/plugins/no-wield-no-wear-in-bank
+++ b/plugins/no-wield-no-wear-in-bank
@@ -1,0 +1,2 @@
+repository=https://github.com/Welkon1/No-Wield-No-Wear-In-Bank.git
+commit=c1578e1c53bd7a4c8549e847fb981bdc29a246c9


### PR DESCRIPTION
Adds the No-Drink-In-Bank plugin.

This plugin removes the "Drink" menu option from potions in your inventory while the bank interface is open. It's meant to prevent accidental clicks when trying to use "deposit all".

Repository: https://github.com/Welkon1/No-Drink-In-Bank