### PR TITLE
Update paint-overlays to 0.1.1

### DIFF
--- a/plugins/paint-overlays
+++ b/plugins/paint-overlays
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/paint-overlays.git
-commit=4a1daee0270bf97d1f74728bb7608e830de69692
+commit=688c8aadf37af7635c61516e27a569f26aac3ee6


### PR DESCRIPTION
Updates Paint Overlays to 0.1.1 hotfix release. 

Changes in the plugin repo:
- fix ESC exiting paint/edit mode immediately after selecting a tool (important for usability)
- remove the stale debug export UI path that no longer exists in the plugin class
- update README and plugin description/version metadata