### PR TITLE
P1770 plugin

### DIFF
--- a/plugins/p1770
+++ b/plugins/p1770
@@ -1,0 +1,2 @@
+repository=https://github.com/septemgeminus/p1770.git
+commit=9d724e43e5d9f156d6ed286fc8bac4d540fdee6a

--- a/plugins/p1770
+++ b/plugins/p1770
@@ -1,2 +1,2 @@
 repository=https://github.com/septemgeminus/p1770.git
-commit=9d724e43e5d9f156d6ed286fc8bac4d540fdee6a
+commit=b38bf1102cae908a766a4ddb245bd28b0076e230

--- a/plugins/p1770
+++ b/plugins/p1770
@@ -1,2 +1,2 @@
 repository=https://github.com/septemgeminus/p1770.git
-commit=b38bf1102cae908a766a4ddb245bd28b0076e230
+commit=8083fce4ab9fab1c9711c8357eeaeeec26d03f02


### PR DESCRIPTION
A simple kill-count/item-count tracker for item-grinds based indirectly on killing NPCs, that also provides some feedback as to how lucky one is on one's grind, based on grind-specific probabilities that users can specify.

The personal motivation is to have a tracker that offers some feedback per kill for a purely Bryophyta-based essence grind. It comes pre-configured for an Obor-based Giant Club grind as well as the Bryophyta-based essence grind; but the plugin intentionally tries to be dumb, simple, and universal.

The plugin is general enough that I believe to have been able to test it sufficiently on different mobs around Lumbridge.

I have tried to write a decent README, please refer to it for further information.

I believe my previous PR,

https://github.com/runelite/plugin-hub/pull/12964

failed due to library scarcity. I've since added a DIY replacement for what I hope was the main culprit.