### PR TITLE
update mazeracebingo

### DIFF
--- a/plugins/mazeracebingo
+++ b/plugins/mazeracebingo
@@ -1,2 +1,2 @@
 repository=https://github.com/TiboDeclercq98/MazeRaceBingoPlugin.git
-commit=f0ef449462734833a29f6235a456bd18105b55ce
+commit=83b3ae0410f28bcc89b95b86add04cfe711538dc

--- a/plugins/mazeracebingo
+++ b/plugins/mazeracebingo
@@ -1,2 +1,2 @@
 repository=https://github.com/TiboDeclercq98/MazeRaceBingoPlugin.git
-commit=83b3ae0410f28bcc89b95b86add04cfe711538dc
+commit=603e1fb48806c42598c622231a1d06906ed1a4b7


### PR DESCRIPTION
Sync xp-gain login fix and partial-completion tracking from mazeracebingo/runelite-plugin

Ports v3.06 (stop tracking on partial completion) and v3.07 (fix
login counting as xp gain) from the upstream monorepo's plugin
folder, which had progressed past this repo's last commit.