### PR TITLE
Add OSRS Flipper Sync

### DIFF
--- a/plugins/osrs-flipper-sync
+++ b/plugins/osrs-flipper-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Ishmarr/osrs-flipper-runelite-sync.git
-commit=3115561520b338e08676e98bfabbf27b0945929d
+commit=01a228af529f9a239b6e6a0a49e9ea49cc3dc570

--- a/plugins/osrs-flipper-sync
+++ b/plugins/osrs-flipper-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/Ishmarr/osrs-flipper-runelite-sync.git
+commit=3115561520b338e08676e98bfabbf27b0945929d

--- a/plugins/osrs-flipper-sync
+++ b/plugins/osrs-flipper-sync
@@ -1,2 +1,3 @@
 repository=https://github.com/Ishmarr/osrs-flipper-runelite-sync.git
 commit=01a228af529f9a239b6e6a0a49e9ea49cc3dc570
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds OSRS Flipper Sync, a plugin that synchronizes the user's eight
Grand Exchange offer slots with the OSRS Flip Tracker web application.

The plugin only sends Grand Exchange offer data required for the
synchronization. It does not send login credentials, bank contents,
inventory contents, chat messages, player location, or information
about other players.

The backend is access-controlled. Each device must be authorized by
the user using a short-lived, one-time pairing code. The resulting
device token has limited permissions and can be revoked through the
web application.

Temporary reviewer access can be provided to RuneLite maintainers
on request.