### PR TITLE
Add Collection Log Helper

### DIFF
--- a/plugins/collection-log-helper
+++ b/plugins/collection-log-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/cha-ndler/collection-log-helper.git
+commit=70c2c43f98b8286d9f38b0c424c557ce4c359220


### PR DESCRIPTION
Adds **Collection Log Helper**, a panel-only plugin that ranks every collection log source by how efficiently it fills your remaining log slots, so you always know the best thing to work on next.

**What it does**
- Efficiency scoring across all 226 collection log sources — the probability of a new log slot per kill (`1 - Π(1 - pᵢ)`), factoring in drop rates, kill times, independent drop tables, sequential prerequisites, raid team sizes, and slayer task overhead.
- Six panel modes: Efficient rankings, Category browser, Search, Pet Hunt, Statistics, and a Dry Streaks feed.
- Account-aware filtering (quest / skill / diary state) to hide content you can't yet access.
- Per-source detail: drop rate, expected kill time, requirements, recommended gear, and a wiki link.

**Notes for review**
- **Panel-only** — no overlays, and it takes no game actions.
- **Network** — one outbound call: an **opt-in, off-by-default** TempleOSRS kill-count fetch that sends only the RS name, and only after the user enables it. No other telemetry or external calls.
- **Reading the collection log** — a local, read-only search-mode scan of the player's own open log: it toggles the log's search (`client.runScript` on the collection-log search script) so the client fires its per-item script once per obtained item, then switches back. This is the same technique used by WikiSync and TempleOSRS; it does not automate or interact with the game world. Full explanation in the README's "How collection-log reading works".
- **License** — BSD 2-Clause.

Repository: https://github.com/cha-ndler/collection-log-helper
