### PR TITLE
Update always-hear-drops to add low prayer feature

### DIFF
--- a/plugins/always-hear-drops
+++ b/plugins/always-hear-drops
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-always-hear-drops.git
-commit=5717f99a9753de05a083b5a4d801a6ef0605c192
+commit=3e8686a30c45b5d7c433dc961cfe7537a75d8f08
 authors=robisa693


### PR DESCRIPTION
Update always-hear-drops → Always Hear Alerts (added low prayer sound)
Added a low prayer alert feature (requested by a user) — plays a sound when prayer drops at or below a configurable threshold (even if game is muted). Also renamed the plugin to "Always Hear Alerts" since it now covers both drops and prayer. Backwards compatible.