### PR TITLE
Add PianoQueen-Music Plugin

### DIFF
--- a/plugins/pianoqueen-music
+++ b/plugins/pianoqueen-music
@@ -1,2 +1,2 @@
 repository=https://github.com/LogicalSoIutions/PianoQueen-Music.git
-commit=c8914e04e96b2db5268ccdef9c6356ab8017e95e
+commit=235086fd3b3df63f6c2c128d4a6729fe6b1f5b39

--- a/plugins/pianoqueen-music
+++ b/plugins/pianoqueen-music
@@ -1,0 +1,2 @@
+repository=https://github.com/LogicalSoIutions/PianoQueen-Music.git
+commit=1adbc17510edfffd8b92c62a078eaba610545113

--- a/plugins/pianoqueen-music
+++ b/plugins/pianoqueen-music
@@ -1,2 +1,2 @@
 repository=https://github.com/LogicalSoIutions/PianoQueen-Music.git
-commit=235086fd3b3df63f6c2c128d4a6729fe6b1f5b39
+commit=a6450c80593dcc8d485210fb1da2e6d977858b85

--- a/plugins/pianoqueen-music
+++ b/plugins/pianoqueen-music
@@ -1,2 +1,2 @@
 repository=https://github.com/LogicalSoIutions/PianoQueen-Music.git
-commit=1adbc17510edfffd8b92c62a078eaba610545113
+commit=c8914e04e96b2db5268ccdef9c6356ab8017e95e

--- a/plugins/pianoqueen-music
+++ b/plugins/pianoqueen-music
@@ -1,2 +1,2 @@
 repository=https://github.com/LogicalSoIutions/PianoQueen-Music.git
-commit=a6450c80593dcc8d485210fb1da2e6d977858b85
+commit=1072be92fc5a7749efff3578460978c2961a7716


### PR DESCRIPTION
Add's the PianoQueen plugin. 

Let's users set one of the recordings from PianoQueen as their sound when they enter their POH and also replaces them in the in-game Audio Player so they can pick to listen to them whenever they want. 

Big thanks to [alowaniak](https://github.com/alowaniak/music-replacer) for having easy to understand and re-use code making this take a lot less time than it should have. 