### PR TITLE
update ospulse

### DIFF
--- a/plugins/ospulse
+++ b/plugins/ospulse
@@ -1,4 +1,4 @@
 repository=https://github.com/jonathanavis96/ospulse.git
-commit=8858ccb9d56a4240a43e23da082344bcd13a9846
+commit=ee4bc68a51c99d7dc1c0de5c18d16b25cc9b9c08
 authors=jonathanavis96
 warning=The optional, off-by-default price-trend feature requests item price history from the OSRS Wiki price API (prices.runescape.wiki), sending only an item id. No account name or player data is sent.

--- a/plugins/ospulse
+++ b/plugins/ospulse
@@ -1,4 +1,4 @@
 repository=https://github.com/jonathanavis96/ospulse.git
-commit=ee4bc68a51c99d7dc1c0de5c18d16b25cc9b9c08
+commit=4bc48faba420e4ad903c1c95f809d6a286c6c23b
 authors=jonathanavis96
 warning=The optional, off-by-default price-trend feature requests item price history from the OSRS Wiki price API (prices.runescape.wiki), sending only an item id. No account name or player data is sent.


### PR DESCRIPTION
Updates OSPulse to 0.2.0.

- Monster combat requirements: the gear calculator now recommends and pins the weapons, ammunition, styles and special items a target needs (e.g. a mirror / V's shield for basilisks, Insulated boots for Rune dragons), and warns about gear a monster is immune to.
- Smarter gear optimiser: factors in combat style, weapon-compatible ammunition, player level, shield compatibility and an expensive-item risk cap, and can highlight the recommended pieces in your bank.
- Gear panel redesign; gear snapshots now also capture Slayer and Agility levels.
- Fixes: better matching for monsters with variant names, no duplicate economic updates within a game tick, improved two-handed and neutral-slot handling, and a read-only session preview path.
