### PR TITLE
Add drop-rate-display

### DIFF
--- a/plugins/drop-rate-display
+++ b/plugins/drop-rate-display
@@ -1,2 +1,2 @@
 repository=https://github.com/Frailrain/drop-rate-display.git
-commit=49f90f1b8d1bdbb232fc9712e869971dd83d3707
+commit=f091f171f8e68fa3559069f03b394622006a21e9

--- a/plugins/drop-rate-display
+++ b/plugins/drop-rate-display
@@ -1,0 +1,2 @@
+repository=https://github.com/Frailrain/drop-rate-display.git
+commit=49f90f1b8d1bdbb232fc9712e869971dd83d3707


### PR DESCRIPTION
**Drop Rate Display** shows the OSRS Wiki drop rate of loot you receive, wherever it appears:

- **Floor drops** (monsters/bosses): the rate is drawn on the ground item. When the core Ground Items plugin is enabled, it is appended to that item's own line (e.g. `Mithril boots (GE: 2,025 gp) 1/128`); otherwise it is shown self-labelled (e.g. `Ensouled goblin head (1/35)`).
- **Reward interfaces**: the rate is painted on each item in Barrows, Chambers of Xeric, Theatre of Blood, Tombs of Amascut, Perilous Moons (Lunar Chest), Fortis Colosseum, Fishing Trawler, Drift Net and clue caskets.
- **Inventory loot**: a chat line plus a brief rate on the item icon — for pickpockets, salvage, world chests, opened containers/caskets, and skilling minigames (Tempoross, Guardians of the Rift, Wintertodt).

Rates, colours and the format are all configurable, with per-surface formatting and per-rarity-tier colours.

Drop-rate data is **bundled from the OSRS Wiki as a local JSON resource — no external/network API calls are made at runtime**. There is no dependency on the Loot Tracker plugin (monster drops come from the core `LootManager`).

License: BSD 2-Clause.
