### PR TITLE
Add GIM Notifications

### DIFF
--- a/plugins/group-event-notifications
+++ b/plugins/group-event-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/DaRoms/group-event-notifications.git
-commit=1743682b49ccb5e6e0517bec9825c51fcc0d0c51
+commit=7229f11e1987026c1c6228710de5bed64a5a24c4

--- a/plugins/group-event-notifications
+++ b/plugins/group-event-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/DaRoms/group-event-notifications.git
-commit=b5e8f5cf2a700943b23e37b846c87f661e1b7eef
+commit=0ae595594f6632a3335834015d52e4189a23acd8

--- a/plugins/group-event-notifications
+++ b/plugins/group-event-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/DaRoms/group-event-notifications.git
-commit=0ae595594f6632a3335834015d52e4189a23acd8
+commit=2ccc6cd79697db8fe4d775da8b4c1b44d031083b

--- a/plugins/group-event-notifications
+++ b/plugins/group-event-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/DaRoms/group-event-notifications.git
-commit=687863709b30fdc40b0732fe580c33e7d9517caf
+commit=e41a544ae376eb41b67fff28f9d0d96cc6f3af3f

--- a/plugins/group-event-notifications
+++ b/plugins/group-event-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/DaRoms/group-event-notifications.git
-commit=2ccc6cd79697db8fe4d775da8b4c1b44d031083b
+commit=3ec5fe2520f55859faf00625df6dfa9649b5167d

--- a/plugins/group-event-notifications
+++ b/plugins/group-event-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/DaRoms/group-event-notifications.git
-commit=3ec5fe2520f55859faf00625df6dfa9649b5167d
+commit=687863709b30fdc40b0732fe580c33e7d9517caf

--- a/plugins/group-event-notifications
+++ b/plugins/group-event-notifications
@@ -1,0 +1,2 @@
+repository=https://github.com/DaRoms/group-event-notifications.git
+commit=1743682b49ccb5e6e0517bec9825c51fcc0d0c51

--- a/plugins/group-event-notifications
+++ b/plugins/group-event-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/DaRoms/group-event-notifications.git
-commit=7229f11e1987026c1c6228710de5bed64a5a24c4
+commit=b5e8f5cf2a700943b23e37b846c87f661e1b7eef

--- a/plugins/group-event-notifications
+++ b/plugins/group-event-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/DaRoms/group-event-notifications.git
-commit=e41a544ae376eb41b67fff28f9d0d96cc6f3af3f
+commit=d6f025323486b898575897e622f1f9cac74f465c


### PR DESCRIPTION
## GIM Notifications

Adds compact animated overlay notifications for Group Ironman broadcasts.

Features include:
- Group drop parsing with item sprites and configurable minimum value
- Optional notifications for quests, achievement diaries, combat achievements, collection log entries, and level-ups
- Notification queue, configurable duration, allow/ignore item lists, sound, and debug logging
- No external network requests or gameplay automation

The real `CLAN_GIM_MESSAGE` drop format has been tested in game, including stacked drops and source names. The Gradle build and unit tests pass.
