### PR TITLE
Update pvp-leaderboard

### DIFF
--- a/plugins/pvp-leaderboard
+++ b/plugins/pvp-leaderboard
@@ -1,3 +1,3 @@
 repository=https://github.com/findarian/pvp-leaderboard.git
-commit=317645b367ba3ab16efd33b66472371c671c0ce6
+commit=2babe7b6dc1f51c8fe43ea1c4ce8b11e4df6d58b
 warning=This submits your IP address, in-game username, and PvP fight statistics to a 3rd-party service not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Freeze logging in LMS now loses 2x the MMR and displays that MMR loss upon login.