### PR TITLE
Update scapestack-sync to v0.3.0

### DIFF
--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
-commit=7a0100efe20f542bfdf623c3fab195eb56bc62b6
+commit=e29f6ac6995ffd8f95c3f71bebeac1d0ea26ebd3
 warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
-commit=dafcfb495aa1221a273e6f0e03d6aff5f2f41b92
+commit=7a0100efe20f542bfdf623c3fab195eb56bc62b6
 warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates `scapestack-sync` from the current v0.2.0 pin to v0.3.0.

## What changed
- Adds account mode, skill levels/XP, and observed boss kill counts to the snapshot contract.
- Adds explicit coverage metadata so unopened or unknown state is not serialized as zero/completed.
- Improves quest, diary, collection-log, Slayer, and optional bank context.
- Adds pairing, schema-readiness handling, compact player feedback, and actionable retry copy.
- Keeps HTTP and snapshot work off the RuneLite client thread and cancels in-flight work on shutdown.
- Keeps the development endpoint override to a JVM system property; environment variables are not read.

## Consent and privacy
- `Sync on login` and `Refresh after quests` default off.
- `Sync now` is an explicit manual action.
- Bank context contains item IDs, names, and quantities only when enabled and after the bank has been opened.
- Never sends inventory, equipment, GE offers, chat, screenshots, clicks, local files, or login credentials.
- Claim/sync send the local install token only as an Authorization bearer; the server stores its SHA-256 hash.
- The JSON payload contains no IP field; like any HTTPS destination, the server receives the connection IP at transport level.

## Verification
- Standalone `./gradlew clean build`: 90 tests passed; 1 live E2E test skipped by design.
- Monorepo `npm run ci:check`: 217 test files and 1,359 tests passed, plus typecheck, smoke, audit, and production build.
- `npm run plugin:release-check`: passed.
- Plugin Hub descriptor: `git diff --check` passed.

Pinned commit: `e29f6ac6995ffd8f95c3f71bebeac1d0ea26ebd3`
Verified RuneLite: `1.12.33`