### PR TITLE
GPS: update to version 0.12.0

### DIFF
--- a/plugins/gps
+++ b/plugins/gps
@@ -1,2 +1,2 @@
 repository=https://github.com/PauloAguiar/runelite-gps-plugin.git
-commit=534561efc568429eca99c8073e2876c4c0f9fffb
+commit=52d6b13521873a28878e91d71d39cb996051ec1f


### PR DESCRIPTION
Update GPS to 0.12.0.

Highlights:
- Bank contents, planted spirit trees and house furniture persist across sessions
- Method priorities: rank travel methods in tiers from the route card, seconds bias for walking/banking, adjustment chips beside the ETA
- Routing: teleport escapes from enclosed starts, time-boxed unreachable sweeps (fixes a reported CPU spike), no more drift-recalc restarts, wall-aware progress tracking, nested duplicate routes dropped
- Data: Mount Karuulm dungeon fully routable (elevator, hall rocks, 88 Agility pipe), Underground Pass mapped from its entrances through the deep band
- A "Report an issue" button that pre-fills a GitHub issue with route context

Full changes: https://github.com/PauloAguiar/runelite-gps-plugin/compare/534561e...v0.12.0