### PR TITLE
chat-fade: update to 1.2

### DIFF
--- a/plugins/chat-fade
+++ b/plugins/chat-fade
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/chat-fade.git
-commit=5b27857928b02f740e169d3004d2d4c9e9963867
+commit=af26591a95d8f767b2d2ac89748be2bcddecbdf2


### PR DESCRIPTION
Updates the chat-fade manifest to the latest commit (af26591).

Change since 1.1:
- Respect the existing "Show Typing Input" toggle for the Key Remapping "Press Enter to Chat" caret. Previously the caret (and its reserved chat height) still showed when a user had Show Typing Input disabled; it now stays hidden in that case.

Contributed by @jarromie. Plugin version bumped 1.1 -> 1.2.