### PR TITLE
Add no-misclick-veng

### DIFF
--- a/plugins/no-misclick-veng
+++ b/plugins/no-misclick-veng
@@ -1,0 +1,2 @@
+repository=https://github.com/perryhuynh/no-misclick-veng.git
+commit=d0978c2a83ee902530a6e4c29d41d62ff12a2ee6


### PR DESCRIPTION
This plugin aims provide similar functionality to https://runelite.net/plugin-hub/show/no-misclick-repot, but for the vengeance spell. It prevents recasting the spell while the effect is still active, and does not affect the Vengeance Other spell.