### PR TITLE
Update deathdotter plugin

### DIFF
--- a/plugins/deathdotter
+++ b/plugins/deathdotter
@@ -1,2 +1,3 @@
 repository=https://github.com/dmgear/deathdotterplugin.git
-commit=4dec1ef6c00e974f205450cc0855a5adf2bd3cf3
+commit=369d417ec2e1ca1ed459fc681e75e524e27fbdb2
+authors=dmgear,DapperMickie


### PR DESCRIPTION
Adds a "hide 2d" config option (on by default to keep default behavior of the plugin the same).
No more (potential) issues with worldviews.
