### PR TITLE
Kick Chat Side Panel

### DIFF
--- a/plugins/kick-chat-side-panel
+++ b/plugins/kick-chat-side-panel
@@ -1,0 +1,3 @@
+repository=https://github.com/georgeparamore/runelite-kick-chat-side-panel.git
+commit=01989a4077d645ee2da6f0a4f272e9ef3a4cd280
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## What this plugin does

Shows a Kick (kick.com) channel's live chat in a RuneLite side panel, Party-Hub style, instead of a separate browser window. Sibling plugin to the already-merged [Twitch Chat Side Panel](https://github.com/georgeparamore/runelite-twitch-chat-side-panel), same concept applied to Kick.

## Why it's useful

Lets a player follow a streamer's live chat without alt-tabbing out of the client, the same value proposition as the Twitch plugin and the official Twitch plugin it's modeled after.

## How players interact with it

1. Set a Kick channel name/URL in the plugin's settings.
2. Open the side panel (toolbar icon) and click Connect - chat starts flowing immediately, no login required.
3. Optionally click "Log in with Kick" (OAuth, opens the system browser) to unlock sending messages from the panel.

Chat renders as plain text only - no emote or badge image rendering, per the policy noted in [Rejected or Rolled Back Features](https://github.com/runelite/runelite/wiki/Rejected-or-Rolled-Back-Features) and already applied on the Twitch plugin.

## External communication

- Reads chat over Kick's WebSocket chat feed (anonymous, no credentials) and Kick's REST API for channel lookup.
- Sending messages and logging in go through Kick's official public REST API (api.kick.com / id.kick.com) via OAuth 2.1.
- No other third-party service is contacted.

Repo: https://github.com/georgeparamore/runelite-kick-chat-side-panel