### PR TITLE
better-dt2-boss-utilities: add plugin

### DIFF
--- a/plugins/better-dt2-boss-utilities
+++ b/plugins/better-dt2-boss-utilities
@@ -1,0 +1,2 @@
+repository=https://github.com/TheSpryt/better-dt2-boss-utilities.git
+commit=7dcaaa6f9329518bfdd612b164fdf7d3def20045

--- a/plugins/better-dt2-boss-utilities
+++ b/plugins/better-dt2-boss-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/better-dt2-boss-utilities.git
-commit=48445d0b9f489c997c5c589c4784f8be1864008d
+commit=ad2a515af37af20c6e403e29aeab7f6bffe39b55

--- a/plugins/better-dt2-boss-utilities
+++ b/plugins/better-dt2-boss-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/better-dt2-boss-utilities.git
-commit=ad2a515af37af20c6e403e29aeab7f6bffe39b55
+commit=e8c6ce291c92434c00d4b3c18c75617d9bf98f15

--- a/plugins/better-dt2-boss-utilities
+++ b/plugins/better-dt2-boss-utilities
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/better-dt2-boss-utilities.git
-commit=7dcaaa6f9329518bfdd612b164fdf7d3def20045
+commit=48445d0b9f489c997c5c589c4784f8be1864008d


### PR DESCRIPTION
Adds Better DT2 Boss Utilities, a quality-of-life plugin for the Desert Treasure 2 bosses, currently focused on Vardorvis. It runs alongside other DT2 plugins.

Features:
- Hide any of the 8 Vardorvis axe spawns (static, moving, or both, per direction), with optional muting of the hidden axes' sounds
- Highlight axes as hull, tile, true tile, or outline, skipping any that are hidden
- Highlight Vardorvis' heads by attack style (magic and ranged), each with its own colours
- Hover feedback on the spore captcha, with an optional outline around every spore
- Swap the Whisperer's and Vardorvis' projectiles to other boss styles

Repository: https://github.com/TheSpryt/better-dt2-boss-utilities

Tested in game against Vardorvis.