### PR TITLE
Add CA-Hider plugin repository information

### DIFF
--- a/plugins/ca-hider
+++ b/plugins/ca-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/PlayerCoder1/CA-Hider.git
-commit=7d837f3d453846bfb12323a649f0e24771440583
+commit=e7fe1a4834828b84457ca7de20ff50ade1c3b608

--- a/plugins/ca-hider
+++ b/plugins/ca-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/PlayerCoder1/CA-Hider.git
+commit=7d837f3d453846bfb12323a649f0e24771440583


### PR DESCRIPTION
Hides the combat achievement description so player can guess the CA only with the name of the task