### PR TITLE
Hotfix PvM Toolkit 3.5.2

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=3b76cc5040ddffa2417835ea40f4e58bbe9bea05
+commit=9d850e13a757655a6c270f35cac951e438e34962

--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=84d0180688ddbecc6edfc4a2ee244498df102ff7
+commit=3b76cc5040ddffa2417835ea40f4e58bbe9bea05


### PR DESCRIPTION
## Hotfix 3.5.2

- removes the in-game PvM Toolkit update scroll completely
- removes its setting, overlay, mouse listener, version state, and login lifecycle code
- prevents the update UI from blocking login or gameplay interaction

## Hotfix 3.5.1

- removes the unreliable loot text value filter and its settings
- restores the user's previous Ground Items value setting and removes generated hidden rules
- keeps drop lifetime timers, outlines, loot click-through, and native Alt-marking behavior unchanged

## Other 3.5.x changes

- persistent Slayer-task timing, reliable tracker resets, and richer task/drop statistics
- improved green-to-red drop lifetime text without the heavy background box
- warning flashes stop when their cause is resolved, including cannon pickup
- potion warnings are limited to recent combat while prayer warnings remain active

## Validation

- `gradlew clean test jar shadowJar --no-daemon` with Java 11
- 3 tests passing
- standard and shadow JARs contain version 3.5.2 metadata
- update overlay class is absent from both JARs