### PR TITLE
Add Overhead Names plugin

### DIFF
--- a/plugins/overhead-names
+++ b/plugins/overhead-names
@@ -1,0 +1,2 @@
+repository=https://github.com/OrMalky/runlite-overhead-names.git
+commit=eff9d802ccd1546f3296dafdf72e54c7885c05c7

--- a/plugins/overhead-names
+++ b/plugins/overhead-names
@@ -1,2 +1,2 @@
 repository=https://github.com/OrMalky/runlite-overhead-names.git
-commit=eff9d802ccd1546f3296dafdf72e54c7885c05c7
+commit=3d3c7cca0ce6e5f477bfa41b81cb7b46cd602bd5

--- a/plugins/overhead-names
+++ b/plugins/overhead-names
@@ -1,2 +1,2 @@
 repository=https://github.com/OrMalky/runlite-overhead-names.git
-commit=3d3c7cca0ce6e5f477bfa41b81cb7b46cd602bd5
+commit=c3a16cc419cd7dd3a0ffcc2ddb0df8a0efaa4bb8


### PR DESCRIPTION
This PR adds the **Overhead Names** plugin.

**What it does:** Displays overhead names above players' and NPCs' heads, with configurable text effects and stacking modes.

**Repository:** https://github.com/OrMalky/runlite-overhead-names
**Author:** Or Malky

- [x] I have tested the plugin
- [x] The repository is public
- [x] The commit hash points to the latest reviewed commit