### PR TITLE
better-monster-examine: update to v1.4

### DIFF
--- a/plugins/better-monster-examine
+++ b/plugins/better-monster-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/prettyrocket/better-monster-examine.git
-commit=bc0ce96d4e6c32ec208b84089ee6e981618a240f
+commit=dca9dc922e46b6ae08a178acacc6fdd88dfa3ff1


### PR DESCRIPTION
Updates **Better Monster Examine** to [`dca9dc922e46b6ae08a178acacc6fdd88dfa3ff1`](https://github.com/prettyrocket/better-monster-examine/commit/dca9dc922e46b6ae08a178acacc6fdd88dfa3ff1).

Released as **Better Monster Examine v1.4** — https://github.com/prettyrocket/better-monster-examine/releases/tag/v1.4

---

## New: Slayer box

A dedicated **Slayer** section now appears at the bottom of the panel (and the overlay's **Info** tab) for any Slayer monster, surfacing the full Slayer data instead of the old "Slayer monster: Yes" line:

- **Required Slayer level** — shown with the Slayer icon on the section header, highlighted red when it's above your own Slayer level (you can't damage the monster yet).
- **Slayer XP** per kill.
- **Assignment categories** the monster can be assigned under.
- **Assigned by** — the Slayer masters who assign it, shown as their chatheads (hover for the name).

(#36)

## Internal

- Release workflow: sync the fork's master and include the release notes in the plugin-hub PR body before opening it.