### PR TITLE
Add Group TCG

### DIFF
--- a/plugins/group-tcg
+++ b/plugins/group-tcg
@@ -1,0 +1,3 @@
+repository=https://github.com/Sqwiglyy/groupman-tcg.git
+commit=126f6990181c0afcdf4afe6fc8a4a099ebb0a7bf
+warning=Enabling group sync submits your IP address, RuneScape display name, OSRS TCG collection, pack events, and Top Trumps activity to a user-configured server not controlled or verified by the RuneLite developers. Enabling card artwork also exposes your IP address and requested image URLs to the OSRS Wiki.

--- a/plugins/group-tcg
+++ b/plugins/group-tcg
@@ -1,3 +1,3 @@
 repository=https://github.com/Sqwiglyy/groupman-tcg.git
-commit=126f6990181c0afcdf4afe6fc8a4a099ebb0a7bf
+commit=fff0e45ec0616ca173a1e89501dd66d9e339476d
 warning=Enabling group sync submits your IP address, RuneScape display name, OSRS TCG collection, pack events, and Top Trumps activity to a user-configured server not controlled or verified by the RuneLite developers. Enabling card artwork also exposes your IP address and requested image URLs to the OSRS Wiki.

--- a/plugins/group-tcg
+++ b/plugins/group-tcg
@@ -1,3 +1,3 @@
 repository=https://github.com/Sqwiglyy/groupman-tcg.git
-commit=fff0e45ec0616ca173a1e89501dd66d9e339476d
-warning=Enabling group sync submits your IP address, RuneScape display name, OSRS TCG collection, pack events, and Top Trumps activity to a user-configured server not controlled or verified by the RuneLite developers. Enabling card artwork also exposes your IP address and requested image URLs to the OSRS Wiki.
+commit=975187f22e591e24c4dc3824a21f3a287218088e
+warning=IMPORTANT MULTIPLAYER PRIVACY WARNING: Group TCG deliberately has no official public server; multiplayer uses only a private server chosen by your group. Only connect to servers run by friends you trust. The host controls the endpoint and may see or record your IP address and synced Group TCG data. Private servers are independently operated; the Group TCG creator does not operate, verify, endorse, or accept responsibility for servers hosted by others. Use a VPN if you need to hide your IP address. Solo play does not connect to a group server. Optional card artwork also sends your IP address and requested image URLs to the OSRS Wiki.

--- a/plugins/group-tcg
+++ b/plugins/group-tcg
@@ -1,3 +1,3 @@
 repository=https://github.com/Sqwiglyy/groupman-tcg.git
-commit=975187f22e591e24c4dc3824a21f3a287218088e
+commit=4d32609df93cbd6e1959389434d6cb08fdfcda89
 warning=IMPORTANT MULTIPLAYER PRIVACY WARNING: Group TCG deliberately has no official public server; multiplayer uses only a private server chosen by your group. Only connect to servers run by friends you trust. The host controls the endpoint and may see or record your IP address and synced Group TCG data. Private servers are independently operated; the Group TCG creator does not operate, verify, endorse, or accept responsibility for servers hosted by others. Use a VPN if you need to hide your IP address. Solo play does not connect to a group server. Optional card artwork also sends your IP address and requested image URLs to the OSRS Wiki.


### PR DESCRIPTION
Group TCG v0.1.1 uses cards opened through OSRS TCG as solo or shared Bronzeman unlocks.

Group TCG is a plugin aimed at making the popular OSRS TCG into a Group Bronzeman experience. Sharing card collections with your team, showing live pack openings from your friends, linked bronzeman progression, a card power leaderboard for healthy competition and the ability to play Top Trumps with your collections against eachother.


## Multiplayer safety and responsibility

Group TCG deliberately has **no official/main public server**. A central service would receive every multiplayer group's connection data; instead, server sync is off by default and each group deliberately chooses the friend who controls its private endpoint and synced data.

Private hosting is not IP anonymity. The host may see or record connecting IP addresses and synced Group TCG data, so players should only connect to servers run by friends they trust and use a VPN when their IP address must be hidden.

Private servers are independently operated. The Group TCG creator does not operate, verify, endorse, or accept responsibility for servers hosted by other people.

Version 0.1.1 adds the following visible safeguards:

- a prominent Plugin Hub installation warning;
- a permanent red multiplayer privacy warning at the top of the sidebar;
- explicit IP/VPN language in server settings;
- a warning dialog and required trust acknowledgement before joining;
- matching warnings at the top of the README and privacy policy.

Solo play remains entirely local. Server sync and OSRS Wiki artwork downloads are both off by default.

## Version 0.1.1 restriction fixes

- block locked ground-item pickup and telegrab;
- block locked Grand Exchange search-result selection and mark locked GE item images;
- block locked shop purchases and mark locked shop stock;
- mark locked item icons in both skill-guide interfaces.

Plugin repository: https://github.com/Sqwiglyy/groupman-tcg
Pinned source commit: 975187f22e591e24c4dc3824a21f3a287218088e

Server repository: https://github.com/Sqwiglyy/groupman-tcg-server

Checks completed:

- clean Java 11 build;
- 49 tests passed;
- standard Plugin Hub build with no additional runtime dependencies;
- no reflection, JNI, subprocess execution, or runtime source downloads.