### PR TITLE
Add Star Sprites plugin

### DIFF
--- a/plugins/star-sprites
+++ b/plugins/star-sprites
@@ -1,0 +1,4 @@
+{
+  "repository": "https://github.com/Barlim1/Star-Sprites",
+  "commit": "69a5c74e16f155c215ef02dd12b8b97c14d837fb"
+}

--- a/plugins/star-sprites
+++ b/plugins/star-sprites
@@ -1,2 +1,2 @@
 repository=https://github.com/Barlim1/Star-Sprites.git
-commit=64ce01398285de66c36cf9d46c8177a6c7f114a1
+commit=9e199f9df610d5335dddb0acb8556f1783521b3a

--- a/plugins/star-sprites
+++ b/plugins/star-sprites
@@ -1,2 +1,2 @@
 repository=https://github.com/Barlim1/Star-Sprites.git
-commit=b33864ff073f630463245de1a665e8dd9e0070c2
+commit=a7b088e5fe00996ffe64c812dba6f98c8fe24988

--- a/plugins/star-sprites
+++ b/plugins/star-sprites
@@ -1,3 +1,2 @@
-
 repository=https://github.com/Barlim1/Star-Sprites.git
-commit=da5d2dd855cc0cf91fc8f5c01ee1c9f920bd1778
+commit=b33864ff073f630463245de1a665e8dd9e0070c2

--- a/plugins/star-sprites
+++ b/plugins/star-sprites
@@ -1,2 +1,2 @@
 repository=https://github.com/Barlim1/Star-Sprites.git
-commit=a7b088e5fe00996ffe64c812dba6f98c8fe24988
+commit=64ce01398285de66c36cf9d46c8177a6c7f114a1

--- a/plugins/star-sprites
+++ b/plugins/star-sprites
@@ -1,4 +1,3 @@
-{
-  "repository": "https://github.com/Barlim1/Star-Sprites",
-  "commit": "69a5c74e16f155c215ef02dd12b8b97c14d837fb"
-}
+
+repository=https://github.com/Barlim1/Star-Sprites.git
+commit=69a5c74e16f155c215ef02dd12b8b97c14d837fb

--- a/plugins/star-sprites
+++ b/plugins/star-sprites
@@ -1,3 +1,3 @@
 
 repository=https://github.com/Barlim1/Star-Sprites.git
-commit=69a5c74e16f155c215ef02dd12b8b97c14d837fb
+commit=da5d2dd855cc0cf91fc8f5c01ee1c9f920bd1778


### PR DESCRIPTION
Star Sprites restores the unused Star Sprite NPC after a Shooting Star has been fully mined.

Features include:

- Spawns the unused Star Sprite after a Shooting Star is depleted.
- The player can speak to the Star Sprite (removed)
- Tracks total number of Star Sprites Rescued
- Dialogue changes based on the number of Star Sprites rescued. (Removed)

Repository:
https://github.com/Barlim1/Star-Sprites