### PR TITLE
update mystix

### DIFF
--- a/plugins/mystix
+++ b/plugins/mystix
@@ -1,4 +1,4 @@
 repository=https://github.com/Dmurph24/mystix-plugin.git
-commit=b72cccfd3178d0abc0f2c1f8d35b91f8f17c80ec
+commit=e196a17df25c9613fd31ddc9fea9b3e79ca31cfa
 authors=Dmurph24
-warning=This plugin submits your RSN, skills, bank, equipment, loadouts, farming timers, and loot data to a 3rd-party server (Mystix) not controlled or verified by Runelite developers.
+warning=This plugin submits your RSN and RuneLite-generated data to Mystix (mystix.app). You can turn off syncing for specific data types in the plugin settings.

--- a/plugins/mystix
+++ b/plugins/mystix
@@ -1,4 +1,4 @@
 repository=https://github.com/Dmurph24/mystix-plugin.git
-commit=e196a17df25c9613fd31ddc9fea9b3e79ca31cfa
+commit=49ae94f19e724824a3f2e464df60cc4f8757bc65
 authors=Dmurph24
 warning=This plugin submits your RSN, skills, bank, equipment, loadouts, farming timers, and loot data to a 3rd-party server (Mystix) not controlled or verified by Runelite developers.

--- a/plugins/mystix
+++ b/plugins/mystix
@@ -1,4 +1,4 @@
 repository=https://github.com/Dmurph24/mystix-plugin.git
 commit=e196a17df25c9613fd31ddc9fea9b3e79ca31cfa
 authors=Dmurph24
-warning=This plugin submits your RSN and RuneLite-generated data to Mystix (mystix.app). You can turn off syncing for specific data types in the plugin settings.
+warning=This plugin submits your RSN, skills, bank, equipment, loadouts, farming timers, and loot data to a 3rd-party server (Mystix) not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps mystix to latest master (`e196a17`) ~~and updates the `warning=` text.~~

New since the last submission:
- Adds collection log sync, including per-item quantities.
- Adds quest completion sync.
- Adds achievement diary sync.
- Adds combat achievement sync.
- Adds boss/NPC kill-count sync.
- Runs a one-time full sync when the App Key is entered while already logged in.
- Reworded the warning to name the destination (mystix.app) and note that individual data types can be turned off in the plugin settings.

Syncing stays user-initiated with the user's own App Key, and every data type has its own opt-out toggle.
