### PR TITLE
create haggle-helper

### DIFF
--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=9180d0675caecc02ac175f682ddad0a8cec1c205
+commit=aebf3de3b4e8d50c61ddb46282fcb06ccb876e02

--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=6a65e58ee477fb603cfb44b66580e8d7cbeb0974
+commit=9180d0675caecc02ac175f682ddad0a8cec1c205

--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=8b5dfc20fdc05903720325229377dfd5f8c40baa
+commit=8cdb2e8b837180779f65f9bd2c5ca604250c1955

--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/gavin-lb/haggle-helper.git
+commit=6a65e58ee477fb603cfb44b66580e8d7cbeb0974

--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=aebf3de3b4e8d50c61ddb46282fcb06ccb876e02
+commit=31e18f2d5c1d5f996f5a7617b8691fdb3358270c

--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=31e18f2d5c1d5f996f5a7617b8691fdb3358270c
+commit=8b5dfc20fdc05903720325229377dfd5f8c40baa

--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=8cdb2e8b837180779f65f9bd2c5ca604250c1955
+commit=d156b4cd324dc180f8bd9522d18814ceae639754


### PR DESCRIPTION
 - Highlight profitable and unprofitable shop sales with configurable overlays
 - Show how many items can be sold profitably (Sell 1, Sell 5, Sell 10, etc.)
 - Display potential profit and current shop prices directly on item overlays
 - Show tooltips detailing the revenue and profit of the current action
 - Display a profit summary panel with total profit and profit/hr
 - Automatically import Grand Exchange prices when adding tracked items
 - Block unprofitable transactions with configurable allowance for bulk transactions
 - Fully customizable colors, text displays, and overlay positioning