### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=7c2a1baee56518a6ba8fbbf15d5f8c866868efd5
+commit=f1178bb9cb0d9c74909b004aec9372bb96aff8f8
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=f1178bb9cb0d9c74909b004aec9372bb96aff8f8
+commit=216e0ba9c46c318aa3700b18e05486bfc9bfefd2
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=a4ddc5f11d7bbc92fe464786f300b531fc67e8bf
+commit=7c2a1baee56518a6ba8fbbf15d5f8c866868efd5
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=37d1f47834069263a283c0f3168f75dfc81030fe
+commit=a4ddc5f11d7bbc92fe464786f300b531fc67e8bf
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
- Fixed the Exchange Viewer overlay so it now shows at the Grand Exchange in all cases and only hides while the GE, bank, or collection/deposit box is actually open on screen
- Fixed the Active Flips tab showing stale completed/cancelled trades by replacing a time-based heuristic with a live-state check
- Reordered auto-recommend priority so collecting a completed buy is suggested before placing a new buy
- Added a short cooldown so skipped items and actions no longer immediately reappear, with auto-refresh continuing once everything is on cooldown
- Fixed the on-screen refresh countdown to stay in sync with the actual refresh timer after a manual refresh
- Fixed Flip Assist surfacing items that Flip Finder's own minimum-profit/minimum-volume filters would have hidden, so the two views now agree on what's shown
- Fixed the Min Profit/Min Volume filter fields in Flip Finder's settings pop-out so a typed value is no longer silently discarded when the pop-out is dismissed by clicking away
- Added a clear "no suggestions matching your criteria" message when filters remove all results, instead of leaving the list blank
- Min Profit/Min Volume filters are now sent to the backend so recommendations are selected under the user's thresholds rather than filtered after the fact on the client
- Fixed inventory item highlights — noted stacks now highlight correctly (canonicalized item IDs) and single (quantity 1) items get the full glow instead of a cropped corner
- Fixed a startup crash that could prevent the plugin from loading for some users
- Redesigned the Active Flips card with clearer profit detail and added a manual refresh button
