### PR TITLE
Update maggot-king

### DIFF
--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/maggot-king.git
-commit=789b337e1881f8116b70e7ce27dba0e003438fb8
+commit=55e4d7f8e51be5f14c9c9fac1254eb03c1cf6c7c

--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/maggot-king.git
-commit=9b27073bddbf9cd1912b7cf4fc2097b621ee558f
+commit=789b337e1881f8116b70e7ce27dba0e003438fb8


### PR DESCRIPTION
Fixes the boss rendering invisible after a respawn ([maggot-king#4](https://github.com/randytkrx/maggot-king/issues/4)): the object draw callback also receives actor-backed scene entries whose id is a scene index rather than an object id, so an npc index colliding with a hidden scenery id could hide the boss. Only entries with hash type 2 (real game objects) are filtered now. Thanks to JZomDev for the report and bopsec for the fix.

Also defaults the corpse preference to Open stomach.