### PR TITLE
Fitzgerald.gg

### DIFF
--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
 commit=2f70ef0dd2b64b6cbefc2adb290549ea3a893376
 authors=Fitzgerald-gg
-warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, group-storage movements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=91f1ec2ad663769cc210dbc5a40db0400300c7e6
+commit=a828a7c3d98e845bfaaa15eb9babbc24c354e6f1
 authors=Fitzgerald-gg
 warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, group-storage movements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=40ed6b5d77aaa5098f9b5c5eab9f17fcd8f9dcb7
+commit=2f70ef0dd2b64b6cbefc2adb290549ea3a893376
 authors=Fitzgerald-gg
 warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, group-storage movements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=a828a7c3d98e845bfaaa15eb9babbc24c354e6f1
+commit=40ed6b5d77aaa5098f9b5c5eab9f17fcd8f9dcb7
 authors=Fitzgerald-gg
 warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, group-storage movements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=c7a0b86021c4cf95f57c39d52c5b7066dc52c79c
+commit=91f1ec2ad663769cc210dbc5a40db0400300c7e6
 authors=Fitzgerald-gg
 warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, group-storage movements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=2f70ef0dd2b64b6cbefc2adb290549ea3a893376
+commit=eaf9dd744a1a2a537d06071fee43b41131e20a6f
 authors=Fitzgerald-gg
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=4fcc8380c34e43f277952ab20bcf1cc75d8ea000
+commit=8d49193f49398cd826c5bd452903b5c1eb9bf6af
 authors=Fitzgerald-gg
 warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=92dd3ea4644d9f5ea99a30e4a7fbdc8d176d3469
+commit=74d0716c3d9bf199be8be83889d5cc4438404ec9
 authors=Fitzgerald-gg
 warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=5e80fa8160349f4a792d54d16a24903571aa83bc
+commit=92dd3ea4644d9f5ea99a30e4a7fbdc8d176d3469
 authors=Fitzgerald-gg
 warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,0 +1,4 @@
+repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
+commit=9a4438fec30c2b016f8f9e75962cc74166a2fbc6
+authors=Fitzgerald-gg
+warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=8d49193f49398cd826c5bd452903b5c1eb9bf6af
+commit=5e80fa8160349f4a792d54d16a24903571aa83bc
 authors=Fitzgerald-gg
 warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=9a4438fec30c2b016f8f9e75962cc74166a2fbc6
+commit=4fcc8380c34e43f277952ab20bcf1cc75d8ea000
 authors=Fitzgerald-gg
 warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.

--- a/plugins/fitzgerald
+++ b/plugins/fitzgerald
@@ -1,4 +1,4 @@
 repository=https://github.com/Fitzgerald-gg/fitzgerald-runelite.git
-commit=74d0716c3d9bf199be8be83889d5cc4438404ec9
+commit=c7a0b86021c4cf95f57c39d52c5b7066dc52c79c
 authors=Fitzgerald-gg
-warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.
+warning=This plugin submits your gameplay data — loot, levels, deaths, quests, slayer kills, collection log, combat achievements, group-storage movements, lifetime counters, screenshots — and your IP address to fitzgerald.gg, a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
**Fitzgerald.gg** — a companion plugin that captures OSRS gameplay (loot, levels, deaths, quests, slayer, collection log, combat achievements, and ~90 lifetime counters) and syncs it to the player's page on fitzgerald.gg, my own site. It's a single-plugin alternative to running a loot-webhook plus a stat-tracker.

A few things reviewers usually ask about, handled up front:

- **Opt-in.** Both `enabled` and `captureScreenshots` default to **false** and carry the standard IP-disclosure `warning`. Nothing is enrolled, captured or transmitted until the user turns it on. I've also set the marker `warning=` and will defer to your wording on it.
- **Fixed, author-owned endpoints.** Every call targets a hard-coded https://fitzgerald.gg/api/... path — no dynamic or remotely-fetched endpoints (same pattern as plugins/runeprofile). The base URL is editable only under Advanced, for self-hosters.
- **Only the local player's own data.** `LootRecordType.PLAYER` records are dropped, so a PK victim's name/loot is never sent; `onActorDeath` gates on the local actor. No other-player data leaves the client.
- **Screenshots** attach only to the user's own notable events and are off by default.
- **Self-service data rights.** From the side panel the user can lock their page behind a passphrase, list/unlist it from the public directory, export all their data as JSON, or schedule a cancellable deletion — all authenticated by the account's own token, no website login. The lock passphrase is never stored in RuneLite config.
- **Dependencies:** depends on the built-in Slayer plugin (`@PluginDependency`) for on-task tagging; degrades gracefully if it's disabled. No third-party deps, no bundled code — OkHttp/Gson come from RuneLite via injection.