### PR TITLE
Add extended-bank-search

### DIFF
--- a/plugins/extended-bank-search
+++ b/plugins/extended-bank-search
@@ -1,0 +1,2 @@
+repository=https://github.com/khendricksen/runelite-extended-bank-search.git
+commit=79876b540e236be9c0c28d1e327da42e01bca53d


### PR DESCRIPTION
Extends the native bank search to filter items by equipment stats, gear slot, warm clothing for Wintertodt, and food. 