### PR TITLE
Update 07flip to 594d171

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=09d10542e6d78150dd701f93a2fcbbefc107c6c0
+commit=594d1714f3984070da795d4873f3760a83bb0f19
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
This update adds an optional toggle in the Capital panel to filter the flip list by your free capital (money not tied up in open buy offers) rather than your full bankroll, so the list reflects what you can actually spend right now. It also tidies the Trades tab header when the stats section is collapsed and removes some unused internal code. No new dependencies and no change to what data the plugin sends.