### PR TITLE
Add GE Offer Webhook plugin

### DIFF
--- a/plugins/ge-offer-webhook
+++ b/plugins/ge-offer-webhook
@@ -1,4 +1,3 @@
 repository=https://github.com/John-AndreS/ge-offer-webhook.git
 commit=e2cc116d492d329c1aa678cacc5fca5f91293783
 authors=John-AndreS
-warning=This plugin submits your Grand Exchange offer data (item, price, quantity, and offer status) to a server or URL you configure. This URL is not controlled or verified by the RuneLite Developers.

--- a/plugins/ge-offer-webhook
+++ b/plugins/ge-offer-webhook
@@ -1,0 +1,4 @@
+repository=https://github.com/John-AndreS/ge-offer-webhook.git
+commit=e2cc116d492d329c1aa678cacc5fca5f91293783
+authors=John-AndreS
+warning=This plugin submits your Grand Exchange offer data (item, price, quantity, and offer status) to a server or URL you configure. This URL is not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Adds **GE Offer Webhook** — a plugin that POSTs a JSON webhook to a user-configured URL on every Grand Exchange offer change: placement, partial fill, completion, and cancellation, plus a full-slot snapshot on login. A listening service can use this to maintain real-time, gapless GE state without polling.

- **Observe-only:** it reads client-reported GE state and sends JSON; it generates no game input.
- **Outbound-data disclosure:** provided via the `warning=` field in this manifest and in the Webhook URL config option's description.
- Uses the client's injected `OkHttpClient` and `Gson` (no fresh instances); `build=standard`; BSD-2-Clause.

Plugin repository: https://github.com/John-AndreS/ge-offer-webhook
