### PR TITLE
Update Chat Tab Hotkeys to 1.1.1

### DIFF
--- a/plugins/chat-tab-hotkeys
+++ b/plugins/chat-tab-hotkeys
@@ -1,3 +1,4 @@
 repository=https://github.com/tinokaartovuori/chat-tab-hotkeys.git
-commit=d4ec59624e32fe3c93d155d2e066d75b25368112
+commit=5f3794f829d6c2ac1b61a4c11218f057136ef70b
 authors=Kart5a
+version=1.1.1

--- a/plugins/chat-tab-hotkeys
+++ b/plugins/chat-tab-hotkeys
@@ -1,4 +1,3 @@
 repository=https://github.com/tinokaartovuori/chat-tab-hotkeys.git
 commit=5f3794f829d6c2ac1b61a4c11218f057136ef70b
 authors=Kart5a
-version=1.1.1


### PR DESCRIPTION
Bumps Chat Tab Hotkeys from 1.1.0 to 1.1.1.

Changes since 1.1.0:
- Fixed: the Close-chat hotkey rebuilds the split friends private-chat overlay when the chatbox collapses or reopens, so the overlay hides and returns with the chatbox instead of lagging until the next chat message (#6).
- Docs only otherwise, no other behaviour change.

Compliance: packet-free and client-side. The plugin only writes client-local VarClient values (which chat tab is shown, the chatbox input channel), runs benign redraw procedures, and clears the local chat-line buffer, so it never sends anything to the game server. Every action is keypress-triggered and matches something a player can already do by mouse; no gameplay automation. No third-party runtime dependencies.

Pinned commit 5f3794f829d6c2ac1b61a4c11218f057136ef70b is the v1.1.1 tag and sits on main.