### PR TITLE
Add Better Notifications

### DIFF
--- a/plugins/better-notifications
+++ b/plugins/better-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/david3200/better-notifications.git
+commit=d181dd9721321998af863f95195910ec0d69e6e9


### PR DESCRIPTION
A RuneLite plugin that replaces abrupt low-hitpoints and low-prayer warnings with a smooth, shooter-style edge warning. The configurable effect grows stronger toward the critical threshold, with optional pulsing and RuneLite notifications.