### PR TITLE
update haggle-helper v1.1.8

### DIFF
--- a/plugins/haggle-helper
+++ b/plugins/haggle-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/gavin-lb/haggle-helper.git
-commit=5cc3a729745d1355238f6b32aeeacc0dcabf25f7
+commit=578b29ed5d2d00a6f6d8fb407be668accd53dcd9


### PR DESCRIPTION
 - fix: show tooltips for noted items at speciality shops