### PR TITLE
Update Anvil

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=1def995972b8f84e7457abb9d9a35615ba66abd8
+commit=9d53e494b6b803e9df661652e926c8a683c66a0e
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Subscribes to ServerNpcLoot so loot from corpse-looted bosses (Maggot King, Araxxor) is detected — the client-side despawn inference never fires for them. Double-fire with NpcLootReceived on regular NPCs is absorbed by the plugin's existing dedup windows.