### PR TITLE
Update rune-loot

### DIFF
--- a/plugins/rune-loot
+++ b/plugins/rune-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/PtrStruct/rune-loot.git
-commit=4298697cdf97d72ce55332a62da4b1a71bb16b45
+commit=113198879724d589e35bca3949c34c8729054256


### PR DESCRIPTION
## Summary
- Adds an "Excluded Items" filter to Rune Loot (comma-separated item names to suppress from popups)
- Bumps plugin version to 1.1.0

Updated commit: PtrStruct/rune-loot@1131988
