### PR TITLE
Add Overheads Reworked

### DIFF
--- a/plugins/overheads-reworked
+++ b/plugins/overheads-reworked
@@ -1,0 +1,2 @@
+repository=https://github.com/Swamisama/overheads-reworked.git
+commit=89a2e1636d5d2cd7d79858af7a5dca0a81598734


### PR DESCRIPTION
# Overheads Reworked

Replaces the large overhead protection-prayer bubbles with a subtle display. In
8-man raids the vanilla bubbles stack up and cover the ground tiles you need to
see; this trades them for an underfoot tile tint (the default) while redrawing
the 2D elements you still want.

**Player-only by design.** NPCs keep their vanilla overheads completely
untouched — non-player renderables are passed through before any prayer state is
even read.

## What it does

- Suppresses the vanilla 2D overhead block per player, independently toggleable
  for yourself, party members, and other players.
- Replaces the prayer bubble with an underfoot tile tint (default), a character
  outline, and/or a compact copy of the original overhead icon. These combine.
- Selectively redraws overhead chat, health bar, hitsplats, and PK skull, each
  individually toggleable with a height offset.
- `Only while praying` (default on) limits hiding to players who currently have
  an overhead icon, so non-praying players are untouched.
- Smite, Redemption, and Retribution each have a separate `Replace` checkbox,
  off by default — their vanilla icons stay intact unless explicitly opted into.

## How it works

A `RenderCallback` registered with `RenderCallbackManager` is consulted for each
renderable per frame. Returning `false` from `addEntity` on a player's
`drawingUI` pass hides that player's entire 2D block — chat, health bar,
hitsplats, and prayer bubble together, since the API exposes no per-element
control. An `ABOVE_SCENE` overlay then redraws the wanted parts for exactly
those players.

Render callbacks from multiple plugins AND together, so this coexists with core
Entity Hider. The replacement overlay also mirrors Entity Hider's **player**
categories: if Entity Hider hides a player's model or 2D elements, this plugin
draws no replacement for that player.

Redrawn hitsplats reuse the active cache's own hitmark component sprites,
colours, movement, and fade timing. If a future cache revision can't be decoded
safely, that hitsplat falls back to a simple coloured marker.

## On the third-party client rules

Flagging this up front, since prayer plugins get scrutiny and this one hides
information by default.

The banned category is anything that indicates **which prayer to use** — prayer
switching indicators, freeze timers, automatic stand-here tiles, resized prayer
book click zones. This plugin does none of that.

It only ever re-displays prayers that are **already active and visible** to
every client in the scene, restyled. It reads no state a vanilla player can't
already see, adds no timing or prediction, and never suggests an action. The
information content of the display is strictly a subset of what vanilla already
renders — by default it shows *less*, not more.

Precedent: core Entity Hider already hides player 2D elements including prayer
overheads, wholesale and with no replacement. Several hider plugins on the hub
do the same. This is the same operation with a cosmetic replacement layered
back on.

## Demo

The clip below walks through each display mode with the config panel open, 
starting with normal prayer and moving through the different options: overheads
hidden with tile replacement, character outline alone, compact overhead alone, and
all three combined (underfoot tile tint + outline + compact icon).


https://github.com/user-attachments/assets/215ffce4-c5e3-4894-bf3f-583bf38e1141

## Notes for reviewers

- The Java package is `com.prayeroverheads` while the display name is
  "Overheads Reworked" — intentional, the plugin was renamed late and the
  package was left stable.
- 30 unit tests cover hitsplat slot assignment, overlay logic, and prayer state
  handling. Slot assignment under multi-splat hits (dual-wield, Scythe, poison
  landing alongside damage) is unit-tested; the drawing itself isn't, since it
  needs a `Graphics2D`, and has been checked in-game instead.
