### PR TITLE
Add Cast Calc

### DIFF
--- a/plugins/cast-calc
+++ b/plugins/cast-calc
@@ -1,0 +1,2 @@
+repository=https://github.com/jdanamato/cast-calc.git
+commit=cc5e8bce25437d2d973a1494600b5a53e56971e0


### PR DESCRIPTION
Adds Cast Calc to the Plugin Hub.

Cast Calc is a RuneLite side-panel plugin for Old School RuneScape that calculates spell cast costs using live GE prices, rune-saving gear, profit/loss tools for utility spells, and Magic goal calculations.

Validation:
- `./gradlew clean build` passes in the plugin repository.
