### PR TITLE
update ospulse

### DIFF
--- a/plugins/ospulse
+++ b/plugins/ospulse
@@ -1,4 +1,4 @@
 repository=https://github.com/jonathanavis96/ospulse.git
-commit=4bc48faba420e4ad903c1c95f809d6a286c6c23b
+commit=87b381e3fee5132be78d393817e7b456096f702d
 authors=jonathanavis96
 warning=The optional, off-by-default price-trend feature requests item price history from the OSRS Wiki price API (prices.runescape.wiki), sending only an item id. No account name or player data is sent.

--- a/plugins/ospulse
+++ b/plugins/ospulse
@@ -1,4 +1,4 @@
 repository=https://github.com/jonathanavis96/ospulse.git
-commit=87b381e3fee5132be78d393817e7b456096f702d
+commit=4a38de53b3655e9a99cf1c6f1ce8a3ee4519a85b
 authors=jonathanavis96
 warning=The optional, off-by-default price-trend feature requests item price history from the OSRS Wiki price API (prices.runescape.wiki), sending only an item id. No account name or player data is sent.

--- a/plugins/ospulse
+++ b/plugins/ospulse
@@ -1,4 +1,4 @@
 repository=https://github.com/jonathanavis96/ospulse.git
-commit=4a38de53b3655e9a99cf1c6f1ce8a3ee4519a85b
+commit=0d75444c7066d7f13804917bfab30b2887251814
 authors=jonathanavis96
 warning=The optional, off-by-default price-trend feature requests item price history from the OSRS Wiki price API (prices.runescape.wiki), sending only an item id. No account name or player data is sent.


### PR DESCRIPTION
Updates OSPulse to 0.2.1 — bumps `commit=` to `87b381e3fee5132be78d393817e7b456096f702d`.

No change to `repository=`, `authors=` or `warning=`: network behaviour is unchanged, and the off-by-default price-trend lookup to the OSRS Wiki price API remains the only outbound request.

Highlights since the pinned 0.2.0 build:

- Session net-worth change is now a checkable sum (Profit + GE flip + GE positions + Bank), with GE positions and Bank individually toggleable — banking loot no longer reads as a loss.
- The expensive-item risk cap now values untradeables at what it costs to keep them on death, so a fire cape or Avernic defender no longer counts as free risk; free-to-replace items no longer consume an expensive slot; and the cap gives up whichever item costs the least DPS rather than whichever comes first in slot order.
- New off-by-default "Hide unprotectable items" setting (local only, no network).
- Fixes: GE flip cost basis now survives a relog and a manual session reset; the Unrealised P/L baseline is scoped per account instead of client-wide; and the expensive-item threshold now has a real default instead of starting at 0.
- Panel readability: numbers render at full size with dimmed decimals, and the attack-style list no longer clips its DPS column or truncates style names.

Full changelog: https://github.com/jonathanavis96/ospulse#-changelog