### PR TITLE
Spawn Predictor - v1.3.3

### DIFF
--- a/plugins/spawnpredictor
+++ b/plugins/spawnpredictor
@@ -1,2 +1,3 @@
 repository=https://github.com/damencs/spawn-predictor.git
-commit=b666333e54aec6c2a5bba151cb7a99a85a586e66
+commit=8c5a34d4c88407cda7a6c60d8014018163d97974
+authors=damencs


### PR DESCRIPTION
- adjusts: using varbits for server time rather than clan  event widget time
- adjusts: verbiage for entering on entrance
- adds: ::setrotation reference on entry regardless if successful or not, just to mitigate support inquiries
- removes: deprecated overlay priority references
