### PR TITLE
Add Barrows Tunnels Kill Tracker

### DIFF
--- a/plugins/barrows-tunnels-kill-tracker
+++ b/plugins/barrows-tunnels-kill-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/vahnx/barrows-tunnels-kill-tracker.git
+commit=1f7823b2db198bfe542e6c4ae85da2325386b71d


### PR DESCRIPTION
Tracks tunnel NPC kills during Barrows runs, supports configurable kill quotas and full tracking in the tunnels. Highlights eligible NPCs and the reward chest if the quota is met when in the chest room.