### PR TITLE
update barrows-tunnels-kill-tracker

### DIFF
--- a/plugins/barrows-tunnels-kill-tracker
+++ b/plugins/barrows-tunnels-kill-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/barrows-tunnels-kill-tracker.git
-commit=de309d82c6e782bf34e72cbc1397ef1257b247a8
+commit=a27415d8aa58cca6957ce94cb3bc143c3a5e2eeb


### PR DESCRIPTION
Updates the plugin manifest to include the standardized GitHub Sponsors and PayPal links in the README. No runtime plugin code changes.