### PR TITLE
Camera smoothing, Roe's fix for cutscenes

### DIFF
--- a/plugins/camera-smoothing
+++ b/plugins/camera-smoothing
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/camera-smoothing.git
-commit=c24cd30e056f59a645140ba642cf386334740d9c
+commit=1a950fc613d058bf6a0577a5b524d4610d023dcc


### PR DESCRIPTION
Two users reported camera on penguin agility would not go back to where it was. Roe looked into this and fixed it and has earned a butter trophy.