### PR TITLE
Add Barrows Sarcophagus Memory

### DIFF
--- a/plugins/barrows-sarcophagus-memory
+++ b/plugins/barrows-sarcophagus-memory
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/barrows-sarcophagus-memory.git
-commit=976c956bad314ee33739cdb585f9d325b57d5e34
+commit=bed1d2898e62cf49b7ec6d2e842c9149b713a5f4

--- a/plugins/barrows-sarcophagus-memory
+++ b/plugins/barrows-sarcophagus-memory
@@ -1,0 +1,2 @@
+repository=https://github.com/vahnx/barrows-sarcophagus-memory.git
+commit=976c956bad314ee33739cdb585f9d325b57d5e34


### PR DESCRIPTION
Labels Barrows sarcophagi and remembers which one leads to the tunnels if you leave pre-maturely.