### PR TITLE
Update bingo-team-icons

### DIFF
--- a/plugins/bingo-team-icons
+++ b/plugins/bingo-team-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/gwigl/bingo-team-icons.git
-commit=3af1fbd764a6fea74fd79e637f3f634c62ab4913
+commit=7dd775fd5552a1f751515f1325af741afba3c102


### PR DESCRIPTION
Updates bingo-team-icons: broadcast team icons now also match raid special loot announcements ("X received special loot from a raid: ..."), alongside drops and collection log items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)