### PR TITLE
update haggle-helper

### DIFF
--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=d156b4cd324dc180f8bd9522d18814ceae639754
+commit=5b280d157b6b9d993c060d5355e9297bc1dd1df2


### PR DESCRIPTION
- since I changed to standard build mode I now need to manually upkeep a copy of project version in resources
- minor docs changes