### PR TITLE
update anvil

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=718376519b434e046a7eb1723030c4b3825fb780
+commit=32a79eb5c8f26ad35a2786baeb5725417be533ba
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Anvil update:

- New Combat Achievement tile kind: credits bingo tiles off the combat task completion chat line, with a session dedup and a once-per-session settings reminder
- Rare-drop notifications now post without the screenshot when frame capture stalls or fails, instead of silently dropping
- Sparse diagnostic logging (once-per-session gate reasons, change-gated config summary) so tracking issues are diagnosable from client.log