### PR TITLE
add visual-bloodwood

### DIFF
--- a/plugins/visual-bloodwood
+++ b/plugins/visual-bloodwood
@@ -1,2 +1,2 @@
 repository=https://github.com/CLColdest/visual-bloodwood.git
-commit=6dd5d1f2b55b541318372b20f1fbeb42faafc6a9
+commit=480e55f964f03cccc58f9271a045f6c74c8983ee

--- a/plugins/visual-bloodwood
+++ b/plugins/visual-bloodwood
@@ -1,0 +1,2 @@
+repository=https://github.com/CLColdest/visual-bloodwood.git
+commit=6dd5d1f2b55b541318372b20f1fbeb42faafc6a9


### PR DESCRIPTION
Adds Visual Bloodwood, a passive visual helper for Bloodwood trees.

The plugin highlights Bloodwood tree states and interaction spots, tracks bucket counts, sap collected, sap/hr, and observed chop counts. It does not automate input, modify menus, or provide tick-cycle click prompts.