### PR TITLE
loadout-lab: move to the AKAddons org

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,2 +1,3 @@
-repository=https://github.com/ajkatz/runelite-loadout-lab.git
+repository=https://github.com/AKAddons/runelite-loadout-lab.git
 commit=9dd5e2d17b9905a38f16f9cd7f3e8b7cb2211fcc
+authors=ajkatz


### PR DESCRIPTION
Ownership move only, mirroring goalplanner (#13641): the plugin repo now lives at AKAddons/runelite-loadout-lab (I am a public member; authors=ajkatz added per the org-repo convention). The pinned commit is unchanged - 9dd5e2d builds identically from the new location (full history was transferred).

A version bump to 0.3.1 will follow as a separate PR once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)