### PR TITLE
Fixed crash on plugin shutdown causing all sorts of funny head bobbles

### DIFF
--- a/plugins/true-tile-movement-animation
+++ b/plugins/true-tile-movement-animation
@@ -1,0 +1,2 @@
+repository=https://github.com/Posiedien76/TrueMovementAnimationsPlugin.git
+commit=545590973df7352b65e135b1b8cc34648b26ddde


### PR DESCRIPTION
The plugin blew up on reddit immediately and of course there is a crash on shutdown. Fixed the crash due to some code meant only for the client thread being ran on the shutdown event.