### PR TITLE
Update consumable-cooldowns to 1.3.3

### DIFF
--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,2 +1,2 @@
 repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
-commit=843d5158204646e0f0fe91d288dd8176fe6749bf
+commit=452d4b496f7157092834a8faeea3fba94e6a3273

--- a/plugins/consumable-cooldowns
+++ b/plugins/consumable-cooldowns
@@ -1,2 +1,2 @@
 repository=https://github.com/CopyPastaOSRS/consumable-cooldowns.git
-commit=09dde1195403c6b1fdda72a4bdb91665d8c881ae
+commit=843d5158204646e0f0fe91d288dd8176fe6749bf


### PR DESCRIPTION
- Migrate plugin to use gameval ItemID API instead of deprecated ItemID
- Added missing sailing consumables
- Added consumables from cow quest & blood moon rises