### PR TITLE
Update GE Uncut

### DIFF
--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,3 +1,3 @@
 repository=https://github.com/uzia35/ge-uncut.git
-commit=ea7f34c3f27ab732495e28e68c7821a48bc0e1fe
+commit=56963a103cfceb802ec1e5cc7e4bce8a9e409c7c
 warning=This plugin submits your IP address and various account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates GE Uncut to 1.4.0 (uzia35/ge-uncut@56963a103cfceb802ec1e5cc7e4bce8a9e409c7c).

The side panel is reorganized into tabs (flip finder, active flips, market movers, history), active flips expand into a full profit breakdown, and archived positions can be restored from the new History tab. Adds a light theme option. Three new endpoints on the existing geuncut.app API (archive, restore, archived list); no new permissions or hosts.