### PR TITLE
Add Volcanic Skiller plugin

### DIFF
--- a/plugins/volcanic-skiller
+++ b/plugins/volcanic-skiller
@@ -1,0 +1,2 @@
+repository=https://github.com/Scheie/vmine-skiller-plugin.git
+commit=91f2351d56a56a230f79e7ec433429a8705bd787

--- a/plugins/volcanic-skiller
+++ b/plugins/volcanic-skiller
@@ -1,2 +1,2 @@
 repository=https://github.com/Scheie/vmine-skiller-plugin.git
-commit=91f2351d56a56a230f79e7ec433429a8705bd787
+commit=ac8f9d9b42b6f6ca16914af0b2e2ff5001743055


### PR DESCRIPTION
Adds **Volcanic Skiller**, a plugin for the Volcanic Mine minigame.

**What it does**
- Tracks your Volcanic Mine reward-point total and shows it in an on-screen overlay and a sidebar panel, visible outside the minigame instance.
- Notifies you when a Volcanic Mine game starts.

**Notes**
- Read-only observation only — no automation, input, or game-state modification.
- Reward points are tracked from the per-game points earned (banked on the Mining-XP granted on completion) and reconciled to the authoritative balance (VarPlayer 261) when Petrified Pete's reward shop is open.
- Source: https://github.com/Scheie/vmine-skiller-plugin
- Builds and passes checkstyle with the standard example-plugin Gradle setup (Java 11).

I am the author of this plugin and license it under the BSD 2-Clause license.