### PR TITLE
Update Dutch Mayhem Clan to v2.0.0

### DIFF
--- a/plugins/dutch-mayhem-clan-plugin
+++ b/plugins/dutch-mayhem-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/nekomana-project/dutch-mayhem-clan-plugin.git
-commit=0c33b235248d0abb42983cb8570ad91bc375fb30
+commit=2dae4ed9e9bbe897ed76f5d7135146b010fcd152
 warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Clan-internal update, bumps the pinned commit. Changes since v1:

- Track PvP loot on PvP/Deadman worlds (whole world), not only the wilderness
- Split-tracker loot now labeled: loot key chest vs direct kill, plus victim name
- New kill/death events with map position/time for the clan's kill-map page
- Batched bingo drop reporting: one request per loot event instead of one per item
- Fixed login stat-replay firing ~20+ bogus level-up events at once
- Removed NPC loot from the split-tracker path (PvP loot only by design)
- Capped retry queue for failed posts (network failures only, 3 attempts, max 50)

All data still goes exclusively to the clan's own configured server; the plugin
is inert until a Server URL is set. README now documents exactly what is sent.
The existing hub warning line is kept unchanged.