### PR TITLE
update grand-flip-out

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=fbb5fe916968377ba9e931bbce1bfbb75899031a
+commit=bdd7045943d902817a489c670b35063f4fe436ac

--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=bdd7045943d902817a489c670b35063f4fe436ac
+commit=18af27759ec49763649ce8de3f9c0e84ee479dc3


### PR DESCRIPTION
Compliance polish + one small display addition, follow-up to the update merged earlier this week:

- The server-functionality consent warning now leads with the canonical disclosure sentence verbatim; the exact data sent is kept in the second sentence.
- Flip-history save, trade-log append, and the GE-history dedupe persist no longer write files on the client thread — snapshots on the calling thread, writes on the injected executor, serialized on one lock.
- Removed a dead new-Thread fallback (the injected executor is always present) and a stale unused GsonBuilder import (the injected Gson is used throughout, unchanged).
- Advisor panels render the server's margin-quality grade as a caution label (ESTIMATE / NO ESTIMATE) when a quoted round-trip is not backed by a fresh two-sided book — display only, no new data collection, no new endpoints, no new dependencies.
- Author field unified with the repo license/build metadata.

No change to data egress or defaults; everything network-related stays behind the existing off-by-default master switch and its warning.