### PR TITLE
update bank-skill-sorting

### DIFF
--- a/plugins/bank-skill-sorting
+++ b/plugins/bank-skill-sorting
@@ -1,2 +1,2 @@
 repository=https://github.com/Frailrain/Bank-Skill-Sorting.git
-commit=6aa9f293328698be30af86426fb441048ceb3f1c
+commit=bd224101a3fa7b2764bb6e77ed3aa842dad1ae15


### PR DESCRIPTION
Updates Auto Bank Sorter (bank-skill-sorting) to the latest release.

Highlights since the last hub build:
- Collision-safe tab naming: fresh installs seed `(auto)`-suffixed tabs; a one-time chooser (Skip / Overwrite / Create alongside) protects same-named user tabs; existing installs migrate their tab names automatically on login.
- Sectioned layouts with labelled divider overlays on every tab (toggleable).
- Dynamic slayer tab that rebuilds around the player's current task (wiki-recommended gear filtered to owned items, per-variant/location requirements, potions, food, cannon).
- Separate-ID item variants (degraded Barrows, charged jewellery, trimmed capes) stay classified in their tabs.
- Large item-data refresh: every bankable item classified, per-tab section audits, new default tab icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)