### PR TITLE
Add Plugin - Daily PvM Tracker

### DIFF
--- a/plugins/dailypvmtracker
+++ b/plugins/dailypvmtracker
@@ -1,0 +1,2 @@
+repository=https://github.com/LogicalSoIutions/daily-pvm-tracker.git
+commit=3168ddcac6a1e8194ce49cedc2d00f899f3fd63a


### PR DESCRIPTION
Adds a Daily PvM Tracker - A local only or online service (optional) that tracks all PvM (Bossing only) and Raid content done within a day. Displays estimated loot, actual loot, and KC variance.