### PR TITLE
Update upper-case-transformer: Fix !-prefixed chat commands being uppercased

### DIFF
--- a/plugins/upper-case-transformer
+++ b/plugins/upper-case-transformer
@@ -1,2 +1,2 @@
 repository=https://github.com/blocks-dot/Upper-Case-Transformer.git
-commit=21717faa42e02f2a49b3fee06671da4e011ff28b
+commit=bbb7687e94b82a92ed325346ae2b177d6aa827aa

--- a/plugins/upper-case-transformer
+++ b/plugins/upper-case-transformer
@@ -1,2 +1,2 @@
 repository=https://github.com/blocks-dot/Upper-Case-Transformer.git
-commit=bbb7687e94b82a92ed325346ae2b177d6aa827aa
+commit=144da6b02ebda9e592f031a05fa89d0f9c0c6e2b


### PR DESCRIPTION
## Summary
- Skip chat messages whose first visible character is `!`, so in-game command lines (e.g. `!kc Wintertodt`) are left unchanged
- Detection ignores chat color tags and leading whitespace before checking for the command prefix
- Normal all-caps/title-case messages are unaffected