### PR TITLE
Update nex-loot-tracker

### DIFF
--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=1009e1039d39f95881961fc5966a776ec8ca2b2b
+commit=f156ddab50110c001f5ba2155b4ce9b630c51c63


### PR DESCRIPTION
Add optional average kill time to the panel.

- Surface chat-parsed fight durations as a toggleable average under contribution, and fix long team-size labels clipping the value.
