### PR TITLE
Update Follow Plus

### DIFF
--- a/plugins/follow-plus
+++ b/plugins/follow-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-follow-plus.git
-commit=9eb718f0b6e519266d557c8ad0b3c9a4134ab37b
+commit=b2cf4ef97abd3b4589a9ae230cfddf8981341214


### PR DESCRIPTION
small update to follow plus.

it reads the soul wars lobby board properly now. players waiting and next game start show whatever the game shows, so 5/20 and a dash before theres enough people, then the live count and the countdown once it starts.

also fixed the separate always on top window cutting off your prayers when you had a few on. they each go on their own line now and the window grows to fit.

still display only, no automation.