### PR TITLE
anvil: update to v1.2.1

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=b11208080684160bf0312317ca2b96e48d898a51
+commit=020b96b9358c185cf3ab62e27ee41c3db57c8f4d
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=ad1b3f0fac83c4cbd74fc00d6a3f7d72f59f88d8
+commit=bae9f012b24c42976dd6421690e7a6f2b2da966c
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=020b96b9358c185cf3ab62e27ee41c3db57c8f4d
+commit=79ca27d13a88925436d2eef001af19739ecaafb9
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
 commit=770c2988f5e27da1bd8a3d3bd7ca997fdd3eb5a0
+warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=bae9f012b24c42976dd6421690e7a6f2b2da966c
+commit=dd23e6c297e309ef284d0a5ae650344e1b7aebad
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
 commit=770c2988f5e27da1bd8a3d3bd7ca997fdd3eb5a0
-warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=770c2988f5e27da1bd8a3d3bd7ca997fdd3eb5a0
+commit=8c9554d26276c2aeaac448baa85f3ef39df8c918
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=aff196bb01bd3c3dac1194f38443ed31b5117e5c
+commit=5c7a2e905a69467522b85ffd7158b93019ab9d91
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=8c9554d26276c2aeaac448baa85f3ef39df8c918
+commit=ad1b3f0fac83c4cbd74fc00d6a3f7d72f59f88d8
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=7276bc13c55f0a2f6fac92dba299bd36fbef3de7
+commit=770c2988f5e27da1bd8a3d3bd7ca997fdd3eb5a0
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=79ca27d13a88925436d2eef001af19739ecaafb9
+commit=7276bc13c55f0a2f6fac92dba299bd36fbef3de7
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,3 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=dd23e6c297e309ef284d0a5ae650344e1b7aebad
+commit=aff196bb01bd3c3dac1194f38443ed31b5117e5c
 warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates the `anvil` plugin to v1.2.1 (commit `020b96b`).

### Changes since v1.2.0
- **Clue-casket source matching**: normalise clue reward loot to `Clue Scroll (Tier)` so a drop tile restricted to a clue source matches regardless of RuneLite's casket/trail naming.
- **Setup warnings**: if a member has a Site URL but no Account Token (or vice versa), tell them in chat which piece is missing.
- **Unlinked-RSN warning**: if the logged-in RSN is a drafted player in a live bingo but this account isn't linked to it, warn 'verify this RSN on the site' — so tracking is never silently off.
- **Skill Realtime sync**: Added a way to sync skilling xp tiles in almost realtime (Hiscores remain the source of truth)
