### PR TITLE
Add pet, collection log and low HP alerts

### DIFF
--- a/plugins/always-hear-drops
+++ b/plugins/always-hear-drops
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-always-hear-drops.git
-commit=3e8686a30c45b5d7c433dc961cfe7537a75d8f08
+commit=279ff3b4a42e1fd8232c6a48eeba91fac4a518ea
 authors=robisa693


### PR DESCRIPTION
- New alerts: pet drops ("funny feeling" messages), new collection log entries, and low HP (mirrors the low prayer alert with threshold, sound ID and repeat)
- Every sound now has its own test checkbox, and each click plays it — no more untick-retick
- Config panel organized into sections; volume slider clarified as the global control for all alerts
- Existing settings keep their keys, nothing resets