### PR TITLE
Update Clan Bank

### DIFF
--- a/plugins/clan-bank
+++ b/plugins/clan-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/Parmvir/Clan-Bank.git
-commit=8ae3afc439fc1435ef64c41b1079b88b670da619
+commit=4c3636a7c68dc0e159ecd84ec5fb637e389d2802


### PR DESCRIPTION
Adds support for uncapped ("no limit") loan-budget ranks to the status display — previously the JSON field for an uncapped cap would have serialized incorrectly. No functional risk to existing capped ranks, purely additive.