### PR TITLE
Update GE Uncut

### DIFF
--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,3 +1,3 @@
 repository=https://github.com/uzia35/ge-uncut.git
-commit=d10ca567642311615e066ffe9a15f140ba5588ff
+commit=1cb851c6de32cf368f52d75ebf0f25566b991c47
 warning=This plugin submits your IP address and various account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates GE Uncut to 1.4.3 (uzia35/ge-uncut@1cb851c6de32cf368f52d75ebf0f25566b991c47).

Working-offer ages now survive client restarts: on startup the panel seeds each slot's placement time from the account's own stored offer record, so an offer placed hours ago shows its real age instead of restarting at login. The finder's capital picker also mirrors the website, showing the player's actual My capital value. Uses the existing geuncut.app API; no new permissions or hosts.