### PR TITLE
Add Bank Count Tooltips plugin

### DIFF
--- a/plugins/bank-count-tooltips
+++ b/plugins/bank-count-tooltips
@@ -1,0 +1,2 @@
+repository=https://github.com/Ugikie/bank-count-tooltips.git
+commit=d1faefd964df5ee49db4fc8899daceb48bbd6713


### PR DESCRIPTION
Shows how many of the hovered item you have in your inventory and bank in the
item's hover tooltip, like Bagnon from WoW:

```
Inv: 4 | Bank: 12,450
```

Works in the inventory, bank, worn equipment, deposit boxes, seed vault and more.

Bank contents are saved whenever the bank updates and persist per account, so
counts are accurate right from login without needing to open the bank first.
Deposits made through deposit boxes are tracked too. Noted items count toward
their base item, and placeholders count as zero.