### PR TITLE
goalplanner: update to 0.4.2

### DIFF
--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-goal-planner.git
-commit=41ef6350fe13a0c417bafb3a05e3d758f74881a8
+commit=840b7124af3f65cf0ac9b89cfec2846a6d08b451
 authors=ajkatz


### PR DESCRIPTION
Followup to #13641 (repo move, merged) — commit bump only.

Goal Planner 0.4.2:
- The Blood Moon Rises quest goal activated (was staged dormant in 0.4.1; the enum is in the 1.12.32 release)
- Maggot King boss goals seed The Blood Moon Rises as a prerequisite
- Boss goal cards can link out to the Loadout Lab plugin ("Search in Loadout Lab" via PluginMessage, fire-and-forget; no entry shown when that plugin isn't installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)