### PR TITLE
anvil: progress sidebar, Active now, and site-relay federation

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=d40f69128dfc855f9eae439a11364072bb9a5812
+commit=2f6836afc0627ee1d80ce8b4ee8cc31fa1cd8532

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=07faf3050ca87ce8060d0562a00687eaa768297a
+commit=d40f69128dfc855f9eae439a11364072bb9a5812

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=26600860696ea81eff38f84de003cdb19262f58a
+commit=07faf3050ca87ce8060d0562a00687eaa768297a

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=17bd6b6046c20d0cb673db0634ff52c0ce8bb053
+commit=26600860696ea81eff38f84de003cdb19262f58a

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=5c7a2e905a69467522b85ffd7158b93019ab9d91
+commit=17bd6b6046c20d0cb673db0634ff52c0ce8bb053

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=2f6836afc0627ee1d80ce8b4ee8cc31fa1cd8532
+commit=a0e486c346ad39ab2cc93c0de74d0723108c9f9f

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=a0e486c346ad39ab2cc93c0de74d0723108c9f9f
+commit=8a01107d5d5afcf0911f8f80c946aac5024c86c2


### PR DESCRIPTION
Updates the **anvil** plugin. Adds an always-on progress side panel for the Anvil clan-events platform, plus the plugin side of optional cross-clan federation.

**Sidebar**
- Per-event board summary + nearest-to-complete tiles
- **Active now** — tiles you and teammates are actively progressing (drops, kills, skill XP, boss KC), attributed per player
- Link to the event's standings on the site

**Federation (new — site-relay, opt-in, off by default)**
- The plugin's *entire* federation footprint is its own home site: it polls `GET /api/plugin/federation/state` and renders the per-clan boards the site already aggregated, and establishes federation via a one-time Discord device-login opened in the system browser (pinned to the Anvil broker host only). It never contacts a broker or another clan's site directly — all server-to-server. With federation off (default), the panel is byte-for-byte the single-home sidebar.

**Other**
- Set-aware progress for collection tiles in the in-game chat/toast (a full set reads "4/4", not "4/1").

Existing tracking/overlay behavior is unchanged. `./gradlew test` passes.