### PR TITLE
Create last protection prayer - Please Review

### DIFF
--- a/plugins/last protection prayer
+++ b/plugins/last protection prayer
@@ -1,0 +1,2 @@
+repository=https://github.com/kp97-bit/recent-prot.git
+commit=f56279c4833dc1c35a4443400f0cc7d116bd341d


### PR DESCRIPTION
Hi - Thank you again for reviewing my plugin. My last attempt to commit this was rejected along these lines: "We will not be hosting plugins that track your last prayer as they are to assist with boss mechanics and are not compliant with the 3rd party client guidelines."

I don't quite understand the meaning behind "to assist with boss mechanics and are not compliant." There are many plugins available on the plugin hub that exist to assist with boss mechanics. Regardless, I reviewed the rules again to make sure. 
I understand the concern regarding the rule against prayer-switching indicators, but I believe this plugin is materially different from the type of assistance that rule is intended to prohibit.

The plugin only records and displays a status after the player manually clicks it. It does not:

-inspect an NPC, boss, projectile, animation, attack style, or encounter state
-predict an upcoming attack
-recommend which prayer the player should use
-indicate when the player should switch
-warn that the current prayer is wrong
-highlight a prayer button or otherwise direct the player’s next input
-automate, remap, or modify any click

The displayed value is therefore not derived from game mechanics or combat conditions. It is simply confirmation of the player’s own most recent manual input, similar in principle to an input-history display. 

I would appreciate if you could reconsider the decision along those lines; or provide further context as to why this plugin would not be allowed.

Thank you.