### PR TITLE
chat-fade: update to 1.1

### DIFF
--- a/plugins/chat-fade
+++ b/plugins/chat-fade
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/chat-fade.git
-commit=a40463ad426297d46aead06d819740708ef29aaf
+commit=5b27857928b02f740e169d3004d2d4c9e9963867


### PR DESCRIPTION
Updates the chat-fade manifest to the latest commit (5b27857).

Changes since the last release:
- Group login/logout notifications with private chat so they follow the "Private Messages" toggle, fixing duplicate login/logout text for users on Jagex split private chat.
- Show the ">" caret as soon as Key Remapping's "Press Enter to Chat" mode is active (before typing begins), so it's clear the client is in chat-input mode.

Both fixes were contributed by @jarromie and address the reported issue. Plugin version bumped 1.0 -> 1.1.