### PR TITLE
Update Stockpile to 1.4

### DIFF
--- a/plugins/stockpile
+++ b/plugins/stockpile
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Stockpile-Plugin.git
-commit=2ba25bfaeea4b74929b5ed4632c65f9e17047742
+commit=df7660b16c32a0a28fd1cd66554cfdb12e1ed696


### PR DESCRIPTION
Updates Stockpile to release 1.4 (https://github.com/Oveduumnakal/Stockpile-Plugin/releases/tag/R-1.4).

Source-based cost tracking (GE/shop/trade/ground/alching/processing), a portfolio value history chart, session stats, list sorting and auto-categorization, export/share, and assorted fixes.