### PR TITLE
Post-200m-xp-tracker

### DIFF
--- a/plugins/post-200m-xp-tracker
+++ b/plugins/post-200m-xp-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Arodab/post200Mtracker.git
+commit=69bed54ec6019ef8879efd357074fe9669c7c7a9


### PR DESCRIPTION
Adds Post 200M XP Tracker.

This plugin accumulates 'FakeXpDrop' events so players at the cap can keep tracking their gains.

Features:
- Sidebar panel with all-time post-200M XP per skill, a "Total gained"
  summary, and "Total XP" (account XP plus everything tracked past the cap)
- Optional overlay showing session XP and/or XP/hr per skill, with per-skill
  visibility toggles and drag-to-reorder in the panel
- XP/hr in the style of the built-in XP Tracker
- All-time totals are stored per RS profile, the `::200mreset` command is the only way to clear them
- No network access, no third-party servers, and no dependencies beyond
  runelite-client