### PR TITLE
Add bloodwood-status plugin repository information

### DIFF
--- a/plugins/bloodwood-status
+++ b/plugins/bloodwood-status
@@ -1,0 +1,2 @@
+repository=https://github.com/alextozzi/bloodwood-status.git
+commit=96ef704067a25facb852dfb286dce4179ac8726a


### PR DESCRIPTION
Adds Bloodwood Status: highlights your character green while chopping a bloodwood tree and shows an unmissable red screen glow the moment you stop, only while near the tree.

