### PR TITLE
Create skilling-cost-calculator

### DIFF
--- a/plugins/skilling-cost-calculator
+++ b/plugins/skilling-cost-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/DuckTown407/skilling-cost-calculator.git
-commit=2ce62559e8249fb1c24c1296e20803ae9a94db26
+commit=c2258facd1730bcffd2a2d5e0b86faf12eab6cc7

--- a/plugins/skilling-cost-calculator
+++ b/plugins/skilling-cost-calculator
@@ -1,0 +1,2 @@
+repository=https://github.com/DuckTown407/skilling-cost-calculator.git
+commit=2ce62559e8249fb1c24c1296e20803ae9a94db26


### PR DESCRIPTION
This plugin expands on the skill calculator and lets you do profit/loss/cost comparisons for skilling methods with live GE pricing. I wanted to see how much it would cost to do the training and how much it would cost if I sold what I made. Handles things that can't be sold. Toggles for all options. 