### PR TITLE
Add Twitch Chat Side Panel

### DIFF
--- a/plugins/twitch-chat-side-panel
+++ b/plugins/twitch-chat-side-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/Runelite-Twitch-Chat-Side-Panel.git
-commit=c4be1608977ab946fbcc83329ef29ccf6c04e9a7
+commit=fb107c1fd06345d274e28b29a3fb65a99642b1cd

--- a/plugins/twitch-chat-side-panel
+++ b/plugins/twitch-chat-side-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/Runelite-Twitch-Chat-Side-Panel.git
-commit=6540bb118d6524965e9750136732e9264820b27c
+commit=ef7f3389106b251059ce082eb224e7d41673d4e2

--- a/plugins/twitch-chat-side-panel
+++ b/plugins/twitch-chat-side-panel
@@ -1,0 +1,2 @@
+repository=https://github.com/georgeparamore/Runelite-Twitch-Chat-Side-Panel.git
+commit=6540bb118d6524965e9750136732e9264820b27c

--- a/plugins/twitch-chat-side-panel
+++ b/plugins/twitch-chat-side-panel
@@ -1,2 +1,3 @@
 repository=https://github.com/georgeparamore/Runelite-Twitch-Chat-Side-Panel.git
 commit=72e9a6efb39ed61ff9d2ad15c469d5051bd36f19
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/twitch-chat-side-panel
+++ b/plugins/twitch-chat-side-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/Runelite-Twitch-Chat-Side-Panel.git
-commit=ef7f3389106b251059ce082eb224e7d41673d4e2
+commit=c4be1608977ab946fbcc83329ef29ccf6c04e9a7

--- a/plugins/twitch-chat-side-panel
+++ b/plugins/twitch-chat-side-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/Runelite-Twitch-Chat-Side-Panel.git
-commit=fb107c1fd06345d274e28b29a3fb65a99642b1cd
+commit=72e9a6efb39ed61ff9d2ad15c469d5051bd36f19


### PR DESCRIPTION
## What it does
Shows the streamer's Twitch chat in a RuneLite side panel, using a
Party-Hub-style layout instead of the official Twitch plugin's PM-style
chatbox overlay.

## Why it's useful
Lets players follow their own or a friend's Twitch chat while playing,
without the visual clutter of PM-formatted chat messages, and with a
dedicated panel that supports emotes, badges, and mention highlighting.

## How players interact with it
- Enter a Twitch channel name in plugin config to view chat read-only,
  anonymously (no login required).
- Optionally log in via Twitch's OAuth device-code flow to additionally
  send messages, use the emote picker, get @mention autocomplete, and see
  a sub/gift event carousel.

## External communication
Connects to Twitch's IRC-over-WebSocket chat service and Twitch's OAuth/API
endpoints (device-code flow, emote/badge lookups). No other third-party
services are contacted, and no user data is sent anywhere besides Twitch
itself.