### PR TITLE
Add Gauntlet Recorder

### DIFF
--- a/plugins/gauntlet-recorder
+++ b/plugins/gauntlet-recorder
@@ -1,2 +1,2 @@
 repository=https://github.com/lsmith090/gauntlet-recorder.git
-commit=46f2039f754ca9e1c31b1126ce04d8b309c6fc9a
+commit=8648ec0fcc9bfaeb5075aeddeda337fd2ad210f2

--- a/plugins/gauntlet-recorder
+++ b/plugins/gauntlet-recorder
@@ -1,0 +1,2 @@
+repository=https://github.com/lsmith090/gauntlet-recorder.git
+commit=46f2039f754ca9e1c31b1126ce04d8b309c6fc9a


### PR DESCRIPTION
Records Gauntlet runs (regular and Corrupted) to tick-stamped log files for offline analysis — per-tick positions of the player, Hunllef, tornadoes, and lit floor tiles, plus resource nodes as rooms load, inventory/equipment deltas over the prep loop, and run outcome. No overlay, no config, no external dependencies (build=standard).

Repository: https://github.com/lsmith090/gauntlet-recorder