### PR TITLE
Update maggot-king

### DIFF
--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/maggot-king.git
-commit=e919f29a0197a4b89edc3c238bc54518cf1402b3
+commit=5df1d653095cda2a72354a7be292d6851343b046


### PR DESCRIPTION
Adds an option to disable the exit door on left click (so you do not accidentally leave the instance mid fight, still right clickable to leave), and splits the exit door into its own hide toggle separate from trees.

Both features were suggested by itsdukey, author of the Maggot King Helper plugin. Thanks to them for the idea.