### PR TITLE
update bank-templates to v1.6.6

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=52780d543cb114bbf09a621c370912fa53105327
+commit=7dda90925af02ecc358dbfb4fb54fd550d4fd82f

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=6e8550d8636b7b7d8aeb9282e8ce593ba65d9a09
+commit=52780d543cb114bbf09a621c370912fa53105327


### PR DESCRIPTION
Updates bank-templates to v1.6.6: repository commit 7dda90925af02ecc358dbfb4fb54fd550d4fd82f.

Changes since the currently published commit (v1.6.4):

v1.6.5
- The side panel's bank value line now refreshes from each background sync, so it stays current without needing a bank change.
- The website button at the bottom of the panel now reads 'Browse on Exchange Insights'.

v1.6.6
- Fixed withdrawing items quickly rearranging the applied template layout (TheSpryt/bank-templates#35). The overlay used its own 5px mouse-movement check to decide a press was a drag, so a fast withdraw click that slid a few pixels could move that slot within the template. It now only treats a press as a drag once the client itself reports a widget drag, which also makes it respect the client's drag dead time and the Anti Drag plugin's settings.