### PR TITLE
Update Kill Clog to 1.6.4

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=86dc10e0c31a5c7f294c1822730b82e0bd07a045
+commit=0015b0c87854f4d7eed050dc55afd05a2c9a6aeb
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=0015b0c87854f4d7eed050dc55afd05a2c9a6aeb
+commit=3b28d6083efd39538e3c7cf16bc8fdb117ad95b7
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=e2662cf275401d37aca710d476c13aef785a0f60
+commit=86dc10e0c31a5c7f294c1822730b82e0bd07a045
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=e14661959328d119b5f9f0021770c0fd3dd2722a
+commit=e2662cf275401d37aca710d476c13aef785a0f60
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill Clog 1.6.4

* boss tooltips get kc in addition to rank and obtained, PB included where available
* new "!kc [item name]" command to reveal kill count it was obtained on, starting with items collected on v1.6.4
* TempleOSRS dates fill in older undated items on self lookup, and the last updated notice tracks the newest item
* comparison summary format fixes
* pvp summary and empty cells follow configured palette
* long tooltip title spacing fix
* kc, pb, and rank tooltip lines each get a settings switch, all on by default