### PR TITLE
pvp profit tracker 1.1.2

### DIFF
--- a/plugins/pvp-profit-tracker
+++ b/plugins/pvp-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-profit-tracker.git
-commit=e53b59ac9c704a02b33d82700713a7a3ba56400e
+commit=5ad5997e756df7fa161e26a1b58887a5173b5702


### PR DESCRIPTION
small visual pass on the side panel. opponent info sits at the top now and the stats show as icons instead of names. same hiscore lookup as before, nothing else changed.