### PR TITLE
Update sea-charting-quest-helper

### DIFF
--- a/plugins/sea-charting-quest-helper
+++ b/plugins/sea-charting-quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JaredEzz/sea-charting-quest-helper.git
-commit=9420eea98352632a44b3c4a93216a12dd37b8aff
+commit=7de4cf7523a94f18c2b90b2b5d908f60ff8c2a13


### PR DESCRIPTION
## What's new

- Weather two-stage re-targeting was actually two-phase when the real mechanic is three-phase (troll → search area → back to troll); the return leg was pointing at the search area instead of back at the troll. Added the missing "collected the station" trigger and fixed the return trigger, confirmed via a real client log trace.
- Gear requirements now key off each task's real sea instead of matching by task name — fixes a Weather task named "Zul Egil" whose actual sea is Porth Neigwl getting the wrong hazard, and a raft requirement that was over-flagging tasks sharing a sea name with the one that actually needs a raft. Also adds a missing hazard category (stormy seas → mast upgrade) and two missing crystal-flecked-waters seas.
- The smart-sort "almost-done sea" priority bonus was keyed off the 7 broad oceans instead of the ~70 real individual seas, so it rarely fired for oceans spanning many seas — now keyed off the correct granularity.
- Real per-sea nearest-teleport data, replacing one hint per ocean.
- Sealed-crate-effect and per-task wiki-note tooltips share one info icon.
- Independent sea/ocean completion toggles, and a "show completed" toggle for reviewing already-charted tasks.

Commit: JaredEzz/sea-charting-quest-helper@7de4cf7523a94f18c2b90b2b5d908f60ff8c2a13