### PR TITLE
Add Nex Loot Tracker plugin

### DIFF
--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=870cdbbf842af44201a25b272dd4bb9b5a6aa90b
+commit=993cd45decdb1afbefdf287065cd511623ff26e9

--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/JJDeakins1/nex-loot-tracker.git
+commit=870cdbbf842af44201a25b272dd4bb9b5a6aa90b


### PR DESCRIPTION
Nex Loot Tracker — tracks Nex boss kills, personal loot, team uniques, MVP, and split/FFA GP.

Features a side panel with kill filters, uniques table (own/seen/dry), split GP earned, regular drops, and a split changer. All data is stored locally at ~/.runelite/nex-loot-tracker/<username>/.

Modeled after Raid Data Tracker for Nex-specific chat/loot handling.