### PR TITLE
Update PvP Profit Tracker

### DIFF
--- a/plugins/pvp-profit-tracker
+++ b/plugins/pvp-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-profit-tracker.git
-commit=0428f00cf3b7d7aeb410fd2a9f7f017179ce1052
+commit=2215f0002689870e2885f8299e14f82e338e3e74


### PR DESCRIPTION
Adds opponent risk tools: right-click a player and choose Risk (or receive a Bounty Hunter target) to see their visible gear, estimated risk and smite value, hiscore stats, and your own hit chance and max hit against them — special attacks included. Estimates only use worn equipment, items seen equipped during the fight, skull state and hiscores; assumptions are labelled on the overlay. Also adds a Protect Item (On)/(Off) indicator beside the risk value. Every new element is toggleable, and a one-time chat message tells players what changed.