### PR TITLE
Add friend-aliases plugin

### DIFF
--- a/plugins/friend-aliases
+++ b/plugins/friend-aliases
@@ -1,0 +1,2 @@
+repository=https://github.com/jakevollkommer/friend-aliases.git
+commit=3a67437e941cb3769996b7665eb0aabe0e7723ae


### PR DESCRIPTION
Adds the **Friend Aliases** plugin.

Give your friends a custom nickname/alias, drawn above their head in-game instead of their real username. Aliases are set by right-clicking a friend in the friends list (like the built-in Friend Notes plugin) and are rendered overhead like Player Indicators.

- Repository: https://github.com/jakevollkommer/friend-aliases
- License: BSD 2-Clause