### PR TITLE
Add Progression Path Companion

### DIFF
--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=eaf4048b7fb74e66011545345c60cc2978640210
+commit=b7b8ae177032e49d99acddbdab66362466820316

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,0 +1,2 @@
+repository=https://github.com/jakebutler83/hcim-progression-companion.git
+commit=c9f63ff1df457e390943037b32912c22db2ac7ec

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=c9f63ff1df457e390943037b32912c22db2ac7ec
+commit=b256f83fc580b2ad7d63a7eb04e712353005089a

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=b7b8ae177032e49d99acddbdab66362466820316
+commit=eabac3524c413df15571b7b10dcaa37f94f4efca

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=b256f83fc580b2ad7d63a7eb04e712353005089a
+commit=eaf4048b7fb74e66011545345c60cc2978640210

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=cdc76816c3f2bb499fe55061ce69709ba5f70e8a
+commit=c485c2d1b8dabdedd90d02b5e3b4070fe028c250

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=86b0e361722b2bd3edb7a0e686315f4cc9b6ceba
+commit=cdc76816c3f2bb499fe55061ce69709ba5f70e8a

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=c485c2d1b8dabdedd90d02b5e3b4070fe028c250
+commit=53631272b016ee59b84d5ecd3e6f4ac84dea329b

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=9748f114c2bf2773bdc894dbc1d1af8c40c34ff1
+commit=86b0e361722b2bd3edb7a0e686315f4cc9b6ceba

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,3 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
 commit=53631272b016ee59b84d5ecd3e6f4ac84dea329b
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=c6d87a22b479ba2854f2ff49030b5317cbe40074
+commit=caab0e364b3cf5a013e75a738770e4dff5bff1e2

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=3601495031c6ce2e02b8fd415371c4f61a0b2110
+commit=3801c2e4809c02f89350fa897eca078f348fff01

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=8e97ba662e72df0a8a0acdef7416ee7c660ee74f
+commit=97a6dd4696c004a397db25f0d8697c408b12046b

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=caab0e364b3cf5a013e75a738770e4dff5bff1e2
+commit=234f7d2be556c91abd66e183c69a119cebbb9a35

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=dddfaf804a7f1546b5e6c64df97490c286f9820a
+commit=9b06b24d185f73096bba8132d6bc389ff0b4c114

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=ca94e3630947ad466a2966d3372e3697eeac5da2
+commit=dfdd8426eeff099b060b9e65d5524f0f12eb66f9

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=40722bbd248a67362c76d49ee89d6034cef74b14
+commit=9975bc22a79b2b7dc83b3b04017dce0a10bb2400

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=854bc406640692b02b70dab42ece2cc6c1288fe0
+commit=ffab6d79bb16efddcd27c45604cf163dc2d39a46

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=87ea208d5637dbd38a6c77f71d0c4eeddebef263
+commit=05a6206cfc6b908eef6f9ef47743ebffc118462f

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=2193912c0d5b14f2aa5d7a58c7964cd8631980b4
+commit=8e97ba662e72df0a8a0acdef7416ee7c660ee74f

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=69466748e010630369306fe2f6557e6d3212ebff
+commit=e77af5de20874889a5e480738645930a7f3278b5

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=e77af5de20874889a5e480738645930a7f3278b5
+commit=87ea208d5637dbd38a6c77f71d0c4eeddebef263

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=6d3d6312276abb99ae7d0c8d2765dcadbb7e38c2
+commit=ca94e3630947ad466a2966d3372e3697eeac5da2

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=134b6e3753bdd5d3208e0d3516bcd634b75e849d
+commit=9074ec73351afe7323846010a9c412670ef3dd16

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=9074ec73351afe7323846010a9c412670ef3dd16
+commit=6d3d6312276abb99ae7d0c8d2765dcadbb7e38c2

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=7d2b66b559701bbf1c614d5e1bca6511f0aee1a5
+commit=00380031f20ce0fb1add9b711ef4b18edca87d2f

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=8ae65ce848724ef105b7d382aab9685d7a64b081
+commit=22bc724692c021f715d59d2157144dfff7fecee4

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=c863ac9cb115fd86cfe79be2ddfe58391d61eb6c
+commit=dddfaf804a7f1546b5e6c64df97490c286f9820a

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=00380031f20ce0fb1add9b711ef4b18edca87d2f
+commit=9748f114c2bf2773bdc894dbc1d1af8c40c34ff1

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=9b06b24d185f73096bba8132d6bc389ff0b4c114
+commit=3601495031c6ce2e02b8fd415371c4f61a0b2110

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=22bc724692c021f715d59d2157144dfff7fecee4
+commit=c863ac9cb115fd86cfe79be2ddfe58391d61eb6c

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=3801c2e4809c02f89350fa897eca078f348fff01
+commit=5ee4679035a30885765a97b4255c7fb2bc9ca314

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=5d34a3beec875e60cafbba00f5efce60313a6c0a
+commit=7d2b66b559701bbf1c614d5e1bca6511f0aee1a5

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=eabac3524c413df15571b7b10dcaa37f94f4efca
+commit=6e2963702d43dde2e4af7a3fe2a6e58b10e87cb2

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=dfdd8426eeff099b060b9e65d5524f0f12eb66f9
+commit=ccfc2f568e500c09b0a7196a9e595f618cc3c538

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=05a6206cfc6b908eef6f9ef47743ebffc118462f
+commit=8ae65ce848724ef105b7d382aab9685d7a64b081

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=c3711cfcf8af30817edd50c8d97a4328ffeebecc
+commit=aa4859d13f104894dbff652d3a4cf2e4c120429f

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=9975bc22a79b2b7dc83b3b04017dce0a10bb2400
+commit=2193912c0d5b14f2aa5d7a58c7964cd8631980b4

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=bd8ddd6d4a061b2d0dd4cec37fece89c2ccdf934
+commit=65ddb76d223b2f5591e5106f4238fe65728109ef

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=65ddb76d223b2f5591e5106f4238fe65728109ef
+commit=134b6e3753bdd5d3208e0d3516bcd634b75e849d

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=97a6dd4696c004a397db25f0d8697c408b12046b
+commit=02554d46a66c9439b2c16f5d333de4e604497016

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=75e672432f1570dd071cd6f0edaed70502d2d96e
+commit=d4cdd873053e6779c270979b296d0f45e87bb3f7

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=ff00482cc356c988c23d1e69774b49a78660d055
+commit=40722bbd248a67362c76d49ee89d6034cef74b14

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=ffab6d79bb16efddcd27c45604cf163dc2d39a46
+commit=ff00482cc356c988c23d1e69774b49a78660d055

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=193182e7a5aa82476982081e074da14d6a1689ee
+commit=75e672432f1570dd071cd6f0edaed70502d2d96e

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=6e2963702d43dde2e4af7a3fe2a6e58b10e87cb2
+commit=c6d87a22b479ba2854f2ff49030b5317cbe40074

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=02554d46a66c9439b2c16f5d333de4e604497016
+commit=193182e7a5aa82476982081e074da14d6a1689ee

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=234f7d2be556c91abd66e183c69a119cebbb9a35
+commit=bd8ddd6d4a061b2d0dd4cec37fece89c2ccdf934

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=aa4859d13f104894dbff652d3a4cf2e4c120429f
+commit=69466748e010630369306fe2f6557e6d3212ebff

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=ccfc2f568e500c09b0a7196a9e595f618cc3c538
+commit=c3711cfcf8af30817edd50c8d97a4328ffeebecc

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=d4cdd873053e6779c270979b296d0f45e87bb3f7
+commit=5d34a3beec875e60cafbba00f5efce60313a6c0a

--- a/plugins/hcim-progression-companion
+++ b/plugins/hcim-progression-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/jakebutler83/hcim-progression-companion.git
-commit=5ee4679035a30885765a97b4255c7fb2bc9ca314
+commit=854bc406640692b02b70dab42ece2cc6c1288fe0


### PR DESCRIPTION
## Plugin description


This adds a Progression Companion, a RuneLite integration for the Progression path web tracker.

The plugin allows a user to link their RuneLite client to their private Progression account using a one-time connection code.

## External communication

The plugin communicates with the user-configured Progression HTTPS API.

It sends:

- RuneScape display name
- Current world
- World coordinates
- Region ID
- Plane
- Timestamp
- Clan mates and friend list

This data is used to display the player on their private group live map.

The plugin also exchanges a user-entered one-time connection code for a private authentication token.

## Gameplay behavior

The plugin does not automate gameplay, send game inputs, interact with menus, or perform actions on behalf of the player.

## Repository

https://github.com/jakebutler83/hcim-progression-companion