### PR TITLE
lootlette: bump to 1.0.9

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=b5be5c9deba1c3e45609e4279a7fb1a764a07d3e
+commit=774b9c97e1a6a6a03692de1356628fe74cfadb42

--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=3524723020d4bc2ed32256408e435e8b3ef7daba
+commit=b5be5c9deba1c3e45609e4279a7fb1a764a07d3e


### PR DESCRIPTION
Bumps Lootlette to v1.0.9.

- **Dedicated pet reel:** a pet is rolled on a separate roll from the main drop table in OSRS, so on a kill where you actually receive one it now spins its own reel instead of competing for a main-table slot. Pets are flagged at build time from the wiki's Pets category (the 65 that appear as monster drop rows); skilling/follower pets that never drop off a kill are excluded.
- Fixes drop tables for monsters whose wiki page is disambiguated as "X (monster)" (Manta ray, Monkey, Penguin, Rock golem, Cave goblin, Scorpia's offspring).
- Higher-quality plugin icon regenerated from the original 500x500 source.