### PR TITLE
update haggle-helper

### DIFF
--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=5b280d157b6b9d993c060d5355e9297bc1dd1df2
+commit=c935597252aab2f924b4f7312dfba1662f0647d0


### PR DESCRIPTION
- Need to manually upkeep a copy of `icon.png` since changed to standard build type