### PR TITLE
update bank-templates to v1.6.2

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=346e7b2a2b2f5ea29ce983a962648d4f5a850725
+commit=c96cdb76bac56f995217bc1b9acbc7c9b0d6e558

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=9496645bd96fbd631f3ddb46d2d195993a547eee
+commit=9aceb9792f2c2c578e6c4b7e48afa5598c6ab19b

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=9aceb9792f2c2c578e6c4b7e48afa5598c6ab19b
+commit=346e7b2a2b2f5ea29ce983a962648d4f5a850725

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=bae8a429f0db1c8e8e69a591fe6960eacc9e7db7
+commit=9496645bd96fbd631f3ddb46d2d195993a547eee


### PR DESCRIPTION
Updates the Bank Templates plugin to v1.6.2.

- My templates now syncs both ways with your Exchange Insights website templates (import/create/edit/delete on either side appears on both). Requires a free Exchange Insights account linked via the Exchange Insights plugin.

- Fixed website-synced templates that could show up without a name, or linger as stale duplicates after being renamed/deleted on the website.