### PR TITLE
Updates Visual Bloodwood to hide the overlay until Bloodwood activity is detected.

### DIFF
--- a/plugins/visual-bloodwood
+++ b/plugins/visual-bloodwood
@@ -1,2 +1,2 @@
 repository=https://github.com/CLColdest/visual-bloodwood.git
-commit=7e34882819573021cd26a546873fc106b0331d52
+commit=ba8c7f3d849643e4a90c657539f8edc408af679c


### PR DESCRIPTION
The overlay now stays hidden when passing through the area, stays visible while remaining at the trees, and hides again after leaving the area. Also updates the README with the plugin behavior.