### PR TITLE
update blast-mine-tracker

### DIFF
--- a/plugins/blast-mine-tracker
+++ b/plugins/blast-mine-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/samkovaly/blast-mine-tracker.git
-commit=af3776455445db3bd68430d89548bdfb58425409
+commit=89c1e4344eaa1b7eb13456eab968210b87739aa1


### PR DESCRIPTION
Blast Mine tracker now pauses and resume when leaving and entering the Blast Zone during an active session.