### PR TITLE
Add OSRS Journal plugin

### DIFF
--- a/plugins/osrs-journal
+++ b/plugins/osrs-journal
@@ -1,2 +1,2 @@
-repository=https://github.com/KyleLandon/osrs-journal-plugin.git
-commit=5e31bfb14ebf6cd2984b5dc24438771959188f58
+﻿repository=https://github.com/KyleLandon/osrs-journal-plugin.git
+commit --trailer "Co-authored-by: Cursor <cursoragent@cursor.com>"=fabef1eee05d609b8f9bb769fd766841692047d1

--- a/plugins/osrs-journal
+++ b/plugins/osrs-journal
@@ -1,2 +1,2 @@
 repository=https://github.com/KyleLandon/osrs-journal-plugin.git
-commit=5c7224ec1502a57923a6b55de2762c91ecc977f4
+commit=4455ea4b8d6aa5d0adf431278ee2b0673530df90

--- a/plugins/osrs-journal
+++ b/plugins/osrs-journal
@@ -1,2 +1,2 @@
 repository=https://github.com/KyleLandon/osrs-journal-plugin.git
-commit=fabef1eee05d609b8f9bb769fd766841692047d1
+commit=eadda2ff3c32a0c5ee709094088bfedfbf55dfa0

--- a/plugins/osrs-journal
+++ b/plugins/osrs-journal
@@ -1,2 +1,2 @@
-﻿repository=https://github.com/KyleLandon/osrs-journal-plugin.git
-commit --trailer "Co-authored-by: Cursor <cursoragent@cursor.com>"=fabef1eee05d609b8f9bb769fd766841692047d1
+repository=https://github.com/KyleLandon/osrs-journal-plugin.git
+commit=fabef1eee05d609b8f9bb769fd766841692047d1

--- a/plugins/osrs-journal
+++ b/plugins/osrs-journal
@@ -1,0 +1,2 @@
+repository=https://github.com/KyleLandon/osrs-journal-plugin.git
+commit=2f9fe4d1881710621c9ff5ee016e88502c496d42

--- a/plugins/osrs-journal
+++ b/plugins/osrs-journal
@@ -1,2 +1,2 @@
 repository=https://github.com/KyleLandon/osrs-journal-plugin.git
-commit=2f9fe4d1881710621c9ff5ee016e88502c496d42
+commit=5c7224ec1502a57923a6b55de2762c91ecc977f4

--- a/plugins/osrs-journal
+++ b/plugins/osrs-journal
@@ -1,2 +1,2 @@
 repository=https://github.com/KyleLandon/osrs-journal-plugin.git
-commit=4455ea4b8d6aa5d0adf431278ee2b0673530df90
+commit=5e31bfb14ebf6cd2984b5dc24438771959188f58

--- a/plugins/osrs-journal
+++ b/plugins/osrs-journal
@@ -1,2 +1,3 @@
 repository=https://github.com/KyleLandon/osrs-journal-plugin.git
 commit=12d89f075c0c0ae93f8c97f9121a96cb5de9935d
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-journal
+++ b/plugins/osrs-journal
@@ -1,2 +1,2 @@
 repository=https://github.com/KyleLandon/osrs-journal-plugin.git
-commit=eadda2ff3c32a0c5ee709094088bfedfbf55dfa0
+commit=686f150bc552dceb1b1a68764b32071924159762

--- a/plugins/osrs-journal
+++ b/plugins/osrs-journal
@@ -1,2 +1,2 @@
 repository=https://github.com/KyleLandon/osrs-journal-plugin.git
-commit=686f150bc552dceb1b1a68764b32071924159762
+commit=12d89f075c0c0ae93f8c97f9121a96cb5de9935d


### PR DESCRIPTION
﻿## OSRS JournalSyncs your character to [journal.osrsjournal.com](https://journal.osrsjournal.com) ΓÇö skills, XP, quest states, worn gear, achievement diaries, and combat achievement tiers ΓÇö with a sidebar summary panel.- **Bank sync is opt-in** (off by default); when enabled, bank data is only visible to the signed-in owner- Pairing flow: the plugin shows a short-lived code that links the in-game character to a website account ΓÇö no credentials are handled by the plugin- All writes go through authenticated backend functions (per-character sync token); no database keys ship in the jar- **Fully open source**, including the backend: [osrs-journal-backend](https://github.com/KyleLandon/osrs-journal-backend) (Edge Functions, schema, RLS policies) and [osrs-journal-web](https://github.com/KyleLandon/osrs-journal-web) (website)- Public profiles show skills/quests only (same data as the official hiscores), disclosed at link time with a one-click privacy toggle; bank/gear are never public- Users can delete their account and all synced data from the website (GDPR-style)- Privacy policy: https://journal.osrsjournal.com/privacy.html (also linked in the plugin description and sidebar)- Uses RuneLite's injected OkHttpClient/Gson/ScheduledExecutorService; no reflection, JNI, or runtime code downloadRepo: https://github.com/KyleLandon/osrs-journal-pluginCommit: `12d89f075c0c0ae93f8c97f9121a96cb5de9935d`