### PR TITLE
update: exact stacks compatibility with inventory-setups bank filter

### DIFF
--- a/plugins/exact-stacks
+++ b/plugins/exact-stacks
@@ -1,3 +1,3 @@
 repository=https://github.com/robisa693/runelite-exact-stacks-plugin.git
-commit=849fda7b2ededff0d4a1d7d0d800d2ee088b5da9
+commit=ecac4167c73388b55a8182f754ef4ea944ebf40c
 authors=robisa693


### PR DESCRIPTION
- Add itemId == -1 guard to skip truly empty/placeholder slots
- Add config option (hideMaxStack, default on) to skip Integer.MAX_VALUE sentinel used by inventory-setups plugin for missing items in filter view