### PR TITLE
Update Chat Overlay plugin

### DIFF
--- a/plugins/chat-overlay
+++ b/plugins/chat-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/devrat0/chat-overlay-plugin.git
-commit=a30aadd90ef83b580f7d7fdad1b2319fa969f7fd
+commit=376d9f2350f5e1cd943dff8054405463286c91b7


### PR DESCRIPTION
- bug fix for peek mode causing it to not work when chat box was open