### PR TITLE
osrscn: 0.1.6

### DIFF
--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=1e299daa379de56348bc8fd14bf0b734c23d6c92
+commit=b74187947a40b11c6814b08e33b945b8eb4429b1
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates OSRSCN to 0.1.6.

- Keep the local AI translation cache clean at the source: only stable
  translations are persisted to disk. Player-authored CJK content, dynamic
  value labels, and number-templated messages that never recur are no longer
  written to the cache. Live on-screen translation and AI-off users are
  unaffected (the in-memory cache is unchanged).
- Add reviewed quest-journal and dialogue translations, and rename the internal
  ai_baked data table to "supplement".
