### PR TITLE
Mugics Game Message Overhaul

### DIFF
--- a/plugins/mugics-game-message-overhaul
+++ b/plugins/mugics-game-message-overhaul
@@ -1,0 +1,2 @@
+repository=https://github.com/squareguard/runelite-game-messages.git
+commit=23ff0220d6e497fe9573269a4f3ecbd498276d5c


### PR DESCRIPTION
Plugin that takes messages from the Game chat tab (e.g. "I can't reach that!", "Nothing interesting happens.", level-up messages) and displays them as large floating text at the top-center of the screen - World of Warcraft error-text style - instead of only as a line in the chatbox.