### PR TITLE
Add Gem Sack plugin

### DIFF
--- a/plugins/gemsack
+++ b/plugins/gemsack
@@ -1,0 +1,2 @@
+repository=https://github.com/serenibyss/osrs-gem-sack-plugin.git
+commit=f6a65fbe246bd8672e710dba2c3d784e3ceb8c4a


### PR DESCRIPTION
Adds a new plugin I made adding overlay text and stored gems tooltips to all 5 of the gem bags:
- Gem Pouch
- Gem Satchel
- Gem Tote
- Gem Bag
- Gem Sack

Each gem-carrying item has configs individually both for the overlay text as well as the tooltip text.
I plan to update this further if I get any more ideas for configurability or find any issues with it (or if anyone suggests any changes to me)