### PR TITLE
Update bingo-team-icons

### DIFF
--- a/plugins/bingo-team-icons
+++ b/plugins/bingo-team-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/gwigl/bingo-team-icons.git
-commit=7dd775fd5552a1f751515f1325af741afba3c102
+commit=7bfb43fb2c9d26289c24da80e0aa95f6663be7ba


### PR DESCRIPTION
Updates bingo-team-icons (supersedes #13649, closed):

- Broadcast team icons now also match pet announcements — "has a funny feeling like ... being followed", the "would have been followed" duplicate-pet variant, and the "feels something weird sneaking into ... backpack" inventory variant.
- Sidebar panel team headers now show roster counts with online status ("Team 1 — 3/7 online"), counting rostered players present in the clan, guest clan, or friends chat channel. Recounts are event-driven and debounced; client state is read on the client thread only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)