### PR TITLE
mastering-mixology-extended: bump to 1.9.1-ext1.1.0

### DIFF
--- a/plugins/mastering-mixology-extended
+++ b/plugins/mastering-mixology-extended
@@ -1,3 +1,3 @@
 repository=https://github.com/PDBoegel/mastering-mixology.git
-commit=3d84eae4fbec1727fc845e68b967842836189090
-authors=pdboegel
+commit=95d748419089d7a9b184ec06e50c541085ebde97
+authors=pdboegel, Mitchole


### PR DESCRIPTION
## Summary

Bumps `mastering-mixology-extended` to `95d7484` — version `1.9.1-ext1.1.0`. Adds Mitchole as co-author.

## What's new

**Misclick protection** (new optional config section, all toggles off by default), contributed by @Mitchole:

- **Lock idle stations** — per-station toggles for Alembic, Agitator, and Retort. Consumes the operate click when the station is empty and no unfulfilled order needs it with the potion currently held. Examine and other options are untouched.
- **Cap Concentrate clicks** — stops Retort clicks once one more would complete the potion; the bar coasts to completion via passive fill so spare clicks can't load the next potion. Self-calibrating: adapts to higher Herblore levels that change per-click progress.

Decision logic sits in two pure classes (`StationGuard`, `RetortProgressTracker`) with 13 unit tests. Reviewed and merged into the fork's `plugin-hub-release` branch after local build + test verification.

## Verification

- `./gradlew build` passes on the target commit (compile + checkstyle + tests, JDK 11).
- Merges cleanly at master.