### PR TITLE
drop-rate-display: anchor boss loot rates to where the loot lands

### DIFF
--- a/plugins/drop-rate-display
+++ b/plugins/drop-rate-display
@@ -1,2 +1,2 @@
 repository=https://github.com/Frailrain/drop-rate-display.git
-commit=8c4d0dba1c18c2d95edf08464179c264234f7331
+commit=74f57566e28369f36b6ddd4514478d342a1775da


### PR DESCRIPTION
Updates the Drop Rate Display plugin to 74f5756.

Fixes floor drop rates not showing for bosses that drop loot away from their own tile. `NpcLootReceived` carries no location, so rates were anchored to the NPC's own tile; but many bosses (the Leviathan, the Wilderness bosses, Vorkath, Nex, the Hueycoatl, …) drop loot under the player or several tiles away, so the rate landed on an empty tile and never showed.

The plugin now records where each item spawns per tick (mirroring how RuneLite's LootManager gathers the loot) and anchors each rate to the item's real spawn tile, falling back to the NPC's tile when the item wasn't seen spawning. Fixes every off-tile boss at once and is a strict improvement for large NPCs; no change to normal monster drops.

Verified in-game on the Hueycoatl (the rate shows on the drop under the player) and against normal monsters (no regression).