### PR TITLE
Add clucksquad-quest-sync plugin

### DIFF
--- a/plugins/clucksquad-quest-sync
+++ b/plugins/clucksquad-quest-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/daklatencoaten-lab/clucksquad.git
-commit=1f8bdc901ab10776845a27dd85d85c7dbd4b6521
+commit=37cf23989a7506aec0c610cb7d4824d341ccf2c1

--- a/plugins/clucksquad-quest-sync
+++ b/plugins/clucksquad-quest-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/daklatencoaten-lab/clucksquad.git
+commit=1f8bdc901ab10776845a27dd85d85c7dbd4b6521

--- a/plugins/clucksquad-quest-sync
+++ b/plugins/clucksquad-quest-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/daklatencoaten-lab/clucksquad.git
-commit=37cf23989a7506aec0c610cb7d4824d341ccf2c1
+commit=737b89ba1b6ef3fb89fc65ec24993df731e9c42e


### PR DESCRIPTION
New plugin: CluckSquad Quest Sync.

What it does: on login (and every 15 min, configurable) it reads the player's quest completion states and real skill levels and POSTs them to the CluckSquad clan website (https://clucksquad.com), where they populate the clan's Quest Calculator and highscores. This is the same approach WikiSync uses, since there is no public OSRS quest-completion API.

Network / data disclosure: this plugin sends quest completion states and skill levels to an external site (clucksquad.com), keyed by RuneScape name and guarded by a shared sync key. Nothing else is collected. Happy to add an in-config warning or adjust as needed.

Repo: https://github.com/daklatencoaten-lab/clucksquad
License: BSD 2-Clause.