### PR TITLE
account-data-exporter: bump to 0.6.2

### DIFF
--- a/plugins/account-data-exporter
+++ b/plugins/account-data-exporter
@@ -1,3 +1,3 @@
 repository=https://github.com/A-Kimpton/account-data-exporter.git
-commit=38cbadb0275715fdeddf889227667447815b8b8b
+commit=24de9e55a188f40562ce7ca600da3c8afc045c5a
 authors=A-Kimpton


### PR DESCRIPTION
Updates Account Data Exporter from 0.5.0 to 0.6.2.

Changes since 0.5.0:
- **Performance:** snapshots are only written when their content actually changed (with a 2-minute heartbeat while logged in); item names, combat-achievement task definitions and slayer DB-table name lookups are cached instead of re-read every export tick on the client thread.
- **New data (additive, schema 1.0.2 → 1.0.4):**
  - `quests.questPoints` (QP varp)
  - `items[].haPrice` / `haValue` (high-alch values) on all containers
  - `bankTabSizes` (bank tabs 1–9 sizes from the `bank_tab_1..9` varbits)
- **New config toggle:** "Combat achievement task list" - off exports tier totals only (the per-task list dominates snapshot size); `tiers[].tasks` may be omitted accordingly.
- One-time warning log if the CA tier enums resolve zero tasks (id-shift canary after game updates).

No new dependencies; schema changes documented in the repo's SCHEMA.md / SCHEMA_CHANGELOG.md.