### PR TITLE
Add Ranked Duels

### DIFF
--- a/plugins/ranked-duels
+++ b/plugins/ranked-duels
@@ -1,0 +1,2 @@
+repository=https://github.com/martynasbutkus/ranked-duels.git
+commit=f3e5d8b912d34e27e9ed87ba7a2f118283e1e3f6

--- a/plugins/ranked-duels
+++ b/plugins/ranked-duels
@@ -1,2 +1,3 @@
 repository=https://github.com/martynasbutkus/ranked-duels.git
 commit=9be47ac47de8b6b5814aed0df8714dd3de9c4222
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/ranked-duels
+++ b/plugins/ranked-duels
@@ -1,2 +1,2 @@
 repository=https://github.com/martynasbutkus/ranked-duels.git
-commit=f3e5d8b912d34e27e9ed87ba7a2f118283e1e3f6
+commit=825f6c291fb070a61ecb497f222fc44d08439d34

--- a/plugins/ranked-duels
+++ b/plugins/ranked-duels
@@ -1,2 +1,2 @@
 repository=https://github.com/martynasbutkus/ranked-duels.git
-commit=825f6c291fb070a61ecb497f222fc44d08439d34
+commit=9be47ac47de8b6b5814aed0df8714dd3de9c4222


### PR DESCRIPTION
Ranked Duels lets players challenge each other to rated duels anywhere in Gielinor. Both clients independently report results to my backend at rankedduel.com (rating, world, gear snapshot, kill/death events); results only count when both reports agree. Players are auto-registered on first login using their account hash (or a SHA-256 of the login name for non-Jagex accounts) — no credentials are ever sent. If the player also runs PvP Performance Tracker, this plugin reads its public fight history via reflection to attach fight stats to the duel — read-only, wrapped in try/catch, degrades gracefully when PPT is absent. No staking, no wagering, no gameplay automation.