### PR TITLE
Create cannon-dimmer

### DIFF
--- a/plugins/cannon-dimmer
+++ b/plugins/cannon-dimmer
@@ -1,0 +1,2 @@
+repository=https://github.com/silly-build/cannon-dimmer.git
+commit=5595b5389cb53a87d1f0b9cee01127c87cf8bf4f

--- a/plugins/cannon-dimmer
+++ b/plugins/cannon-dimmer
@@ -1,2 +1,2 @@
 repository=https://github.com/silly-build/cannon-dimmer.git
-commit=5595b5389cb53a87d1f0b9cee01127c87cf8bf4f
+commit=1cddec1c47f10c8136c0cfe676409827d7625a66

--- a/plugins/cannon-dimmer
+++ b/plugins/cannon-dimmer
@@ -1,2 +1,2 @@
 repository=https://github.com/silly-build/cannon-dimmer.git
-commit=64c5c8047c42fe59fd462b529f5c3ac845221f25
+commit=2c1aa538fe0898b7f068b99b1303053e599cd115

--- a/plugins/cannon-dimmer
+++ b/plugins/cannon-dimmer
@@ -1,2 +1,2 @@
 repository=https://github.com/silly-build/cannon-dimmer.git
-commit=1cddec1c47f10c8136c0cfe676409827d7625a66
+commit=64c5c8047c42fe59fd462b529f5c3ac845221f25


### PR DESCRIPTION
Adds Cannon Dimmer, a visual overlay plugin that dims the game screen while the player's dwarf multicannon is placed and loaded.

Features:
- Configurable dim opacity
- Two dimming modes
- Configurable cannonball thresholds for 30, 45, and 60 capacity cannons
- Cannonball count overlay
- Optional estimated time until the configured threshold is reached
- Toggle hotkey
- Optional safety visibility settings for reloads, movement, damage, and manual interactions

The plugin is visual-only and does not perform any player actions.