### PR TITLE
clan-management: display and validation fixes

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=a7d21bd72dbfd60c4373dd5d7e0bd4a08da9e4bf
+commit=eb6792dc5dc77b0da2eb2d3ab9e4ef46a8eaa7b8
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates clan-management to `eb6792dc5dc77b0da2eb2d3ab9e4ef46a8eaa7b8`.

- Fixes the client window resizing when the plugin sidebar panel opens
- Stops the ranks tab re-rendering on every inventory event
- Personal-best baselines use the game's printed PB value and submit without chat spam
- Rank requirement corrections
