### PR TITLE
boss-helper-bank-sync: update to 2a4bfa5

### DIFF
--- a/plugins/boss-helper-bank-sync
+++ b/plugins/boss-helper-bank-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/ENiceApps/boss-helper-bank-sync.git
-commit=1167044c6abfa83ab9c55169fa3f53e4016ccbd9
+commit=2a4bfa5c7c8e988b366600f021f5dd9e0b5a6b4e


### PR DESCRIPTION
Updates Boss Helper Bank Sync to [`2a4bfa5`](https://github.com/ENiceApps/boss-helper-bank-sync/commit/2a4bfa5c7c8e988b366600f021f5dd9e0b5a6b4e). Batched changes since the currently pinned `1167044`:

- **Trailing-edge write throttle** — the 2s throttle was leading-edge only, so the last container change in a burst (e.g. the end of a deposit-all) was silently dropped and `bank.json` stayed stale until the next change or relog. Changes landing inside the window now schedule one trailing write at the window's end (RuneLite's shared `ScheduledExecutorService`; the pending task is cancelled in `shutDown`).
- **Skip qty-0 items** — bank placeholders are reported with quantity 0 and aren't owned; they're now filtered out of the payload.
- **Quieter chat confirmations** — the full 3-line setup message previously replayed on every plugin enable/toggle. It now appears only when the write actually creates `bank.json` for the first time; otherwise a single short "Bank file updated" line, once per enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
