### PR TITLE
Add Chat Tab Hotkeys

### DIFF
--- a/plugins/chat-tab-hotkeys
+++ b/plugins/chat-tab-hotkeys
@@ -1,3 +1,3 @@
 repository=https://github.com/tinokaartovuori/chat-tab-hotkeys.git
-commit=2af8749f21085bc47d2184591688ff5a7eb5854d
+commit=d4ec59624e32fe3c93d155d2e066d75b25368112
 authors=Kart5a

--- a/plugins/chat-tab-hotkeys
+++ b/plugins/chat-tab-hotkeys
@@ -1,0 +1,3 @@
+repository=https://github.com/tinokaartovuori/chat-tab-hotkeys.git
+commit=2af8749f21085bc47d2184591688ff5a7eb5854d
+authors=Kart5a


### PR DESCRIPTION
**Chat Tab Hotkeys** lets you drive the chat from the keyboard. You can switch tab, cycle through a set of tabs you pick, open and close the chatbox, clear a tab's history, and set which channel you type into. It only does things you can already do with the mouse, so it adds no automation or overlay and sends nothing to the game server.

**What changed since #13356**

The earlier version switched the active tab by replaying the tab button's click handler through a client script. I removed it.

To switch a tab, the plugin now sets the client variable the game uses for the active tab and redraws the chatbox. No script switches the pane. Opening, closing, and cycling tabs use the same variable.

I asked about this on the development channel before trying again. A reviewer said RuneLite does not ban client scripts as a blanket rule. The problem was using a client script to switch interface panes on a keypress, and setting the variable itself might be fine. This version does that.

**The rest**

For chat input mode, the plugin writes the chat mode variable and reruns the input line build step, the same thing the right click Set chat mode menu does. To clear history, it drops the active tab's stored lines and rebuilds the chatbox, the same as the core Chat History plugin.

**Notes for review**

- Client side and packet free.
- No third party dependencies, no reflection, no external processes, no network.
- It reads state from the game variables on each keypress, so it stays correct after you click tabs with the mouse.
- If it cannot do something, it does nothing instead of erroring.

Version stays at 1.0.0.
