### PR TITLE
Update PvP Profit Tracker

### DIFF
--- a/plugins/pvp-profit-tracker
+++ b/plugins/pvp-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-profit-tracker.git
-commit=0428f00cf3b7d7aeb410fd2a9f7f017179ce1052
+commit=758007ea85d3503d7721232a3f3caaf128b96b65


### PR DESCRIPTION
Update for pvp-profit-tracker, reworked after the feedback in #13290 and resubmitted from a clean state.

What the update adds:

- protect item indicator next to your own risk, (On) or (Off)
- your own max hit on the overlay, spec aware. your numbers only
- auto stat lookup when you receive a bounty target, the same behaviour as the core hiscore plugin's bounty lookup option
- manual right click inspect that shows a player's worn gear with the GE price per item, like equipment inspector

no risk numbers, no totals, no estimates, and nothing automated about other players beyond the stat lookup. a one time chat message tells players what changed and that everything is toggleable.