### PR TITLE
account-data-exporter: bump to 0.9.7

### DIFF
--- a/plugins/account-data-exporter
+++ b/plugins/account-data-exporter
@@ -1,3 +1,3 @@
 repository=https://github.com/A-Kimpton/account-data-exporter.git
-commit=860018c090510d226583bddeeed49687a5d5c428
+commit=25ac3f97f53f038a48698c2e77bf74cec2de0bf3
 authors=A-Kimpton


### PR DESCRIPTION
Updates Account Data Exporter to 0.9.7.

Changes since 0.9.6:
- Fix the Malevolent Masquerade (slayer helmet) unlock export: it read the hooded-variant varbit (SLAYER_UNLOCK_HELM_HOODED) instead of SLAYER_HELM_UNLOCKED
- The hooded cosmetic variant is now exported separately as slayerHelmetHooded

Repo: https://github.com/A-Kimpton/account-data-exporter