### PR TITLE
lootlette: update to 1.0.6

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=85eb000d71209834e29f85f692fb53a2a4d4a87c
+commit=5ffa806c4be1c74e986034bc327b7d5c44a9c5bc


### PR DESCRIPTION
Bumps the pinned commit for Lootlette to 1.0.6.

Changes since 1.0.5:
- One slot per NPC kill (was one reel per drop-table roll); it lands on the rarest item received, so a unique always displays over a normal drop.
- Refreshed the bundled drop-table snapshot from the wiki (2061 -> 2089 monsters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)