### PR TITLE
Update maggot-king

### DIFF
--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/maggot-king.git
-commit=89eaaf3a915652136aa82425f5fc0f864a9de0be
+commit=9b27073bddbf9cd1912b7cf4fc2097b621ee558f


### PR DESCRIPTION
Adds two entity hiding options, both mirroring what the core Entity Hider plugin already offers, scoped to the boss:

- Hide killed larvae (on by default): larvae become invisible the moment they die instead of lingering through the death animation. Uses the renderable draw listener, the same mechanism as Entity Hider's hide dead NPCs.
- Hide your player in arena (off by default): hides the local player's 3D model while inside the Maggot King arena only, for a clearer view of tiles during the larvae phase. 2D elements (hitsplats, overhead icons) stay visible.

Also refines the loot capture from the previous update: the snapshot now counts inventory plus worn equipment together, so a gear swap during the capture window nets to zero and is never miscounted as loot.