### PR TITLE
add inventory-retexture plugin 0.1.0

### DIFF
--- a/plugins/inventory-retexture
+++ b/plugins/inventory-retexture
@@ -1,0 +1,2 @@
+repository=https://github.com/technicallyengineers/inventory-retexture.git
+commit=a1f4b77add82e2c37b9a8b9f6cde1cb521016495


### PR DESCRIPTION
Plugin allows you to change the visual texture of an item type in your inventory to a different texture

Use case:
someone is used to clicking anglerfish in their inventory, and don't want to get used to the new icon of the marlin fish