### PR TITLE
Fix a noted items bug for the high alc plugin

### DIFF
--- a/plugins/high-alc-highlight
+++ b/plugins/high-alc-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/bloogeyz/high-alc-value.git
-commit=ce973a58999bae81314fd8336353c188ecc5475a
+commit=f3ef63f2b91d97a647f6e835690f2d6c99bb265d

--- a/plugins/high-alc-highlight
+++ b/plugins/high-alc-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/bloogeyz/high-alc-value.git
-commit=f3ef63f2b91d97a647f6e835690f2d6c99bb265d
+commit=4869986cefadbcaa076fb44c8f14424be9bacf82


### PR DESCRIPTION
Stops noted items being marked as untradeable