### PR TITLE
Submit Follow Plus

### DIFF
--- a/plugins/follow-plus
+++ b/plugins/follow-plus
@@ -1,0 +1,2 @@
+repository=https://github.com/anonyser/runelite-follow-plus.git
+commit=9eb718f0b6e519266d557c8ad0b3c9a4134ab37b


### PR DESCRIPTION
new plugin for soul wars taxiing and general following.

puts follow at the top of the right click menu on other players so you dont fat finger attack when you just want a taxi. plus a small status overlay you can show in the game window or as a separate always on top window: who youre following, hp and a combat warning, your prayers and prayer time left, and the soul wars activity and game timers.

display only, no automation. the menu change just reorders entries, nothing gets removed.