### PR TITLE
volcanic-skiller: fix reward points mis-parse

### DIFF
--- a/plugins/volcanic-skiller
+++ b/plugins/volcanic-skiller
@@ -1,2 +1,2 @@
 repository=https://github.com/Scheie/vmine-skiller-plugin.git
-commit=ac8f9d9b42b6f6ca16914af0b2e2ff5001743055
+commit=4310c993c26157fd2d09ab7d24b274a9f08036f9


### PR DESCRIPTION
Bumps Volcanic Skiller to a fix for a reward-point display bug.

The reward shop renders its total as `Points: <col=ffa82f>N</col>`. The plugin stripped all non-digits from the raw widget text, so the colour hex `ffa82f` contributed `82` in front of the real value (e.g. a true 4,000 balance showed as 824,000). The fix strips `<...>` tags before parsing, reads the shop balance each tick while it is open (so it reflects spending, including 0), and removes a varp read whose `> 0` guard rejected a legitimate zero.

Source: https://github.com/Scheie/vmine-skiller-plugin (commit 4310c99). Builds and passes checkstyle with the example-plugin Gradle setup (Java 11).