### PR TITLE
log-adviser: bump to 9ab6ba9

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=c76521ea055aeba0ce8eab98e9f33c813b8e1785
+commit=9ab6ba97fa3983cafe980a4c3b557766c1e69bcb


### PR DESCRIPTION
Bumps Log Adviser to v1.2.2.

Fixes a bug where clicking the plugin's collection log Sync button could leave the
client unresponsive to mouse clicks until the sync completed.

The sync merged its harvested items one at a time, and each newly recorded item
triggered a full sidebar rebuild on the Swing EDT. On an account whose recorded data
was well behind its real collection log, that queued thousands of rebuilds and starved
AWT input until they drained. The harvest is now merged in a single batch with one
recompute and one UI update; the per-item path used for live drops is unchanged.

Also coalesces sidebar refreshes so only the newest ranking snapshot is applied.