### PR TITLE
Update AFK Stats Tracker

### DIFF
--- a/plugins/afk-stats-tracker
+++ b/plugins/afk-stats-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Reasel/AFK-Stats-Tracker.git
-commit=72d110c808404b431800df32195ced060a49b331
+commit=1fbe7cd3f888724cd7794cdbaffab02fd135fd03


### PR DESCRIPTION
Updates AFK Stats Tracker to 1.2.0.

The plugin panel gains a footer link that opens the community stats site (https://afk.statstracker.workers.dev/) in the browser via `LinkBrowser`. The plugin sends no data to the site; users share stats by copying session JSON from the panel and pasting it on the site's Submit page.