### PR TITLE
Update ge-offer-webhook

### DIFF
--- a/plugins/ge-offer-webhook
+++ b/plugins/ge-offer-webhook
@@ -1,3 +1,3 @@
 repository=https://github.com/John-AndreS/ge-offer-webhook.git
-commit=e2cc116d492d329c1aa678cacc5fca5f91293783
+commit=49533e101814452e787ae89c3192acae7323b95c
 authors=John-AndreS


### PR DESCRIPTION
Reliability: login snapshot now re-emits terminal (BOUGHT/SOLD/CANCELLED) offers and per-slot dedup resets on login/hop/reconnect, so completions whose webhook delivery was lost are re-delivered on the next login (the receiving endpoint dedups replays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

