### PR TITLE
Adds leechfin fishing plugin

### DIFF
--- a/plugins/leechfin-fishing
+++ b/plugins/leechfin-fishing
@@ -1,0 +1,2 @@
+repository=https://github.com/andrew-s28/leechfin-fishing.git
+commit=9fdcdab38139f04669b530b024f29ecd60710e21

--- a/plugins/leechfin-fishing
+++ b/plugins/leechfin-fishing
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-s28/leechfin-fishing.git
-commit=9fdcdab38139f04669b530b024f29ecd60710e21
+commit=9d2ce2bfe7fefcfed6caaf597140942c8b30a626


### PR DESCRIPTION
The leechfin fishing plugin highlights leechfin tiles when you need to click on them to catch the fish. Optionally, one can also configure the next tile to be clicked to also highlight. Users can configure fill and highlight colors for these tiles.

It also includes highlighting options for the fishing spots themselves (which aren't yet highlighted in the base fishing plugin) and a red highlight when the player's inventory is full to remind them to cut the leechfin.