### PR TITLE
Update improved-tears-of-guthix-interface to version 1.1.1

### DIFF
--- a/plugins/improved-tears-of-guthix-interface
+++ b/plugins/improved-tears-of-guthix-interface
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/improved-tears-of-guthix-interface.git
-commit=adaae7dbe3ff3710e47eba12a32dfe1d71dd14c9
+commit=689b91146da40edbe8d5f5db1f46d4886377aed8

--- a/plugins/improved-tears-of-guthix-interface
+++ b/plugins/improved-tears-of-guthix-interface
@@ -1,2 +1,2 @@
 repository=https://github.com/Cyborger1/improved-tears-of-guthix-interface.git
-commit=689b91146da40edbe8d5f5db1f46d4886377aed8
+commit=57e41a21ddd773812caf77f4522d8ae848b93e19


### PR DESCRIPTION
Fixes a plugin crash when starting the plugin when in-game (the check needed to run on ClientThread)

Changes some deprecated API calls