### PR TITLE
bank-templates: re-point 1.5.2 to a clean commit

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=f58c82b310f3883f98ee7590f23d80af529ee4a4
+commit=0b88d68fe102bfa7cadc89dd39a81d6f0a108c49


### PR DESCRIPTION
Re-points the live bank-templates 1.5.2 build to a byte-identical commit after a source-history cleanup.

The previously pinned commit (`f58c82b...`) was made unreachable when the plugin's git history was rewritten to correct commit authorship. The new commit `0b88d68fe102bfa7cadc89dd39a81d6f0a108c49` is the same 1.5.2 release with an identical file tree - only commit metadata changed - so the built plugin is unchanged. This just ensures the live build keeps pointing at a reachable commit.

(A separate PR, #13270, updates bank-templates to 1.5.4 and supersedes this once merged.)