### PR TITLE
update barrows-sarcophagus-memory

### DIFF
--- a/plugins/barrows-sarcophagus-memory
+++ b/plugins/barrows-sarcophagus-memory
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/barrows-sarcophagus-memory.git
-commit=bed1d2898e62cf49b7ec6d2e842c9149b713a5f4
+commit=7b89f6990fec53530f2b73c250ff667cf3de6a2d


### PR DESCRIPTION
Updates the plugin manifest to include the standardized GitHub Sponsors and PayPal links in the README. No runtime plugin code changes.