### PR TITLE
log-adviser: bump to 1c4261a (v1.2.3)

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=9ab6ba97fa3983cafe980a4c3b557766c1e69bcb
+commit=1c4261a18b23f90e317caa667e99682eab712c1f


### PR DESCRIPTION
Updates Log Adviser to v1.2.3.

Data-only update: corrects the Maggot marquess pet drop rates for the Killing Maggot King activity (1/3500 on the regular loot roll, 1/1502 on the destroy roll).