### PR TITLE
update bank-tab-names

### DIFF
--- a/plugins/bank-tab-names
+++ b/plugins/bank-tab-names
@@ -1,2 +1,2 @@
 repository=https://github.com/Psyda/bank-tab-names.git
-commit=dee7759d9323adfb1aa53989a6b2590ac4f97b96
+commit=a8cd8e90a4cdd250cee3b1d4d45e48d0ff8cc9d4


### PR DESCRIPTION
Updates bank-tab-names.

**Issue 1: Configs from the original plugin were lost on update**

The rewrite moved to a new config group and never read the old "BankTabNames" group, so anyone updating from the pre-rewrite plugin lost their tab names. This has been my most common support issue by far.

Fixed with a one-time import that runs on startup, gated by a config version stamp. If the user has nothing set up in the new version, their old setup is restored live. If they have configs in both, both are kept as loadable presets in the panel and nothing gets overwritten. The old keys are never deleted, so the import can't destroy anything. A single chat message on next login tells the user where their config went.

Files: BankTabNamesPlugin.java (migration + login notice), BankTabNamesPanel.java (shared preset key constant).

**Issue 2: Clicking near the edge of a bank tab could shuffle tab designs**

A slipped click onto a neighboring tab was enough to swap the name layouts even when the game itself never reordered the tabs.

Fixed by requiring a short hold and a minimum cursor movement before a swap registers. Both thresholds are adjustable in a new "Drag protection" config section, and either can be set to 0 to disable the guard.

Files: BankTabNamesPlugin.java (threshold checks), BankTabNamesConfig.java (new config section).