### PR TITLE
Update pvp-performance-tracker to v1.8.5

### DIFF
--- a/plugins/pvp-performance-tracker
+++ b/plugins/pvp-performance-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Matsyir/pvp-performance-tracker.git
-commit=a9a321938082134527cfdb9de1704633e328b858
+commit=c3063618a6421e4e1c381335517d3b5bce8675cc


### PR DESCRIPTION
Various fixes in preparation for the upcoming tourny for mage damage
- Augury now properly applies +4% mage damage boost. Was never included since this was changed in 2024. I was inactive at the time myself, how did nobody notice this or just mention it when it happened!? I just learned this today that augury gives damage now. whatever, fixed now xd. Mage damage hit ranges seem accurate now.
- Support for Virtus set hidden damage boost on ancients, +3% damage per piece.
- Improved reliability when fetching synced fights from PvP-Hub.
- Minor tooltip clarifications.

Thanks to @LogicalSoIutions for basically all these fixes

Big thanks to Pan1c & Lagunarium for extensively testing, reporting feedback, and comparing fight data between their two clients & the merged PvP-Hub result.