### PR TITLE
Add ironkin clan plugin

### DIFF
--- a/plugins/ironkin-clan-plugin
+++ b/plugins/ironkin-clan-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/garryhuang1/ironkin-clan-plugin.git
+commit=537ae491c4a9b6c6322b4ac8a1d87c90065b78fa


### PR DESCRIPTION
Adds the ironkin clan plugin. This plugin will be used to support our clan bingos, but is configured such that other clans can utilize it.