### PR TITLE
Add quick-wiki plugin repository information

### DIFF
--- a/plugins/quick-wiki
+++ b/plugins/quick-wiki
@@ -1,2 +1,2 @@
 repository=https://github.com/jake219/quick-wiki.git
-commit=4f9cbf75939875c807d440805641d26b1649ec95
+commit=a13b4f92f29378b80932df3c10c3cfb0e61d538b

--- a/plugins/quick-wiki
+++ b/plugins/quick-wiki
@@ -1,0 +1,2 @@
+repository=https://github.com/jake219/quick-wiki.git
+commit=987c086fb47936c57f80777fe47b834eabcc0182

--- a/plugins/quick-wiki
+++ b/plugins/quick-wiki
@@ -1,2 +1,2 @@
 repository=https://github.com/jake219/quick-wiki.git
-commit=987c086fb47936c57f80777fe47b834eabcc0182
+commit=4f9cbf75939875c807d440805641d26b1649ec95


### PR DESCRIPTION
A RuneLite plugin that lets you right-click any item, NPC, or object in-game and instantly view its wiki info — description, Grand Exchange price, high/low alch value, release date, members status, and more — all in a compact sidebar panel.

Features
Right-click "Wiki" option on items, NPCs, and objects
Item icon, name, and GE price with high/low alch
Release date, members status, and quest item info
Full item properties (tradeable, equipable, stackable, etc.)
Toggle between short and full wiki descriptions