### PR TITLE
Add No 0's

### DIFF
--- a/plugins/no-0s
+++ b/plugins/no-0s
@@ -1,0 +1,2 @@
+repository=https://github.com/UserD40/No_0s.git
+commit=59423d51764a3baaef31d0ff260b7203d5e6fb8f


### PR DESCRIPTION
No 0's hides zero-damage ("0") hitsplats — the ones shown on a block, a miss, or a spell splash — so only hits that dealt actual damage are displayed.

Three independent config toggles (all enabled by default) control whether it applies to NPCs, your own player, and other players. Everything else renders as normal: real damage, heals, poison, venom, health bars, and overhead prayer/skull icons are all preserved.

Repository: https://github.com/UserD40/No_0s