### PR TITLE
Update recipe-tracker

### DIFF
--- a/plugins/recipe-tracker
+++ b/plugins/recipe-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/recipe-tracker.git
-commit=9af2337c5761f031c261cabe2997663dc24e1797
+commit=7c85c3dd112b7fa76f5dc9a05d8a890858ef6acd


### PR DESCRIPTION
Updates Recipe Tracker to fix tracking from legacy skill guides.

The plugin now adds **Track materials** directly to legacy guide item widgets and resolves the selected recipe from the widget's canonical item ID, the same reliable source used by Wiki Lookup.

Validation: the plugin's Gradle test suite passes locally.
