### PR TITLE
Update Bronzeman TCG

### DIFF
--- a/plugins/bronzeman-tcg
+++ b/plugins/bronzeman-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Felmeme/bronzeman-tcg.git
-commit=0c4853ae64c9c58d9b60e20d5c6dd3004d26fe39
+commit=802e7c90675e87702118a68e243840ae68baaead

--- a/plugins/bronzeman-tcg
+++ b/plugins/bronzeman-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Felmeme/bronzeman-tcg.git
-commit=7b570cbce35849a309f51a3d46d769d80158e7c5
+commit=d7aec9d8637454f9737b341fa3a79e681d37854d

--- a/plugins/bronzeman-tcg
+++ b/plugins/bronzeman-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Felmeme/bronzeman-tcg.git
-commit=802e7c90675e87702118a68e243840ae68baaead
+commit=7b570cbce35849a309f51a3d46d769d80158e7c5

--- a/plugins/bronzeman-tcg
+++ b/plugins/bronzeman-tcg
@@ -1,0 +1,2 @@
+repository=https://github.com/Felmeme/bronzeman-tcg.git
+commit=0c4853ae64c9c58d9b60e20d5c6dd3004d26fe39


### PR DESCRIPTION
Fixes chat feedback not displaying; adds quest & PvM readiness checklists to the side panel, thieving/superior slayer difficulty options, and an opt-in TCG stats overlay.