### PR TITLE
Update nex-loot-tracker: kill contribution tracking

### DIFF
--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=286a79908b332639f82572ea3eeaeaaa1e0677ed
+commit=2c88fcd9444bb58c769a5f2c7bccc74da4f0553c

--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=2c116eab3b6da9aa5fa9dbb381b2c8f71b9fb5e6
+commit=286a79908b332639f82572ea3eeaeaaa1e0677ed

--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=2c88fcd9444bb58c769a5f2c7bccc74da4f0553c
+commit=28fbc80788c015f12d55de03cfa4d2590eb75469

--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=ffc5d0ecf4e20165ca035b981e414ddc1570e9fe
+commit=2c116eab3b6da9aa5fa9dbb381b2c8f71b9fb5e6


### PR DESCRIPTION
## Summary

Updates [nex-loot-tracker](https://github.com/JJDeakins1/nex-loot-tracker) to commit `2c88fcd9444bb58c769a5f2c7bccc74da4f0553c`.

**Kill contribution**
- Logs optional per-kill `killContribution` (% of total fight damage) to `nex_loot_data.log` using RuneLite's **DPS Counter** plugin when enabled
- Snapshots DPS data before DPS Counter resets on boss despawn
- Fixes JSON persistence so `killContribution: null` is written correctly to the log file
- Shows filtered **Average Kill Contribution** in the side panel (includes +2% MVP bonus when you were MVP)

**Due rates**
- Adds a **Due** column per unique showing contribution-weighted progress toward your next personal drop (e.g. **1.00** = on rate, **1.36** = ~36% overdue)
- Uses OSRS Wiki per-item drop rates, scaled by your contribution each kill
- Subtracts **1.00** when you receive a personal drop so overdue progress carries over
- Adds **Kills Since Last Drop** — consecutive kills since any team unique was seen

**Panel & filters**
- Adds **10+** team size filter; removes Solo and Last X Kills options
- Fixes **Today** filter to use calendar midnight instead of a rolling 24-hour window
- README updated with screenshots and Due rate explanation

## Test plan

- [x] Verified kill contribution logs correctly when DPS Counter is enabled
- [x] Verified `killContribution` is `null` when DPS Counter is disabled
- [x] Verified Due values update with contribution data and MVP bonus
- [x] Verified Due carryover after receiving a personal unique
- [x] Verified time, team size, MVP, and split filters apply correctly
- [x] `./gradlew test` passes (`DropRateCalculatorTest`, `KillListFilterTest`, `FileReadWriterJsonTest`)