### PR TITLE
Add Jumpscare plugin

### DIFF
--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=ca866483a3749950550bab9dc771f523c15790d1
+commit=2bceb0ee45d166fdf182c011e7174ca22867f023
 authors=vividflash

--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=2bceb0ee45d166fdf182c011e7174ca22867f023
+commit=137a306be06ac2af0b6df27fd937bf0cff53eba3
 authors=vividflash

--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=2f846978ba0411d1aff7975f33afa20758b8db11
+commit=72e3038285a5ea00e60e3f118b942b3e59bb01a8
 authors=vividflash

--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=72e3038285a5ea00e60e3f118b942b3e59bb01a8
+commit=ca866483a3749950550bab9dc771f523c15790d1
 authors=vividflash

--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,0 +1,3 @@
+repository=https://github.com/vividflash/jumpscare.git
+commit=2f846978ba0411d1aff7975f33afa20758b8db11
+authors=vividflash


### PR DESCRIPTION
Adds **Jumpscare** — a very rare full-screen jumpscare (default 1 in 100,000 chance per game tick, roughly once per ~16.7 hours of play): a bundled scare image plus a scream sound, shown for a configurable duration.

**Features**
- Configurable odds, duration, volume, and image/flash mode
- Two bundled themes (scary / happy), selectable in config
- Users can supply their own local image (PNG/JPG) and sound (WAV) via config paths
- `::stest` chat command to preview/tune without waiting on the odds

**Notes for review**
- All code and bundled assets are original; images and sounds are procedurally generated (no copyrighted material).
- The sound plays via the client `AudioPlayer` and is intentionally independent of the in-game volume sliders (it is a jumpscare); plugin-level volume control and a sound-off toggle are provided.
- Flash mode rapidly flashes the screen; the plugin description and README carry a photosensitivity warning and the default mode is the static image.

Repository: https://github.com/vividflash/jumpscare (BSD 2-Clause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)