### PR TITLE
update voiced-dialogue

### DIFF
--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=e7ed97ff52c6790468304220bad338871103256c
+commit=45bdafb8b7211ed68b7d6472eea8a6fe8b026fef
 authors=grabartley
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates voiced-dialogue to [v0.3.0](https://github.com/grabartley/runelite-voiced-dialogue/releases/tag/v0.3.0). The pinned commit is the `v0.3.0` release tag commit.

**Time-sensitive:** the currently pinned v0.2.0 runs its translation and speaking-style features through the `google/gemini-3.1-flash-lite-preview` model, which is retired on **9 July**. v0.3.0 pins the stable `google/gemini-3.1-flash-lite` release of the same model, so merging before then keeps those features working uninterrupted for existing users.

Highlights since v0.2.0:

- Translation and speaking styles run on the stable Gemini 3.1 Flash Lite model rather than the retiring preview alias.
- A voice correction so an Aldarin citizen speaks with the right voice for their gender.
- A friendlier, fully player-focused README: an at-a-glance feature tour, accurate NPC coverage counts, and simpler config descriptions.
