### PR TITLE
regear 1.5.0

### DIFF
--- a/plugins/regear
+++ b/plugins/regear
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-regear.git
-commit=5d8cf4fbd48f519b8e4b19c07c6ca2aca3f2c233
+commit=c11012e54bebfa3d243605be83178fe467e175c1


### PR DESCRIPTION
another small one.

added an "update group" button next to "group checked". before, to change what's in a group you had to delete it and make a new one. now you pick the group, tick the setups you want, and hit update group.

also fixed the setup dropdown. clicking the button while it's already open now closes it, instead of reloading the list. before you had to click off it or pick a setup to get it to close.

that's it.
