### PR TITLE
Create hide-warned-attack

### DIFF
--- a/plugins/hide-warned-attack
+++ b/plugins/hide-warned-attack
@@ -1,0 +1,2 @@
+repository=https://github.com/PureIllenium/hide-warned-attack.git
+commit=a5f993b2143f7def26a7721dca407701621213e0

--- a/plugins/hide-warned-attack
+++ b/plugins/hide-warned-attack
@@ -1,2 +1,2 @@
 repository=https://github.com/PureIllenium/hide-warned-attack.git
-commit=a5f993b2143f7def26a7721dca407701621213e0
+commit=028d32414115b83c5b768c02c8181dfdeea84f09


### PR DESCRIPTION
Creating the Hide Warned Attacks plugin that will hide NPC attack options when the selected attack style is a warned attack style in the Attack Styles plugin and the Attack Styles plugin is enabled.