### PR TITLE
lootlette 1.0.11

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=604756d8c5bdc638b3cfa7912e8fbb3561cbf62c
+commit=2680007fd0a1edc087734be27243b073a208bf7b


### PR DESCRIPTION
Fixes a duplicate slot rolled for the same Nightmare / Phosani's Nightmare kill: its ground loot pile spawns ~10 ticks after death, so the kill's loot arrived via two events on different ticks and slipped past the plugin's same-tick dedupe. Loot claims are now tracked per event source with a cross-source dedupe window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)