### PR TITLE
update bank-templates to 1.5.6

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=13fa1967f837da34ec9d665391165c3a4420774a
+commit=0f337830579809ad5e3c76b677bd21dfee8ad849


### PR DESCRIPTION
Updates my Bank Templates plugin to 1.5.6.

- Preview: import a template's Main (all-items) view, not just numbered tabs.
- Reorganise helper: fixed wrong-slot labels when a template lists the same item in two tabs, plus the layout editor now prevents that duplicate at the source.
- Community repository: clearer connection-error message.