### PR TITLE
bank-templates: 1.5.4

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=f58c82b310f3883f98ee7590f23d80af529ee4a4
+commit=13fa1967f837da34ec9d665391165c3a4420774a


### PR DESCRIPTION
Update bank-templates to 1.5.4 (from 1.5.2). Two releases since:

**1.5.3**
- Reorganise helper (step-by-step): when you drag an item into the wrong slot while sorting, the guide now sends that one item straight to its correct spot in a single insert, instead of nudging every following item over one slot at a time. Correcting a slip, or sorting a bank that is only slightly out of order, now takes far fewer drags.

**1.5.4**
- Layout editor: the Add-item search no longer lists duplicate entries for items the game keeps several copies of (for example three identical "Law rune" results). Each item appears once, matched to the real item so it applies and counts correctly.
- Layout editor: the Add-item search results no longer leave a tall empty area you can scroll through when only a few items match; the list now fits the results.