### PR TITLE
Add Loadout Lab

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-loadout-lab.git
-commit=6af29545f5622aaabd51a7621cd0f2dcd361f56f
+commit=10fae64240759bda79901af9834cce719eff9b96

--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-loadout-lab.git
-commit=9b13aee4852f1184f57835cf5f8fc312356b9fd8
+commit=6af29545f5622aaabd51a7621cd0f2dcd361f56f

--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
 commit=cb52ac2f46be4e2e63a7b42f8346b7005dfa588a
+authors=ajkatz

--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,2 @@
-repository=https://github.com/AKAddons/runelite-loadout-lab.git
+repository=https://github.com/ajkatz/runelite-loadout-lab.git
 commit=cb52ac2f46be4e2e63a7b42f8346b7005dfa588a
-authors=ajkatz

--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-loadout-lab.git
-commit=cb52ac2f46be4e2e63a7b42f8346b7005dfa588a
+commit=9b13aee4852f1184f57835cf5f8fc312356b9fd8

--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,0 +1,2 @@
+repository=https://github.com/AKAddons/runelite-loadout-lab.git
+commit=cb52ac2f46be4e2e63a7b42f8346b7005dfa588a


### PR DESCRIPTION
Loadout Lab computes the strongest gear set you actually own for any monster, per combat style, with exact DPS - from live knowledge of your bank, inventory, and equipment.

- Repository: https://github.com/ajkatz/runelite-loadout-lab
- Highlights: owned-gear best-in-slot per style with exact DPS; Max DPS / Balanced / Tanky modes (output vs damage-taken frontier); incoming-damage estimate + protection prayer; wilderness low-risk sets with per-item death costs; upgrade budgets; slayer-task awareness; bank show/filter via the core Bank Tags plugin.
- Fully documented feature guide with screenshots in the README.
- No external network calls; all computation is local. Cross-plugin search via PluginMessage (namespace "loadoutlab").

🤖 Generated with [Claude Code](https://claude.com/claude-code)