### PR TITLE
goalplanner: bump to 0.4.1

### DIFF
--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-goal-planner.git
-commit=b557baf9441c531acd9b58aa41684d096904e5c8
+commit=41ef6350fe13a0c417bafb3a05e3d758f74881a8

--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-goal-planner.git
-commit=238f1a7f71c5c3fcb90f22719e8e40d85579cdf3
+commit=b557baf9441c531acd9b58aa41684d096904e5c8


### PR DESCRIPTION
Updates **Goal Planner** to 0.4.1 (commit b557baf9441c531acd9b58aa41684d096904e5c8).

Content update for The Blood Moon Rises (2026-06-30 game update):
- Maggot King boss: kill-count tracking, pet card icon, and drop source tags for its collection-log items
- Quest-point total bumped to 339 (Quest Cape / max-QP account goals)
- The quest goal itself ships staged/dormant: the plugin now tolerates quests forward-declared ahead of the RuneLite API, so it activates automatically once the hub builds against a RuneLite release containing the quest — no further plugin update needed

`./gradlew preSubmit` (test + docs + token + glyph gates) green against latest.release; main source 177,231 / 200,000 tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)