### PR TITLE
Update Barrows Tunnels Kill Tracker to 1.1.0

### DIFF
--- a/plugins/barrows-tunnels-kill-tracker
+++ b/plugins/barrows-tunnels-kill-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/barrows-tunnels-kill-tracker.git
-commit=1f7823b2db198bfe542e6c4ae85da2325386b71d
+commit=de309d82c6e782bf34e72cbc1397ef1257b247a8


### PR DESCRIPTION
Updates Barrows Tunnels Kill Tracker to commit de309d82c6e782bf34e72cbc1397ef1257b247a8.
Changes include persistent tunnel kill-count memory across logout, disconnect, and client restart, with reset tied to the local Barrows reward interface.