### PR TITLE
Add prayer-icons-overlay

### DIFF
--- a/plugins/prayer-icons-overlay
+++ b/plugins/prayer-icons-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/JashyardEngDev75/prayer-icons-overlay.git
+commit=04dba304ab2b8650ca7eb4cc52a4179680cccb12

--- a/plugins/prayer-icons-overlay
+++ b/plugins/prayer-icons-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/JashyardEngDev75/prayer-icons-overlay.git
-commit=04dba304ab2b8650ca7eb4cc52a4179680cccb12
+commit=c218fc7675f8f5a4023f667c8521af171481b4fb


### PR DESCRIPTION
Prayer Icons Overlay is a small, visual-only overlay that shows an icon for each currently active prayer, similar in spirit to the built-in Timers & Buffs overlay but focused on prayers specifically.

- Read-only: only ever reads prayer state via `Client.isPrayerActive` (plus a couple of read-only unlock varbits to disambiguate Eagle Eye/Deadeye and Mystic Might/Mystic Vigour, the same approach RuneLite's own bundled Prayer plugin uses). No input injection, no menu/interface modification, no reflection, no network calls.
- Per-prayer show/hide toggles use a fixed, hardcoded list of the 31 standard prayers, no free-text/player-provided IDs.
- Configurable anchor position, layout (horizontal/vertical/grid), and background panel visibility/opacity. Icons are drawn at their native sprite size.
- No new dependencies beyond what runelite-client already provides.

Repo: https://github.com/JashyardEngDev75/prayer-icons-overlay