### PR TITLE
update haggle-helper 1.1.6

### DIFF
--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=4dc4e7a66b06654a3c0db9e963a9978b05631400
+commit=5cc3a729745d1355238f6b32aeeacc0dcabf25f7


### PR DESCRIPTION
- update docs to hopefully fix gifs on plugin hub page 