### PR TITLE
Add Clan Bank

### DIFF
--- a/plugins/clan-bank
+++ b/plugins/clan-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/Parmvir/Clan-Bank.git
-commit=4dc7d4185884b07db5582a32bede9ba4b20d36bd
+commit=8378d45727e43849382c34aa71446c30b1c19706

--- a/plugins/clan-bank
+++ b/plugins/clan-bank
@@ -1,0 +1,2 @@
+repository=https://github.com/Parmvir/Clan-Bank.git
+commit=4dc7d4185884b07db5582a32bede9ba4b20d36bd

--- a/plugins/clan-bank
+++ b/plugins/clan-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/Parmvir/Clan-Bank.git
-commit=8378d45727e43849382c34aa71446c30b1c19706
+commit=8ae3afc439fc1435ef64c41b1079b88b670da619


### PR DESCRIPTION
## What it does
Companion plugin for a self-hosted OSRS clan bank Discord bot ([source](https://github.com/Parmvir/Clan-Bank)). Shows a member's loan status in-game (compact overlay + a sidebar panel with full detail and item icons), and lets them request or settle a loan from the panel without switching to Discord.

## About the network calls
The plugin only ever talks to a local/self-hosted API exposed by the companion Discord bot (URL + API key configured by the user in plugin settings, defaulting to `http://localhost:3939`). It fetches the requester's own loan status and, when they submit a request from the panel, forwards it to the bot — functionally identical to that member typing a Discord slash command. Every request still requires manual officer approval via Discord DM; nothing is auto-approved and no game input/automation is ever performed.

## Notes
- Not tied to a specific clan — the plugin fetches the connected clan's name directly from the bot (which reads it from the linked Discord server) and displays it dynamically, so the same build works for any clan running the bot.
- Bot source is linked in the plugin's README for anyone wanting to self-host it for their own clan.