### PR TITLE
account-data-exporter: bump to 0.9.8

### DIFF
--- a/plugins/account-data-exporter
+++ b/plugins/account-data-exporter
@@ -1,3 +1,3 @@
 repository=https://github.com/A-Kimpton/account-data-exporter.git
-commit=25ac3f97f53f038a48698c2e77bf74cec2de0bf3
+commit=5518224deb626870c6a0437d89eeabdb855c7a19
 authors=A-Kimpton


### PR DESCRIPTION
Bumps Account Data Exporter to 0.9.8.

Fixes the assigning-master name for the current slayer task. The SLAYER_MASTER varbit is ordered by when each master was added to the game, not by combat level, so Duradel is 5 and Nieve is 6. Those two were swapped in the lookup, which made Duradel tasks report as Nieve. Krystilia (7) and Konar (8) were already correct.

Repo: https://github.com/A-Kimpton/account-data-exporter