### PR TITLE
update exchange-insights to v1.1.2

### DIFF
--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,3 +1,3 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=f4501efc624c10760248205d75369d82be31ba1a
+commit=c8daf9f97cbd6934808fd682e027fff0430d7bae
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
adds automatic reuse of the Bank Templates plugin's token when no own token is set, read locally, never transmitted or stored twice