### PR TITLE
Update bingo-team-icons

### DIFF
--- a/plugins/bingo-team-icons
+++ b/plugins/bingo-team-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/gwigl/bingo-team-icons.git
-commit=b4fa8dfbf40bf1c11aeb559b84b18ab73b7d70b2
+commit=3af1fbd764a6fea74fd79e637f3f634c62ab4913


### PR DESCRIPTION
Bugfix update for bingo-team-icons:

- Fixes duplicate icons accumulating in the clan/guest clan member lists: CLAN_SIDEPANEL_DRAW fires per panel while both lists were tagged, so the panel that was not rebuilt kept its previous tag and gained another. Tags are now stripped before re-tagging (idempotent).
- Debounces sidebar panel config writes (500ms) so chat retags and list redraws no longer run per keystroke while editing rosters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)