### PR TITLE
Add EventTeams plugin

### DIFF
--- a/plugins/event-teams
+++ b/plugins/event-teams
@@ -1,0 +1,2 @@
+repository=https://github.com/Tboodle/EventTeams.git
+commit=e22a74b41f08ff971101c15a64386b4aabac9479

--- a/plugins/event-teams
+++ b/plugins/event-teams
@@ -1,2 +1,2 @@
 repository=https://github.com/Tboodle/EventTeams.git
-commit=e22a74b41f08ff971101c15a64386b4aabac9479
+commit=c9e860d46e00c5c77211ca793682f9cb2ff3c28a


### PR DESCRIPTION
A plugin for running clan event teams (bingo, etc.). Assign clan members to color-coded teams in a sidebar panel, then see those teams everywhere during the event.

**In-World and Minimap:** team-colored names above players and dots on the minimap
**Chat**: messages from tracked players get a colored [Team Name] tag
**Sidebar roster:** live online/offline status per player (with world), pulled from your clan channel

Teams are managed in the panel and shared between organizers via copy/paste JSON. Everything's toggleable in config.