### PR TITLE
update pb-tracker-sync

### DIFF
--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/0xJeu/pb-tracker-sync.git
-commit=fc3ee21d0c38180fbc574d2f195a4060eab69ef0
+commit=adfd5754a8029aeb4d5dfb77846b9f9d88cd7fab
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/0xJeu/pb-tracker-sync.git
-commit=84526098c36737921040437f3e36c6cfe7c7c720
+commit=fc3ee21d0c38180fbc574d2f195a4060eab69ef0
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates PB Tracker Sync to `adfd5754a8029aeb4d5dfb77846b9f9d88cd7fab`.

This release adds:

- A RuneLite side panel for browsing personal bests, searching players, viewing boss leaderboards, and opening highlighted leaderboard entries.
- A `!pbr <boss> [mode] [team size]` chat command for viewing the player's synced PB and leaderboard rank.
- Protection against syncing another player's Adventure Log records when viewing their log inside their POH.
- Sidebar reliability fixes for row navigation, delayed player availability, stale asynchronous responses, deep-rank highlighting, and boss filtering.

I verified the ownership protection live: while logged in as `0xSteph`, the plugin detected that the opened Adventure Log belonged to `Blitzen`, skipped the sync, and no PB rows were written for `0xSteph`.

I also manually verified the side panel in RuneLite, including layout, player search, boss search, row navigation, highlighted player results, rapid requests, and disabling/re-enabling the plugin.

Validation:

- JDK 17 full unit test suite: passed
- JDK 17 clean build: passed
- Plugin Hub manifest is the only file changed
