### PR TITLE
Update recipe-tracker

### DIFF
--- a/plugins/recipe-tracker
+++ b/plugins/recipe-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/recipe-tracker.git
-commit=d3d00e2bcc3c3cc36056a3014e6154cd3ee63f43
+commit=e1ac00fba57f95ab6c236a2ad496cdddc7fa16bc

--- a/plugins/recipe-tracker
+++ b/plugins/recipe-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/recipe-tracker.git
-commit=e1ac00fba57f95ab6c236a2ad496cdddc7fa16bc
+commit=9af2337c5761f031c261cabe2997663dc24e1797


### PR DESCRIPTION
Fix Track materials in native skill-guide menus without using client.menuAction. Also add profile-scoped bank material tracking: green when the required quantity is held, white when inventory plus the cached bank snapshot is sufficient, and red when the combined quantity is short. Bank snapshots refresh whenever the player opens or changes their bank.