### PR TITLE
Update mystix

### DIFF
--- a/plugins/mystix
+++ b/plugins/mystix
@@ -1,4 +1,4 @@
 repository=https://github.com/Dmurph24/mystix-plugin.git
-commit=49ae94f19e724824a3f2e464df60cc4f8757bc65
+commit=77816e0d21f1b2d55fd1848b3432cf7fea2465a5
 authors=Dmurph24
 warning=This plugin submits your RSN, skills, bank, equipment, loadouts, farming timers, and loot data to a 3rd-party server (Mystix) not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates the Mystix plugin to the latest master commit.

This release fixes a bug where the Roadmaps side panel, on a roadmap with many goals, forced the RuneLite client window taller than the screen and would not let it be resized back down. The panel used a non-wrapped `PluginPanel` and added the goals list directly to `BorderLayout.CENTER` with no scroll pane, so the list's full height propagated into the panel's preferred and minimum size. The goals list now scrolls inside its own scroll pane, keeping the panel height bounded.

No new data collection or third-party dependencies were introduced; the `warning=` field is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)