### PR TITLE
slayer-block-lists: fix slayer master mapping

### DIFF
--- a/plugins/slayer-block-lists
+++ b/plugins/slayer-block-lists
@@ -1,3 +1,3 @@
 repository=https://github.com/A-Kimpton/slayer-block-lists.git
-commit=429e6303aa1135e68eb3bfc113a0c5c70508dab7
+commit=18452716a3a3f4f24fb9d1a6459bf4e56c290f4c
 authors=A-Kimpton


### PR DESCRIPTION
Fixes the current-task master label in Slayer Block Lists.

The SLAYER_MASTER varbit is ordered by when each master was added to the game, not by combat level, so Duradel is 5 and Nieve is 6. Those two were swapped in the lookup, so a Duradel task showed as Nieve and highlighted the wrong master card. Krystilia (7) and Konar (8) were already correct.

Repo: https://github.com/A-Kimpton/slayer-block-lists