### PR TITLE
update route-planner

### DIFF
--- a/plugins/route-planner
+++ b/plugins/route-planner
@@ -1,2 +1,2 @@
 repository=https://github.com/BlackDeath-Osrs/route-planner.git
-commit=703821fcf251ead735b623a696b6fb2ecc0011e1
+commit=befe77a748cc5980b2c6e6febbf992469ba6605b


### PR DESCRIPTION
transition object highlights now work on ladders too — because apparently we thought stairs were the only way up.