### PR TITLE
loadout-lab: bump to 0.2.1

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-loadout-lab.git
-commit=fb9c1deb85b0d8db90dec820ccfa9d5617e9a0e6
+commit=117b576badac4d6686ca3301665e24d0d22572c1

--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-loadout-lab.git
-commit=117b576badac4d6686ca3301665e24d0d22572c1
+commit=f715df2bbd6d54008f92f2f798bdea559f6ad304

--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-loadout-lab.git
-commit=55587ac2d68346d2b1306b687a884b91d8197825
+commit=fb9c1deb85b0d8db90dec820ccfa9d5617e9a0e6


### PR DESCRIPTION
Version bump for Loadout Lab (commit-only; repository line unchanged).

Highlights since the last release:
- Optimizer performance: ~2.5x faster recompute; results cached per style so a pin/toggle no longer recomputes every style; background-priority worker so a search doesn't compete with the client thread.
- New settings: a Display/Controls section in the config panel to show or hide each set-card detail line and input control; a "Connections" toggle for the Dude, Where's My Stuff integration.
- Wilderness: a per-item "only bring if protected on death" flag.
- Exclusions gain per-monster and per-monster+style scopes.
- Correctness: on-task DPS can never fall below off-task; DPS ties no longer surface a lower-strength or pure-tank piece over the damage piece; counted-bonus lines show exact percentages.
- Data: released Yama gear (oathplate, Confliction gauntlets) now suggestible.

preSubmit (test + checkDocs + checkTokens + checkGlyphs) passes; source is ~61% of the token cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)