### PR TITLE
clan-management: attribution and validation fixes

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=9b7f382ec1cd627a1fae9a8ea02a37ea92aef727
+commit=eff72ba3dd91e6e5279efd603e4200fb7d47731f
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=eb6792dc5dc77b0da2eb2d3ab9e4ef46a8eaa7b8
+commit=dc5bf27f534a2e73e3775b0a51ee4e0170fe211b
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=dc5bf27f534a2e73e3775b0a51ee4e0170fe211b
+commit=9b7f382ec1cd627a1fae9a8ea02a37ea92aef727
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates clan-management to `dc5bf27f534a2e73e3775b0a51ee4e0170fe211b`.

- Pet drops attribute to their boss (collection-log category fix) with correct kill counts
- Ornament-kit and upgraded item variants count for rank requirement checks
- Rejects third-party phase-timer output that produced impossible completion times
- Fight duration lines no longer misattribute to a previously-killed boss
- High-value repeat drops post even when not on the clan whitelist
