### PR TITLE
exchange-insights: add plugin

### DIFF
--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=64c1f65a32be70cd81192e2cfeab88da937283db
+commit=b97998529bfceca32c7e2586136954f6b65125a3

--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,0 +1,2 @@
+repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
+commit=64c1f65a32be70cd81192e2cfeab88da937283db

--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=40969e2f9e89e1c5e19cec55d0774d7ae2e13c61
+commit=2d849d780c6f2e691dd7c6fb0b770623bfc056fb

--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=b97998529bfceca32c7e2586136954f6b65125a3
+commit=4da6dd21e7b94d3c7aab78056c8fb29c84b82100

--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=2d849d780c6f2e691dd7c6fb0b770623bfc056fb
+commit=19aeff770d15701246e74c0c9c6b93bfea405f81

--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=4da6dd21e7b94d3c7aab78056c8fb29c84b82100
+commit=2632e3c287b8364accfdae28a02db70e71d81797

--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=2632e3c287b8364accfdae28a02db70e71d81797
+commit=40969e2f9e89e1c5e19cec55d0774d7ae2e13c61

--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,2 +1,3 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
 commit=19aeff770d15701246e74c0c9c6b93bfea405f81
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,3 +1,3 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=6d1cbd06ea3575138cd85c0c779fb772ce5682d0
+commit=e40a18acfa219c4f358bfff2968f4706b782eb29
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,3 +1,3 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=19aeff770d15701246e74c0c9c6b93bfea405f81
+commit=6d1cbd06ea3575138cd85c0c779fb772ce5682d0
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds **Exchange Insights** — live Grand Exchange market data inside the native GE interface.

**What it does (zero setup, works anonymously):**
- Replaces the examine text in the GE offer setup/details with live market data: insta-buy / insta-sell, item margin, buy limit and actively-traded price
- Offer-age badges on GE slots, and slot outlines/labels showing how far an offer is behind the market ("Sell -14,774 at market")
- Optional left-click Collect to bank

**Optional account link (off by default, one-click browser approval):**
- Syncs your GE offer book to your own Exchange Insights dashboard for verified flip tracking (buy→sell round-trips) and opt-in "offer behind market" alerts delivered as chat messages / RuneLite notifications

**Review notes:**
- All network I/O is HTTPS to a single user-configurable endpoint (default `https://exchange-insights.gg`); token is a per-user secret stored via ConfigManager (`secret = true`); no third-party telemetry
- Read-only display + data sync — no gameplay automation, no reflection, standard RuneLite APIs (widgets, sprite override, Notifier, ConfigManager, @Schedule)
- BSD 2-Clause, icon 48×48
