### PR TITLE
Add CSV Lifetime Drop Ledger

### DIFF
--- a/plugins/csv-lifetime-drop-ledger
+++ b/plugins/csv-lifetime-drop-ledger
@@ -1,0 +1,2 @@
+repository=https://github.com/Taizur/TaizursLootLogger.git
+commit=0870c8086d9a85c811bb1b9b7eacb0bc5289d0a7


### PR DESCRIPTION
Adds CSV Lifetime Drop Ledger, a RuneLite plugin that tracks lifetime NPC drops and saves item totals to a local CSV file.

The plugin:
- Tracks NPC loot received through RuneLite loot events
- Stores lifetime quantities by item ID
- Records item name, tradeable status, and GE price
- Loads and saves data locally under the RuneLite directory