### PR TITLE
update haggle-helper v1.1.7

### DIFF
--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=5cc3a729745d1355238f6b32aeeacc0dcabf25f7
+commit=f2fdf808d5f558e838e09409ab82c40338fc5272


### PR DESCRIPTION
- fix: correct Betty's Magic Emporium shop name

(sorry for minuscule PR)