### PR TITLE
Add lootdeck plugin

### DIFF
--- a/plugins/lootdeck
+++ b/plugins/lootdeck
@@ -1,0 +1,3 @@
+repository=https://github.com/Dejelle/lootdeck-runelite-plugin.git
+commit=535ec458bab5090fd525c95038c23169d774ad18
+warning=After you link an account, this plugin submits your OSRS display name, account hash, gameplay activity and IP address to a 3rd-party server (the LootDeck service) not controlled or verified by the RuneLite developers.

--- a/plugins/lootdeck
+++ b/plugins/lootdeck
@@ -1,3 +1,3 @@
 repository=https://github.com/Dejelle/lootdeck-runelite-plugin.git
-commit=535ec458bab5090fd525c95038c23169d774ad18
+commit=7d9ca1b61eb60a39427e397479dd89d79863539a
 warning=After you link an account, this plugin submits your OSRS display name, account hash, gameplay activity and IP address to a 3rd-party server (the LootDeck service) not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
## LootDeck — cosmetic collectible card plugin

**Unofficial fan project. Not affiliated with, endorsed by, or sponsored by Jagex.**

LootDeck awards **cosmetic** collectible trading cards for qualifying Old School RuneScape gameplay. The plugin is **read-only**: it reports qualifying activity to the LootDeck service and plays a drop animation when the server awards a card pack. It does **not** automate anything, read the bank or chat, or affect gameplay, and cards have **no real-money value**.

**Packs are earned through gameplay, never purchased** — there is no way to buy packs, cards, or better odds with money. This is a cosmetic collection, not a paid loot box.

- **Repository:** https://github.com/Dejelle/lootdeck-runelite-plugin
- **Website:** https://www.lootdeck.org (card catalog, collection, account linking; privacy policy + terms in the footer)
- **Pinned commit:** `535ec458bab5090fd525c95038c23169d774ad18` (v1.4)
- **License:** BSD 2-Clause
- **Dependencies:** only `net.runelite:client` (OkHttp + Gson are transitive from it — no extra third-party jars to hash-verify)
- **Profile:** Standard only — Leagues / DMM / beta / seasonal worlds are ignored.

### Network usage disclosure

**Opt-in — nothing is sent until the player links an account** by pasting a code from the website. Before linking, the plugin makes no network calls.

**Endpoint:** `https://api-production-decd.up.railway.app`

**What is sent (after opt-in):**
- OSRS **account hash** (`getAccountHash()`, a non-reversible number) and **display name**.
- A **gameplay event** on a qualifying activity: an activity id (e.g. `KILL_ZULRAH`, `CLUE_HARD`) or, for gathering, a resource **item id + quantity** — plus a timestamp and a random idempotency id.
- The linked account's **low-privilege bearer token** (issued at link time) and a plugin-version header on each request.
- **World number** — only when the player submits a bug report from the plugin.

**What is NOT sent:** no passwords, no bank contents, no chat, no location data, no automation.

All reporting runs **off the client thread**. The bearer token is low-privilege (report drops; read/open the player's own packs) and can be **revoked anytime** from the website's Link page, which invalidates it server-side immediately. It is stored in RuneLite's per-profile config (device-local), as with any plugin that holds an API key. A privacy policy and terms of service are linked in the site footer.

### Donations

The side panel has a **Donate** button linking to `https://ko-fi.com/lootdeck`. Donations are voluntary, fund server costs, and **grant nothing in-game** — no packs, cards, or odds changes. There are no paid or "premium" plugin features; everything works for free.

### Icon / build

`icon.png` (48×48) is at the repo root; `./gradlew build` passes on JDK 11. The in-client side panel shows this same data-sharing disclosure before the opt-in link step.
