### PR TITLE
Add Bronzeman TCG

### DIFF
--- a/plugins/bronzeman-tcg
+++ b/plugins/bronzeman-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Felmeme/bronzeman-tcg.git
-commit=0c4853ae64c9c58d9b60e20d5c6dd3004d26fe39
+commit=802e7c90675e87702118a68e243840ae68baaead

--- a/plugins/bronzeman-tcg
+++ b/plugins/bronzeman-tcg
@@ -1,0 +1,2 @@
+repository=https://github.com/Felmeme/bronzeman-tcg.git
+commit=0c4853ae64c9c58d9b60e20d5c6dd3004d26fe39


### PR DESCRIPTION
Adds Bronzeman TCG — a card-collection challenge mode driven by the OSRS TCG plugin's gacha collection (read-only via ConfigManager, no compile-time dependency; both plugins install independently).

Attacking, looting, equipping, buying, gathering and processing are blocked until the matching card is pulled, with per-skill toggles and difficulty modes. Anything without a card in the TCG catalog is never restricted. Enforcement is menu-click consumption only.

Repo includes a full architecture walkthrough (docs/HOW_IT_WORKS.md) and the data-audit reports behind the bundled card catalogs. Vibe coded with Claude and manually reviewed before submitting.