### PR TITLE
Update maggot-king

### DIFF
--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/maggot-king.git
-commit=5df1d653095cda2a72354a7be292d6851343b046
+commit=89eaaf3a915652136aa82425f5fc0f864a9de0be


### PR DESCRIPTION
Fixes the loot tracker after the update that made Maggot King loot drop straight into the inventory. It now snapshots the inventory when the corpse appears and captures the kill's loot from the first inventory change, then stops, so re-gearing or other inventory actions are no longer miscounted as loot.