### PR TITLE
Add bingo-team-icons

### DIFF
--- a/plugins/bingo-team-icons
+++ b/plugins/bingo-team-icons
@@ -1,0 +1,2 @@
+repository=https://github.com/gwigl/bingo-team-icons.git
+commit=4f3606a20591104cdb0230f46c36a8e98558af28


### PR DESCRIPTION
Adds Bingo Team Icons: shows a small colored team badge next to player names in chat (public, friends chat, clan/guest/GIM chat, and PMs) based on which bingo team they are on, for clan bingo events.

- Teams are configured from a sidebar panel: a team-count spinner dynamically creates one name box per team; each team has a color picker (badges are generated 11x11 dots matching rank icon dimensions, registered via ChatIconManager).
- Optionally also tags collection log / drop broadcasts with the badge of the player named in the broadcast (config toggle).
- Roster/color changes re-tag messages already in the chat history.

Unlike bingo-team-indicators (which highlights names with colors), this shows an icon badge and supports dynamic team counts with per-team color pickers.

Repository: https://github.com/gwigl/bingo-team-icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)