### PR TITLE
Update Kill Clog to 1.6.3

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=c7d54ba3d0a3ef969fd3e90890dc300c34d254b9
+commit=e14661959328d119b5f9f0021770c0fd3dd2722a
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Kill Clog to 1.6.3.

Highlights:
- live collection log unlocks bump the sidebar total the moment the chat message lands, with upward-only reconciliation so a lagging varp cannot revert it
- collection log totals also reconcile straight from game state and from your own clan broadcast, so the count stays current whatever your notification settings
- a world hop or relog marks your own cached hiscores stale so the next self-search fetches fresh
- EHB stat in the PvM summary and comparison, computed from hiscore kill counts against EHB rates by TempleOSRS, bundled with the plugin as a versioned resource
- hiscore parsing now fails safe if Jagex changes the CSV format: boss stats show as unavailable until the plugin updates, instead of ever showing wrong kill counts