### PR TITLE
Update dvd-bounce to 1.1.1

### DIFF
--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=1f8bb825f0c202e67c8f3227639fd29d9d1a88ae
+commit=d2d3012b280404555aa883a62e955414a7ae3f75

--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=3399b13409ae171453113a323827148081fdffa2
+commit=1f8bb825f0c202e67c8f3227639fd29d9d1a88ae

--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=d2d3012b280404555aa883a62e955414a7ae3f75
+commit=787b240b7bb6d8f8655c4841838bafd6b295e8af


### PR DESCRIPTION
Allows animated GIFs as the bounce image, plus a memory hotfix; 1.1.1 also removes the corner-hit screen flash. Verified in-client.