### PR TITLE
better-monster-examine: update to v1.5

### DIFF
--- a/plugins/better-monster-examine
+++ b/plugins/better-monster-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/prettyrocket/better-monster-examine.git
-commit=dca9dc922e46b6ae08a178acacc6fdd88dfa3ff1
+commit=c53007ca51866baa318a490b478693bd06cadd79


### PR DESCRIPTION
Updates **Better Monster Examine** to [`c53007ca51866baa318a490b478693bd06cadd79`](https://github.com/prettyrocket/better-monster-examine/commit/c53007ca51866baa318a490b478693bd06cadd79).

Released as **Better Monster Examine v1.5 — Drops** — https://github.com/prettyrocket/better-monster-examine/releases/tag/v1.5

---

## 🎁 New: Drops

Every monster's full loot is now in the side panel, sourced straight from the OSRS Wiki's own drop tables.

- **A new `Stats | Drops` tab strip** — flip between a monster's combat stats and its drops without losing your place. Right-click any monster in game and pick **Stats** or **Drops** (configurable — show Stats, Drops, both, or neither).
- **The wiki's own drop-table sections, in page order** — 100% · Weapons and armour · Runes · Herbs · **Gem drop table** · **Rare drop table** · **Catacombs of Kourend** · **Wilderness Slayer Cave** · Tertiary, and the rest — grouped exactly as they appear on the wiki, region tables included.
- **Rarity at a glance** — each drop's odds are colour-coded by rarity tier (common → ultra-rare), including the wiki's compound multi-roll rates. Honours the colour-blind-friendly highlighting mode.
- **Prices on hover** — GE price and High Alch for every item (the larger of the two highlighted). Noted drops render the noted icon, and clicking a drop opens the item's wiki page.
- **No extra network for icons or prices** — item icons and values come straight from your own client.

Drops are read from each monster's rendered wiki page and cached weekly (offline-friendly), so the panel shows the same sections and odds a player sees on the wiki.

See the panel in action in the [README](https://github.com/prettyrocket/better-monster-examine#drops).

**Full changelog:** https://github.com/prettyrocket/better-monster-examine/compare/v1.4...v1.5