### PR TITLE
Add OSPulse plugin

### DIFF
--- a/plugins/ospulse
+++ b/plugins/ospulse
@@ -1,4 +1,4 @@
 repository=https://github.com/jonathanavis96/ospulse.git
-commit=f378197668cd3e550be57d17b38659b1a767e0b3
+commit=3f24b51c291b8233a3a4220eff6a4bc21db4a792
 authors=jonathanavis96
 warning=The optional, off-by-default price-trend feature requests item price history from the OSRS Wiki price API (prices.runescape.wiki), sending only an item id. No account name or player data is sent.

--- a/plugins/ospulse
+++ b/plugins/ospulse
@@ -1,0 +1,4 @@
+repository=https://github.com/jonathanavis96/ospulse.git
+commit=f378197668cd3e550be57d17b38659b1a767e0b3
+authors=jonathanavis96
+warning=The optional, off-by-default price-trend feature requests item price history from the OSRS Wiki price API (prices.runescape.wiki), sending only an item id. No account name or player data is sent.


### PR DESCRIPTION
OSPulse is an all-in-one information panel for Old School RuneScape: banking-aware session profit (bank trips are not counted as losses), a complete loot feed (wealth-delta based, so it catches everything, not just NPC drops), total net worth (bank + inventory + equipment + GE), XP gained, GE flip P&L, and a live gear DPS / max-hit calculator and optimiser. All item valuation uses RuneLite's built-in GE prices via `ItemManager` — no socket for pricing.

**Repository:** https://github.com/jonathanavis96/ospulse (BSD-2-Clause; `NOTICE` credits data provenance — equipment stats are clean-room from the game cache, monster/weapon data from weirdgloop/OSRS Wiki).

**Build:** pure Java (targets 11), `build=standard`, no dependencies outside runelite-client transitives.

**Network:** the plugin makes no network calls except one optional, off-by-default "Price trends" feature, which requests item price history from the OSRS Wiki price API (prices.runescape.wiki) and sends only an item id — no account name or player data. This is disclosed on the config option that enables it and via the manifest `warning=`.