### PR TITLE
Add Braindead Sea Charting

### DIFF
--- a/plugins/sea-charting-quest-helper
+++ b/plugins/sea-charting-quest-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/JaredEzz/sea-charting-quest-helper.git
+commit=38b704adc9717487b3289a502d3443370a518944


### PR DESCRIPTION
## What it does

A Quest Helper-style side panel for Sailing's 358-task sea-charting grind: nearest incomplete task first (with a smart-sort option that also weighs finishing a sea/ocean soon), per-sea completion counters, dangerous-water gear filters (adamant keel, eternal brazier, inoculation station), an overall progress bar, and optional [Shortest Path](https://github.com/Skretzo/shortest-path) route integration, including auto-retargeting for two-stage Weather/Current Duck tasks.

Repo: https://github.com/JaredEzz/sea-charting-quest-helper

## Relationship to quest-helper's ChartingHelper

[quest-helper](https://github.com/Zoinkwiz/quest-helper) already has a merged `ChartingHelper` (proximity-sortable per-sea sidebar). Two earlier submissions covering similar ground were closed citing it (#9556, #9597).

This plugin covers the same core (sorted checklist) and adds:
- Numeric per-sea "(x/y)" counters
- A weighted smart-sort that prioritizes near-complete seas, not just a binary sort/proximity toggle
- Gear-hazard filters (adamant keel, eternal brazier, inoculation station)
- Shortest Path routing integration
- Automatic route re-targeting for two-stage tasks (Weather, Current Duck)

None of the above exist in ChartingHelper today. Full comparison table in the README.

## Notes

- No `@PluginDependency`. The Shortest Path integration is an optional `PluginMessage`, no-ops if that plugin isn't installed.
- `build=standard`.
- Sea-chart task data (locations/varbits/level reqs) is mechanically compiled from LlemonDuck/sailing's public game-data constants (BSD-2-Clause, credited in LICENSE). No code or creative-expression reuse, no dependency on that plugin.
- Full test suite covering the sort algorithm, region/gear mappings, and two-stage re-targeting.