### PR TITLE
Update music-cape-helper

### DIFF
--- a/plugins/music-cape-helper
+++ b/plugins/music-cape-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-music-cape-helper.git
-commit=72c34cf5a8554a4e8042d41b2a0703f043ea24ef
+commit=8442b25e96f0fe69fd32e9a45e5f153c53161427
 authors=robisa693


### PR DESCRIPTION
Guide players to tracks in any map area, not just the one they're in.
## What's new

- **Click a track from anywhere.** Standing in the Wizards' Tower basement? Clicking a surface track now guides you there instead of falling back to the wiki — and the other way around.
- **Map area support.** The world map's own areas (Kourend Underground, Mor Ul Rek, Cam Torum, ...) are now understood: if a track's exact spot is shown by one of them, the chat message names the entry to pick, the map list button and the matching row get highlighted — with scroll up/down arrows when the row is out of view — and the map centers on the spot once you select the area.
- **Clearer messages.** Shorter, the map area name is color-highlighted, and every message ends with the track's own in-game unlock hint.
- **Better data.** Re-scraped from the current wiki, historical (removed-content) locations filtered out, wrong zone matches validated away, and instances with no map anywhere (like the Temple of the Eye) now guide to their real entrance instead of projecting onto empty ground.
- **Fixed unreliable side panel clicks** — Swing dropped clicks if the mouse moved a pixel between press and release.

## Under the hood

- New `map_areas.json`: every in-game map area with the squares it actually renders, probed from the wiki's tile server (missing tile = empty square), so markers can't land on blank map anymore.
- README now documents the full data pipeline and which curated table to edit for each kind of wrong guidance — contributions welcome.