### PR TITLE
Update guide-overlay

### DIFF
--- a/plugins/guide-overlay
+++ b/plugins/guide-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/RunelitePlugin/guide-overlay.git
-commit=e1decc8acf00be2204c305bb36cd638f966b195d
+commit=9504b1c2bf786cb1f08feb88b84874c59cde833d


### PR DESCRIPTION
Update:  BRUHsailer guide added, route suggestions/shortest path

   Changes since the accepted version:
   - Second built-in guide: BRUHsailer Ironman Guide, parsed from its
     structured JSON (new one-time, user-confirmed download from a
     commit-pinned umkyzn/BRUHsailer file - disclosed below)
   - Fastest-route suggestions: an optional HUD hint showing the quickest
     teleport toward the current objective, checked against the runes and
     charged jewelry the player owns (inventory/equipment/bank). Display
     only - no automation of any kind.
   - Optional hand-off of the objective to the Shortest Path plugin over
     the PluginMessage bus (no dependency; inert when not installed)
   - Discrete config sections, security hardening (bounded network reads,
     lifecycle guards), and performance work (lazy loading with a small
     prefetch buffer)

   Network disclosure (all one-time, all behind explicit user confirmation
   dialogs, zero automatic traffic): the OSRS wiki API (guide import), a
   commit-pinned umkyzn/BRUHsailer file (built-in guide JSON), and a
   commit-pinned mejrs/data_osrs file (optional NPC location dataset).