### PR TITLE
better-monster-examine: update to v1.5.1

### DIFF
--- a/plugins/better-monster-examine
+++ b/plugins/better-monster-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/prettyrocket/better-monster-examine.git
-commit=c53007ca51866baa318a490b478693bd06cadd79
+commit=08572691e142ce5fadc0b6bb296a0618e723d0c6


### PR DESCRIPTION
Updates **Better Monster Examine** to [`08572691e142ce5fadc0b6bb296a0618e723d0c6`](https://github.com/prettyrocket/better-monster-examine/commit/08572691e142ce5fadc0b6bb296a0618e723d0c6).

Released as **Better Monster Examine v1.5.1 — Drops & config polish** — https://github.com/prettyrocket/better-monster-examine/releases/tag/v1.5.1

---

## 🛠️ Drops & config polish

Refinements on top of the v1.5 Drops release — a tidier drops panel, smarter price highlighting, and a better-organised config.

**Drops panel**
- **Rarity/odds under the item name** — each drop's odds now sit directly under the item name (left-aligned) instead of at the right edge, so the whole row reads top-to-bottom.
- **Smarter price highlighting** — a drop's GE or High Alch value is highlighted only when it clears the cost of casting High Alchemy (1 nature + 5 fire runes, priced live from the GE). Junk drops where both sit below that cost stay unhighlighted, while a low-alch/high-GE drop such as a herb seed still highlights its GE.
- **More complete drop tables** — per-level drop sections are now recognised, not only a page's main `Drops` section.

**Right-click menu**
- **Shift to reveal** — a new option to add the Stats/Drops right-click entries only while **Shift** is held, to keep the normal menu uncluttered.

**Config**
- **Grouped into sections** — options are now organised into collapsible *Right-click menu* / *Side panel* / *Accessibility* sections, with the stats render target moved next to the menu it controls.
- **Clearer labels** — e.g. **Show stats in** (was "Stats render target"), **Overlay** (was "In-game overlay"), **Colour palette** under *Accessibility* (was "Stat highlighting"). Saved settings carry over.

**Full changelog:** https://github.com/prettyrocket/better-monster-examine/compare/v1.5...v1.5.1