### PR TITLE
Update Ring of Recoil Helper

### DIFF
--- a/plugins/ring-of-recoil-helper
+++ b/plugins/ring-of-recoil-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/mdarkwell/ring-of-recoil-helper.git
-commit=641852ef8be11181a05b24049010b16793e9307b
+commit=2b535c1cd018701734f43ba31b0da54a332e1087


### PR DESCRIPTION
### Changes
- Fix bug with info box not refreshing when checking charges via equipment ring slot
- Add charge detection when using ring of recoils directly onto a ring of suffering from the inventory
- Add charge detection from the Ring of Recoil break chat interface