### PR TITLE
Submit Item ID and Lookup

### DIFF
--- a/plugins/item-id
+++ b/plugins/item-id
@@ -1,0 +1,2 @@
+repository=https://github.com/anonyser/runelite-item-id.git
+commit=7970527ca92701f19138125bacb01fe75dad62f8


### PR DESCRIPTION
item id and lookup. two parts:

- hover an item and it shows the item id in brackets after the name, like Dragon dagger (1215)
- a side panel to search any item in the game. click one and you get its id (click to copy),
  the ge price or a note if its not on the ge, high alch, repair cost if it breaks, its stats,
  and what its made from if its a combination item with each part's price. theres a button to
  open the item's wiki page, and a compare button to put two items side by side.

all display only, no automation. it uses the client's own item data and prices, and the wiki
description is an optional fetch you can turn off.
