### PR TITLE
Add BiS Gear plugin

### DIFF
--- a/plugins/bis-gear
+++ b/plugins/bis-gear
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/bis-gear-plugin.git
-commit=babd599a0c472ea2b453e93557b1b15bf77e522b
+commit=728b0d5f1aa59f3d72d2d7172b40a95952912d56

--- a/plugins/bis-gear
+++ b/plugins/bis-gear
@@ -1,0 +1,2 @@
+repository=https://github.com/Diogo-G-Dias/bis-gear-plugin.git
+commit=486ddb7187d4fb9dfdbbd71f0f39d9ccabaeab46

--- a/plugins/bis-gear
+++ b/plugins/bis-gear
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/bis-gear-plugin.git
-commit=164448e70727cf890fbb2f5793b877f988ee26cd
+commit=4eff9f60470ccf3d8d4e52ae324363e2b9fab1ed

--- a/plugins/bis-gear
+++ b/plugins/bis-gear
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/bis-gear-plugin.git
-commit=486ddb7187d4fb9dfdbbd71f0f39d9ccabaeab46
+commit=babd599a0c472ea2b453e93557b1b15bf77e522b

--- a/plugins/bis-gear
+++ b/plugins/bis-gear
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/bis-gear-plugin.git
-commit=728b0d5f1aa59f3d72d2d7172b40a95952912d56
+commit=df38e5ef23aaa8848b0c025af0decfdba089ef8c

--- a/plugins/bis-gear
+++ b/plugins/bis-gear
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/bis-gear-plugin.git
-commit=df38e5ef23aaa8848b0c025af0decfdba089ef8c
+commit=164448e70727cf890fbb2f5793b877f988ee26cd


### PR DESCRIPTION
Adds **BiS Gear**: pick a boss and see the highest-DPS setup you can actually build from the items in your bank, rather than the theoretical best-in-slot you may not own.

Repository: https://github.com/Diogo-G-Dias/bis-gear-plugin

### What it does
- Best setup per style (melee / ranged / magic), with DPS, max hit, accuracy and prayer bonus, gear shown as the worn-equipment grid.
- Only suggests items the player owns: bank (as last seen), inventory and worn gear.
- Slots that make no difference to DPS are filled with the player's best prayer gear, at zero DPS cost.
- Special attacks (spec max hit, accuracy, DPS contribution, energy cost).
- Options for prayer/boost overrides, defence reductions already landed, soul stacks, slayer task, wilderness, and per-item exclusions.

### Notes for review
- **Licence is GPL-3.0.** The combat engine is a Java port of [weirdgloop/osrs-dps-calc](https://github.com/weirdgloop/osrs-dps-calc) (the calculator behind dps.osrs.wiki), which is GPL-3.0, so this plugin is too. Attribution is in `NOTICE.md`.
- **Network use:** the plugin fetches the item/monster/spell JSON published by that same project (`raw.githubusercontent.com/weirdgloop/osrs-dps-calc`) once, then caches it on disk under `.runelite/bis-finder/`. It is a plain GET of static data — no user data is sent anywhere, so I have not added a `warning=` line, but happy to add one if you would prefer.
- The port is verified against upstream's own test suite, including the 28 loadouts whose max hits Weird Gloop verified in game.