### PR TITLE
update route-planner to v1.4

### DIFF
--- a/plugins/route-planner
+++ b/plugins/route-planner
@@ -1,2 +1,2 @@
 repository=https://github.com/BlackDeath-Osrs/route-planner.git
-commit=aa3a488540341b392577d0417a046e0e0e86f9e3
+commit=35d220c4f7d5c5810713b7a275685d6c41e0824e

--- a/plugins/route-planner
+++ b/plugins/route-planner
@@ -1,2 +1,2 @@
 repository=https://github.com/BlackDeath-Osrs/route-planner.git
-commit=01507de7099d0305bbe018f079ed2561151c022c
+commit=aa3a488540341b392577d0417a046e0e0e86f9e3

--- a/plugins/route-planner
+++ b/plugins/route-planner
@@ -1,2 +1,2 @@
 repository=https://github.com/BlackDeath-Osrs/route-planner.git
-commit=35d220c4f7d5c5810713b7a275685d6c41e0824e
+commit=341aaf70c774739d20064a52acc2e99d02d542f2


### PR DESCRIPTION
Adds an in-plugin Route Hub for browsing and installing community-shared routes. Routes are fetched read-only from a curated, PR-gated GitHub repo — the plugin never uploads anything; sharing is a manual pull request. All route text is scanned for links on both creation and import, independent of prior review. Network use and data handling are disclosed in the README and in the plugin's own config.