### PR TITLE
update exchange-insights to v1.1.3

### DIFF
--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,3 +1,3 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=c8daf9f97cbd6934808fd682e027fff0430d7bae
+commit=451ee6d07a21e296f1f5040f85ad3e8cb56c573f
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
GE offer slot badges now write gaps under 1,000 coins as '-3 gp' instead of a bare '-3', which read like a broken abbreviation next to values like '-3.607M'.