### PR TITLE
PocketGE Flip Tracker

### DIFF
--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/lazyblob/pocketge-flip-tracker.git
+commit=6dbf4af2a2d9d7f2804960d3611f358bc4dc28f8

--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lazyblob/pocketge-flip-tracker.git
-commit=80aae580f5484a127f6586ca89fcc9368a921373
+commit=8ce0f8a9eff13cc0548f7b78acb3edcf04131eb9

--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lazyblob/pocketge-flip-tracker.git
-commit=6dbf4af2a2d9d7f2804960d3611f358bc4dc28f8
+commit=2c3359ba90c50e69efdbcfe0560d8fe885a2063f

--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lazyblob/pocketge-flip-tracker.git
-commit=2c3359ba90c50e69efdbcfe0560d8fe885a2063f
+commit=80aae580f5484a127f6586ca89fcc9368a921373


### PR DESCRIPTION
Adds PocketGE Flip Tracker — tracks the player's GE offers via GrandExchangeOfferChanged, records incremental fills, FIFO-matches buys against sells, and shows session flip profit after the 2% GE tax in a sidebar panel, with links to pocketge.com price charts.

Network disclosure: the plugin makes zero outbound requests. It has one opt-in, default-off feature that opens a loopback-only listener (127.0.0.1:8477) so the pocketge.com website open in the user's own browser can read their session flips locally. CORS is restricted to the PocketGE origins and no data ever leaves the machine.