### PR TITLE
Add Spell Timers Plugin

### DIFF
--- a/plugins/spell-timers
+++ b/plugins/spell-timers
@@ -1,0 +1,2 @@
+repository=https://github.com/DapperMickie/SpellTimers.git
+commit=c5afcecba3d60ce70620f0dfdebaeae72c43bf58

--- a/plugins/spell-timers
+++ b/plugins/spell-timers
@@ -1,2 +1,2 @@
 repository=https://github.com/DapperMickie/SpellTimers.git
-commit=c5afcecba3d60ce70620f0dfdebaeae72c43bf58
+commit=c22d4fc9796794e8d80d74339bc4facea975c270


### PR DESCRIPTION
# Spell Timers

RuneLite plugin that shows XP-drop-based timers for skilling spells with delayed or batched results.

<img width="626" height="250" alt="image" src="https://github.com/user-attachments/assets/0ee7dd42-cfab-4331-8e49-4d80529fd39a" />

<img width="600" height="234" alt="image" src="https://github.com/user-attachments/assets/2802d262-b79f-44eb-8aae-e67ae6fa3869" />

Spell Timers supports Humidify, Superglass Make, Degrime, Spin Flax, Tan Leather, Plank Make, String Jewellery, and Bake Pie. The overlay uses spell icons, progress colors, and configurable ticks-or-seconds remaining display.

Notifications use RuneLite's built-in notification settings and fire when a spell timer is ready or done.
