### PR TITLE
Update inf-colo-additions

### DIFF
--- a/plugins/inf-colo-additions
+++ b/plugins/inf-colo-additions
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/bop-plugins.git
-commit=40b66698bf37545d58ef90c4fae5774fd9873694
+commit=ec20b5c96a7c23352e051e2ebee76e2befcea1f6


### PR DESCRIPTION
lowkey who knew that actors were tileobject and doing ID based filtering can sometimes filter out the NPCs if the ID overlaps with the NPC's index
because I didn't

fixed for real this time I think