### PR TITLE
Soul Wars Status 1.1.0

### DIFF
--- a/plugins/follow-plus
+++ b/plugins/follow-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-follow-plus.git
-commit=91369749da51781709291e3dcb14d9202bf69cbb
+commit=4920b4f42fcc964b53f7c11d9b6dc740b286dbb1


### PR DESCRIPTION
soul wars status update. new stuff:

- side panel: zeal calculator (target by level or xp, from and target both editable, all 7 zeal skills), crate count, a daily zeal-xp tracker with a reset countdown, and an xp-per-zeal-token reference table
- team colour (blue / red)
- zeal tracking: current tokens, session, last game, lifetime, and per hour
- while in a game: your captures, avatar damage, avatar kills, avatar health and strength, fragments sacrificed, bones buried
- a line for when you're fighting the avatar, with its hp
- following now shows moving / still
- run energy
- flashing warnings for low activity, low prayer, and the last 5 min of a game, and the prayer line is coloured by how much prayer is left

all of it is individually toggleable. also dropped the old "being attacked" line.
