### PR TITLE
Update projectile-override to v1.0.9

### DIFF
--- a/plugins/projectile-override
+++ b/plugins/projectile-override
@@ -1,2 +1,2 @@
 repository=https://github.com/Loze-Put/projectile-override.git
-commit=17364255c574c3fd76c588ed7d6c39ae2511c5e2
+commit=efafd9406b6fdd523e15502a2a8e4e74633067e8


### PR DESCRIPTION
Fixed an issue where Maggot King projectile overrides would override projectiles of other bosses.