### PR TITLE
drop-rate-display: fix stacked-drop row order, add impling loot, floor rates persist

### DIFF
--- a/plugins/drop-rate-display
+++ b/plugins/drop-rate-display
@@ -1,2 +1,2 @@
 repository=https://github.com/Frailrain/drop-rate-display.git
-commit=5b2adbd097edc9062832bdd2de7ed6b982bc4fea
+commit=3ad66e952e05b19d57608eeb7b7b9c294ca3e19d


### PR DESCRIPTION
Update **drop-rate-display** to `3ad66e952e05b19d57608eeb7b7b9c294ca3e19d`.

Changes since the merged version:

- **Fix per-row alignment on stacked floor drops.** When a tile holds more than one item, each rate now sits on the correct item's line. This is done by mirroring Ground Items' own item table — an independent Guava `HashBasedTable` fed the same public `ItemSpawned`/`ItemDespawned` events, so our row order matches its iteration order. No reflection, and no runtime dependency on that plugin (we never read its state).
- **Add impling loot.** Impling catches (net, barehand, or looting an impling jar) deliver loot to the inventory and are reported via `ServerNpcLoot`, not `NpcLootReceived`; the rate now shows in chat and briefly on the item icon.
- **Floor rates persist with the item.** A ground rate now lives exactly as long as its item is on the floor (removed on despawn) rather than a fixed 30s timeout. Inventory rates keep their timeout.

No external/network calls at runtime (drop data is a bundled resource); no reflection.
