### PR TITLE
update grand-flip-out

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=9fea2c43f4564433e7096f570591d1d7c575480f
+commit=fbb5fe916968377ba9e931bbce1bfbb75899031a


### PR DESCRIPTION
Removes the clipboard copy-assist (unusable in the GE input), defaults the gated GE price-fill to off, corrects the README data-egress disclosure to match the in-plugin warning, and fixes the panel footer/signup links to land on the intended pages (adds a ref query param, no new egress). No new dependencies.