### PR TITLE
Update sea-charting-quest-helper

### DIFF
--- a/plugins/sea-charting-quest-helper
+++ b/plugins/sea-charting-quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JaredEzz/sea-charting-quest-helper.git
-commit=38b704adc9717487b3289a502d3443370a518944
+commit=9420eea98352632a44b3c4a93216a12dd37b8aff


### PR DESCRIPTION
## What's new

- Sealed crate tasks now show an info icon on hover with the drink's real in-game effect, colored red when the effect is actively harmful (damage, poison, stat drain, forced combat, lost courier cargo, etc). Covers 59 of the 65 named drinks; the other 6 have no documented effect anywhere and are left out rather than guessed.
- Fixed a gap in the icy-sea gear requirement list: it only flagged 6 of the 10 seas that actually require an eternal brazier, missing Idestia Strait, Lunar Sea, Kannski Tides, and V's Belt.
- Fixed a click dead-zone the new info icon would have introduced on crate rows (the icon's own tooltip listener was swallowing row clicks before they reached the existing "click to route" handler).

Commit: JaredEzz/sea-charting-quest-helper@9420eea98352632a44b3c4a93216a12dd37b8aff