### PR TITLE
Add Ore Ratios plugin

### DIFF
--- a/plugins/ore-ratios
+++ b/plugins/ore-ratios
@@ -1,0 +1,2 @@
+repository=https://github.com/cipscript/ore-ratios.git
+commit=c9f95c50ade92128d3c50c11be6f21eece2f6f53


### PR DESCRIPTION
Hover tooltips for ores and coal in the inventory and bank:

- Smelting recipe and coal-per-bar ratio for every smeltable ore (bronze through runite, including the Sailing lead/nickel ores)
- Optimal 28-slot trip splits, with coal bag, Smithing cape, and Blast Furnace modes
- Bank totals: bars smeltable from banked ore and coal, trips needed, leftovers, and coal needed to smelt all banked ore

Repository: https://github.com/cipscript/ore-ratios