### PR TITLE
Create remove-chatbox-separator

### DIFF
--- a/plugins/remove-chatbox-separator
+++ b/plugins/remove-chatbox-separator
@@ -1,2 +1,2 @@
 repository=https://github.com/Sessle/remove-chatbox-separators.git
-commit=4dccfb4ae8169e2ec7e468e855ede06f6090754f
+commit=93cf79e518d2207e4befda0e8cbbd1a35957238e

--- a/plugins/remove-chatbox-separator
+++ b/plugins/remove-chatbox-separator
@@ -1,0 +1,2 @@
+repository=https://github.com/Sessle/remove-chatbox-separators.git
+commit=4dccfb4ae8169e2ec7e468e855ede06f6090754f


### PR DESCRIPTION
This plugin hides the separator line above the chatbox and the line above the user input section of the chatbox. This is accomplished by finding the widget with a groupId of 162 and childId of 56 and setting all its children opacity to 255.