### PR TITLE
Add Bink Block

### DIFF
--- a/plugins/bink-block
+++ b/plugins/bink-block
@@ -1,2 +1,2 @@
 repository=https://github.com/gwigl/bink-block.git
-commit=ca401044026399f3764bafd7392bdba5c80fbead
+commit=3ebbe6b2a179137dc2dab2bee062d0ae00cd4657

--- a/plugins/bink-block
+++ b/plugins/bink-block
@@ -1,0 +1,2 @@
+repository=https://github.com/gwigl/bink-block.git
+commit=ca401044026399f3764bafd7392bdba5c80fbead


### PR DESCRIPTION
Bink Block lets users replace or censor words in incoming chat messages and overhead text with custom replacements of their choice, configured as word/replacement pairs in the plugin panel. Matching is case-insensitive and whole-word by default (both toggleable), and words without a replacement are censored with asterisks. Formatting tags such as <col> and <img> are skipped so chat icons and colors are unaffected.

Repository: https://github.com/gwigl/bink-block

🤖 Generated with [Claude Code](https://claude.com/claude-code)