### PR TITLE
Add Path Timer plugin v1.0.0

### DIFF
--- a/plugins/path-timer
+++ b/plugins/path-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/cnnnr/path-timer.git
+commit=5cbd62a4e582d95732473a9d198cd6bdef9679ae


### PR DESCRIPTION
# Path Timer

**Version 1.0.0**

A plugin for practising tick-perfect movement. It records your recent tile-by-tile
path and labels each tile with how many game ticks you spent on it, so you can review the
timing of a movement sequence.

## How it works

- Recording follows you tile by tile as you move
- Each tile shows how many ticks you occupied it
- Includes Party support so you and your friends can observe each other's movement

## Settings

- **Idle reset (ticks)** — how long you must be idle before the path resets
- **Reset animation / Animation length** — Retract, Fade or Instant, and its duration
- **Show tick counts / Show start tile / Show start tile count** — what to draw on tiles
- **Connect tiles / Line width** — the connecting line through the path
- **Tile fill colour / Tile border colour** — per-tile fill and outline (transparent = off)
- **Path colour** — colour of the line and tick counts

![GIF example of Path Timer plugin](https://i.imgur.com/RLNvZlx.gif)