### PR TITLE
Add Group Slot Locked plugin

### DIFF
--- a/plugins/group-slot-locked
+++ b/plugins/group-slot-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/surajjagadeesh/GroupSlotLocked.git
-commit=f28272117e2ea1051d0512e855f2cf56a3d9637f
+commit=25098c9eff65a9470a7380e83c2439ba227d055b

--- a/plugins/group-slot-locked
+++ b/plugins/group-slot-locked
@@ -1,0 +1,2 @@
+repository=https://github.com/surajjagadeesh/GroupSlotLocked.git
+commit=f28272117e2ea1051d0512e855f2cf56a3d9637f


### PR DESCRIPTION
Adds Group Slot Locked plugin, a voluntary Group Ironman challenge helper for inventory slot token claims and equip limits. We treat 11 team capes as the 11 inventory slots, and if you have a slot in your bank or inventory, you can then equip a corresponding item. For example, if the user has the "head slot" item, they are now able to equip a slayer helmet. Items that users are not allowed to equip have a red outline around them, and make the screen black when equipped. 

Repository: https://github.com/surajjagadeesh/GroupSlotLocked