### PR TITLE
Update bank templates 1.6.4

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=d6371caaf37469e2900b4695f3d7e393a96cb99a
+commit=6e8550d8636b7b7d8aeb9282e8ce593ba65d9a09


### PR DESCRIPTION
- If no account token is set in Bank Templates but the Exchange Insights plugin on the same client has one configured, that token is now used automatically (read live from local config, never copied or transmitted anywhere new), so the account link and verified bank sync work with zero setup for users of both plugins. A token set in Bank Templates itself still takes precedence.
- The account link status is now a single button below the search box that toggles link/unlink by status. Unlinking asks for confirmation and is remembered locally and server-side, so automatic linking never silently relinks a character the user chose to unlink.
- The bank value line moved under that button and reads "Your current bank value: ...".