### PR TITLE
Update hitsplat-customizer

### DIFF
--- a/plugins/hitsplat-customizer
+++ b/plugins/hitsplat-customizer
@@ -1,2 +1,2 @@
-repository=https://github.com/nanopink/HitsplatCustomizer.git
-commit=8e3483ffd85be56aee2677f3454027dfb4a0ce70
+repository=https://github.com/nanopink/CustomizeALot.git
+commit=ffb32cb1f28d347bf6f15cfff5612017dfd72bfe

--- a/plugins/hitsplat-customizer
+++ b/plugins/hitsplat-customizer
@@ -1,2 +1,2 @@
 repository=https://github.com/nanopink/CustomizeALot.git
-commit=ffb32cb1f28d347bf6f15cfff5612017dfd72bfe
+commit=8e3483ffd85be56aee2677f3454027dfb4a0ce70


### PR DESCRIPTION
Renames the hitsplat-customizer repository to CustomizeALot. The plugin commit update will be submitted separately after this PR merges.