### PR TITLE
Update bingo-team-icons

### DIFF
--- a/plugins/bingo-team-icons
+++ b/plugins/bingo-team-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/gwigl/bingo-team-icons.git
-commit=4f3606a20591104cdb0230f46c36a8e98558af28
+commit=72a42f86a0e5cfb3b5888f87c6ba2ea0631fba55


### PR DESCRIPTION
Updates bingo-team-icons to the latest commit:

- New feature: overhead nameplate team icons — draws the team badge above rostered players' heads at the overhead-name position (mirrors Player Indicators rank icon placement), gated by an "Overhead icons" config toggle.
- Trims the README to user-facing docs and removes local development helper files from the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)