### PR TITLE
takeover rl-goal-tracker

### DIFF
--- a/plugins/goal-tracker
+++ b/plugins/goal-tracker
@@ -1,3 +1,3 @@
-repository=https://github.com/Toofifty/rl-goal-tracker.git
+repository=https://github.com/Darkforge317/rl-goal-tracker.git
 commit=69c346f619ecdb7e25515e76e986c84c432f03d1
 authors=Toofifty,cecilia-sanare,AhDoozy

--- a/plugins/goal-tracker
+++ b/plugins/goal-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Darkforge317/rl-goal-tracker.git
-commit=69c346f619ecdb7e25515e76e986c84c432f03d1
+commit=93cd9a01c7bbc022fe4363a9456c23b32f8451ff
 authors=Toofifty,cecilia-sanare,AhDoozy


### PR DESCRIPTION
Hi RuneLite team! 

I'm requesting a plugin takeover for `rl-goal-tracker`, and have followed all the steps indicated in the [Plugin Takeover Policy](https://github.com/runelite/runelite/wiki/Plugin-takeover-policy). 

- **Activity:** The repository has had no development activity since February 10th, 2026. (5 months)
- **Communication:** I opened an issue requesting collaborator access 14 days ago and followed up multiple times with no response (Issue link: https://github.com/Toofifty/rl-goal-tracker/issues/67).
- **Status:** I have enabled the "Issues" feature on my fork, and I currently have 4 open PRs ready to merge and maintain the project once the takeover window passes. 
- **Open Issues:** Once the transfer is complete, I will triage existing issues on Toofifty's version of the repository and recreate the ones that are still relevant, have high impact, or have community support.

Feel free to tag me here if you have any questions or concerns. 

Thank you!