### PR TITLE
Update HCIM Guide to 1.1.0

### DIFF
--- a/plugins/hcim-guide-plugin
+++ b/plugins/hcim-guide-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/nandobrazil/hcim-guide-plugin.git
-commit=9702708df3969fe3077cd79ba75634ec0eb0cfba
+commit=6bfdbd01f13a72b8d942db5ed6dd8a0e696e3155


### PR DESCRIPTION
Updates HCIM Guide to [6bfdbd0](https://github.com/nandobrazil/hcim-guide-plugin/commit/6bfdbd01f13a72b8d942db5ed6dd8a0e696e3155).

Changes:
- Fix client crash when interacting with the panel during or shortly after login: quest/skill/item evaluation now runs on the client thread instead of the Swing EDT, and panel refreshes are dispatched to the EDT (fixes nandobrazil/hcim-guide-plugin#1)
- Add an on-screen overlay showing the current step (movable with Alt, configurable opacity)
- Add optional Shortest Path integration: the current step's destination is sent via PluginMessage when available