### PR TITLE
Add PriceCheck Flipping

### DIFF
--- a/plugins/pricecheck-flipping
+++ b/plugins/pricecheck-flipping
@@ -1,3 +1,3 @@
 repository=https://github.com/pricecheckgg/pricecheck-runelite-plugin.git
-commit=2b8acbed3a71062df55a34952d5c0dff206c4d0a
+commit=de2d723a2e4442c27d950e1998b3455589f30aff
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/pricecheck-flipping
+++ b/plugins/pricecheck-flipping
@@ -1,3 +1,3 @@
 repository=https://github.com/pricecheckgg/pricecheck-runelite-plugin.git
-commit=de2d723a2e4442c27d950e1998b3455589f30aff
+commit=10e9900a12109fe8abfdef3302d052bc88f45d53
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/pricecheck-flipping
+++ b/plugins/pricecheck-flipping
@@ -1,2 +1,3 @@
 repository=https://github.com/pricecheckgg/pricecheck-runelite-plugin.git
 commit=2b8acbed3a71062df55a34952d5c0dff206c4d0a
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/pricecheck-flipping
+++ b/plugins/pricecheck-flipping
@@ -1,3 +1,3 @@
 repository=https://github.com/pricecheckgg/pricecheck-runelite-plugin.git
-commit=10e9900a12109fe8abfdef3302d052bc88f45d53
+commit=3f2dbfb094ecbba864457fa8008498b6cb2ceb5d
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/pricecheck-flipping
+++ b/plugins/pricecheck-flipping
@@ -1,0 +1,2 @@
+repository=https://github.com/pricecheckgg/pricecheck-runelite-plugin.git
+commit=85179cf8577f11551804a243067bb3173243c811

--- a/plugins/pricecheck-flipping
+++ b/plugins/pricecheck-flipping
@@ -1,2 +1,2 @@
 repository=https://github.com/pricecheckgg/pricecheck-runelite-plugin.git
-commit=85179cf8577f11551804a243067bb3173243c811
+commit=2b8acbed3a71062df55a34952d5c0dff206c4d0a


### PR DESCRIPTION
PriceCheck Flipping is a Grand Exchange flipping plugin: a free flip tracker plus an optional subscription flip board.

The tracker works with no account or key, fully locally: exact fills from offer deltas, FIFO flip matching with cost basis, open positions with hold time, session/daily/weekly profit and win rate, GE-history import for trades completed while logged out, and right-click deletion. Optionally (off by default, with config warnings) the log can sync to the user's PriceCheck account for a web portfolio and multi-computer consistency.

With a paid key the sidebar adds a live flip board, an offer advisor for open GE slots, click-to-fill prices in the GE price input, and a slot planner. All paid data is computed server-side; the plugin renders what the API returns.

Network behavior: the plugin makes no requests until a key is entered, and every data-submitting feature is opt-in with a warning stating exactly what it sends. Details are in the repository README's data disclosure section.