### PR TITLE
Update jumpscare to 1.1

### DIFF
--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=ed93145fa138533ce108bb1132b6c7347b6e0fc7
+commit=d8f489273ac04fbc61b2bc2225c36a97aca54b44
 authors=vividflash

--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=137a306be06ac2af0b6df27fd937bf0cff53eba3
+commit=ed93145fa138533ce108bb1132b6c7347b6e0fc7
 authors=vividflash


### PR DESCRIPTION
Hotfix: stretched-mode rendering and an epilepsy-warning flow for flash mode. Verified in-client.