### PR TITLE
update pb-tracker-sync

### DIFF
--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/0xJeu/pb-tracker-sync.git
-commit=adfd5754a8029aeb4d5dfb77846b9f9d88cd7fab
+commit=012c1400d5fb47016505ae0ce8528de93f1d742b
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates PB Tracker Sync to `012c1400d5fb47016505ae0ce8528de93f1d742b`.

This follow-up release improves the RuneLite side panel with:

- Boss icons loaded from RuneLite's own sprite cache.
- A redesigned My PBs view with Top Bosses and collapsible All Bosses sections.
- Unrecorded bosses displayed with a dash.
- Collapsible raid variants and a scalable mode/team-size picker.
- Boss-search abbreviations such as `tob`, `cox`, `toa`, and `sol`.
- Automatic scrolling to the highlighted player when opening a leaderboard from a PB row.
- A direct View My Profile on Website action.

It also includes the final review fixes for Swing EDT-safe icon callbacks, awakened/TzHaar challenge icon aliases, late boss-list rendering, and best-rank selection under Top Bosses while preserving the fastest-time summary under All Bosses.

I verified the complete flow live in RuneLite, including layout, icon rendering, Top Bosses ranking, All Bosses summaries, late boss loading, player and boss search, abbreviations, raid modes and team sizes, rapid navigation, highlighted leaderboard rows, and disabling/re-enabling the plugin. The live PB Tracker logs showed the expected click and request sequences with no plugin warnings or exceptions.

Validation:

- JDK 17 unit tests: 71/71 passed
- JDK 17 clean build: passed
- Plugin Hub manifest is the only file changed
