### PR TITLE
Add Iron Path plugin

### DIFF
--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,2 +1,2 @@
 repository=https://github.com/Mangodrink/iron-path.git
-commit=7e51f6446ca208d67d198837284ede057196120f
+commit=56b548feb230724c136c6d14e915656a682e7b10

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,0 +1,2 @@
+repository=https://github.com/Mangodrink/iron-path.git
+commit=7e51f6446ca208d67d198837284ede057196120f


### PR DESCRIPTION
## Iron Path — 1-to-max Ironman Companion

A display-only RuneLite plugin for ironmen that provides:

- **Phased milestone path** (~75 milestones across 5 phases) with auto-detection for quests, skill gates, and key bank items. Manual checkboxes for gear/habit milestones, persisted per RS profile.
- **Supply watchdog** — scans bank + inventory for prayer pots, restores, staminas, super combats, anti-venom+, food, and herb seeds. Low items show a restock hint naming the input chain.
- **Session & progress header** — total level progress bar toward 2,376, session XP, and bank net-worth snapshot.
- **Slayer readout** — current task, amount remaining, and streak read directly from varps (same pattern as the core Slayer plugin, including the boss-task DB-table lookup).
- **Daily Loop checklist** — herb run, birdhouse run, Kingdom, Hespori, battlestaff purchase, Tears of Guthix. Auto-resets daily at 00:00 UTC (weekly for Tears).
- **Next Up overlay** — compact on-screen box with current milestone, slayer task, and supply warning count.

The plugin is entirely display-only: no automation, no input injection, no hidden data. Fully within Jagex's third-party client rules.

All API usage has been verified against runelite/runelite master: quest enum names, Skill constants (including SAILING), ItemID/VarPlayerID/VarbitID/DBTableID constants, and slayer task name resolution. No deprecated API is used.

Plugin repo: https://github.com/Mangodrink/iron-path