### PR TITLE
Fix Disconnect not actually closing the chat connection

### DIFF
--- a/plugins/twitch-chat-side-panel
+++ b/plugins/twitch-chat-side-panel
@@ -1,3 +1,3 @@
 repository=https://github.com/georgeparamore/Runelite-Twitch-Chat-Side-Panel.git
-commit=2df89910d297e98a1991952701c7777fab11b90f
+commit=ea430d71ab0080edc9b5e8b66ff3c41d80d26552
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/twitch-chat-side-panel
+++ b/plugins/twitch-chat-side-panel
@@ -1,3 +1,3 @@
 repository=https://github.com/georgeparamore/Runelite-Twitch-Chat-Side-Panel.git
-commit=72e9a6efb39ed61ff9d2ad15c469d5051bd36f19
+commit=2df89910d297e98a1991952701c7777fab11b90f
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## What this fixes
Clicking "Disconnect" showed the panel as disconnected immediately, but
the underlying WebSocket connection to Twitch stayed open and kept
delivering chat messages, since `disconnect()` only started a graceful
close handshake (`sendClose()`) that doesn't complete until Twitch acks
its own close frame back - not guaranteed to happen promptly.

## Fix
Uses `WebSocket.abort()` to tear down the connection immediately instead,
and drops any message already in flight when `disconnect()` runs.