### PR TITLE
update visual-bloodwood

### DIFF
--- a/plugins/visual-bloodwood
+++ b/plugins/visual-bloodwood
@@ -1,2 +1,2 @@
 repository=https://github.com/Dazakio/visual-bloodwood.git
-commit=e9520d477b1e4d65ef742ad061bf8e4e84dc0aa2
+commit=ba8c7f3d849643e4a90c657539f8edc408af679c

--- a/plugins/visual-bloodwood
+++ b/plugins/visual-bloodwood
@@ -1,2 +1,2 @@
-repository=https://github.com/CLColdest/visual-bloodwood.git
-commit=ba8c7f3d849643e4a90c657539f8edc408af679c
+repository=https://github.com/Dazakio/visual-bloodwood.git
+commit=e9520d477b1e4d65ef742ad061bf8e4e84dc0aa2


### PR DESCRIPTION
Updates Visual Bloodwood to the latest plugin commit.

This update adds support for the engorged Bloodwood tree, including:

- separate overlay states for ready, no bucket, chopping, second click, and draining
- a 45 second draining countdown
- optional notifications when the first phase is done and when draining finishes
- separate config sections for regular Bloodwood trees and the engorged Bloodwood tree
- updated README documentation