### PR TITLE
Update pb-tracker-sync plugin

### DIFF
--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/0xJeu/pb-tracker-sync.git
-commit=8206dd6895019ed16576c274007d5de169694b1d
+commit=84526098c36737921040437f3e36c6cfe7c7c720
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Summary
Updates the PB Tracker Sync plugin to its latest commit, adding:
- A confirmation warning shown when changing the API base URL (so users don't accidentally send PB data to an unintended server)
- An "open my profile in browser" config action
- A raw PB data diagnostic dump (copies cached `personalbest.*` values to clipboard for troubleshooting sync issues)
- A fix for Nightmare team-size variant PBs being miscategorized as raid-variant PBs
- Removal of unused dead code

No changes to plugin permissions, external endpoints, or the existing 3rd-party-server warning.