### PR TITLE
Bump mastering-mixology-extended to 1.9.1-ext1.0

### DIFF
--- a/plugins/mastering-mixology-extended
+++ b/plugins/mastering-mixology-extended
@@ -1,3 +1,3 @@
 repository=https://github.com/PDBoegel/mastering-mixology.git
-commit=3d84eae4fbec1727fc845e68b967842836189090
+commit=99e079b1f0f8f1c7f05ebec5c335a25483e05ea9
 authors=pdboegel


### PR DESCRIPTION
## Summary

Bumps `mastering-mixology-extended` to commit `99e079b`, tagged as version `1.9.1-ext1.0` in build.gradle.

Adds an explicit version string (previously the manifest was pointing at a commit without a version, so users saw a commit-hash version in the client) and a README changelog entry documenting the current feature set.

No code changes.