### PR TITLE
clan-management: WOM boss leaderboards, membership gating, and fixes

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=389d5103a779233c29f97c5e610cb3c356c28dbd
+commit=68ceb5efd3764d1db689b339514fd612838b5238
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=c592fcfffd220ffa0c0ed9904934d5616a3094b2
+commit=a7d21bd72dbfd60c4373dd5d7e0bd4a08da9e4bf
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=c556614a868da8b42e78ebf90483384ebff9902b
+commit=389d5103a779233c29f97c5e610cb3c356c28dbd
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=2601f82f65f70d178baaf50918a222186d7e34d0
+commit=c556614a868da8b42e78ebf90483384ebff9902b
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=68ceb5efd3764d1db689b339514fd612838b5238
+commit=c592fcfffd220ffa0c0ed9904934d5616a3094b2
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates the clan-management plugin.

- WOM-backed clan leaderboards: boss KC boards (current standings or
  gained-over-period) alongside the existing skill boards — served by the
  plugin's own API from cached WiseOldMan group data.
- Clan-membership gate: drops/times from an account that is not in the
  clan (e.g. a member's alt) are no longer submitted.
- Raid/chest kill counts: CoX/ToB/ToA and Barrows drops now carry their
  completion count; collection-log unlocks attribute to the item's log
  category instead of "Skilling".
- Loud in-chat warning when the API rejects the member's key (previously
  failed silently).
- Panel sizing pass (no clipped text, long labels wrap), Sailing-aware
  max total, misc leaderboard pagination.

Compliance unchanged: only contacts the hardcoded https://api.solusosrs.com;
no response-derived URLs; network off the client thread; warning= line intact.
