### PR TITLE
PvP Profit Tracker 1.1.1

### DIFF
--- a/plugins/pvp-profit-tracker
+++ b/plugins/pvp-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-profit-tracker.git
-commit=758007ea85d3503d7721232a3f3caaf128b96b65
+commit=e53b59ac9c704a02b33d82700713a7a3ba56400e


### PR DESCRIPTION
small update. inspecting a player now opens the side panel for the hiscore lookup. before, it only opened when you got assigned a bounty hunter target. also fixed the special attack max hit for a few bh weapons that were showing the wrong number: the statius warhammer (bh) wasn't in the list at all, and the barrelchest anchor (bh) and abyssal dagger (bh) were using their non-imbued values.
