### PR TITLE
Add Noots Rank Ladder

### DIFF
--- a/plugins/noots-rank-ladder
+++ b/plugins/noots-rank-ladder
@@ -1,0 +1,2 @@
+repository=https://github.com/lrdigital/noots-rank-ladder.git
+commit=e4fa27023941a834851ca306b7eb95e244b4f8e1


### PR DESCRIPTION
Adds Noot's Rank Ladder, a side panel that shows where you sit on the hiscores for any boss or activity, with the players ranked just above and below you.

You pick a hiscore board and an activity, and the plugin shows the ladder around your rank, the score gap to the next rank, your pace and rank trend from your own locally saved history, and an ETA to the next rank. It polls the official Jagex hiscores a few requests at a time, only while the panel is open, once a minute by default.

Nothing is automated and nothing leaves the client apart from the hiscores lookups. As far as I can tell there is no existing hub plugin that shows your rank position or a ladder like this; the closest is Hiscore Notifications, which fires rank-up notifications but has no panel or ladder view.

Repo: https://github.com/lrdigital/noots-rank-ladder