### PR TITLE
account-data-exporter: bump to 0.9.7

### DIFF
--- a/plugins/account-data-exporter
+++ b/plugins/account-data-exporter
@@ -1,3 +1,3 @@
 repository=https://github.com/A-Kimpton/account-data-exporter.git
-commit=a9d311ba2dd74893a6e509d3913b626432ad91dd
+commit=2c85d77ff10b18d4b61db2099ef7cd2949ee9f79
 authors=A-Kimpton

--- a/plugins/account-data-exporter
+++ b/plugins/account-data-exporter
@@ -1,3 +1,3 @@
 repository=https://github.com/A-Kimpton/account-data-exporter.git
-commit=2c85d77ff10b18d4b61db2099ef7cd2949ee9f79
+commit=860018c090510d226583bddeeed49687a5d5c428
 authors=A-Kimpton


### PR DESCRIPTION
Updates Account Data Exporter to 0.9.5.

Changes since 0.9.4:
- Side panel: current slayer task, slayer master headings, and hunter masters are now wiki-linked (creatures and rumours already were)
- New config toggle to show/hide the side panel (on by default)

Repo: https://github.com/A-Kimpton/account-data-exporter