### PR TITLE
Update maggot-king

### DIFF
--- a/plugins/maggot-king
+++ b/plugins/maggot-king
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/maggot-king.git
-commit=55e4d7f8e51be5f14c9c9fac1254eb03c1cf6c7c
+commit=ae9c8e87d8a16c8c7770d6004bbf7dc5a49054dd


### PR DESCRIPTION
Adds an item overlay showing each maggot egg's Maggot King pet hatch chance (1/3000 for a base egg up to 1/2 for a writhing egg) on the egg in the inventory and bank, coloured by tier. Toggle in the Tracking section.