### PR TITLE
Add Item Notes

### DIFF
--- a/plugins/item-notes
+++ b/plugins/item-notes
@@ -1,0 +1,2 @@
+repository=https://github.com/FreeArcanes/runelite-item-notes.git
+commit=4adf2ab4e44015dfbdea45824d34c9da3859a9e7


### PR DESCRIPTION
## Summary

Adds Item Notes, a local-only plugin for attaching private notes to items and keeping a lightweight item loan ledger.

Repository: https://github.com/FreeArcanes/runelite-item-notes

## Features

- Add or edit notes from item context menus in supported item containers.
- Display saved notes in hover tooltips and after examining an item.
- Configure the note label and note text colors.
- Treat a user-entered `@username` in a note as a local loan record, with a recorded timestamp and a **Mark returned** action.
- Canonicalize linked item variants so notes remain associated with the underlying item.

## Privacy and behavior

All data stays in the user's local RuneLite configuration. The plugin has no network service, does not synchronize between players, does not collect friend or clan rosters, and does not automate gameplay or send chat messages.

## Validation

- Built with the standard Plugin Hub configuration and RuneLite `latest.release`.
- `./gradlew clean test shadowJar` completed successfully.
- Unit tests cover note storage, canonical item handling, and loan parsing.
- Primary inventory, tooltip, examine, configuration, and loan-ledger flows were tested in the development client.
