### PR TITLE
Update Anvil

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=cfc2b132156601768c02990566a4984222746aa5
+commit=9ef64117647c69aa893de5937a619861a9990707
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=03a03395c335e5de3b963a2d8bfe8a2fe0a8517f
+commit=cfc2b132156601768c02990566a4984222746aa5
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=01fccc80d4e0baed88be541cb4e2e31ef11c46d7
+commit=03a03395c335e5de3b963a2d8bfe8a2fe0a8517f
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=9ef64117647c69aa893de5937a619861a9990707
+commit=1def995972b8f84e7457abb9d9a35615ba66abd8
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=572bd340bbbfa4968b50d8804c1251d5409dc312
+commit=01fccc80d4e0baed88be541cb4e2e31ef11c46d7
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates Anvil to the latest release.

- Fixed tile descriptions overflowing the collection-log task list (proper word wrap, newlines respected).
- Skill/timed/value tiles now show meaningful icons instead of a placeholder sprite.
- Timed-clear parsing covers Barracuda Trials, Hallowed Sepulchre, ToA challenge times and Tempoross.
- New tracked tile kinds: item gains (counted from inventory changes, bank/GE/trade-suppressed) and deathless raid runs (ActorDeath counting inside instances).
- A drop that matches several bingo tiles now credits all of them.
