### PR TITLE
update 117hd

### DIFF
--- a/plugins/117hd
+++ b/plugins/117hd
@@ -1,3 +1,3 @@
 repository=https://github.com/117HD/RLHD.git
-commit=76c8098d66d567ec2df63289fbbaba89fabf8c29
+commit=35e89fffafa7b97136148f5b179834d523758441
 authors=aHooder


### PR DESCRIPTION
Hold for next release. Implements support for `Model.getTransparency()`.