### PR TITLE
lootlette: update to 1.0.7

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=5ffa806c4be1c74e986034bc327b7d5c44a9c5bc
+commit=3524723020d4bc2ed32256408e435e8b3ef7daba


### PR DESCRIPTION
Updates lootlette from 1.0.6 to 1.0.7.

Changes:
- New "Max reels" setting (Advanced, default 5): the most reels shown for one kill or raid chest.
- A kill shows one slot with up to Max reels reels again, instead of collapsing to a single reel.
- Monster uniques (scraped from the OSRS Wiki drop-table sections, plus a small manual supplement) are prioritised when the reel cap trims and trigger the unique sound, with the very-rare rarity colour as a fallback.
- Enlarged the plugin icon to fill the canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)