### PR TITLE
Update visual-metronome to V1.5.4

### DIFF
--- a/plugins/visual-metronome
+++ b/plugins/visual-metronome
@@ -1,2 +1,2 @@
 repository=https://github.com/vincent0955/Visual-metronome.git
-commit=9377145ea7614fcb69cac37aef8cef6dca5045e7
+commit=04326033bf5e38656cd8a390088fc7743acafa45


### PR DESCRIPTION
- Fixed bug where Cycle 2 and Cycle 3 overlay positions were not saved correctly between sessions