### PR TITLE
loadout-lab: 0.3.4

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=9dd5e2d17b9905a38f16f9cd7f3e8b7cb2211fcc
+commit=dbead0ed083c695f01cc1392d5afbb127e4a9702
 authors=ajkatz

--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=dbead0ed083c695f01cc1392d5afbb127e4a9702
+commit=f0a95a03a1ebc588f228de9607d4069b77ea4940
 authors=ajkatz


### PR DESCRIPTION
Updates Loadout Lab to 0.3.4 (pin f0a95a0).

0.3.4 removes all network I/O: the "Wiki calc" chip, which POSTed the shown setup to the wiki's shortlink service, and the async monster thumbnails on the mob rows. The plugin now makes no network requests at all.

Highlights since 0.3.2: bank setup view (equipment cross + inventory laid out via core bank-tag layouts), trip supplies with per-mob overrides, thralls + Death Charge modeling with autocast-clash handling, prayer/boost assumption pickers with per-style defaults, divine potions preferred as BiS, a fully optional Display/Controls/Defaults settings surface, DWMS integration moved to its new PluginMessage storages API (2.11.5+), and an elemental-weakness accuracy fix verified against the official calculator.
