### PR TITLE
Add ClanHQ

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=1951aeff63cefc04ce9f18c14c150d610d4100b3
+commit=ca5dca52620e08df4597a4d4d3c4025d270fe58d

--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,0 +1,2 @@
+repository=https://github.com/jewatson1994/clanhq-runelite.git
+commit=1951aeff63cefc04ce9f18c14c150d610d4100b3


### PR DESCRIPTION
## What this plugin does

ClanHQ connects RuneLite to clan-run events through a modular side panel. It lets players pair an installation, view active events and daily tasks, join Bingo teams, submit eligible event observations, and claim server-verified daily-task rewards.

## Data and player control

- The plugin ships with no API destination or installation token. A player supplies their clan's HTTPS endpoint and pairs using a short-lived, single-use Discord code.
- Complete bank, inventory, and equipment snapshots are submitted only after the player clicks Character Submit or Character Sync and confirms a disclosure dialog describing the data being sent.
- Gameplay screenshots are disabled by default. If explicitly enabled, an eligible Bingo observation may include a watermarked gameplay screenshot captured in memory and not saved to disk.
- The Overview module lets the player revoke the current installation and removes its stored token locally.
- The plugin observes and submits data; it does not perform game actions, award ranks, or contain clan rank rules.

## Validation

- `./gradlew clean test --no-daemon`
- Standalone repository GitHub Actions build passes on Java 17.
- Resource loading is tested from packaged classpath streams.
- A RuneLite reviewer informally confirmed that the proposed plugin scope sounds acceptable before submission.

Privacy and testing details are documented in the plugin repository.
