### PR TITLE
add ge-uncut

### DIFF
--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,0 +1,2 @@
+repository=https://github.com/uzia35/ge-uncut.git
+commit=e8cfb021002b9b79945842fdee1af72a3eb6907f

--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,2 +1,3 @@
 repository=https://github.com/uzia35/ge-uncut.git
 commit=e8cfb021002b9b79945842fdee1af72a3eb6907f
+warning=This plugin submits your IP address and various account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Forward-tested flip finder for the Grand Exchange, with profit tracking from your own trades.

**Features**
- Flips are forward-tested on geuncut.app, so the picks have a real track record instead of being raw margin math
- Each one shows buy/sell prices, how many to buy, margin after tax, ROI per day, whether demand is rising or falling, and rough fill times
- Three scan modes (standard, fast-fill, high-volume) plus a risk setting
- Tap an item to open its full price history and chart on geuncut.app
- Works without an account (f2p flips); linking a geuncut.app account unlocks members-item flips
- Automatic profit tracking from your own GE fills once linked
- Per-item buy-limit timers
- A live view of your current GE offers

**Network / data**
- Only talks to geuncut.app, over HTTPS, and only after you link. Nothing leaves your client while unlinked.
- Sends your account hash (not your username), your own fills, and a snapshot of your open offers. Full breakdown of endpoints and fields is in the README.
- Pairing uses a short code, no password is ever sent.
- No automation, it only reads and displays your own GE activity.

All network calls comply with Jagex's third-party client guidelines and the Plugin Hub rules. BSD 2-Clause.

<img width="316" height="892" alt="image" src="https://github.com/user-attachments/assets/dd02009f-7411-4881-aa88-6922a742d339" />

