### PR TITLE
goalplanner: move repository to the AKAddons org

### DIFF
--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,2 +1,3 @@
-repository=https://github.com/ajkatz/runelite-goal-planner.git
-commit=41ef6350fe13a0c417bafb3a05e3d758f74881a8
+repository=https://github.com/AKAddons/runelite-goal-planner.git
+commit=840b7124af3f65cf0ac9b89cfec2846a6d08b451
+authors=ajkatz

--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-goal-planner.git
-commit=840b7124af3f65cf0ac9b89cfec2846a6d08b451
+commit=41ef6350fe13a0c417bafb3a05e3d758f74881a8
 authors=ajkatz


### PR DESCRIPTION
Repository/authors change only — the repo moved to the AKAddons org (I'm a public member; the old ajkatz URL redirects). Pinned commit unchanged per review; the 0.4.2 version bump will come as a followup submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)