### PR TITLE
update anvil

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=32a79eb5c8f26ad35a2786baeb5725417be533ba
+commit=e64e32c3961afe7e8d7a01227fc361400082258b
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates Anvil to `e64e32c3961afe7e8d7a01227fc361400082258b`. Since the last release:

- PvP-kill bingo tiles — credits a kill off the "You have defeated <name>!" game message (sent only to the player the game awards the kill to), gated to the Wilderness / PvP worlds so safe minigames can't trigger it.
- Timed tiles: ToA Entry Mode guard + optional exact-party-size gate.
- Drop-attribution chat lines ("X received a drop: …") now parse from any non-player-authored channel, with the clan drop broadcast as a recipient-checked fallback — fixes corpse-boss spill drops (Maggot King) never crediting.
- Support-log export: `::anvillog` or a configurable hotkey bundles a diagnostic header + the relevant client.log slice into `.runelite/anvil-debug/` for members to share.
- Bingo tab: long tile labels ellipsize (wrap on expand) and tiles list in board order within status groups.