### PR TITLE
pvp profit tracker 1.5.0

### DIFF
--- a/plugins/pvp-profit-tracker
+++ b/plugins/pvp-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-profit-tracker.git
-commit=d89c2771419928d3c0f9f8742075a7fe5276a248
+commit=98d7505c2d0698d5978be419da95f77918af5d54


### PR DESCRIPTION
small update.

added double death recovery. if you and your opponent die within a few seconds of each other, a little card shows up on the side panel where you type how much you looted back. it gets added to your session and baseline profit so a double death you partly recover from doesn't just read as a full loss. you can enter it as 4m, 4000k, 4,000,000 or just plain numbers.

nothing else changed.
