### PR TITLE
loadout-lab: bump to 0.2.4

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-loadout-lab.git
-commit=55587ac2d68346d2b1306b687a884b91d8197825
+commit=9dd5e2d17b9905a38f16f9cd7f3e8b7cb2211fcc


### PR DESCRIPTION
Bumps loadout-lab to 0.2.2.

Changes since the last release:
- Fix: set cards now expand into available sidebar space instead of showing a premature scrollbar (removed a redundant inner scroll pane).
- New: "Classic gear layout" toggle - lays each set out like the in-game worn-equipment tab (5x3) as an alternative to the compact grid.
- New: two additional loading animations (a cooking mascot and a World Cup keepy-uppies mascot) mixed into the existing one.
- New: "NPC right-click entry" toggle to hide the "Search in Loadout Lab" menu option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)