### PR TITLE
Add BIS Loadouts

### DIFF
--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,0 +1,2 @@
+repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
+commit=ed00c5c3fa7343c93421991416ea4627c45356eb

--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
-commit=ed00c5c3fa7343c93421991416ea4627c45356eb
+commit=5ad13d5a4f4a6af651971f0442e2dfd4dacff766

--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
-commit=5ad13d5a4f4a6af651971f0442e2dfd4dacff766
+commit=10d9f7bd0441751665bfaf0e2d839be4d8c82700


### PR DESCRIPTION
Adds BIS Loadouts, a boss-focused gear recommendation and pre-fight loadout sanity-check plugin.

Plugin repository: https://github.com/ItMeansBigMountain/bis-loadouts-osrs

Validation: `./gradlew clean test assemble --no-daemon --console=plain` with Java 11.