### PR TITLE
create always-hear-drops

### DIFF
--- a/plugins/always-hear-drops
+++ b/plugins/always-hear-drops
@@ -1,0 +1,3 @@
+repository=https://github.com/robisa693/runelite-always-hear-drops.git
+commit=5717f99a9753de05a083b5a4d801a6ef0605c192
+authors=robisa693


### PR DESCRIPTION
For those muted PVMers

Other plugins make you download sound files or keep your game sounds on. This one just uses the game's own sounds and works even when you muted everything via ingame sound settings— set it and forget it, for most users no further setup is needed.