### PR TITLE
update squeaky-toy

### DIFF
--- a/plugins/squeaky-toy
+++ b/plugins/squeaky-toy
@@ -1,2 +1,2 @@
 repository=https://github.com/H-Mill/Squeaky-Toy.git
-commit=84d71b08c69ee60467b1c5aff9e285c44881542c
+commit=1d13b0fe720851d6d2850becb6a8455ab16f53bf


### PR DESCRIPTION
- Add Regular attack amount and Special attack amount triggers — play a sound only when a hit deals more than, less than, or exactly the damage you choose. Enable the trigger, pick >, <, or =, and type a number (e.g. = 73 for an exact hit, or > 50 for any big hit).
- Add correct handling for multi-hit weapons whose hits can land a little apart — dragon claws, burning claws, dark bow, and twinflame staff. Their attacks now play one sound for the whole attack instead of several.