### PR TITLE
Update GE Uncut

### DIFF
--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,3 +1,3 @@
 repository=https://github.com/uzia35/ge-uncut.git
-commit=f317c66bf0153d651d685173c637f70c84677a98
+commit=14c3fa20dad80e6c3f63973630b254b5f64cdbb8
 warning=This plugin submits your IP address and various account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates GE Uncut to 1.2.0 (uzia35/ge-uncut@9593980a7d4267431c06e9a2ffde62026378a8c1).

Adds scan settings to the side panel (capital and account type, matching the website), shows the full ranked flip list instead of the top 10, slows the movers rotation, and makes account linking easier to find.
