### PR TITLE
update loadout-lab

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-loadout-lab.git
-commit=10fae64240759bda79901af9834cce719eff9b96
+commit=55587ac2d68346d2b1306b687a884b91d8197825


### PR DESCRIPTION
Loadout Lab 0.2.0 - UIM storage support:

- Gear in the looting bag, POH costume room, STASH units (via the chart), and boat cargo holds now counts as owned
- A manual "stored elsewhere" list for storages nothing can track (cold storage, nest storage)
- Optional import of storages already tracked by Dude, Where's My Stuff (read of its saved data via public ConfigManager API - no reflection)
- Item location hints: source dots + a contextual legend for gear that needs fetching before a trip

`repository=` intentionally unchanged this PR (the old URL redirects to the AKAddons org); the repoint + authors line will follow as a separate manifest-only PR, per the review guidance on #13641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)