### PR TITLE
Add Loot Bank Filter

### DIFF
--- a/plugins/loot-bank-filter
+++ b/plugins/loot-bank-filter
@@ -1,0 +1,2 @@
+repository=https://github.com/lathenso/loot-bank-filter.git
+commit=e0a0762b048e49c5f0db013734c34eafca3d535a


### PR DESCRIPTION
Tracks the loot you receive per monster/boss during your session and lets you filter your bank to show **only the items you looted** — either everything, or one source at a time.

<img width="234" height="373" alt="Screenshot 2026-07-09 153307" src="https://github.com/user-attachments/assets/e14a43a2-d8c7-41f2-8200-c498193f4eeb" />
<img width="392" height="187" alt="Screenshot 2026-07-09 153424" src="https://github.com/user-attachments/assets/135993b6-eecc-428a-acf7-e852537d6e33" />
