### PR TITLE
Update exact-stacks plugin

### DIFF
--- a/plugins/exact-stacks
+++ b/plugins/exact-stacks
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-exact-stacks-plugin.git
-commit=d5e2b51d148b70898ab1d63b8aecc82716df615e
+commit=849fda7b2ededff0d4a1d7d0d800d2ee088b5da9
 authors=robisa693


### PR DESCRIPTION
Pure essence (and similar items) aren't flagged stackable in item data, so the isStackable() guard skipped rendering entirely once the item landed in the bank unnoted. The quantity >= 100K threshold already limits rendering to real large stacks, so drop the redundant isStackable() check and the now-unused ItemManager dependency.