### PR TITLE
Add Next Move

### DIFF
--- a/plugins/next-move
+++ b/plugins/next-move
@@ -1,0 +1,2 @@
+repository=https://github.com/willcampbell433/next-move-runelite.git
+commit=05618bf0e5d65044b5e129268327d7b4e47a2ea9

--- a/plugins/next-move
+++ b/plugins/next-move
@@ -1,3 +1,3 @@
 repository=https://github.com/willcampbell433/next-move-runelite.git
-commit=55808f23d2d0426c6b4ebc2339a27748d1710b0b
-warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.
+commit=dc1823261bca5982951e62f4b3eeaf3a949bf348
+warning=This plugin submits your IP address, RSN, and quest progress to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/next-move
+++ b/plugins/next-move
@@ -1,2 +1,2 @@
 repository=https://github.com/willcampbell433/next-move-runelite.git
-commit=05618bf0e5d65044b5e129268327d7b4e47a2ea9
+commit=b7583475cbc61715f173f0078816705be3d3ec6c

--- a/plugins/next-move
+++ b/plugins/next-move
@@ -1,2 +1,3 @@
 repository=https://github.com/willcampbell433/next-move-runelite.git
-commit=b7583475cbc61715f173f0078816705be3d3ec6c
+commit=55808f23d2d0426c6b4ebc2339a27748d1710b0b
+warning=This plugin submits your IP address and RSN to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/next-move
+++ b/plugins/next-move
@@ -1,3 +1,3 @@
 repository=https://github.com/willcampbell433/next-move-runelite.git
-commit=dc1823261bca5982951e62f4b3eeaf3a949bf348
-warning=This plugin submits your IP address, RSN, and quest progress to a 3rd-party server not controlled or verified by Runelite developers.
+commit=a5ccdf7a18f34269816657ff6baef4719270d48f
+warning=This plugin submits your IP address, RSN, quest progress, and locally completed recommendation IDs to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/next-move
+++ b/plugins/next-move
@@ -1,3 +1,3 @@
 repository=https://github.com/willcampbell433/next-move-runelite.git
 commit=af0d3b8a8602e097dc4d05fd8659d2d2c676d020
-warning=This plugin submits your IP address, RSN, quest progress, and locally completed recommendation IDs to a 3rd-party server not controlled or verified by RuneLite developers.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/next-move
+++ b/plugins/next-move
@@ -1,0 +1,3 @@
+repository=https://github.com/willcampbell433/next-move-runelite.git
+commit=af0d3b8a8602e097dc4d05fd8659d2d2c676d020
+warning=This plugin submits your IP address, RSN, quest progress, and locally completed recommendation IDs to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Next Move is a read-only RuneLite sidebar that turns public OSRS account data
into an Account Power score, short-term recommendations, and boss progression.

Public lookup is disabled by default and requires RuneLite's third-party-server
consent. The plugin sends only the selected OSRS username to a fixed HTTPS
endpoint and does not automate or modify gameplay.

Repository:
https://github.com/willcampbell433/next-move-runelite

Privacy:
https://github.com/willcampbell433/next-move-runelite/blob/master/docs/privacy.md