### PR TITLE
Add World Splitter

### DIFF
--- a/plugins/world-splitter
+++ b/plugins/world-splitter
@@ -1,0 +1,2 @@
+repository=https://github.com/LLLosrs/world-splitter.git
+commit=05cfd5de64884ee859124e05f158c112e4f33cee

--- a/plugins/world-splitter
+++ b/plugins/world-splitter
@@ -1,2 +1,2 @@
 repository=https://github.com/LLLosrs/world-splitter.git
-commit=05cfd5de64884ee859124e05f158c112e4f33cee
+commit=f5c57a2bb1774fe64fc5203e517c9e2399a35427

--- a/plugins/world-splitter
+++ b/plugins/world-splitter
@@ -1,2 +1,2 @@
 repository=https://github.com/LLLosrs/world-splitter.git
-commit=f5c57a2bb1774fe64fc5203e517c9e2399a35427
+commit=fd324f9d1fdf6bc0b2bdaf448b72d24c42290bd4


### PR DESCRIPTION
Adds World Splitter to the Plugin Hub.

World Splitter divides assignable member worlds between group members and displays each member's assigned world range.

The plugin can optionally communicate with a configured third-party server for group-code sync. The README and config describe that it sends the configured RSN, group code, and assignable member world list.

The plugin does not automate gameplay, click, hop, or perform actions for the player. It only displays world assignment information.