### PR TITLE
Fix equipped item detection and add version number to quick-wiki

### DIFF
--- a/plugins/quick-wiki
+++ b/plugins/quick-wiki
@@ -1,2 +1,2 @@
 repository=https://github.com/jake219/quick-wiki.git
-commit=4f9cbf75939875c807d440805641d26b1649ec95
+commit=a13b4f92f29378b80932df3c10c3cfb0e61d538b

--- a/plugins/quick-wiki
+++ b/plugins/quick-wiki
@@ -1,2 +1,2 @@
 repository=https://github.com/jake219/quick-wiki.git
-commit=a13b4f92f29378b80932df3c10c3cfb0e61d538b
+commit=2ea6bc0822f73b3b6c35f051f660a97538e095c1

--- a/plugins/quick-wiki
+++ b/plugins/quick-wiki
@@ -1,0 +1,2 @@
+repository=https://github.com/jake219/quick-wiki.git
+commit=987c086fb47936c57f80777fe47b834eabcc0182

--- a/plugins/quick-wiki
+++ b/plugins/quick-wiki
@@ -1,2 +1,2 @@
 repository=https://github.com/jake219/quick-wiki.git
-commit=987c086fb47936c57f80777fe47b834eabcc0182
+commit=4f9cbf75939875c807d440805641d26b1649ec95


### PR DESCRIPTION
 Fixes a bug where examining an equipped chargeable item (e.g. a charged Pendant of ates) from the Equipment tab could show wiki data for the wrong variant. Also adds a version number to the plugin manifest.