### PR TITLE
Add immersive sound notifications plugin

### DIFF
--- a/plugins/immersive-sound-notifications
+++ b/plugins/immersive-sound-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/TrevorMDev/immersive-sound-notifications.git
-commit=88c5e6fc4afeabfad605237c54aca65f4f909483
+commit=e153493f637eee52e4e35d88bb62139280ca5770

--- a/plugins/immersive-sound-notifications
+++ b/plugins/immersive-sound-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/TrevorMDev/immersive-sound-notifications.git
+commit=e483c5d949e605c38d8028e77bcf366c9b4211f6

--- a/plugins/immersive-sound-notifications
+++ b/plugins/immersive-sound-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/TrevorMDev/immersive-sound-notifications.git
-commit=e483c5d949e605c38d8028e77bcf366c9b4211f6
+commit=ad38ef1fc11bc68cf95b049a43776dbb28cf800f

--- a/plugins/immersive-sound-notifications
+++ b/plugins/immersive-sound-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/TrevorMDev/immersive-sound-notifications.git
-commit=e153493f637eee52e4e35d88bb62139280ca5770
+commit=8cda91e0ed548bf104d1c67f8531d11b57034464

--- a/plugins/immersive-sound-notifications
+++ b/plugins/immersive-sound-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/TrevorMDev/immersive-sound-notifications.git
-commit=ad38ef1fc11bc68cf95b049a43776dbb28cf800f
+commit=88c5e6fc4afeabfad605237c54aca65f4f909483


### PR DESCRIPTION
This plugin adds sound queues for specific events.

Supported events:
- Divine expired
- Cannon out of ammo or broken
- Slaughter bracelet breaking
- Low prayer
 - Scales volume based on current prayer %, maxing at 0 prayer.
 - Under 50% prayer, plays every 5% change.
 - Under 10% prayer, plays every 2% change.

The sound effects can be changed(using in game soundIds) but the triggering events cannot.
This is to limit the power of the plugin, and avoid the need to disable it in tons of locations like WatchDog, while still allowing some cool effects.