### PR TITLE
Added Warriors Guild Catapult Helper

### DIFF
--- a/plugins/warriors-guild-catapult-helper
+++ b/plugins/warriors-guild-catapult-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/salan7/catapultHelper.git
+commit=abb783bf1053fbe4c959c5f94ba90c260b98b6d0


### PR DESCRIPTION
Added a simple plugin that reads which of the four incoming projectiles the catapult minigame in the warrior's guild is firing and highlights the corresponding defense option widget to block it.