### PR TITLE
Add GPS plugin

### DIFF
--- a/plugins/gps
+++ b/plugins/gps
@@ -1,2 +1,2 @@
 repository=https://github.com/PauloAguiar/runelite-gps-plugin.git
-commit=d4e2abadac6a11f57aee33beee87d4d30faad05b
+commit=e24bb135d7abd8dfd5e062c03a57c94128470b99

--- a/plugins/gps
+++ b/plugins/gps
@@ -1,2 +1,2 @@
 repository=https://github.com/PauloAguiar/runelite-gps-plugin.git
-commit=f1618763155cd486f4ca56f32c93b4dd008aaa01
+commit=d4e2abadac6a11f57aee33beee87d4d30faad05b

--- a/plugins/gps
+++ b/plugins/gps
@@ -1,0 +1,2 @@
+repository=https://github.com/PauloAguiar/runelite-gps-plugin.git
+commit=f1618763155cd486f4ca56f32c93b4dd008aaa01


### PR DESCRIPTION
GPS is a turn-by-turn navigation. Draws the fastest route to a destination with live directions, progress and ETA, plus alternative routes using different teleports/transports, a searchable teleport-method catalog with availability modes, and destination search (places, dungeons, minigames, nearest-amenity). Built on Shortest Path (BSD-2, credited); adds the navigation layer and routes explorer on top.

GPS is different enough that after discussing it with the shortest path team, I decided to branch it off into its own plugin.

<img width="300" height="92" alt="image" src="https://github.com/user-attachments/assets/16672bc4-7ffa-44db-b0a1-1417e2c40451" />
