### PR TITLE
Update bank templates 1.6.3

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=c96cdb76bac56f995217bc1b9acbc7c9b0d6e558
+commit=648141746b8d5c7daaeb0fc8dbc9070e24685ac9

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=b630d905e6d83b7186772de1a13f591ce8ce3286
+commit=1de47bf5527d07d82f9b549b821b51d9ca8c1031

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=648141746b8d5c7daaeb0fc8dbc9070e24685ac9
+commit=b630d905e6d83b7186772de1a13f591ce8ce3286

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=1de47bf5527d07d82f9b549b821b51d9ca8c1031
+commit=d6371caaf37469e2900b4695f3d7e393a96cb99a


### PR DESCRIPTION
Updates Bank Templates to v1.6.3.

- Opt-in bank snapshot sync for characters linked to an Exchange Insights account (item IDs and quantities only; nothing is sent for unlinked characters; new "Sync bank value" setting to turn it off).

- The side panel shows the bank's live GE value for linked characters once a snapshot has synced.

- README privacy section updated to document the new sync and its retention.