### PR TITLE
adding burning woman

### DIFF
--- a/plugins/burning-woman
+++ b/plugins/burning-woman
@@ -1,0 +1,2 @@
+repository=https://github.com/losergirltwink/burning-woman-osrs.git
+commit=5b7fb50aa91d1f80af72d0a7302418827631d31f


### PR DESCRIPTION
burning woman plugin, requested by a friend. lets you mark a tile after burning a fire on it, like tileman (currently no restricted movement mode)