### PR TITLE
Update inventory-highlighter v1.2.3

### DIFF
--- a/plugins/inventory-highlighter
+++ b/plugins/inventory-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/Emtec-byte/InventoryHighlighter.git
-commit=419b00ae7af1b70a2b16874c98cde570ad0b0915
+commit=e0d50c412c89d7f50b32ad50f9255269f3658b23


### PR DESCRIPTION
Add recolour-on-interaction highlighting (v1.2.3) - Player requested feature

- New "Show interact" option (off by default) recolours a highlighted
  item's outline for the tick you interact with it - eat, drink, wear,
  use, fletch, etc. The outline shows only during the click tick, so it
  never lingers into a later tick.
- Adds an "Interact Color" picker for that outline, and an optional
  "Interact min. display (ms)" (default 0) that can hold the recolour a
  few ms into the next tick for clicks late in a tick.
- All new options are opt-in; existing highlight settings, item lists,
  and behaviour are unchanged.
- Bump version to 1.2.3.