### PR TITLE
Update music-cape-helper

### DIFF
--- a/plugins/music-cape-helper
+++ b/plugins/music-cape-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-music-cape-helper.git
-commit=692804594fde11d5c5bfd623b925798bdc697f22
+commit=e397ada8228ad8dc0573b2a23c47b9176ff311bb
 authors=robisa693

--- a/plugins/music-cape-helper
+++ b/plugins/music-cape-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-music-cape-helper.git
-commit=e397ada8228ad8dc0573b2a23c47b9176ff311bb
+commit=72c34cf5a8554a4e8042d41b2a0703f043ea24ef
 authors=robisa693


### PR DESCRIPTION
Update: clicking a track can now guide you there instead of just opening the wiki.

  - New Map mode: click a track and the world map jumps to its unlock spot, with the area highlighted
  - Underground tracks get a red UNDERGROUND marker — either the surface right above the dungeon, or the actual entrance (Rat Pits, GWD, Zanaris etc.) with a chat note on how to get in
  - When you're close, the tile gets highlighted in-game with a hint arrow — works in dungeons too, clue-scroll style
  - Tracks with no map data open the wiki and tell you in chat where they unlock
  - Location data scraped from the OSRS Wiki, bundled as JSON, fully reproducible (scripts + contributor guide in the repo) 
  - For failed scrapes it falls back to Wiki
  
<img width="606" height="327" alt="Screenshot 2026-07-04 234713" src="https://github.com/user-attachments/assets/29299d53-dd13-4c00-8299-733493874680" />
<img width="742" height="550" alt="Screenshot 2026-07-04 234702" src="https://github.com/user-attachments/assets/ebdb6489-99ea-408d-b986-d06fa8ed5908" />
