### PR TITLE
update osrs-tcg

### DIFF
--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=cde65fbdc40efb57824e18b4c80f9b277a0bde49
+commit=132fe59a0d740a100a8e9d5554b43b605b91b52d

--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=2835bddd0bf5de6d2319e98a4bdd8d932a585795
+commit=1c2bf0ed7a032e34a85ecf03fd0d73c3456b3d80

--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=1c2bf0ed7a032e34a85ecf03fd0d73c3456b3d80
+commit=cde65fbdc40efb57824e18b4c80f9b277a0bde49


### PR DESCRIPTION
Credits
CoX Challenge Mode completions (18,500)
The Gauntlet (1,750) / Corrupted Gauntlet (4,500)
Phantom Muspah (741)
Abyssal Sire (350)
Shellbane Gryphon (235)

Fixes
Pets no longer trigger safe-mode combat check
Foil cards sort correctly in the album
Pack opening blocked on the welcome screen
Unicode symbol fix in the album

UI / QoL
Debug message toggle outside developer mode
Foil collection status indicator
Shop button adjustments
Sidebar layout update + links
Prep for additional booster packs