### PR TITLE
Add Blood Moon Rises Helper

### DIFF
--- a/plugins/blood-moon-rises-helper
+++ b/plugins/blood-moon-rises-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JaanBOT/blood-moon-rises-helper.git
-commit=823f9893e70b0bd197f1afc2d6284f652d8ea19a
+commit=6b543637df2d48cf9e1d8da5ea7d2e4fac6d4896

--- a/plugins/blood-moon-rises-helper
+++ b/plugins/blood-moon-rises-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/JaanBOT/blood-moon-rises-helper.git
+commit=823f9893e70b0bd197f1afc2d6284f652d8ea19a


### PR DESCRIPTION
## Blood Moon Rises Helper

A quest helper built specifically for **The Blood Moon Rises** (quest #180, Grandmaster, released 30 June 2026), which Quest Helper does not currently support.

**Features:**
- Full step-by-step walkthrough across all 12 quest phases, in a sidebar panel with collapsible per-phase sections and an on-screen overlay
- All puzzle solutions inline (book plinths, bust order, clocks, painting chest, statue racks, lockbox, passcode doors, basin placements, refiner, prayer chest, etc.)
- Boss mechanic cheat-sheets for the Lowerniel Drakan encounters, the Wyrd, and the Ver Sinhaza gauntlet (dodge directions, prayer-switch timing, blood-wave patterns)
- Name-based NPC/object highlighting for the current step, travel-target tile marker, minimap guide line and world map point
- Per-step item lists; progress saved between sessions with manual step cycling

Purely informational overlay/panel - no automation or input assistance. Walkthrough content sourced from the OSRS Wiki.

Repository: https://github.com/JaanBOT/blood-moon-rises-helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)