### PR TITLE
Add scroll-behavior plugin

### DIFF
--- a/plugins/scroll-behavior
+++ b/plugins/scroll-behavior
@@ -1,0 +1,2 @@
+repository=https://github.com/aismael234/runelite-scroll-behavior.git
+commit=dd9c503b9d49f473faeafdfc97c31d1d4f52824a


### PR DESCRIPTION
I created a plugin that allows users to:

- adjust their scrolling sensitivity 
- reverse scrolling direction
- (open to suggestions for more features)

This plugin addresses an ongoing issue plaguing MacOS users where they experience inconsistent scrolling sensitivity depending on whether they're using a trackpad or an external mouse.

In my specific case, simply scrolling 1 wheel tick with my external mouse on MacOS would completely zoom in/out the camera view, as well as scroll to the top/bottom of menus (bank, settings, etc.).

This plugin provides a flexible solution that allows each user to finely tune their mouse's scroll behavior based on their own unique setup.