### PR TITLE
Add drop lists

### DIFF
--- a/plugins/drop-lists
+++ b/plugins/drop-lists
@@ -1,0 +1,2 @@
+repository=https://github.com/dojr/drop-lists
+commit=f90193400898772bb93bb3d81575f941b88e0c79

--- a/plugins/drop-lists
+++ b/plugins/drop-lists
@@ -1,2 +1,2 @@
-repository=https://github.com/dojr/drop-lists
+repository=https://github.com/dojr/drop-lists.git
 commit=f90193400898772bb93bb3d81575f941b88e0c79


### PR DESCRIPTION
Adds side panel that can create lists of items you want to swap to left click drop. Create multiple lists and share them. And finally toggle them off or on at will. 

Useful for specific activities where you drop specific items but don't want to have to manually right click drop all of them and then turn them off afterwards. I've been using it for salvaging to test as an example.

Any advice and constructive criticism is welcome as I'd like to learn and understand more about plugin development.