### PR TITLE
Add account snapshot export

### DIFF
--- a/plugins/account-snapshot-export
+++ b/plugins/account-snapshot-export
@@ -1,2 +1,2 @@
 repository=https://github.com/trilliam25/osrs-account-snapshot.git
-commit=71f011d656aedd05b0f5bfde44f91c9d0725f548
+commit=a9f59cbc22847dcd50d6da42ca098d6cab920c2b

--- a/plugins/account-snapshot-export
+++ b/plugins/account-snapshot-export
@@ -1,0 +1,2 @@
+repository=https://github.com/trilliam25/osrs-account-snapshot.git
+commit=71f011d656aedd05b0f5bfde44f91c9d0725f548


### PR DESCRIPTION
Adds Account Snapshot Export, a passive plugin that exports observed account progress and interface-backed game data to compact JSON files.

The plugin does not perform actions on behalf of the user. It only records data and relies on the player to open the relevant OSRS interfaces normally.