### PR TITLE
drop-rate-display: per-quantity drop rates, wall beast loot, README screenshots

### DIFF
--- a/plugins/drop-rate-display
+++ b/plugins/drop-rate-display
@@ -1,2 +1,2 @@
 repository=https://github.com/Frailrain/drop-rate-display.git
-commit=3ad66e952e05b19d57608eeb7b7b9c294ca3e19d
+commit=8c4d0dba1c18c2d95edf08464179c264234f7331


### PR DESCRIPTION
Updates the Drop Rate Display plugin to 8c4d0db.

Changes since the last release:

**Bug Fixes!**
- **Per-quantity drop rates**: items dropped at several stack sizes (e.g. Numulite x2/x4/x8, coin stacks) now show the rate for the exact quantity received, instead of one rate for every stack. Applies on the ground, in chat, on the inventory icon and on reward interfaces.
- **Wall beast loot** now shows a rate. Wall beasts report loot via ServerNpcLoot rather than a normal on-tile death, so it is shown in chat and on the item icon.

**Not bug fixes!**
- **README**: added screenshots of each display surface.

Bundled drop data regenerated from the OSRS Wiki (2026-07-08).

