### PR TITLE
Update inventory-highlighter

### DIFF
--- a/plugins/inventory-highlighter
+++ b/plugins/inventory-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/Emtec-byte/InventoryHighlighter.git
-commit=3248a34b158d7a2cc01b140d359f5a767d1fb5c1
+commit=419b00ae7af1b70a2b16874c98cde570ad0b0915


### PR DESCRIPTION
Add whitelist/blacklist highlight mode (v1.1.0) - Player requested feature
- New "Highlight mode" dropdown (Whitelist/Blacklist) under the Item List
  box. The item list is shared by both modes: Whitelist highlights only
  listed items (default, unchanged); Blacklist highlights everything except
  listed items, and an empty list highlights everything. Stays hover-only;
  the match cache is mode-agnostic and the inversion is applied on top, so
  performance is unchanged.
- Rename the "Items to Highlight" label to "Item List" and update its
  description and help text for the shared dual-mode use.
- Fix stale highlighting when the item list is fully cleared: clearCache()
  used "" as its force-rebuild sentinel, which collided with the empty-list
  value and skipped the rebuild, leaving old patterns cached.