### PR TITLE
Update tile racer

### DIFF
--- a/plugins/tile-racer
+++ b/plugins/tile-racer
@@ -1,3 +1,3 @@
 repository=https://github.com/AaronDemond/TileRacer.git
-commit=24e38650145babe355988d50eceead5c1606e457
+commit=0600adbdb2ba867d81d1cc3981193aba647295bb
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/tile-racer
+++ b/plugins/tile-racer
@@ -1,3 +1,3 @@
 repository=https://github.com/AaronDemond/TileRacer.git
-commit=e782933bcf26123ee94b6dc2dc15e5cb9d96cf08
+commit=24e38650145babe355988d50eceead5c1606e457
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Fixed a critical bug where if users didn't have a certain RuneLite configuration their player model would render below highlighted tiles.

Fixed a non critical bug that would break the camera rotational axis.

Fixed minor multiplayer edge cases surrounding stale lobbies.