### PR TITLE
Create fishing-counter-ultimate

### DIFF
--- a/plugins/fishing-counter-ultimate
+++ b/plugins/fishing-counter-ultimate
@@ -1,2 +1,2 @@
 repository=https://github.com/sleepywaffle96-maker/runelite-fishing-counter.git
-commit=70d419b6ca040a40a9313aef284b25dc827e27d4
+commit=d7fb0ba30162dc5d385ae0e2526723b77d59cd80

--- a/plugins/fishing-counter-ultimate
+++ b/plugins/fishing-counter-ultimate
@@ -1,0 +1,2 @@
+repository=https://github.com/sleepywaffle96-maker/runelite-fishing-counter.git
+commit=5f1d70f454acad4f4fab627633c53928c8872974

--- a/plugins/fishing-counter-ultimate
+++ b/plugins/fishing-counter-ultimate
@@ -1,2 +1,2 @@
 repository=https://github.com/sleepywaffle96-maker/runelite-fishing-counter.git
-commit=a38bf87e7ca531066fe25fd2e64afb0e0c52ae0d
+commit=f4b86e3531991d3b35de8a91695d54789fb00916

--- a/plugins/fishing-counter-ultimate
+++ b/plugins/fishing-counter-ultimate
@@ -1,2 +1,2 @@
 repository=https://github.com/sleepywaffle96-maker/runelite-fishing-counter.git
-commit=5f1d70f454acad4f4fab627633c53928c8872974
+commit=70d419b6ca040a40a9313aef284b25dc827e27d4

--- a/plugins/fishing-counter-ultimate
+++ b/plugins/fishing-counter-ultimate
@@ -1,2 +1,2 @@
 repository=https://github.com/sleepywaffle96-maker/runelite-fishing-counter.git
-commit=d7fb0ba30162dc5d385ae0e2526723b77d59cd80
+commit=a38bf87e7ca531066fe25fd2e64afb0e0c52ae0d


### PR DESCRIPTION
Adds a persistent fishing counter to track caught fish across standard and seasonal game modes (Main, Leagues, and Deadman) with multi-mode isolation.

Features:
- Individual checkbox visibility toggles for major fish types.
- Manual starting KC inputs (Start KC) for custom counters.
- Individual fish reset options dynamically updated for the active world type.
- Statistical cumulative binomial luck percentage tracker for Big Fish drops.
