### PR TITLE
loadout-lab: bump to 0.3.0

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/ajkatz/runelite-loadout-lab.git
-commit=9dd5e2d17b9905a38f16f9cd7f3e8b7cb2211fcc
+commit=b9cf2870b08b5b2b6b5642091d1f3d60d4ca8170


### PR DESCRIPTION
Loadout Lab 0.3.0 - the multi-mob canvas.

Player-facing highlights:
- Results can now hold several mobs at once: add mobs to a search and get ONE set per style optimized across the whole list (weighted by each mob's hitpoints), with per-mob rows showing what that shared set does against each one. The carried spec weapon is chosen once for the trip too, and spec weapons now compete across styles (e.g. a crystal halberd spec on a magic setup).
- The results card was redesigned around per-result parameter chips (slayer task, wilderness, antifire mode, optimize mode, upgrade budget, risk cap) and a compact icon-based stat column.
- Engine correctness: Augury and Mystic Vigour no longer stack (they share a prayer group in game), the Moons of Peril set effects are modeled (Bloodrager, Eclipse burn, Frostweaver), void armour is properly considered for well-equipped accounts and elite magic void gains its missing +2.5% damage, and multi-form bosses (Zulrah) carry per-form protect prayers and damage-taken numbers.

Built and tested against latest.release; source is under the hub token cap (checkTokens).