### PR TITLE
Add OSRS GE Tracker

### DIFF
--- a/plugins/osrsge-tracker
+++ b/plugins/osrsge-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/LearnPythonThroughOSRS/osrsge-tracker.git
-commit=981344d415fc2705012c481f1017cf0631f508a4
+commit=8125c2aaba7bfdcd485910945e735d4d575a4d9a

--- a/plugins/osrsge-tracker
+++ b/plugins/osrsge-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/LearnPythonThroughOSRS/osrsge-tracker.git
+commit=981344d415fc2705012c481f1017cf0631f508a4

--- a/plugins/osrsge-tracker
+++ b/plugins/osrsge-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/LearnPythonThroughOSRS/osrsge-tracker.git
-commit=8125c2aaba7bfdcd485910945e735d4d575a4d9a
+commit=094e0b523f370642972dfd2989d4aedfa9f92850

--- a/plugins/osrsge-tracker
+++ b/plugins/osrsge-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/LearnPythonThroughOSRS/osrsge-tracker.git
-commit=d772fa36e1de4fff692c9708f1611bb708116ff7
+commit=422dec7720de5c39c9be3558594484e70a62a57d

--- a/plugins/osrsge-tracker
+++ b/plugins/osrsge-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/LearnPythonThroughOSRS/osrsge-tracker.git
-commit=094e0b523f370642972dfd2989d4aedfa9f92850
+commit=d772fa36e1de4fff692c9708f1611bb708116ff7


### PR DESCRIPTION
Tracks Grand Exchange flips with FIFO buy/sell matching and GE tax included in profit, shown in a side panel (session stats, time-range filter, per-item breakdown with icons).

Optional, off-by-default sync: users of osrsge.io can generate a personal API key on their dashboard and configure the plugin to upload their own completed trades and active offers (character name, item, prices, quantities, timestamps) over HTTPS to their account. Nothing is sent unless the user configures both the URL and key and enables the toggle.

Repository: https://github.com/LearnPythonThroughOSRS/osrsge-tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)