### PR TITLE
Update AFK Stats Tracker to allow copiable JSON

### DIFF
--- a/plugins/afk-stats-tracker
+++ b/plugins/afk-stats-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/AFK-Stats-Tracker.git
-commit=52125d059359a1d1bfbbf8bcb812c61dc6817c75
+commit=72d110c808404b431800df32195ced060a49b331


### PR DESCRIPTION
Adds a Copy JSON option to each session's copy menu and rounds the exported values to two decimals.

This is in an effort to allow submission of data to a community site I am building. Keeping it completely optional so I do not force anyone to ship their data out.