### PR TITLE
Add TCG Locked

### DIFF
--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,0 +1,2 @@
+repository=https://github.com/randytkrx/tcg-locked.git
+commit=e49b4c4d4cedaa5edb0d0b176b4b3f64857daafb


### PR DESCRIPTION
Adds TCG Locked, a challenge gamemode plugin.

You can only equip or use an item once you own its card in the OSRS TCG plugin. Equipment and teleport items stay locked until the matching card is pulled, a side panel tracks your unlocks, and lock icons show what is still locked. The plugin reads the OSRS TCG collection and stays inactive when no collection is present.

Repository: https://github.com/randytkrx/tcg-locked
Builds cleanly with gradlew build and includes a unit test for the item name matching.