### PR TITLE
Update combat-logger to v1.6.8

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=2d10a5ecb0c20d2c2a2187ddd5b8e8df67e2c665
+commit=f1c168996aa1cd1aed4ff881ca60a6fae03bbbfb


### PR DESCRIPTION
- Fix plugin not starting
- Log Spells:
  - Vengeance
  - Vengeance Other
  - Spellbook Swap
  - Death Charge
  - Mark of Darkness
  - Ward of Arceuus
  - Lesser Corruption
  - Greater Corruption
  - Dark Lure
  - Thrall Ghost
  - Thrall Skeleton
  - Thrall Zombie