### PR TITLE
slayer-block-lists: new plugin

### DIFF
--- a/plugins/slayer-block-lists
+++ b/plugins/slayer-block-lists
@@ -1,3 +1,3 @@
 repository=https://github.com/A-Kimpton/slayer-block-lists.git
-commit=dc72a88f576254131cdb4192064453dc16b078de
+commit=88dfcf06d5945c39be09bc909d0cf3571fee7531
 authors=A-Kimpton

--- a/plugins/slayer-block-lists
+++ b/plugins/slayer-block-lists
@@ -1,3 +1,3 @@
 repository=https://github.com/A-Kimpton/slayer-block-lists.git
-commit=80c6d8e298a3f9687ad3495c2b785ab2ace3891d
+commit=429e6303aa1135e68eb3bfc113a0c5c70508dab7
 authors=A-Kimpton

--- a/plugins/slayer-block-lists
+++ b/plugins/slayer-block-lists
@@ -1,0 +1,3 @@
+repository=https://github.com/A-Kimpton/slayer-block-lists.git
+commit=dc72a88f576254131cdb4192064453dc16b078de
+authors=A-Kimpton

--- a/plugins/slayer-block-lists
+++ b/plugins/slayer-block-lists
@@ -1,3 +1,3 @@
 repository=https://github.com/A-Kimpton/slayer-block-lists.git
-commit=8e95a47aabe226cb50e987d727465914110ba79a
+commit=80c6d8e298a3f9687ad3495c2b785ab2ace3891d
 authors=A-Kimpton

--- a/plugins/slayer-block-lists
+++ b/plugins/slayer-block-lists
@@ -1,3 +1,3 @@
 repository=https://github.com/A-Kimpton/slayer-block-lists.git
-commit=88dfcf06d5945c39be09bc909d0cf3571fee7531
+commit=8e95a47aabe226cb50e987d727465914110ba79a
 authors=A-Kimpton


### PR DESCRIPTION
New plugin: **Slayer Block Lists**.

Shows your slayer block list for every master in a side panel, not just the one you're standing next to. Blocked creatures, masters and the current task are wiki-linked buttons; empty and locked slots show their unlock requirements (N x 50 quest points per slot; Elite Lumbridge & Draynor diary for the seventh slot).

- A current-task card and points/streak chips sit above collapsible per-master cards; the master who gave your current task is accented and auto-expanded.
- Reads game state only (vars and the game's own data tables).

Repo: https://github.com/A-Kimpton/slayer-block-lists

<img width="418" height="1053" alt="Screenshot" src="https://github.com/user-attachments/assets/7330c136-6117-4570-927b-d1e97ad5be30" />
