### PR TITLE
Create guide-overlay

### DIFF
--- a/plugins/guide-overlay
+++ b/plugins/guide-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/RunelitePlugin/guide-overlay.git
+commit=bf8ca804dbd4f80916f5f7bc5648248655b6f48b

--- a/plugins/guide-overlay
+++ b/plugins/guide-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/RunelitePlugin/guide-overlay.git
-commit=bf8ca804dbd4f80916f5f7bc5648248655b6f48b
+commit=e1decc8acf00be2204c305bb36cd638f966b195d


### PR DESCRIPTION
Adds Guide Overlay: wiki guides (B0aty HCIM Guide V3 built in, any OSRS-wiki guide addable by link) as an in-client checklist with verifiable-step auto-completion, NPC/ground-item highlighting, a far-target compass, and per-character progress.
Network disclosure: two HTTPS endpoints, both strictly one-time and behind explicit user confirmation dialogs — the OSRS wiki API (guide text import) and a commit-pinned mejrs/data_osrs file (optional NPC location dataset, the data behind the wiki's world map). Zero automatic network traffic; everything is cached locally. No automation of any kind — display and tracking only.