### PR TITLE
Add tile racer

### DIFF
--- a/plugins/tile-racer
+++ b/plugins/tile-racer
@@ -1,2 +1,3 @@
 repository=https://github.com/AaronDemond/TileRacer.git
 commit=e782933bcf26123ee94b6dc2dc15e5cb9d96cf08
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/tile-racer
+++ b/plugins/tile-racer
@@ -1,2 +1,2 @@
-repository=https://github.com/AaronDemond/TileRacer
+repository=https://github.com/AaronDemond/TileRacer.git
 commit=e782933bcf26123ee94b6dc2dc15e5cb9d96cf08

--- a/plugins/tile-racer
+++ b/plugins/tile-racer
@@ -1,0 +1,2 @@
+repository=https://github.com/AaronDemond/TileRacer
+commit=e782933bcf26123ee94b6dc2dc15e5cb9d96cf08


### PR DESCRIPTION
Adds TileRacer, a tile-coloring challenge plugin where players race to complete marked tile layouts as quickly as possible.

The plugin supports solo play, multiplayer matches, custom level creation, level import/export, highscores, and fun gameplay modifiers.