### PR TITLE
Add Station's Cozy Clutter

### DIFF
--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,0 +1,2 @@
+repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
+commit=4514b6466b6955967f03b7a7df22a3b1ce0d4d5a

--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=4514b6466b6955967f03b7a7df22a3b1ce0d4d5a
+commit=a5147400c425818d84986f6d70cd2e7c5224697f


### PR DESCRIPTION
Adds Station's Cozy Clutter, a cosmetic client-side scenery building plugin.

Features:
- Browse and preview placeable in-game scenery
- Place, rotate, raise, resize, duplicate, and delete cosmetic props
- Export and import portable Tilepacks
- Safety validation and recovery for unsupported models

All placements are client-side only and do not alter collision or the game server.