### PR TITLE
Update Gem Sack plugin to 1.1

### DIFF
--- a/plugins/gemsack
+++ b/plugins/gemsack
@@ -1,2 +1,2 @@
 repository=https://github.com/serenibyss/osrs-gem-sack-plugin.git
-commit=f6a65fbe246bd8672e710dba2c3d784e3ceb8c4a
+commit=ed7d4bed8af71de72c31a130526dfbd5c98e7880


### PR DESCRIPTION
- Fixes "Check" option not working on Gem Bag
- Fixes pickup and mining checks not checking if bag is open or closed
- Fixes pickup logic being out of sync if the action is interrupted before the gem is picked up
- Fixes empty to bank logic