### PR TITLE
regear 1.2.0

### DIFF
--- a/plugins/regear
+++ b/plugins/regear
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-regear.git
-commit=d1b2381e89e003ef564a1138e8e0cbb992ebadd0
+commit=ba68dd0c0a2412c22880d0df4cb5d33344cea059


### PR DESCRIPTION
small update. fixes the "or" fallback when the primary item is only a bank placeholder (placeholders were counting as present so it never fell back to the alternate), adds up to 28 items per list (a full inventory, good for quest setups), an "add current inventory" button, and a click-to-set pattern (tick the box and click cells in the preview to build it in the order you click).
