### PR TITLE
Add QuantScapers Market Intelligence

### DIFF
--- a/plugins/quantscapers
+++ b/plugins/quantscapers
@@ -1,0 +1,2 @@
+repository=https://github.com/tjessberger/quantscapers-runelite.git
+commit=3b695e0c098fb51b206d36aadcb3e326c63ae690

--- a/plugins/quantscapers
+++ b/plugins/quantscapers
@@ -1,2 +1,2 @@
 repository=https://github.com/tjessberger/quantscapers-runelite.git
-commit=3b695e0c098fb51b206d36aadcb3e326c63ae690
+commit=4ce06c8c455c9962f45af91f4865db216a1b4e06

--- a/plugins/quantscapers
+++ b/plugins/quantscapers
@@ -1,2 +1,3 @@
 repository=https://github.com/tjessberger/quantscapers-runelite.git
-commit=4ce06c8c455c9962f45af91f4865db216a1b4e06
+commit=602bfa18242660dc100779431d553115f27d59eb
+warning=This plugin can connect to the OSRS Wiki price API. When enabled, it submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers. No RuneScape account, player, Grand Exchange offer, or telemetry data is sent.


### PR DESCRIPTION
## Summary

QuantScapers is an in-client OSRS Market Intelligence tool for players who want current Grand Exchange context before making their own decisions.

Rather than presenting a single recommendation list, QuantScapers combines a first-tab market overview with supplemental opportunity scanning, item research, risk checks, price history audits, and local tracking in one RuneLite sidebar:

- **Market Overview:** summarizes meaningful 24-hour gainers, losers, heating and cooling momentum, and most-traded items. Volume, item-value, and price-movement thresholds help filter low-signal options.
- **Trade Scanner:** ranks candidates using after-tax profit, ROI, volume, estimated fill time, quote freshness, budget, and risk checks.
- **Alch Scanner:** evaluates high-alchemy opportunities using current item and nature-rune prices.
- **Item Research:** provides current prices, volume context, trade tickets, freshness indicators, and plain-language BUY, DECENT, RISKY, or AVOID verdicts.
- **Price history audits:** use hourly history to estimate sell-price hit rate and seven-day margin stability.
- **Local Watchlist:** saves up to 25 items, compares current prices with saved values, and reuses completed audits.

The Market Overview is the primary intelligence layer. Scanner and Watchlist provide supplemental tools for acting on that context. QuantScapers does not promise profits or replace player judgment.

### Player safety and privacy

- No Grand Exchange automation: the plugin never places, edits, or cancels an offer.
- No RuneScape account data, paywall, telemetry, cloud sync, player-data collection, or QuantScapers backend connection.
- Watchlist data, audit results, and settings remain local in RuneLite.
- Wiki market data is off by default and enabled explicitly in plugin settings.
- Website and X links open in the player's browser only when clicked.
- Trade tickets are guidance for manual entry; copy actions use the local clipboard only.

### Network usage

The plugin connects only to the OSRS Wiki Real-time Prices API at `https://prices.runescape.wiki/api/v1/osrs`.

- No request is made until Wiki market data is explicitly enabled.
- The Wiki API receives the player's IP address as normal HTTP metadata.
- Every request includes a fixed project User-Agent linking to the public GitHub issue tracker. No personal email is requested.
- While the panel is visible, the latest-price snapshot refreshes at most once per 60 seconds. Polling stops when the panel is closed.
- The item mapping is cached for 24 hours. Five-minute and 24-hour market statistics are cached for five minutes, and tabs, searches, filters, and the Watchlist reuse the scheduled snapshot.
- Transient API failures use capped exponential backoff.
- Automatic price history audits are capped at three calls per 30 minutes. Manual audits are capped at ten calls per 10 minutes, and completed results are cached locally.

### Testing

- Unit and integration tests: `./gradlew test`
- Clean development build and current screenshot set verified locally.
- Final owner UI smoke test covers consent, fresh market data, filters, audits, Watchlist persistence, and polling pause/resume.