### PR TITLE
Update GE Uncut

### DIFF
--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,3 +1,3 @@
 repository=https://github.com/uzia35/ge-uncut.git
-commit=14c3fa20dad80e6c3f63973630b254b5f64cdbb8
+commit=ea7f34c3f27ab732495e28e68c7821a48bc0e1fe
 warning=This plugin submits your IP address and various account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates GE Uncut to 1.3.0 (uzia35/ge-uncut@ea7f34c3f27ab732495e28e68c7821a48bc0e1fe).

Reads the Grand Exchange trade history window when the player opens it, so trades made while the client was closed (or on mobile) sync into their tracked flips instead of leaving stale positions. Active flips in the panel now refresh on their own, and a fully-sold offer shows a green bar. No new permissions or endpoints beyond the existing geuncut.app API.
