### PR TITLE
Add Gustav's Helper

### DIFF
--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,2 @@
-repository=https://github.com/dangraagu/Osiris-guide.git
+repository=https://github.com/dangraagu/Gustav-s-helper.git
 commit=4a3233b52cd4754e1671b4509045b7feee5382af

--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/dangraagu/Osiris-guide.git
+commit=4a3233b52cd4754e1671b4509045b7feee5382af

--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=4a3233b52cd4754e1671b4509045b7feee5382af
+commit=2fa55707b6b7ac66c2884610c09757b5fd64f166


### PR DESCRIPTION
Adds Gustav's Helper — a Quest-Helper-style ironman *progression* helper. It walks a player through whole-account ironman guides as one continuous, auto-tracked route: current step, world/minimap arrows, a highlight on the NPC/object/item to use, dialogue-option highlight, requirement checks, and auto-advance as skills/quests/items/varbits change.

Repo: https://github.com/dangraagu/Osiris-guide

Technical: no reflection, no runtime network (reads bundled JSON guide data + game state only); third-party deps are compileOnly. Builds via the standard plugin template.

Content/attribution: the bundled guide ROUTES are the work of their authors and are credited in NOTICE — Oziris (ironman.guide), several OSRS Wiki guides (CC BY-NC-SA 3.0), and a community alt-guide by "Max". The plugin is an unofficial companion, not affiliated with Jagex, Oziris, or ironman.guide. Happy to adjust the plugin name, description, or which guides ship based on your feedback.