### PR TITLE
Add Deckscape

### DIFF
--- a/plugins/deckscape
+++ b/plugins/deckscape
@@ -1,2 +1,2 @@
 repository=https://github.com/jona139/DeckscapePlugin.git
-commit=2aecfaab9883cab99abb7433f72954640b699ebb
+commit=46eb759b2cbea43538829ab7e34f6301dca8f2fa

--- a/plugins/deckscape
+++ b/plugins/deckscape
@@ -1,0 +1,2 @@
+repository=https://github.com/jona139/DeckscapePlugin.git
+commit=13b5db927b017aa8c200d5e28b71f900e22a54c0

--- a/plugins/deckscape
+++ b/plugins/deckscape
@@ -1,2 +1,2 @@
 repository=https://github.com/jona139/DeckscapePlugin.git
-commit=13b5db927b017aa8c200d5e28b71f900e22a54c0
+commit=00d3f10b0710e9e8d1008971dd6c32fd9d732ae1

--- a/plugins/deckscape
+++ b/plugins/deckscape
@@ -1,2 +1,2 @@
 repository=https://github.com/jona139/DeckscapePlugin.git
-commit=00d3f10b0710e9e8d1008971dd6c32fd9d732ae1
+commit=ee2750af7b94ae4cfa92442413beb3c6e3f07b7d

--- a/plugins/deckscape
+++ b/plugins/deckscape
@@ -1,2 +1,2 @@
 repository=https://github.com/jona139/DeckscapePlugin.git
-commit=ee2750af7b94ae4cfa92442413beb3c6e3f07b7d
+commit=2aecfaab9883cab99abb7433f72954640b699ebb

--- a/plugins/deckscape
+++ b/plugins/deckscape
@@ -1,2 +1,3 @@
 repository=https://github.com/jona139/DeckscapePlugin.git
-commit=46eb759b2cbea43538829ab7e34f6301dca8f2fa
+commit=719ea498db4ac4c11d02c7b50ff78a30f69e489b
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Description

Deckscape is an opt-in RuneLite companion for the playable Deckscape card game. Players can earn card packs through eligible OSRS activity, open animated packs, browse their collection, and synchronize their cards with the external Deckscape website, where the collected cards can be used in a working card game.

The collection also supports alternate card artwork made by OSRS community artists and gold card trims associated with real in-game achievements.

## External service and privacy

Deckscape is an independent third-party service and is not affiliated with RuneLite or Jagex. Communication with Deckscape is disabled by default and requires the user to enable “Share data with Deckscape (third party)” in the plugin settings.

When enabled, the plugin communicates with the Deckscape Supabase backend to synchronize account linking, rewards, packs, collection data, and verified challenge progress. Remote card artwork may also be loaded from the OSRS Wiki artwork host when it is not bundled with the plugin.

The plugin does not send RuneScape credentials, website passwords, chat messages, bank contents, inventory contents, or the player's RuneScape display name.

Progression and rewards are server-authoritative, idempotent, and restricted to eligible normal worlds where applicable.

Additional information:

- Repository: https://github.com/jona139/DeckscapePlugin
- Privacy notice: https://github.com/jona139/DeckscapePlugin/blob/main/PRIVACY.md
- Deckscape website: https://deckscape.gamecubejona.com

## Review notes

- Uses the standard Plugin Hub build
- Targets Java 11 and RuneLite `latest.release`
- Does not use reflection, native code, process execution, or additional runtime dependencies
- The larger plugin JAR is primarily caused by bundled card artwork, reducing the need for runtime artwork downloads