### PR TITLE
Update nex-loot-tracker to fix MVP due rate calculation

### DIFF
--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=28fbc80788c015f12d55de03cfa4d2590eb75469
+commit=436b38376521f14ac61aca3d2bff715c4e5fb219


### PR DESCRIPTION
## Summary

- Bumps [nex-loot-tracker](https://github.com/JJDeakins1/nex-loot-tracker) to `436b38376521f14ac61aca3d2bff715c4e5fb219`
- **Fixes MVP contribution in Due rate calculations** — MVP now applies a **10% multiplicative boost** to damage share (e.g. 20% → 22%), matching how Nex awards MVP, instead of a flat +2% addition
- Updates README with side-by-side screenshots and revised Due rates documentation

## Test plan

- [x] Build plugin from `436b383` and verify it loads in RuneLite
- [x] Kill Nex as MVP and confirm Due progress uses the 10% multiplicative boost on contribution
- [x] Kill Nex without MVP and confirm Due progress matches raw damage share
- [x] Verify average kill contribution in the panel reflects MVP boost when applicable

