### PR TITLE
log-adviser: bump to c76521e

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=0a108dc1cd378724fb223eaeea5172cb25b746c4
+commit=c76521ea055aeba0ce8eab98e9f33c813b8e1785


### PR DESCRIPTION
Bumps the pinned commit for `log-adviser` from `0a108dc` to `c76521e` (v1.2.1).

This release repositions the sidebar's hover preview popup. It previously appeared vertically centered on the activity list with an 8px horizontal gap; it now anchors to the top of the list, level with the first row, and sits flush against the list's left edge so the pointer can move onto it without crossing a dead zone and dismissing it.

Swing-only UI change within the plugin's own sidebar panel. No new RuneLite client APIs, no data changes, no outbound network calls.