### PR TITLE
Update drop-rates-clog

### DIFF
--- a/plugins/drop-rates-clog
+++ b/plugins/drop-rates-clog
@@ -1,2 +1,2 @@
 repository=https://github.com/pairofcrocs/drop-rates-clog.git
-commit=9a8cdaa851de0545c1bc32d497d46e10cc4e8a6c
+commit=eb1d63c072fe037500c1e7e78440b8ae949957d2


### PR DESCRIPTION
Adds on-Slayer-task drop rate annotations (task-boosted rates shown inline, superior-monster sources tagged), plus data fixes.