### PR TITLE
Update TCG Locked

### DIFF
--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=e49b4c4d4cedaa5edb0d0b176b4b3f64857daafb
+commit=2f4755510007e5134c3b48d11641a7958186d53e


### PR DESCRIPTION
Reworks TCG Locked into a group card collection challenge for the OSRS TCG plugin.

Since the last version it adds: monster locking, one click difficulty presets, an unlock reveal with item art and a chime, a collection lockbook, and RuneLite party play where the whole group pools its unlocks (a card owned by any member unlocks that item for everyone). Also fixes a party message threading issue and contains the lockbook grid in a scrolling box.

Repository: https://github.com/randytkrx/tcg-locked
Builds cleanly with gradlew build; includes a unit test for the item name matching.