### PR TITLE
Remove TCG Locked

### DIFF
--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,0 @@
-repository=https://github.com/randytkrx/tcg-locked.git
-commit=e49b4c4d4cedaa5edb0d0b176b4b3f64857daafb


### PR DESCRIPTION
Removing tcg-locked; it substantially overlaps Bronzeman TCG (#13638), as raised in #13902.