### PR TITLE
Update music-cape-helper v1.2.1

### DIFF
--- a/plugins/music-cape-helper
+++ b/plugins/music-cape-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-music-cape-helper.git
-commit=8442b25e96f0fe69fd32e9a45e5f153c53161427
+commit=44a4f504235e8c8fc7e0c61bfdab2cda38b073fd
 authors=robisa693


### PR DESCRIPTION
Scraper updates (not in plugin build)

- Can now scrape single page instead of all 800+ track pages
- Updated map coordinate extraction
- catches 42 more data points

Java updates

- Fixed wiki-mode clicks opening a 404 for tracks whose page has no '(music track)' suffix (e.g. Work Work Work)"

track_coords.json

- New entries from mentioned improved scraper