### PR TITLE
GPS: update to 0.9.2

### DIFF
--- a/plugins/gps
+++ b/plugins/gps
@@ -1,2 +1,2 @@
 repository=https://github.com/PauloAguiar/runelite-gps-plugin.git
-commit=04275bd1fca8182ffa22a011baabfbf14c37e0cd
+commit=04275bd375cca32ae343322480a9788452f02882

--- a/plugins/gps
+++ b/plugins/gps
@@ -1,2 +1,2 @@
 repository=https://github.com/PauloAguiar/runelite-gps-plugin.git
-commit=e06a0853f05c604a2c4a3e57c927f2c1c3bc1478
+commit=04275bd1fca8182ffa22a011baabfbf14c37e0cd

--- a/plugins/gps
+++ b/plugins/gps
@@ -1,2 +1,2 @@
 repository=https://github.com/PauloAguiar/runelite-gps-plugin.git
-commit=e24bb135d7abd8dfd5e062c03a57c94128470b99
+commit=e06a0853f05c604a2c4a3e57c927f2c1c3bc1478


### PR DESCRIPTION
Updates GPS to 0.9.2
Changes since the previously submitted version:
Bug fixes:
- Enabled-state no longer collides with the Shortest Path plugin (was keyed
  by the shared class name, so disabling one could disable the other)
- Off-route recalculation measures the displayed route and actually
  recomputes it
- Nearest bank could suggest a distant teleport while ignoring the bank a
  few tiles away
- Round trips no longer falsely complete when the bank is opened
- Amenity destinations use wall-aware access tiles, so routes can't target
  tiles through a wall
- Blast Furnace minigame teleport landing position corrected

Other:
- Off-route handling in three distance bands: on-route, red overlay warning,
  and route recalculation, with configurable distances
- Arrival reworked into a real zone: walkable tiles within the finish distance
  of the destination (collision-map flood), so arrival works from any
  direction but never through a wall
- "Show more routes" can keep widening the search instead of stopping at a
  fixed cap
- Panel header: secondary actions moved into a menu, added a GitHub issues link
- Resetting method exclusions keeps seasonal (Leagues) methods disabled
- Retuned distance defaults (arrival 3, warning 10, recalculate 18)
