### PR TITLE
Update bingo-team-icons

### DIFF
--- a/plugins/bingo-team-icons
+++ b/plugins/bingo-team-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/gwigl/bingo-team-icons.git
-commit=7dd775fd5552a1f751515f1325af741afba3c102
+commit=7528cec5944c05cd3677df595504ce007cdc6c40


### PR DESCRIPTION
Updates bingo-team-icons: broadcast team icons now also match pet announcements — "has a funny feeling like ... being followed", the "would have been followed" duplicate-pet variant, and the "feels something weird sneaking into ... backpack" inventory variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)