### PR TITLE
update jumpscare

### DIFF
--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=ea8b879a68ab88573069f5ef544c55ba2c533353
+commit=920bafd1db71222573900ec26a95d9e550d08469
 authors=vividflash


### PR DESCRIPTION
Jumpscare 1.4:

- one-time migration seeds the Image/Sound source dropdowns from pre-1.2 settings (custom file paths, Happy theme), which 1.2 silently reset to Default
- custom files are re-checked on each trigger and reloaded when they change or appear, so late drops and same-name replacements no longer need a plugin toggle
- plain ::stest prints a chat line reporting which image/sound sources were used and why a custom file couldn't be loaded