### PR TITLE
Add tempoross-solo-helper plugin

### DIFF
--- a/plugins/tempoross-solo-helper
+++ b/plugins/tempoross-solo-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/RyanTamulevicz/tempoross-solo-helper.git
+commit=3573fd1aa8faa205f210dbd7c9491926c79d8814


### PR DESCRIPTION
Adds a solo tempoross method helper in the form similar to quest helper. Shows panel tracking progress of fish 26 (for example) and then highlights to load the hopper etc. and so on for the solo method.