### PR TITLE
Request Modern Chat plugin ownership transfer

### DIFF
--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
-repository=https://github.com/BenDol/Modern-Chat.git
+repository=https://github.com/GimmitheBong/Modern-Chat-Enhanced.git
 commit=aaf254897061835b308ff42321ad27b5af7727a2


### PR DESCRIPTION
I'd like to request ownership of the Modern Chat plugin.

I contacted the current maintainer more than 7 days ago but have not received a response.
(https://github.com/BenDol/Modern-Chat/issues/58)

Following the Plugin Hub takeover guidelines, I've updated the plugin manifest to point to my fork while leaving the existing commit hash unchanged.

Issues are enabled on my fork, and I'm happy to maintain the plugin going forward.

Thank you for your consideration.
