### PR TITLE
anvil: raid clear-time, gain equip/unequip, kill-proof throttle, real-time boss-KC, PvP-kill fix

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=e64e32c3961afe7e8d7a01227fc361400082258b
+commit=49cd35501019c891bc430da3c13b1d40cc3a73b0
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=2382bdf2b3096885d27991d9967d1e98ea1c3049
+commit=39e37b5444a5cab10fd2fb31df11c930827eb302
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=39e37b5444a5cab10fd2fb31df11c930827eb302
+commit=517265550bee6e937a5a3ee33cd6ed8c87b7426b
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=d7d68ded26468cc602d4bc4b1460e12492cb1eb1
+commit=b082f1c50c2bf7ec4ae42255b5aae57f36ea33b2
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=b082f1c50c2bf7ec4ae42255b5aae57f36ea33b2
+commit=2382bdf2b3096885d27991d9967d1e98ea1c3049
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=49cd35501019c891bc430da3c13b1d40cc3a73b0
+commit=d7d68ded26468cc602d4bc4b1460e12492cb1eb1
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=517265550bee6e937a5a3ee33cd6ed8c87b7426b
+commit=2576aa01ac3b8ec782a60d8de24ff7eff4105c03
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Bumps the Anvil plugin pin to b082f1c (current main). Changes since the last pinned commit (e64e32c):

- Raid timed/deathless clears: accept FRIENDSCHATNOTIFICATION (CoX/ToB/ToA send completion-time lines on that channel) and ignore ToA per-room sub-times, so a raid tile credits off the real total raid time.
- Gain tiles: diff inventory + worn equipment combined so equipping/unequipping a tracked item isn't counted as a gain.
- Kill tiles: throttle proof screenshots to 25% milestones.
- Real-time boss-KC: on a tracked boss's KC chat line, push the absolute count (debounced, no screenshot) so boss-KC tiles update without waiting on the ~1h hiscores lag.