### PR TITLE
Item ID and Lookup 1.0.1

### DIFF
--- a/plugins/item-id
+++ b/plugins/item-id
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-item-id.git
-commit=7970527ca92701f19138125bacb01fe75dad62f8
+commit=06cda82d34fd8a849414a7ed7486c04bf8ef0819


### PR DESCRIPTION
another small item id update. the search panel was calling some tradeable items not on GE even when they have a price. the buy limit data it was checking just doesn't cover every item on the GE (the ultor ring is one). now it checks the actual price when it fills in each row, so those show the price and aren't greyed out. also added a one-time in-game note so people know what changed.
