### PR TITLE
slayer-drop-prioritizer: relicense to BSD 2-Clause, re-enable

### DIFF
--- a/plugins/slayer-drop-prioritizer
+++ b/plugins/slayer-drop-prioritizer
@@ -1,4 +1,3 @@
 repository=https://github.com/hamilton-junior/SlayerDropPrioritizer.git
-commit=c621b8e1b832281dd1909dc3577d3dea9f760c49
+commit=ec41ab8351238e8002747376464442f2f1044ae8
 authors=hamilton-junior
-disabled=license


### PR DESCRIPTION
`slayer-drop-prioritizer` was merged in #12626 but marked `disabled=license`: the repository shipped a GPL-3.0 `LICENSE` file, although the README already stated BSD 2-Clause.

This has been corrected upstream:

- `LICENSE` replaced with the BSD 2-Clause "Simplified" License
- BSD 2-Clause header added to all 19 Java source files
- Version bumped to 1.0.1

This PR points the manifest at the new commit and drops the `disabled=license` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)