### PR TITLE
Adds Specatator Oculus Hints remover plugin

### DIFF
--- a/plugins/specatator-oculus
+++ b/plugins/specatator-oculus
@@ -1,0 +1,2 @@
+repository=https://github.com/LogicalSoIutions/Specator-Oculus-Hint-Remover.git
+commit=c20268aadf7151b179f1267507c099a614436348

--- a/plugins/specatator-oculus
+++ b/plugins/specatator-oculus
@@ -1,2 +1,2 @@
 repository=https://github.com/LogicalSoIutions/Specator-Oculus-Hint-Remover.git
-commit=c20268aadf7151b179f1267507c099a614436348
+commit=5870f135d639eb53549285139f138c6a8319427d


### PR DESCRIPTION
This is for the upcoming https://crusaderclassic.cc/ -- they need a way to hide the "Teleport & Show" and "Walk Here" option when in Spectator Oculus 