### PR TITLE
Add Recipe Tracker

### DIFF
--- a/plugins/recipe-tracker
+++ b/plugins/recipe-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/nassarao/recipe-tracker.git
+commit=d7697a6f5de1ee9b15322fd406e4810f64994a35

--- a/plugins/recipe-tracker
+++ b/plugins/recipe-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/recipe-tracker.git
-commit=40ac5d738e503684708e9558f3a94197d4c667a1
+commit=d3d00e2bcc3c3cc36056a3014e6154cd3ee63f43

--- a/plugins/recipe-tracker
+++ b/plugins/recipe-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/recipe-tracker.git
-commit=d7697a6f5de1ee9b15322fd406e4810f64994a35
+commit=40ac5d738e503684708e9558f3a94197d4c667a1


### PR DESCRIPTION
## What changed

Adds Recipe Tracker, a RuneLite plugin that lets players search OSRS Wiki recipes or right-click supported items and compare their required materials with inventory, equipment, and rune-pouch contents.

## User impact

Players can track multiple makeable outputs, adjust target quantities, see reusable tools, and view requirement progress in the sidebar and an optional in-game overlay.

## Validation

- `gradlew clean test` using Java 11
- Plugin tested in the RuneLite developer client
- Plugin source repository is public and licensed under BSD 2-Clause
