### PR TITLE
add friend-groups

### DIFF
--- a/plugins/friend-groups
+++ b/plugins/friend-groups
@@ -1,0 +1,2 @@
+repository=https://github.com/H-Mill/Runelite-Plugins.git
+commit=5adf3cdfb179ab1ab43f7410b580880d0291a57b

--- a/plugins/friend-groups
+++ b/plugins/friend-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/H-Mill/Runelite-Plugins.git
-commit=5adf3cdfb179ab1ab43f7410b580880d0291a57b
+commit=43f3c434f63671ff58359f1e6267d0f44a275671

--- a/plugins/friend-groups
+++ b/plugins/friend-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/H-Mill/Runelite-Plugins.git
-commit=43f3c434f63671ff58359f1e6267d0f44a275671
+commit=2eca8d91b196de5242f1340170a9bde9ea4e3c5f


### PR DESCRIPTION
Add Friend Groups
- Add friends to groups to easily organize/find them
- Display friend groups in-game and in runelite side panel
- Hop to friends from runelites side panel