### PR TITLE
Add plugin: Runie

### DIFF
--- a/plugins/runie
+++ b/plugins/runie
@@ -1,2 +1,2 @@
 repository=https://github.com/RamJeaux/Runie.git
-commit=58fbead116e57700d5206d42300d12f711eda29d
+commit=78a9315d8e05c934b6f61c96c41291f93cf14209

--- a/plugins/runie
+++ b/plugins/runie
@@ -1,2 +1,2 @@
 repository=https://github.com/RamJeaux/Runie.git
-commit=bda48bfacbab068430adc71b98d5f6b64b429358
+commit=58fbead116e57700d5206d42300d12f711eda29d

--- a/plugins/runie
+++ b/plugins/runie
@@ -1,2 +1,2 @@
 repository=https://github.com/RamJeaux/Runie.git
-commit=4078555141a6b8f3848ee392890b8b31378d90b4
+commit=bda48bfacbab068430adc71b98d5f6b64b429358

--- a/plugins/runie
+++ b/plugins/runie
@@ -1,0 +1,2 @@
+repository=https://github.com/RamJeaux/Runie.git
+commit=4078555141a6b8f3848ee392890b8b31378d90b4

--- a/plugins/runie
+++ b/plugins/runie
@@ -1,2 +1,2 @@
 repository=https://github.com/RamJeaux/Runie.git
-commit=78a9315d8e05c934b6f61c96c41291f93cf14209
+commit=776925bdbe566ff5987a20a446ace527d6601603


### PR DESCRIPTION
Runie is a cozy, non-monetized, local-first companion-collector. You earn eggs through normal OSRS play, hatch original OSRS-inspired creatures (transparent published odds + a visible pity counter; no real money, no trading, no cash-out), and raise one on-screen animated companion that levels with your XP, evolves through its family line, and prestiges to 120. Duplicates upgrade a creature through star tiers with a rare chance to become Shiny, and every creature has stage-by-stage lore in an in-plugin codex.

- Repo: https://github.com/RamJeaux/Runie  ·  Commit: 4078555141a6b8f3848ee392890b8b31378d90b4
- Original art only — no Jagex assets are bundled, extracted, or traced; no trademarked boss/NPC names are used. Ships the Fan Content Policy attribution.
- Local-only — no network calls, no telemetry, no automation, and no gameplay advantage. No new dependencies (build=standard).
- License: BSD 2-Clause.

Happy to address any review feedback — thanks for taking a look!