### PR TITLE
Update RaidParty v.2.5.3

### DIFF
--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,3 +1,2 @@
 repository=https://github.com/Kalsupes/RaidParty.git
-commit=a8eabcc5709f561ac4e65dabcdd2bf770afc8d44
-disabled=excessive party traffic
+commit=ad059bc79c694b53770c8dfb572a0d7c36ba4ed8


### PR DESCRIPTION
This update resolves the `disabled=excessive party traffic` issue raised by Adam by implementing all three requested network optimizations (`send data less frequently`, `send diffs`, `use shorter field names`):

### What Caused the Issue
Around June 27 (`v2.5.1`/`v2.5.2`), routine combat stat checks and XP gains triggered `needsPartySync = true` every combat tick (`600ms`). Because of non-nullable primitive properties and full field names (`activePrayers`, `skillLevels`, `skillXps`), the plugin was serializing and broadcasting ~850-byte JSON payloads (including all 48 skill integers and 24 long XP numbers) on nearly every game tick per active player (~11.3 Kbps per combat player). Across ~8k installs, this generated the ~5 Mbit/s spike.

### How v2.5.3 Completely Resolves This

1. **Shorter Field Names (`@SerializedName`):** Every field in `RaidPartyPlayerSync` now uses 1–2 letter JSON keys (`ap`, `hp`, `pr`, `ii`, `sl`, `sx`, `avp`, `up`, `cl`, `tl`, etc.) to minimize JSON overhead.

2. **True Delta / Diff Packets:** Converted packet fields to nullable Object wrappers (`Integer`, `Long`, `Boolean`) so `null` indicates *"unchanged since last broadcast"*. A player flicking a prayer or taking damage now transmits only the modified field delta: `{"type":"RaidPartyPlayerSync","ap":134480000}` (~40 bytes instead of ~850 bytes — a **~95% bandwidth reduction** per packet).

3. **Less Frequent Broadcasts & Array Throttling:** `skillLevels` and `skillXps` are excluded from routine fast combat ticks. Full baseline snapshots (`fullSync`) are only dispatched upon party join and every ~90 seconds as a keepalive. Idle heartbeat intervals were increased to 25 ticks (~15s), with remote ghost timeouts raised to 70 ticks (~42s) so idle bank-standing parties generate almost zero background traffic (`<= 0.02 Mbit/s`).

4. **Default Configuration Adjustments:**
   - Disabled `Play Audio Pings` by default out of the box (`false`).
   - Verified `Enable Low HP Glow` and `Enable Critical HP Glow` are disabled by default (`false`). -  
  
  Please re-enable `RaidParty` with this update (`v2.5.3`). Thank you!