### PR TITLE
Update commit reference for loot-bank-filter plugin

### DIFF
--- a/plugins/loot-bank-filter
+++ b/plugins/loot-bank-filter
@@ -1,2 +1,2 @@
 repository=https://github.com/lathenso/loot-bank-filter.git
-commit=5899382939ff563144b8f2783705c3edd56a3d09
+commit=013c19cf2ee6fc05bb5b2e10d3895bdddf12ab3e


### PR DESCRIPTION
Adds a permanent lifetime archive so the all-time view never loses loot when old sessions age out