### PR TITLE
Update Better Object Hider to 904cdac

### DIFF
--- a/plugins/better-object-hider
+++ b/plugins/better-object-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/JakhRS/better-object-hider.git
-commit=3b092c0770ee77064a2f7b53d677e93bf744ab10
+commit=904cdac047b01e43e56daf25e7a7bc7b94525167


### PR DESCRIPTION
Updates Better Object Hider (1.0 → 1.1).

Commit: 904cdac047b01e43e56daf25e7a7bc7b94525167

- Side-panel search/filter with wildcards and area:/group:/scope: terms
- Readable location labels, e.g. "Castle Wars (Kandarin)" — from bundled
  static map data (generated offline; net.runelite:cache is test-scope only)
- Import preview/confirmation with size caps
- Config to trim which hide reaches the right-click menu offers
- Reveal-mode toggle in the panel, one-click undo, optional chat confirmation
- Fixes: import de-duplication/unhide, menu targeting for adjacent identical
  objects, panel responsiveness

Hiding model unchanged: name + location only, unnamed objects excluded,
client-side draw suppression, no new runtime dependencies.
