### PR TITLE
Removed Gear Locking feature when using Members APWorld

### DIFF
--- a/plugins/osrs-archipelago
+++ b/plugins/osrs-archipelago
@@ -1,2 +1,2 @@
 repository=https://github.com/digiholic/osrs-archipelago.git
-commit=58983078781ab44a8f6468fc02f16d6a3a92d82a
+commit=3b3b877897879b28f4c638f694aaa69eeef22f5d


### PR DESCRIPTION
Members randomizer currently doesn't support gear locking, and since the gear lock check is looking specifically for items to be permitted, every item failed to pass the check and you couldn't equip anything. Add in a short-circuit to allow all items when using Members mode, to fix the problem while I consider an overhaul to the gear-locking system.