### PR TITLE
planker-runelite-plugin

### DIFF
--- a/plugins/planker-runelite-plugin
+++ b/plugins/planker-runelite-plugin
@@ -1,0 +1,2 @@
+repository=https://github.com/plankrs/Planker-RuneLite-Plugin.git
+commit=fe853ead0e68e4b3d640f06d0d88c71d7635bc05


### PR DESCRIPTION
RuneLite companion plugin for the PlankRS clan.

Sends the following

- Drop notifications
- Level-up notifications
- Quest completions
- Collection log unlocks
- Combat achievements
- Optional clan chat relay
- Optional event screenshots
- Offline queue and automatic retry

Clan chat relay and screenshots are disabled by default. Enabling either feature opens a confirmation dialog describing what may be forwarded or captured.