### PR TITLE
update `collection-log-master` to v2.0.2

### DIFF
--- a/plugins/collection-log-master
+++ b/plugins/collection-log-master
@@ -1,4 +1,4 @@
 repository=https://github.com/OSRS-Taskman/collection-log-master.git
-commit=7eaa5aed1a1ddff031006068422ac4d167908439
+commit=20cc7f997237f58e7b1915267b0ca2312cb9f434
 authors=ImTedious,rmobis
 warning=This plugin submits your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
## v2.0.2 Changelog
- Fixed an issue where old active LMS/master tier tasks would cause the plugin to break