### PR TITLE
update ospulse

### DIFF
--- a/plugins/ospulse
+++ b/plugins/ospulse
@@ -1,4 +1,4 @@
 repository=https://github.com/jonathanavis96/ospulse.git
-commit=3f24b51c291b8233a3a4220eff6a4bc21db4a792
+commit=7de6e1fa64540790afdb9701941d616fad6303a4
 authors=jonathanavis96
 warning=The optional, off-by-default price-trend feature requests item price history from the OSRS Wiki price API (prices.runescape.wiki), sending only an item id. No account name or player data is sent.

--- a/plugins/ospulse
+++ b/plugins/ospulse
@@ -1,4 +1,4 @@
 repository=https://github.com/jonathanavis96/ospulse.git
-commit=7de6e1fa64540790afdb9701941d616fad6303a4
+commit=8858ccb9d56a4240a43e23da082344bcd13a9846
 authors=jonathanavis96
 warning=The optional, off-by-default price-trend feature requests item price history from the OSRS Wiki price API (prices.runescape.wiki), sending only an item id. No account name or player data is sent.


### PR DESCRIPTION
Updates OSPulse to 0.1.1.

- Fish barrel: caught fish count as loot as they're stored; emptying at a bank or deposit box stays accurate (no double-count, no drop), and full-barrel overflow catches now count as loot.
- Fishing bait and feathers count as supplies.
- Depositing any item at a bank deposit box is now treated as banking, so it's no longer booked as a loss.
- Shortened the plugin description.