### PR TITLE
Add Ring of Recoil Helper

### DIFF
--- a/plugins/ring-of-recoil-helper
+++ b/plugins/ring-of-recoil-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/mdarkwell/ring-of-recoil-helper.git
+commit=afdacc33657d91fa4f70d248057477737e03819e

--- a/plugins/ring-of-recoil-helper
+++ b/plugins/ring-of-recoil-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/mdarkwell/ring-of-recoil-helper.git
-commit=afdacc33657d91fa4f70d248057477737e03819e
+commit=641852ef8be11181a05b24049010b16793e9307b


### PR DESCRIPTION
Adds Ring of Recoil Helper, a plugin which helps with the regular usage of jewelry with recoiling effects.

### Features
- Proper recoil tracking based on latent hit splats applied to attackers
- Display how many charges are left on the currently equipped ring
- Display charges of recoiling rings stored within bank
- Notifications at popular areas/bosses which make use of rings of recoil/ring of suffering
- Warning when wearing recoiling jewelry at an immune enemy
- Control which types of recoil notifications appear, and when they appear
- Play sound FX when your ring of recoil shatters

### Notes
While there is the Ring of Recoil Utility plugin, that plugin is primarily focused on displaying when you don't have a ring equipped. This plugin adds functionality such as charge tracking for both Ring of recoil and Ring of suffering, conditional-based notifications, sound effects on shatter, warnings when the target is immune to the recoiling effect, as well as indicators at popular areas where rings with recoiling effects are used, such as Zulrah.

<img width="318" height="179" alt="image" src="https://github.com/user-attachments/assets/833c27f1-d717-403a-aecc-ffbfce9a34f4" />
<img width="592" height="220" alt="image" src="https://github.com/user-attachments/assets/18d91402-9d50-4ead-842c-7c38d397e1ce" />
<img width="2418" height="1591" alt="image" src="https://github.com/user-attachments/assets/9846bcc5-dbab-4242-af01-1fbf3d3dd8c2" />
<img width="2418" height="1591" alt="image" src="https://github.com/user-attachments/assets/72962695-41a2-434c-bc8b-884c995e28a0" />
