### PR TITLE
update pb-tracker-sync

### DIFF
--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/0xJeu/pb-tracker-sync.git
-commit=012c1400d5fb47016505ae0ce8528de93f1d742b
+commit=84a19748b8935ffed860b8a628edcaf3e538f880
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
I've updated PB Tracker Sync to `84a19748b8935ffed860b8a628edcaf3e538f880`.

This release adds the redesigned side panel and player search, right-click and `!pbr` lookups, panel decluttering and variant controls, Zenyte Labs branding, and recovery of normal and awakened Desert Treasure II boss PBs from their in-game scoreboards.

Validation:
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) gradle test` — 80 tests passed
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) gradle build` — passed

The Plugin Hub change is limited to the pinned commit hash.
