### PR TITLE
anvil: drop the connection warning

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,3 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
 commit=5c7a2e905a69467522b85ffd7158b93019ab9d91
-warning=This plugin submits your IP address and bingo drop screenshots to a 3rd-party server (your configured Anvil site) not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Removing the `warning=` line for anvil. The site URL is user-configured now (used to be hardcoded), so pointing it somewhere means they're knowingly opting into a third-party endpoint themselves.