### PR TITLE
Add Trouble Brewing Highlighter

### DIFF
--- a/plugins/trouble-brewing-highlighter
+++ b/plugins/trouble-brewing-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/trouble-brewing-highlighter.git
-commit=2144ffe110f6e0a1559b86504001a030bbbf3e15
+commit=5db13298070e23ce458127367c9f21edf44f6b31

--- a/plugins/trouble-brewing-highlighter
+++ b/plugins/trouble-brewing-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/xboxnuker-rgb/trouble-brewing-highlighter.git
+commit=2144ffe110f6e0a1559b86504001a030bbbf3e15


### PR DESCRIPTION
Adds Trouble Brewing Highlighter, a passive overlay for the Trouble Brewing minigame.

Features:
- Highlights resource sources, ingredients, monkeys and processing stations.
- Highlights relevant ground and inventory items.
- Highlights the supplied tools in the Trouble Brewing tool selector.
- Separates each brewing stage with configurable colours and display options.

The plugin does not automate interactions, modify menus, inject input, access the network or read/write files. It uses RuneLite gameval constants, Java 11 and the standard Plugin Hub build.

The existing Trouble Brewing plugin focuses on points and scoring. This plugin has a separate purpose: visual resource-route and processing guidance.

Tested manually in an active match across both team bases, both floors, inventory items, ground items and the tool-selector interface.