### PR TITLE
Add dense-runestone-notifier as a new plugin

### DIFF
--- a/plugins/dense-runestone-notifier
+++ b/plugins/dense-runestone-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/alonzoc1/dense-runestone-notifier.git
+commit=cb7aa870f321c50ee7b704db257a84dd9ee7f7ad

--- a/plugins/dense-runestone-notifier
+++ b/plugins/dense-runestone-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/alonzoc1/dense-runestone-notifier.git
-commit=cb7aa870f321c50ee7b704db257a84dd9ee7f7ad
+commit=8352a00d84a2f97ddb29a962d8bfaad5fa9066df


### PR DESCRIPTION
Dense Runestone Notifier is a small quality of life plugin for training Runecrafting at the dense essence mine (Arceuus blood/soul runecrafting). Dense runestones deplete randomly with no real feedback, and since most people are half-watching another screen while training this, it's easy to idle for a while without noticing your rock died. This plugin overlays a colored textbox above the chatbox the moment you start mining, and changes it to a red box when the rock you're working depletes, inventory full, or you otherwise stop mining so you notice right away and can switch to the other rock or go to the altar. Box colors, text color, and messages are all configurable.