### PR TITLE
Update Anvil

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=9d53e494b6b803e9df661652e926c8a683c66a0e
+commit=718376519b434e046a7eb1723030c4b3825fb780
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Credits drops announced only by the server's drop-attribution chat line ("<player> received a drop: ...") — Maggot King's spill-out uniques bypass the in-game loot tracker, so ServerNpcLoot never fires for them. Recipient-checked against the local player and deduped against loot events when both fire. Also corrects a bundled drop-rate entry.