### PR TITLE
Update dutch-mayhem-clan-plugin: fix PvP kill detection on wildy map

### DIFF
--- a/plugins/dutch-mayhem-clan-plugin
+++ b/plugins/dutch-mayhem-clan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/nekomana-project/dutch-mayhem-clan-plugin.git
-commit=2dae4ed9e9bbe897ed76f5d7135146b010fcd152
+commit=279563ed4590143d5b845b5c55538dca0cf04624
 warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Fixes PvP kill detection for the clan's wilderness kill map: kills are now attributed from the victim's death event (own damage via Hitsplat.isMine()) instead of a "You have defeated X!" game message, which OSRS does not emit for loot-key kills. 
Also sends the killer's damage total so multi-attacker kills can be credited to the top-damage attacker.

No new dependencies; no change to permissions or the existing data-sharing warning.