### PR TITLE
osrscn: update to 0.1.5

### DIFF
--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=a94cecef89a2416e1ac0624778ba3bc971d8cd2d
+commit=1e299daa379de56348bc8fd14bf0b734c23d6c92
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update osrscn to 0.1.5.

- Translate the new-style skill guide: the word-per-widget prose is reassembled, translated and reflowed, keeping inline icons, clickable links (with their hitboxes) and the wiki banner intact
- Journal reconstruction enabled by default; dialogue <col> colour preservation; minor fixes (glyph prewarm, precompiled regexes, panel timer cleanup)