### PR TITLE
fbclan-plugin: bump to 8771a44

### DIFF
--- a/plugins/fbclan-plugin
+++ b/plugins/fbclan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/orgonag/fbclan-plugin.git
-commit=7601841030fd34cdff0d8cedc9fccb8a89098bbd
+commit=8771a44d1da5b3376bd6b54b71eb92511256d81e
 warning=This plugin submits your IP address, RSN, drop data, and Party to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates the Final Boss clan plugin to orgonag/fbclan-plugin@8771a44.

- CA slayer helm chat icons (Tztok/Vampyric/Tzkal) next to clan members' names in chat for Elite/Master/Grandmaster combat achievement tiers
- Abbreviated raid names on the PB leaderboards (TOB/HMT/COX/CM/TOA)
- Drop log panel now fits the sidebar width, with tighter rows
- Removed the Kill Counts dashboard section
- New plugin icon
- Default LFG timeout raised to 240 minutes