### PR TITLE
Add Star AFK Timer

### DIFF
--- a/plugins/star-afk-timer
+++ b/plugins/star-afk-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/silly-build/star-afk-timer.git
-commit=0e28d7281c62e164d44f2145e0f8f6ec382638ef
+commit=6e4e73356b605029fd84049005f2d08411eeec3f

--- a/plugins/star-afk-timer
+++ b/plugins/star-afk-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/silly-build/star-afk-timer.git
+commit=0e28d7281c62e164d44f2145e0f8f6ec382638ef


### PR DESCRIPTION
Adds Star AFK Timer, a minimalist Shooting Star overlay plugin.

The plugin dims the screen while mining a crashed star and displays the current layer timer and tier.

It does not automate gameplay, send input, or communicate with external servers.