### PR TITLE
Add drop-rate-display

### DIFF
--- a/plugins/drop-rate-display
+++ b/plugins/drop-rate-display
@@ -1,0 +1,2 @@
+repository=https://github.com/Frailrain/drop-rate-display.git
+commit=5b2adbd097edc9062832bdd2de7ed6b982bc4fea


### PR DESCRIPTION
**Drop Rate Display** shows the OSRS Wiki drop rate of loot you receive, wherever it appears.

- **Floor drops** (monsters/bosses): the rate is drawn on the item's tile. With the core Ground Items plugin on, it's placed flush after each item's line (`Abyssal whip (1/512)`), aligned per item so a pile of 2+ drops each gets its own rate. This is reproduced entirely from public data — the live scene plus Ground Items' own config (price display, hidden/highlighted lists) — so there is no dependency on it and no reflection. Without Ground Items, a self-labelled `Item (rate)` line is drawn instead.
- **Reward interfaces**: the rate is painted on each item in Barrows, Chambers of Xeric, Theatre of Blood, Tombs of Amascut, Perilous Moons (Lunar Chest), Fortis Colosseum, Fishing Trawler, Drift Net and clue caskets.
- **Inventory loot**: a chat line plus a brief rate on the item icon — for pickpockets, salvage, world chests, opened containers/caskets, and skilling minigames (Tempoross, Guardians of the Rift, Wintertodt).

Drop-rate data is **bundled from the OSRS Wiki as a local JSON resource — no external/network calls are made at runtime**. There is no dependency on the Loot Tracker plugin (monster drops come from the core `LootManager`).

Resubmission of #13386 (closed): the reflection the earlier review flagged has been removed — the Ground Items integration now reproduces its layout from public config/scene data only.

License: BSD 2-Clause.
