### PR TITLE
Add Better Blackjacking

### DIFF
--- a/plugins/better-blackjacking
+++ b/plugins/better-blackjacking
@@ -1,0 +1,2 @@
+repository=https://github.com/RPBTwisted/better-blackjacking.git
+commit=0f3d68ffcfe9c9567c5b90e84f96d44465636ec8


### PR DESCRIPTION
Adds Better Blackjacking: quality of life for blackjacking.

Menu-only, no automation. On your target NPCs it reorders the existing right-click options so one click is Pickpocket and the other is Knock-Out, with a single config toggle to swap which is which. It only ever promotes an option that is already present, and never adds, removes, or clicks anything - all inputs remain the player's own.

Source: https://github.com/RPBTwisted/better-blackjacking