### PR TITLE
Add vividflash-qol-aio

### DIFF
--- a/plugins/vividflash-qol-aio
+++ b/plugins/vividflash-qol-aio
@@ -1,0 +1,2 @@
+repository=https://github.com/vividflash/vividflash-qol-aio.git
+commit=04446abd5b38314afc593f6179413eda7a6de3e3


### PR DESCRIPTION
Adds **VividFlash QoL AIO** — a single plugin bundling a set of small quality-of-life and misclick-guard tweaks (No Use Player, Easy Unnote, withdraw limits, Require Tool, Pickpocket/Foundry/Motherlode safety guards, Take-before-Attack menu swap, potion misclick guards, clue held-count reminder, category sound muting, and more), so users can enable just the ones they want from one place instead of running many tiny plugins. Every feature is off-by-default or config-gated.

Repo: https://github.com/vividflash/vividflash-qol-aio

🤖 Generated with [Claude Code](https://claude.com/claude-code)