### PR TITLE
Add Visual Bank Tags

### DIFF
--- a/plugins/loose-bank-tags
+++ b/plugins/loose-bank-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/nanopink/VisualBankTags.git
-commit=24a2763cd1ddbf29fec62b5faf4c7136062c45f8
+commit=2d1c2e57b7cd5d39442099710d706edb924a2c2d

--- a/plugins/loose-bank-tags
+++ b/plugins/loose-bank-tags
@@ -1,0 +1,2 @@
+repository=https://github.com/nanopink/VisualBankTags.git
+commit=24a2763cd1ddbf29fec62b5faf4c7136062c45f8

--- a/plugins/visual-bank-tags
+++ b/plugins/visual-bank-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/nanopink/VisualBankTags.git
-commit=2d1c2e57b7cd5d39442099710d706edb924a2c2d
+commit=a3ef8c43b9634dcd803888868d21fafea8785251


### PR DESCRIPTION
Adds Visual Bank Tags to the Plugin Hub.

Visual Bank Tags helps users find bank items that do not have Bank Tags, with optional visuals for tagged items and tag tab color indicators.

Plugin repository: https://github.com/nanopink/VisualBankTags
Plugin commit: 24a2763cd1ddbf29fec62b5faf4c7136062c45f8

Validation:
- Ran local prepublish check against the plugin repo and Plugin Hub manifest.
- Ran the plugin test task through the prepublish check.