### PR TITLE
Add Smoke Devil Effects Hider

### DIFF
--- a/plugins/smoke-devil-effects-hider
+++ b/plugins/smoke-devil-effects-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/psihosrs/smoke-devil-effects-hider.git
+commit=92d0a33de962f4e1dc7d7238731e51e8ba7a52fc


### PR DESCRIPTION
Submitting a new plugin: **Smoke Devil Effects Hider**.

It hides the smoke attack effects of Smoke devils to reduce eye strain during Slayer tasks:
- the smoke projectile flying at the player
- the smoke puff spot-anim that appears on the player when hit

Works the same on the regular Smoke devil, the Nuclear smoke devil (superior) and the Thermonuclear smoke devil boss, since they share the same attack effects. Purely cosmetic and client-side, both effects are individually toggleable, on by default.

Repository: https://github.com/psihosrs/smoke-devil-effects-hider