### PR TITLE
Update ge-companion to v1.1.1

### DIFF
--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=ab775d62206db21bd80f0f5acaeba2849fd85616
+commit=788d5784e4fe7b7ffa5dcb4042e03f366475462e

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=c7db4dab74b5cd362fed946c836414f459524822
+commit=a7d25e438030f4f60d37cecba4c421be81658d6d

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=3e54e1bf34c28509f26a97bcb24261cb0caa084e
+commit=c7db4dab74b5cd362fed946c836414f459524822

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=a7d25e438030f4f60d37cecba4c421be81658d6d
+commit=0885d457853e3783d0f43d52616ea8b0377e770c

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=788d5784e4fe7b7ffa5dcb4042e03f366475462e
+commit=3e54e1bf34c28509f26a97bcb24261cb0caa084e


### PR DESCRIPTION
v1.1.1 — Adds variant item indicator (* gold badge) on Bank tab item icons. Hovering a variant item icon shows the original bank item name and its tradeable base. Top Gainers/Losers header tooltip explains the * indicator.