### PR TITLE
update visual-bloodwood

### DIFF
--- a/plugins/visual-bloodwood
+++ b/plugins/visual-bloodwood
@@ -1,2 +1,2 @@
 repository=https://github.com/Dazakio/visual-bloodwood.git
-commit=e9520d477b1e4d65ef742ad061bf8e4e84dc0aa2
+commit=4179af36b7828c9636091b50019fa7f7f0e32ccb


### PR DESCRIPTION
Updates Visual Bloodwood to the latest tested commit.

  Changes included:
  - Pauses the engorged Bloodwood drain timer when the player interrupts the drain
  action by moving.
  - Removes the Inventory: Full line from the session overlay.