### PR TITLE
Add Noot's Mixology

### DIFF
--- a/plugins/noots-mixology
+++ b/plugins/noots-mixology
@@ -1,0 +1,2 @@
+repository=https://github.com/lrdigital/noots-mixology.git
+commit=199ba1d44c9963c344c727127d0e21140def4eaf


### PR DESCRIPTION
Adds Noot's Mixology, a helper for the Mastering Mixology minigame.

You pick which reward you are saving for and it suggests which orders to make based on that reward's mox/aga/lye price. It also guides you through the lab one step at a time (levers, stations, conveyor), flashes the agitator and alembic speed-boost click windows, alerts you when a digweed spawns and when to combine it, and tracks your goal with an ETA in a side panel. Overlays only show inside the lab.

Nothing is automated and nothing leaves the client. It reads varbits, varps, the inventory and the lab scene objects, and draws highlights.

I know there is an existing Mastering Mixology plugin on the hub. This one is built around a different idea: you choose a target reward and every suggestion optimises your resin ratio toward that specific reward, with goal and ETA tracking on top. It is not a config variation on the existing plugin.

Repo: https://github.com/lrdigital/noots-mixology