### PR TITLE
Create osrs-game-session-tracker

### DIFF
--- a/plugins/osrs-game-session-tracker
+++ b/plugins/osrs-game-session-tracker
@@ -1,2 +1,3 @@
 repository=https://github.com/Golddcaleb/osrs-game-session-tracker.git
 commit=a6ecfa44d4e8d33f014a09381c3ef1f6a96582c4
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-game-session-tracker
+++ b/plugins/osrs-game-session-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Golddcaleb/osrs-game-session-tracker.git
-commit=4578d3e82c585e6c23b7d8bac492f79f9274491f
+commit=a6ecfa44d4e8d33f014a09381c3ef1f6a96582c4

--- a/plugins/osrs-game-session-tracker
+++ b/plugins/osrs-game-session-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Golddcaleb/osrs-game-session-tracker.git
+commit=4578d3e82c585e6c23b7d8bac492f79f9274491f


### PR DESCRIPTION
A personal session tracking plugin for two players bossing together. 
Tracks boss kill counts (via KC chat message parsing) and loot drops 
(via NpcLootReceived/LootReceived) and sends them to a personal Firebase 
Realtime Database via the REST API.

Data sent: player name, boss name, kill count, loot item names/quantities/GE values, 
and a 60s presence heartbeat. All data goes to a Firebase RTDB URL configured 
by the user in the plugin settings. No data is sent to any RuneLite or 
third-party server not controlled by the user.

Third-party disclosure is shown prominently in the plugin config panel.
All network calls are async (OkHttp enqueue) and never block the game thread.
Plugin does not interact with or modify game state in any way.