### PR TITLE
Update raids-death-indicator to 4ba310f97808462ee11bfc6d594d07f973b91f14

### DIFF
--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=a6ef1246ef141c762f232a4d5b9a4c1593ec8227
+commit=63229f866bc313c16f716389c6804346b18f9bcb


### PR DESCRIPTION
4ba310f ci: Automatically update plugin-hub on tags
e4c46b1 misc: Replace nightmare totems on npc change