### PR TITLE
Update DropTracker to v5.4.0

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=2a33535b9c677e4c13791f2a69e8066f0882396e
+commit=abb7818fb5e83722029091690b9371077e47c7ef
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=abb7818fb5e83722029091690b9371077e47c7ef
+commit=7f76641149c0d908cabb0e76f2eef80e2e8fb1b7
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=dbf916467265e445dfa6fc2b4f9a6788b1f24324
+commit=2fb52ec58f081d3e29e9433b7b678f47b036b050
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=7f76641149c0d908cabb0e76f2eef80e2e8fb1b7
+commit=dbf916467265e445dfa6fc2b4f9a6788b1f24324
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=2fb52ec58f081d3e29e9433b7b678f47b036b050
+commit=7ad6720d1fb55cdd9e039afa328cfd40157f19aa
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
Adds a number of reliability enhancements and features:
- Fixes raid split tracking logic
- Reset data for various handlers on relog to prevent partial data issues
- fix EDT blocking group config fetching
- fix webhook url management to be more resilient
- move image conversion off frame listener thread to prevent client stalls
- replace boss-name switch method with a registry
- implement unit tests for future development
- support tracking deaths
- support tracking achievement diaries
- accurately determine if the player's plugin is out of date and notify them
- enhancements to submission panel to provide better insights into the lifestyle of a submission

_edit_
Also:
- Removed all video / lwgjl functionality
- Enhanced in/outbound connections for users who enable them
- Added support for events
- Fixed Maggot King tracking
- Removed the every-single-login welcome message the plugin sent its users.

Much of these changes were assisted using Claude Fable 5, just for full transparency :)