### PR TITLE
Update Area loot v1.5.1

### DIFF
--- a/plugins/arealoot
+++ b/plugins/arealoot
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/AreaLoot.git
-commit=7c1e90099b52c30083623f6d2a4afbbcd1b38e81
+commit=16eb6647c62afb06bbfa4390bb686316f2ff9f0c

--- a/plugins/arealoot
+++ b/plugins/arealoot
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/AreaLoot.git
-commit=903e96bf36a2a5cbb2c133c303e1c78b613e9d43
+commit=851734a45dbdd33d9514818fd1366feaebfaa3d6

--- a/plugins/arealoot
+++ b/plugins/arealoot
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/AreaLoot.git
-commit=3a1b306d58486d732cebe7bf9256c618b3a41612
+commit=7c1e90099b52c30083623f6d2a4afbbcd1b38e81

--- a/plugins/arealoot
+++ b/plugins/arealoot
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/AreaLoot.git
-commit=851734a45dbdd33d9514818fd1366feaebfaa3d6
+commit=3a1b306d58486d732cebe7bf9256c618b3a41612

--- a/plugins/arealoot
+++ b/plugins/arealoot
@@ -1,2 +1,2 @@
 repository=https://github.com/Aiirik/AreaLoot.git
-commit=16eb6647c62afb06bbfa4390bb686316f2ff9f0c
+commit=8c79dadf84283bb84cc53f41034e44bf6abac8ee


### PR DESCRIPTION
### Added

- Added selected-item minimap markers with separate dot and line toggles, plus independent color settings for each.
- Added a dedicated `Minimap Settings` section for the selected-item minimap markers.

### Changed

- Removed the `Line matches tile outline` option and now use the explicit line color setting directly.

### Fixed

- Fixed list overlay sizing so hiding item names still lets the box shrink and stacks the total loot summary on narrow layouts.