### PR TITLE
Submit Movable Orbs

### DIFF
--- a/plugins/movable-orbs
+++ b/plugins/movable-orbs
@@ -1,0 +1,2 @@
+repository=https://github.com/anonyser/runelite-movable-orbs.git
+commit=20cfdd6643202b36c667b9100c157cb28a673b57


### PR DESCRIPTION
movable orbs lets you move the hp, prayer, run, special attack and xp orbs around the minimap. flip on unlock, drag them where you want, flip it off and they click like normal. they're kept near the minimap so you cant fling them across the screen, and it works with the minimap minimized too, with its own separate area. no menu changes, no automation, it just moves the icons.