### PR TITLE
pvp profit tracker 1.6.1

### DIFF
--- a/plugins/pvp-profit-tracker
+++ b/plugins/pvp-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-profit-tracker.git
-commit=109edc90aa63ae84aa8f2a312ee921b94b7d1fdc
+commit=d3e8cda25a5830c2bf286e1cc50cfc6e15079ff7


### PR DESCRIPTION
quick hotfix. dying with protect item on could count the loss as more than you actually lost. fixed.
