### PR TITLE
Update osrscn to 0.1.3

### DIFF
--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=bd9c432c06f9c5dbaf9842b1b3bcc1b4ebd9d2cb
+commit=e367e1fac27ba3853b9355ffc95229f5e91bd0b6
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates OSRSCN to 0.1.3.

Changes:
- Data update detection: on startup, tables are refreshed against the published hash list (previously existing installs never received data updates); downloads are now written to a temp file and swapped in atomically
- shutDown now restores translated text to English and clears per-session state; the collector's scheduled task is cancelled on shutdown
- More chat message types translated (WELCOME, BROADCAST, DIDYOUKNOW, LEVELUPMESSAGE); trailing-punctuation-tolerant lookups
- "Use A -> B" menu targets translate each side; sub-CJK punctuation folded to ASCII before glyph rendering (was garbage glyphs)
- Messages arriving while toggled to English are translated after switching back