### PR TITLE
fix: Rework POH Dynamic portal naming

### DIFF
--- a/plugins/poh-portal-labels
+++ b/plugins/poh-portal-labels
@@ -1,2 +1,2 @@
 repository=https://github.com/jcbmcn/poh-portal-labels.git
-commit=373fb233cab9fdde8cd0caa073d409b4767d2510
+commit=2ad6c62eb19212eab41ce7e44996249a6d8de610

--- a/plugins/poh-portal-labels
+++ b/plugins/poh-portal-labels
@@ -1,2 +1,2 @@
 repository=https://github.com/jcbmcn/poh-portal-labels.git
-commit=a31dadb38697d222e1d2d0acdf751630166acfd7
+commit=373fb233cab9fdde8cd0caa073d409b4767d2510


### PR DESCRIPTION
Resolve 3 bugs with better dynamic name generation: 
Closes https://github.com/jcbmcn/poh-portal-labels/issues/41 — portals on upper floors not labeled (scan is plane-agnostic)
Closes https://github.com/jcbmcn/poh-portal-labels/issues/43 — labels missing under the Wilderness house theme (no theme-specific IDs)
Closes https://github.com/jcbmcn/poh-portal-labels/issues/44 — Varrock/Grand Exchange not labeled (shared model, distinct varbit)