### PR TITLE
Update ge-companion - fix description encoding

### DIFF
--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=dbb2d5496857f942af5523c84b1f3385a2919344
+commit=8a321883bd54315b293f0bce7f5467901209e9ab


### PR DESCRIPTION
Replaces em dash with hyphen in description to fix encoding issue on Plugin Hub listing.