### PR TITLE
Update bingo-team-icons

### DIFF
--- a/plugins/bingo-team-icons
+++ b/plugins/bingo-team-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/gwigl/bingo-team-icons.git
-commit=2bab0080fe161945c351fed90099dbe1d12702d7
+commit=cfb068529838829c703c8ef0c4d89a70f6021e2f


### PR DESCRIPTION
Updates bingo-team-icons with a new feature: team icons on the friends list.

Appends the team badge after names during friends list layout (same friendsChatSetText/friendsChatSetPosition script callback approach as the core Friend Notes plugin), and re-runs FRIENDS_UPDATE when the roster changes. Gated by a "Friends list icons" config toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)