### PR TITLE
update fashionscape to 2.0.1

### DIFF
--- a/plugins/fashionscape
+++ b/plugins/fashionscape
@@ -1,2 +1,2 @@
 repository=https://github.com/equirs/fashionscape-plugin.git
-commit=611f5394541cbd52e9008b8ce4fc9df843809cac
+commit=6964c952df5cbe0641695a8ef971fbec5e74d03d


### PR DESCRIPTION
* fix for players' transformed npc models screwing up while fashionscape is on
* prevent failed legacy equip ids migration from trying and failing with every client restart