### PR TITLE
Update bingo-team-icons

### DIFF
--- a/plugins/bingo-team-icons
+++ b/plugins/bingo-team-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/gwigl/bingo-team-icons.git
-commit=72a42f86a0e5cfb3b5888f87c6ba2ea0631fba55
+commit=2bab0080fe161945c351fed90099dbe1d12702d7


### PR DESCRIPTION
Updates bingo-team-icons with a new feature: overhead nameplate team icons.

Draws the team badge above rostered players' heads next to the overhead name position (mirrors Player Indicators' rank icon placement; skips the local player). Gated by an "Overhead icons" config toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)