### PR TITLE
Added Inspect plugin

### DIFF
--- a/plugins/enhanced
+++ b/plugins/enhanced
@@ -1,0 +1,2 @@
+repository=https://github.com/DevOldSchool/enhanced.git
+commit=812c595461ec1e66740b5b619570bcec18490713

--- a/plugins/enhanced
+++ b/plugins/enhanced
@@ -1,2 +1,0 @@
-repository=https://github.com/DevOldSchool/enhanced.git
-commit=812c595461ec1e66740b5b619570bcec18490713

--- a/plugins/inspect
+++ b/plugins/inspect
@@ -1,0 +1,2 @@
+repository=https://github.com/DevOldSchool/inspect.git
+commit=812c595461ec1e66740b5b619570bcec18490713

--- a/plugins/inspect
+++ b/plugins/inspect
@@ -1,2 +1,2 @@
 repository=https://github.com/DevOldSchool/inspect.git
-commit=812c595461ec1e66740b5b619570bcec18490713
+commit=216af9a647126dcbe33f0afd64dff15b5f993f3d


### PR DESCRIPTION
Adds Inspect, an optional inspection and information plugin for OSRS.

Inspect provides:
- Item and NPC inspection using OSRS Wiki data
- Locally derived visible-player equipment inspection
- Recent inspection history
- Equipment recommendations and bank highlights
- Item prices, requirements, Slayer details and drop summaries

OSRS Wiki communication is disabled by default and must be explicitly enabled in the plugin configuration. Player equipment inspection uses locally visible RuneLite client data and does not upload, store or expose player information over HTTP.

--

Edit: Renamed from Enhanced to Inspect.