### PR TITLE
Add Better Object Hider

### DIFF
--- a/plugins/better-object-hider
+++ b/plugins/better-object-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/JakhRS/better-object-hider.git
-commit=3d81c167f5b84dfe1942001b79955db88ef5a857
+commit=52862bacfa96c2c4acc9dfcd3133fda1393e1662

--- a/plugins/better-object-hider
+++ b/plugins/better-object-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/JakhRS/better-object-hider.git
+commit=3d81c167f5b84dfe1942001b79955db88ef5a857

--- a/plugins/better-object-hider
+++ b/plugins/better-object-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/JakhRS/better-object-hider.git
-commit=d9eb7738e2ac1e8ad952b09406817c8b6ffbc5b9
+commit=e7b04227945db65db305775660ffe7824cd91c54

--- a/plugins/better-object-hider
+++ b/plugins/better-object-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/JakhRS/better-object-hider.git
-commit=52862bacfa96c2c4acc9dfcd3133fda1393e1662
+commit=d9eb7738e2ac1e8ad952b09406817c8b6ffbc5b9


### PR DESCRIPTION
Adds **Better Object Hider**, a client-side scenery-decluttering plugin. This supersedes #13385, which was closed under the "no new ID-based hiding" policy. Following the guidance in `#development` — key off **object name + tile/area location**, and don't operate on objects that have no name — I reworked the plugin to that model rather than resubmit the same thing.

Repo: https://github.com/JakhRS/better-object-hider (BSD-2-Clause)

### What it does
You shift+right-click a **named** scenery object you can see and hide it. That's the whole interaction — nothing is typed. You pick the reach:

- **Hide this** — that name, on that one tile.
- **Hide all in this area** — that name, anywhere in the local map region.
- **Hide all everywhere** — every object of that name, wherever it appears.

Guarantees across all three:

- **No object IDs** are entered, stored, or targeted. A hide is a `{object name, scope, location}` record, stored the way Ground Markers / Object Indicators store a spot.
- **Objects with no name get no hide option** — the gate. Unnamed objects (Fight Caves floor tiles, Vardorvis axes, etc.) can't be hidden at all.
- Every option is by **name**: it hides *all* objects of that name in the chosen scope, and never singles out one ID variant of a shared name (per the "hide everything named ice chunks, not just ice chunk 250" point in #development — the widest option applies that at any scope).
- Hides are organized into named groups you can enable/disable, rename, reorder by drag-and-drop, and share as clipboard codes (which carry names + locations).

### What changed since the closed PR
- Every hide is now keyed by object **name + scope**, not by ID. All ID-based storage paths/keys are gone.
- Added the named-only gate in the right-click menu.
- Names resolve on the client thread (`getObjectDefinition` isn't render-thread safe) into a position set the render callback reads.
- Reworked the plugin description, tags, README, and menu option text to be name/location based, with no combat/boss framing.

### Compliance
- Purely cosmetic: `RenderCallback` draw suppression only. Menu entries are `MenuAction.RUNELITE` and are never sent to the server.
- No automation — every hide is a manual, in-world selection.
- No network calls, no data collection, no new dependencies.
- A short hardcoded list of raid-mechanic objects is blocked from hiding and stripped from imports.

Thanks to riktenx, Shaggy, Polar and others in `#development` for spelling out where the line is — the rework follows that directly.