### PR TITLE
Update bingo-team-icons

### DIFF
--- a/plugins/bingo-team-icons
+++ b/plugins/bingo-team-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/gwigl/bingo-team-icons.git
-commit=cfb068529838829c703c8ef0c4d89a70f6021e2f
+commit=b4fa8dfbf40bf1c11aeb559b84b18ab73b7d70b2


### PR DESCRIPTION
Updates bingo-team-icons with a new feature: team icons in the clan and guest clan member lists.

Tags names in the clan sidepanel member lists after CLAN_SIDEPANEL_DRAW rebuilds them, and re-runs the draw script on roster changes via the sidepanel var-transmit listener (same redraw approach as the core Chat Channel plugin). Gated by a "Clan member list icons" config toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)