### PR TITLE
update jumpscare

### DIFF
--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=d8f489273ac04fbc61b2bc2225c36a97aca54b44
+commit=ea8b879a68ab88573069f5ef544c55ba2c533353
 authors=vividflash


### PR DESCRIPTION
v1.3: custom image/sound preloaded off the client thread, full cleanup on shutdown, scare duration capped at 10s, default chance 1 in 6000 (about one scare per hour), config and wording polish.