### PR TITLE
Add Group Storage Tracker Plugin

### DIFF
--- a/plugins/groupstoragetracker
+++ b/plugins/groupstoragetracker
@@ -1,0 +1,2 @@
+repository=https://github.com/MerryGusmas/groupstoragetracker.git
+commit=61c03648e825300d5ad04355ad0bd7badd013edc

--- a/plugins/groupstoragetracker
+++ b/plugins/groupstoragetracker
@@ -1,2 +1,2 @@
 repository=https://github.com/MerryGusmas/groupstoragetracker.git
-commit=cf2dbd025d747602d88dc65522c6a7f1bd13583e
+commit=d7ef70227da19bee76a671b53773ca8bc3160bca

--- a/plugins/groupstoragetracker
+++ b/plugins/groupstoragetracker
@@ -1,2 +1,2 @@
 repository=https://github.com/MerryGusmas/groupstoragetracker.git
-commit=d7ef70227da19bee76a671b53773ca8bc3160bca
+commit=7c20690ce5c1368fe2e5c741aa6abc078ddcdecf

--- a/plugins/groupstoragetracker
+++ b/plugins/groupstoragetracker
@@ -1,2 +1,2 @@
 repository=https://github.com/MerryGusmas/groupstoragetracker.git
-commit=a2cee7dd4e91d2dd59bc9c65ad94d729cac9ce13
+commit=cf2dbd025d747602d88dc65522c6a7f1bd13583e

--- a/plugins/groupstoragetracker
+++ b/plugins/groupstoragetracker
@@ -1,2 +1,2 @@
 repository=https://github.com/MerryGusmas/groupstoragetracker.git
-commit=740425cb1915242190e5757d58287ed116a3a8e9
+commit=a2cee7dd4e91d2dd59bc9c65ad94d729cac9ce13

--- a/plugins/groupstoragetracker
+++ b/plugins/groupstoragetracker
@@ -1,2 +1,2 @@
 repository=https://github.com/MerryGusmas/groupstoragetracker.git
-commit=db848f3b99e28e2a883c93f47c8543d744dd4d52
+commit=740425cb1915242190e5757d58287ed116a3a8e9

--- a/plugins/groupstoragetracker
+++ b/plugins/groupstoragetracker
@@ -1,2 +1,2 @@
 repository=https://github.com/MerryGusmas/groupstoragetracker.git
-commit=61c03648e825300d5ad04355ad0bd7badd013edc
+commit=db848f3b99e28e2a883c93f47c8543d744dd4d52


### PR DESCRIPTION
Group Storage Tracker is a RuneLite plugin for Group Ironman accounts that helps track valuable shared-storage items which have been withdrawn and not returned.

The plugin learns items from Group Storage, watches bank, inventory, and equipment state, and shows a bank-only item viewer so forgetful group members can quickly see what needs to go back into Group Storage.