### PR TITLE
Add Combat Skill Calculator

### DIFF
--- a/plugins/combat-skill-calculator
+++ b/plugins/combat-skill-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/darkharasho/combat-skill-calculator.git
-commit=bae1b20ea1ec2998d31bff775f7167635605c6a0
+commit=d0d5c917ca7f748f2d9d47f4ae8c4e569b92e2b3

--- a/plugins/combat-skill-calculator
+++ b/plugins/combat-skill-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/darkharasho/combat-skill-calculator.git
-commit=13592daa3b0ce45d7471c0c62ef10b392c61dd15
+commit=bae1b20ea1ec2998d31bff775f7167635605c6a0

--- a/plugins/combat-skill-calculator
+++ b/plugins/combat-skill-calculator
@@ -1,0 +1,2 @@
+repository=https://github.com/darkharasho/combat-skill-calculator.git
+commit=13592daa3b0ce45d7471c0c62ef10b392c61dd15


### PR DESCRIPTION
Adds the **Combat Skill Calculator** plugin.

- Repository: https://github.com/darkharasho/combat-skill-calculator
- License: BSD 2-Clause

**What it does:** shows how many kills until your next combat level, in two forms:
- A compact live overlay that counts down kills-to-level for the combat skill(s) you're currently training (hybrid HP-computed + measured-per-kill estimate).
- A plan-ahead panel styled after the built-in Skill Calculator: pick a skill (Attack/Strength/Defence/Ranged/Magic/Slayer) and a target level, then browse a searchable monster list with per-monster kill counts.

Combat XP is derived from damage dealt (≈4 XP/damage to the trained skill, 1.33 to Hitpoints), so kills-to-level is directly calculable from a monster's HP.

Note: the calculator panel lazily fetches monster sprites from the OSRS Wiki (cached in memory and on disk). Happy to make that opt-in or remove it if preferred.