### PR TITLE
Update Ore Ratios to 1.1.0

### DIFF
--- a/plugins/ore-ratios
+++ b/plugins/ore-ratios
@@ -1,2 +1,2 @@
 repository=https://github.com/cipscript/ore-ratios.git
-commit=c9f95c50ade92128d3c50c11be6f21eece2f6f53
+commit=e2e9f6e3e7c422ba6d88ef79cf4b51467ac3860f


### PR DESCRIPTION
Adds a bank overlay: a sidebar panel to pick a smelting recipe with per-trip Blast Furnace / coal bag overrides, marking the recipe's ores and coal in the bank with the count still needed for one trip, live-counting down against the inventory, with toggleable borders around the bank items.

Repository: https://github.com/cipscript/ore-ratios