### PR TITLE
Add Merchant Flipper plugin

### DIFF
--- a/plugins/merchant-flipper
+++ b/plugins/merchant-flipper
@@ -1,3 +1,3 @@
 repository=https://github.com/KevinNLPG/merchant-flipper-runelite-plugin.git
-commit=5e51a0d638947ef94e671d87b70eb87a5a2a7644
+commit=e8746344f847eca2f2f0cc7ee41669dd56575716
 authors=KevinNLPG

--- a/plugins/merchant-flipper
+++ b/plugins/merchant-flipper
@@ -1,0 +1,3 @@
+repository=https://github.com/KevinNLPG/merchant-flipper-runelite-plugin.git
+commit=5e51a0d638947ef94e671d87b70eb87a5a2a7644
+authors=KevinNLPG

--- a/plugins/merchant-flipper
+++ b/plugins/merchant-flipper
@@ -1,3 +1,3 @@
 repository=https://github.com/KevinNLPG/merchant-flipper-runelite-plugin.git
-commit=e8746344f847eca2f2f0cc7ee41669dd56575716
+commit=6ae4716844620912338b8f70c253e23314220ae0
 authors=KevinNLPG


### PR DESCRIPTION
Merchant Flipper is a read-only sensor plugin that watches your own Grand Exchange
offers and reports changes to a local companion desktop app over a 127.0.0.1-only
WebSocket. It never clicks, types, or automates anything in-game — it only reads
GrandExchangeOfferChanged events through the standard RuneLite API.

- No third-party server: the plugin only ever talks to 127.0.0.1 (your own machine).
- No reflection, no native code, one small dependency (Java-WebSocket).
- Full data-handling writeup: https://github.com/KevinNLPG/merchant-flipper-runelite-plugin/blob/main/PRIVACY.md