### PR TITLE
Update nex-loot-tracker

### DIFF
--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=993cd45decdb1afbefdf287065cd511623ff26e9
+commit=44040f62d1368d101a88b18f9c1b88a4ad5ec572

--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=44040f62d1368d101a88b18f9c1b88a4ad5ec572
+commit=ffc5d0ecf4e20165ca035b981e414ddc1570e9fe


### PR DESCRIPTION
## Summary
Bumps `nex-loot-tracker` to the latest commit in the plugin repo.

- Updates `plugins/nex-loot-tracker` commit pointer to `ffc5d0ecf4e20165ca035b981e414ddc1570e9fe`.



