### PR TITLE
Add Better Object Hider

### DIFF
--- a/plugins/better-object-hider
+++ b/plugins/better-object-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/JakhRS/better-object-hider.git
+commit=3d81c167f5b84dfe1942001b79955db88ef5a857


### PR DESCRIPTION
Adds **Better Object Hider**, a client-side scenery-decluttering plugin.

Repo: https://github.com/JakhRS/better-object-hider (BSD-2-Clause)

### What it does
Hides game objects at three scopes, each a deliberate manual right-click choice:
- **This tile** — one specific object on one tile (the core differentiator).
- **This map area** — one object ID within a single map region.
- **Everywhere** — one object ID globally (the classic behaviour).

Hides are organized into named groups you can enable/disable, rename, reorder via drag-and-drop, and import/export as clipboard codes. Tile/area hides are stored instance-safely (region-relative, like Ground Markers) and are scoped so an instance hide never leaks to the template's overworld location.

### Why a new plugin rather than a PR to custom-object-hider
Custom Object Hider is ID-only. The headline feature here is hiding a *single* object on a *single* tile (and per-region), plus instanced-area safety, groups, and sharing — a different data model and UX that outgrew a minimal upstream diff. Full credit to LuxOG's custom-object-hider in the README; the render-suppression approach builds on it.

### Compliance
- Purely cosmetic: `RenderCallback` draw suppression only. Nothing is sent to the server; menu entries are `MenuAction.RUNELITE`.
- No automation — every hide/unhide is a manual click.
- No network calls, no data collection, no new dependencies.
- Raid-mechanic objects (ToB Bloat pillar, Sotetseg maze tiles) are blocked from hiding and stripped from imports.