### PR TITLE
Soul Wars Status 1.2.0

### DIFF
--- a/plugins/follow-plus
+++ b/plugins/follow-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-follow-plus.git
-commit=4920b4f42fcc964b53f7c11d9b6dc740b286dbb1
+commit=59884445624566e01232b0f429b3de97f7fd0f0e


### PR DESCRIPTION
soul wars status update. new stuff:

- session win/loss record
- team composition for the session: red wins/losses, blue wins/losses (RW/RL/BW/BL)
- click the always-on-top window to bring the game to the front, handy for alts
- activity and the inactive timer now share one colour: green over 50%, red under 50%, flashing under 35%

all toggleable. a one time chat message on login says whats new. no automation, no menu changes.
