### PR TITLE
Add 3-Tick Fishing Helper

### DIFF
--- a/plugins/tick-fishing-helper
+++ b/plugins/tick-fishing-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/RPBTwisted/tick-fishing-helper.git
+commit=65d45779145b289a363788a64f4b70c4a297f4a3


### PR DESCRIPTION
Adds the 3-Tick Fishing Helper plugin: a click-by-click visual guide and tick metronome for learning 3-tick barbarian fishing.

Overlay-only - no automation. It lists the clicks of the current 3t cycle (knife/log or herb/tar, cut or drop, spot) and highlights the next one, advancing on the player's own menu clicks and re-anchoring on Fishing XP drops. Also includes fishing spot highlighting, optional tick sounds, an on-tick rhythm history based on XP-drop intervals, and warnings for accidentally completed fletching/herblore actions.

Source: https://github.com/RPBTwisted/tick-fishing-helper