### PR TITLE
Add OSRS FlipHub plugin

### DIFF
--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,2 +1,2 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=2a0380495ce2ac441a9db592dd1ea6d0290a7efb
+commit=4d938bbed6a0a0cde4c7c0bf2fe0e9d1fdded1ed

--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,2 +1,2 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=68a1bfc3d643d5979dd640105a448d5eec873893
+commit=2a0380495ce2ac441a9db592dd1ea6d0290a7efb

--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,0 +1,2 @@
+repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
+commit=68a1bfc3d643d5979dd640105a448d5eec873893

--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,2 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
 commit=f1222128e09149574b10a8453a1496553894c6ee
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,2 +1,2 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=b0ded985fc86d6b4ef6af6cf1b4829429da8b38c
+commit=3e73dec3a423b59cccbf8f64b7055d345ead82ea

--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,2 +1,2 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=3e73dec3a423b59cccbf8f64b7055d345ead82ea
+commit=f1222128e09149574b10a8453a1496553894c6ee

--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,2 +1,2 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=4d938bbed6a0a0cde4c7c0bf2fe0e9d1fdded1ed
+commit=b0ded985fc86d6b4ef6af6cf1b4829429da8b38c


### PR DESCRIPTION
Adds **OSRS FlipHub**, a Grand Exchange flip tracker.

### What it does
- Records GE offer history locally (buys/sells/completed/aborted)
- Per-flip and rolling profit/margins, GE buy-limit timers, live OSRS Wiki prices
- Item bookmarks and price context in a side panel

### Read-only / no automation
The plugin only observes `GrandExchangeOfferChanged` and related client events. It performs no automation and sends no input to the game. No RuneScape/Jagex credentials are requested, read, or transmitted.

### Network / data handling
- **Default (not linked): local-only.** All trade data stays on the user's machine. The only network calls are read-only price lookups to the public OSRS Wiki price API (`prices.runescape.wiki`).
- **Optional account link:** if the user pastes a FlipHub license key in the plugin settings, their GE offer events (item, quantity, price, offer state, timestamps) are uploaded over HTTPS to FlipHub's servers (`osrsfliphub.com`) to power an online dashboard. This is **opt-in** - nothing is uploaded until the user links - and is disclosed both in the plugin description and in a dedicated config section. Clearing the key or clicking **Unlink** stops uploads immediately.

Source: https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public
Licensed BSD 2-Clause.
