### PR TITLE
Update mokha-tracker

### DIFF
--- a/plugins/mokha-tracker
+++ b/plugins/mokha-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/camjewell11/Mokha-Loot-Tracker.git
-commit=ee9e4e8c3fe9bf1f05c56bcc2ac03962a0bb1a3e
+commit=0df4a9509836ded4a69ac5cfa023b5d01cf03dc9


### PR DESCRIPTION
Add wave tracking improvements and UI enhancements
- Store exact wave keys for claimed loot (no longer bucketed at 9+)
- Bump unclaimed wave archiving limit from 20 to 100
- Show wave-of-obtain tooltip for uniques in claimed/unclaimed combined views
- Add unique chance % and depth label to Previous Run section
- Add avg wave depth to dryness summary display (both states)
- Ignore passive +1 prayer ticks in performance tracker
- Restore MokhaLootTracker launcher class lost in rename
- Expand CLAUDE.md with full file reference, UI panel, and schema docs