### PR TITLE
disable path-timer

### DIFF
--- a/plugins/path-timer
+++ b/plugins/path-timer
@@ -1,2 +1,3 @@
 repository=https://github.com/cnnnr/path-timer.git
 commit=5cbd62a4e582d95732473a9d198cd6bdef9679ae
+disabled=violates 3pc guidelines


### PR DESCRIPTION
~~Disabling as it can be abused at sotetseg to show party members the correct path~~

~~@cnnnr If you would like the plugin to be re-enabled please restrict / remove the party integration at sotetseg.~~

~~Watchdog can be used as a reference to find the regions to block: https://github.com/adamk33n3r/runelite-watchdog/blob/master/src/main/java/com/adamk33n3r/runelite/watchdog/Region.java~~