### PR TITLE
Add buddies plugin

### DIFF
--- a/plugins/buddies
+++ b/plugins/buddies
@@ -1,2 +1,2 @@
 repository=https://github.com/CampbellTrevor/buddies.git
-commit=fb8c6bdefa92125eabf1fdec50b2d001eeb65a2e
+commit=22be2e0a99108b7e2e7ca3f2ecc2aeec3f1f6175

--- a/plugins/buddies
+++ b/plugins/buddies
@@ -1,2 +1,2 @@
 repository=https://github.com/CampbellTrevor/buddies.git
-commit=735c54d0dca4327d45ee2a7da4d09737269d6abf
+commit=1731e10ab439ec7aa8c848d4090f178161b8e91d

--- a/plugins/buddies
+++ b/plugins/buddies
@@ -1,0 +1,2 @@
+repository=https://github.com/CampbellTrevor/buddies.git
+commit=735c54d0dca4327d45ee2a7da4d09737269d6abf

--- a/plugins/buddies
+++ b/plugins/buddies
@@ -1,2 +1,2 @@
 repository=https://github.com/CampbellTrevor/buddies.git
-commit=1731e10ab439ec7aa8c848d4090f178161b8e91d
+commit=fb8c6bdefa92125eabf1fdec50b2d001eeb65a2e

--- a/plugins/buddies
+++ b/plugins/buddies
@@ -1,2 +1,2 @@
 repository=https://github.com/CampbellTrevor/buddies.git
-commit=22be2e0a99108b7e2e7ca3f2ecc2aeec3f1f6175
+commit=2923b356c35d8ff91448c07a457471fabfc2cdcb

--- a/plugins/buddies
+++ b/plugins/buddies
@@ -1,2 +1,3 @@
 repository=https://github.com/CampbellTrevor/buddies.git
 commit=2923b356c35d8ff91448c07a457471fabfc2cdcb
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Summary

Adds Buddies, a focused friends panel with:

- RuneLite-authoritative friend online status and world
- opt-in recent activity and named location sharing between room members
- OSRS hiscore skill stats, activity scores, boss scores, and ranks

The presence relay stores only short-lived in-memory records. Location and activity sharing can be disabled independently, the shared room key is hashed before transmission, and received presence is displayed only for an existing online RuneLite friend.

## Verification

- Java 11 `clean build`
- Plugin Hub Gradle packaging tasks against RuneLite 1.12.33
- Node presence relay test suite