### PR TITLE
Update commit reference in stymphike-hunter

### DIFF
--- a/plugins/stymphike-hunter
+++ b/plugins/stymphike-hunter
@@ -1,2 +1,2 @@
 repository=https://github.com/JoadsV/Stymphike.git
-commit=5829dbea7ee28bc5ca27ff7c0baabaa1f752c137
+commit=cd22c311a34d83236adcafccfc630bebcb7e5792


### PR DESCRIPTION
Fixes catch and flee detection: catches now announce reliably (they were being dropped on the larger trees), flees are detected properly, and the "no longer hidden" reminder no longer fires mid-catch.
