### PR TITLE
pvp profit tracker 1.6.0

### DIFF
--- a/plugins/pvp-profit-tracker
+++ b/plugins/pvp-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-profit-tracker.git
-commit=98d7505c2d0698d5978be419da95f77918af5d54
+commit=109edc90aa63ae84aa8f2a312ee921b94b7d1fdc


### PR DESCRIPTION
another update.

fight breakdowns. fights now record a breakdown you can open from past fights by clicking the win/loss label. it opens in its own window with the fight's hits, damage and times, plus totals up top. only the most recent fights keep one.

draws. if you and your opponent die at the same time it counts as a draw now instead of a win and a loss, and records show wins, losses and draws.

past fights got cleaner. one row per opponent, their most recent fight. click the name for your full history with them. fights where nobody dies still get saved for review, they just don't touch your record.

two small overlays, both optional and movable: a damage counter for the current fight and the opponent's hp.

all display only like the rest of the plugin.
