### PR TITLE
re-enable follow-plus (renamed Soul Wars Status)

### DIFF
--- a/plugins/follow-plus
+++ b/plugins/follow-plus
@@ -1,3 +1,2 @@
 repository=https://github.com/anonyser/runelite-follow-plus.git
-commit=b2cf4ef97abd3b4589a9ae230cfddf8981341214
-disabled=true
+commit=91369749da51781709291e3dcb14d9202bf69cbb


### PR DESCRIPTION
took out the follow at the top and left click to follow toggles, that was the player menu reordering. didnt realise that wasnt allowed, my bad. also renamed it to soul wars status since thats what it is now, just the status overlay. let me know if theres anything else.