### PR TITLE
pvp profit tracker 1.3.1

### DIFF
--- a/plugins/pvp-profit-tracker
+++ b/plugins/pvp-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-profit-tracker.git
-commit=5867d0a2a98572ae00510f80f6ea24b31c5caec1
+commit=e03d19c2661ac63705a6ca339a5c7f30ea666f19


### PR DESCRIPTION
small update. added a jad kc icon next to the other bosses (sized the icons down so all four fit), evened out some side panel spacing, and the name lookup corrects for case now.