### PR TITLE
Add paint-overlays

### DIFF
--- a/plugins/paint-overlays
+++ b/plugins/paint-overlays
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/paint-overlays.git
-commit=ac71c08f2f55005d635311f77fc8177c9c3face2
+commit=295849eaeb5c6497ad4097b8c80cf055bb111068

--- a/plugins/paint-overlays
+++ b/plugins/paint-overlays
@@ -1,0 +1,2 @@
+repository=https://github.com/vahnx/paint-overlays.git
+commit=ac71c08f2f55005d635311f77fc8177c9c3face2

--- a/plugins/paint-overlays
+++ b/plugins/paint-overlays
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/paint-overlays.git
-commit=405ec1c3a276f2f0f4f51dc5d843c7fe62233fd1
+commit=405ec1caade484f8fe3f1c1579e4690c3b4e2b10

--- a/plugins/paint-overlays
+++ b/plugins/paint-overlays
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/paint-overlays.git
-commit=405ec1caade484f8fe3f1c1579e4690c3b4e2b10
+commit=0227a8c1a505d682706373697498b12743d6f21b

--- a/plugins/paint-overlays
+++ b/plugins/paint-overlays
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/paint-overlays.git
-commit=295849eaeb5c6497ad4097b8c80cf055bb111068
+commit=405ec1c3a276f2f0f4f51dc5d843c7fe62233fd1

--- a/plugins/paint-overlays
+++ b/plugins/paint-overlays
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/paint-overlays.git
-commit=0227a8c1a505d682706373697498b12743d6f21b
+commit=4a1daee0270bf97d1f74728bb7608e830de69692


### PR DESCRIPTION
Adds Paint Overlays, a RuneLite plugin for persistent painting on both the in-game scene and the world map.

Current features:
- Brush, shape, text, and eraser tools
- Scene and world map painting
- Persistent text notes, shapes, and strokes
- Undo support for recent actions
- Sidepanel-driven configuration