### PR TITLE
lootlette: update to 1.0.10

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=774b9c97e1a6a6a03692de1356628fe74cfadb42
+commit=604756d8c5bdc638b3cfa7912e8fbb3561cbf62c


### PR DESCRIPTION
Bumps Lootlette to 1.0.10.

Removes Ancient essence and Frozen cache from Phantom Muspah's tagged unique set — both sit under the wiki's "Unique" header but are common drops, so the plugin's "cha-ching" was firing on nearly every Muspah kill. The genuine uniques (Ancient icon, Venator shard) still trigger it.

(The hub manifest was last at 1.0.7's commit; this also carries the intervening 1.0.8/1.0.9 changes.)