### PR TITLE
anvil: update to v1.2.0

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=2d7686bbf45671fdbdfb636b2943e80acca6894b
+commit=653341d6a90f56ca46fbc2ae3bd47fd3ad6f1255
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=07560de0b87dfa9426f056767cb23c5685825f97
+commit=93158cb942b7fe5d03cf61c38add13fab6704649
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=93158cb942b7fe5d03cf61c38add13fab6704649
+commit=a030ad8c904b266880881b320a9016cf92b416d5
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=2576aa01ac3b8ec782a60d8de24ff7eff4105c03
+commit=d15e854be3ec711d009990820609eb09306a3726
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=a030ad8c904b266880881b320a9016cf92b416d5
+commit=6b35e5b9ea9d4ba3ae727bf84f42d42b34561ba2
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=d15e854be3ec711d009990820609eb09306a3726
+commit=07560de0b87dfa9426f056767cb23c5685825f97
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=6b35e5b9ea9d4ba3ae727bf84f42d42b34561ba2
+commit=2d7686bbf45671fdbdfb636b2943e80acca6894b
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=653341d6a90f56ca46fbc2ae3bd47fd3ad6f1255
+commit=b11208080684160bf0312317ca2b96e48d898a51
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates the `anvil` plugin from commit `2576aa0` to `d15e854` (v1.2.0).

### Changes since the last pinned commit
- **Loot-value tiles**: price each haul and, for 'total' tiles, accumulate hauls toward a gp target (PvP kills + opened loot keys both count); single-haul tiles bake a proof screenshot.
- **Item-gain tracking reliability**: a config refresh now snapshots/restores the local progress floor instead of clobbering it, with a bounded coalesce window and a logout/hop flush — fixes catches (implings/karambwans) intermittently not counting.
- **Collection-log tile detail**: clicking a tile (not just the +) opens the shared detail page with 'what counts' for every tile kind and who completed it; manual-only tiles are surfaced.
- **Clog unlock banner**: long labels wrap onto a second line then ellipsise (no bitmap-font scaling), detail lines use the natively-smaller RS font, tighter header spacing.
- **Hardening**: reject non-HTTPS base URLs (except localhost) so the account token can't be sent over plaintext.
