### PR TITLE
Add Slayer Bank Tab plugin

### DIFF
--- a/plugins/slayer-bank-tab
+++ b/plugins/slayer-bank-tab
@@ -1,0 +1,3 @@
+repository=https://github.com/Maximuis94/runelite-plugins.git
+commit=45682589cfb7271090368a3427ae72a4df6ba229
+authors=maximuis94


### PR DESCRIPTION
Plugin that allows one to set a unified Slayer bank tab.  The Slayer bank tab is managed by the plugin and it can have task-specific layouts set that will be loaded automatically, depending on the currently active task. The sidebar panel provides utilities that can be used to manage/share layouts.