### PR TITLE
update `clan-chat-country-flags` to v1.3.0

### DIFF
--- a/plugins/clan-chat-country-flags
+++ b/plugins/clan-chat-country-flags
@@ -1,2 +1,2 @@
 repository=https://github.com/rmobis/clan-chat-country-flags.git
-commit=aa8866fac701da48fbc3f2ae61986ac0708d03eb
+commit=24821eada93a00e7c58fdda7d6cff4b311e1d665


### PR DESCRIPTION
Small changes to use more up to date APIs and support new world regions (Brazil, Singapore, Japan and South Africa). Thanks @cbgama

edit: all flags were obtained by modifying images available in wikipedia under public domain