### PR TITLE
Add choice-man-helper plugin

### DIFF
--- a/plugins/choice-man-helper
+++ b/plugins/choice-man-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/eghernqvist/choice-man-helper.git
+commit=faa48797c9e0b1e1cfee50e6f486062bcede92fc


### PR DESCRIPTION
Adds Choice Man Helper, a companion plugin for the Choice Man game mode
(https://runelite.net/plugin-hub/show/choice-man).

<img width="277" height="485" alt="image" src="https://github.com/user-attachments/assets/30123c75-146a-492f-98e1-59ce8db6d9c9" />

What it does
------------
Choice Man requires players to unlock individual items before they can use them. This plugin adds a sidebar panel listing every quest (all 210, including miniquests) and shows whether the account can complete each one based on the items it has unlocked in Choice Man, so players do not have to check the wiki by hand. Quests can be filtered by in-game progress and by readiness (`ready` / `partial` / `blocked` / `no items needed`), and each quest expands to show its required, obtained-during-quest and recommended items marked unlocked or missing.

How it works
------------
- Unlock data is read (read-only) from Choice Man's own RuneLite configuration (config group "choiceman") and refreshed via ConfigChanged. Nothing is written.
- An item is treated as gating only if it is one Choice Man can unlock; the plugin bundles a copy of Choice Man's item table to decide this. Untradeable quest items never block a quest; tradeable items received mid-quest do.
- Quest completion state comes from net.runelite.api.Quest.getState.

Compliance
----------
- Purely informational / quality-of-life
- Entirely local
- No third-party runtime dependencies

Attribution
-----------
Bundles Choice Man's item table (ChunkyAtlas/choice-man, BSD 2-Clause) and a quest dataset derived from Quest Helper (Zoinkwiz/quest-helper, BSD 2-Clause), both credited in the README.