### PR TITLE
Bank Watcher: add high alch sorting and scan info

### DIFF
--- a/plugins/bank-watcher
+++ b/plugins/bank-watcher
@@ -1,2 +1,2 @@
 repository=https://github.com/Khaled2143/bank-watcher.git
-commit=8bc4749dbdb50878f37095c39a88a5b21f7bc4e5
+commit=19b914476db6af986c45ae60f28f1819c886a3db

--- a/plugins/bank-watcher
+++ b/plugins/bank-watcher
@@ -1,2 +1,2 @@
 repository=https://github.com/Khaled2143/bank-watcher.git
-commit=ce3f0d5bb99285034e9807439538b138b7733b1e
+commit=8bc4749dbdb50878f37095c39a88a5b21f7bc4e5


### PR DESCRIPTION
Adds a High Alch filter that sorts your bank by each item's single-item high alch value, so you can see exactly what's worth alching without tabbing out to the wiki.

Added a tooltip on the Scan Bank button that shows your last scan time and when the daily limit resets, plus some UI cleanup (fixed card spacing and made the scrollbar actually visible).

<img width="273" height="852" alt="Screenshot 2026-07-05 160643" src="https://github.com/user-attachments/assets/ccff87d2-4550-4b42-8029-7cd4d7c371c5" />
