### PR TITLE
bis-gear: 0.2.0

### DIFF
--- a/plugins/bis-gear
+++ b/plugins/bis-gear
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/bis-gear-plugin.git
-commit=4eff9f60470ccf3d8d4e52ae324363e2b9fab1ed
+commit=82fd0cb212baa40f5a201509bb3b55b27ac5fce7


### PR DESCRIPTION
Bumps BiS Gear to 0.2.0 (`82fd0cb`).

This release restores a layer of target-specific effects that the plugin was not applying, so several
weapons were being scored at their raw stats and never suggested:

- **Reach and immunity** — melee was offered at Zulrah (only a halberd reaches it, since 7 May 2025) and
  ranged at Tekton; Kurask/Turoth accepted any weapon rather than leaf-bladed / broad ammo / Magic Dart.
- **Wilderness weapons** — the "in wilderness" option was never read, so Craw's bow and friends never won.
- **On task** — the black mask bonus only reached melee, and the helm was matched by name prefix, which
  missed every themed slayer helmet.
- **Bane weapons** — demonbane, keris, Barronite mace and ratbane were unimplemented.
- **Powered staffs** — only Tumeken's shadow had a max-hit formula; tridents, sanguinesti and the sceptres
  scored zero and could never be suggested.
- Raid target defence scaling (CoX party size / Challenge Mode, ToA invocation).

Licence is unchanged (BSD-2). No new dependencies. `./gradlew clean build` is green with 70 tests.