### PR TITLE
Update scapestack-sync

### DIFF
--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
-commit=5a6d11f2663f349ffa6f1baaf906edfef9207045
+commit=c7ff42816ad4ebedf04c0df6a24d110c07fc60b0
 warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
-commit=8d839d4e1cdfd9bad89f05e3286977086ba761a9
+commit=dafcfb495aa1221a273e6f0e03d6aff5f2f41b92
 warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
-commit=c7ff42816ad4ebedf04c0df6a24d110c07fc60b0
+commit=8d839d4e1cdfd9bad89f05e3286977086ba761a9
 warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates scapestack-sync to the latest standalone plugin commit.

Changes in the pinned plugin commit:
- Bank readiness is included by default for new installs when the player syncs, limited to bank item IDs, names and quantities.
- Sync on login still defaults off, so no progress POST happens until the player opts in or uses a manual sync.
- The player can turn off Use bank for readiness if they only want progress sync.
- The RuneLite settings/panel copy was tightened around what is sent and what is not sent.

Verification:
- Standalone plugin: ./gradlew test --console=plain
- Standalone plugin: ./gradlew build --console=plain
- Monorepo release check: npm run plugin:release-check -- --offline
- Plugin Hub descriptor: git diff --check

Pinned commit: c7ff42816ad4ebedf04c0df6a24d110c07fc60b0