### PR TITLE
Update Kill Clog to 1.6.1

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=ee38ad9b93ad398947c1be0e5021668b7aa9741a
+commit=c7d54ba3d0a3ef969fd3e90890dc300c34d254b9
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Kill Clog to 1.6.1.

Highlights:
- Maggot King vanilla hiscores order parity and interim scaffolding removal
- skill summary reserved chrome for XP and rank instead of replacing rifts
- item hover names formatting cleanup

No new external endpoints and no client-to-server upload paths in this release.
