### PR TITLE
Add equipment-check plugin

### DIFF
--- a/plugins/equipment-check
+++ b/plugins/equipment-check
@@ -1,0 +1,2 @@
+repository=https://github.com/andyli2005/equipment-check.git
+commit=627035448e586347f3137776f23b64fea78c4612


### PR DESCRIPTION
Equipment Check is an informational plugin that reminds you when a gear slot is empty or isn't holding a specific item you've configured. Each of the 11 equipment slots can be set to Off, Empty (warn when slot is empty), or Item-specific (warn when slot does not have certain item in it), with a context option so a check fires either everywhere or only in the Wilderness. Warnings can exist in three forms: as a chat message, a notification, and/or an overlay listing the slots. It only reads your own equipment and location and never acts on the game.