### PR TITLE
Add better-pings

### DIFF
--- a/plugins/better-pings
+++ b/plugins/better-pings
@@ -1,2 +1,2 @@
 repository=https://github.com/oshaunbeck/better-pings-extension.git
-commit=be060e917d66c68d3587197b5f28fe653511527e
+commit=ee4b83e50da73cd2d21c9bd273adaa46bc211904

--- a/plugins/better-pings
+++ b/plugins/better-pings
@@ -1,2 +1,2 @@
 repository=https://github.com/oshaunbeck/better-pings-extension.git
-commit=dd266416070cb030023664cde2e7f92b38cc04bd
+commit=be060e917d66c68d3587197b5f28fe653511527e

--- a/plugins/better-pings
+++ b/plugins/better-pings
@@ -1,0 +1,2 @@
+repository=https://github.com/oshaunbeck/better-pings-extension.git
+commit=dd266416070cb030023664cde2e7f92b38cc04bd


### PR DESCRIPTION
Adds Better Pings — a League of Legends–style radial ping wheel for the party system. 

Hold hotkey and click a tile to open a 4-option wheel: Danger, Pray melee, Pray ranged, Pray magic (real prayer-book sprites loaded from the game cache). 

Pings render in the scene, on the minimap, as colored chat lines, and as distinct synthesized sounds — chat/minimap/sounds each toggleable, with an optional per-member alert cooldown (prevent/enable spamming). 

Rides the existing party service via a custom party message; sends nothing to the game and performs no game actions. 

Repo: https://github.com/oshaunbeck/better-pings-extension