### PR TITLE
Update pvp-leaderboard

### DIFF
--- a/plugins/pvp-leaderboard
+++ b/plugins/pvp-leaderboard
@@ -1,3 +1,3 @@
 repository=https://github.com/findarian/pvp-leaderboard.git
-commit=f63d3342211c1a1d436eccf8b893399999dd5134
+commit=317645b367ba3ab16efd33b66472371c671c0ce6
 warning=This submits your IP address, in-game username, and PvP fight statistics to a 3rd-party service not controlled or verified by RuneLite developers.


### PR DESCRIPTION
feat(discord): server-brokered login; remove loopback OAuth + Cognito

Networking change: replace the local 127.0.0.1:49215 loopback HTTP server
with a server-brokered handshake. The OAuth redirect now lands on the hosted
pvp-leaderboard.com page (no localhost page is served by the plugin), and the
plugin detects login by polling the API instead of listening on a socket:
  - GET /auth/discord/plugin-init opens the browser
  - poll /auth/discord/plugin-poll (2s interval, 120s budget) -> adopt session

Ripped out the previous login method:
  - Delete the loopback HTTP server and all client-side PKCE/state handling
    (buildAuthorizeUrl/exchangeCode) - least-function; drop the now-unused
    ConfigManager dependency.
  - Delete CognitoAuthService entirely (~420 lines).
  - PvPLeaderboardConstants: drop DISCORD_CLIENT_ID/DISCORD_REDIRECT_URI
    (loopback) in favor of DISCORD_PLUGIN_INIT_URL/DISCORD_PLUGIN_POLL_URL
    off one shared API base.

UI:
  - LoginPanel: Discord blurple (#5865F2) button that doubles as 'Cancel login'
    while a handshake is in flight.
  - AdditionalStatsPanel: clamp getMaximumSize() height to preferred height so
    the box no longer absorbs BoxLayout slack and leaves an empty gap.