### PR TITLE
Add RuneVersus

### DIFF
--- a/plugins/rune-versus
+++ b/plugins/rune-versus
@@ -1,2 +1,2 @@
 repository=https://github.com/hakimbalestrieri/RuneVersus.git
-commit=891df6f93777c4e91bf826b19c7521e9c807d424
+commit=f2254c76763e812a184af3982a6b415c9decddd2

--- a/plugins/rune-versus
+++ b/plugins/rune-versus
@@ -1,2 +1,2 @@
 repository=https://github.com/hakimbalestrieri/RuneVersus.git
-commit=b80edd629b10003d6a491af08fa17b5b46d76c07
+commit=25e53193ea949f0b8ea030f5308c6b72a4f7cbc1

--- a/plugins/rune-versus
+++ b/plugins/rune-versus
@@ -1,2 +1,2 @@
 repository=https://github.com/hakimbalestrieri/RuneVersus.git
-commit=25e53193ea949f0b8ea030f5308c6b72a4f7cbc1
+commit=b80edd629b10003d6a491af08fa17b5b46d76c07

--- a/plugins/rune-versus
+++ b/plugins/rune-versus
@@ -1,0 +1,2 @@
+repository=https://github.com/hakimbalestrieri/RuneVersus.git
+commit=891df6f93777c4e91bf826b19c7521e9c807d424

--- a/plugins/rune-versus
+++ b/plugins/rune-versus
@@ -1,2 +1,2 @@
 repository=https://github.com/hakimbalestrieri/RuneVersus.git
-commit=f2254c76763e812a184af3982a6b415c9decddd2
+commit=25e53193ea949f0b8ea030f5308c6b72a4f7cbc1

--- a/plugins/rune-versus
+++ b/plugins/rune-versus
@@ -1,2 +1,2 @@
 repository=https://github.com/hakimbalestrieri/RuneVersus.git
-commit=89f95cc41f24514ece706bdd487a560d93488f7f
+commit=e2abbe9c2eec490df37879e9d48fe4711b3bfc49

--- a/plugins/rune-versus
+++ b/plugins/rune-versus
@@ -1,2 +1,2 @@
 repository=https://github.com/hakimbalestrieri/RuneVersus.git
-commit=25e53193ea949f0b8ea030f5308c6b72a4f7cbc1
+commit=89f95cc41f24514ece706bdd487a560d93488f7f


### PR DESCRIPTION
## Summary

Adds RuneVersus, a RuneLite plugin for clear player-versus-player comparisons, clan progress leaderboards, fair monthly clan leagues, and shareable OSRS-styled result cards.

RuneVersus uses RuneLite/official hiscore data and bounded HTTPS requests to Wise Old Man. It has no additional runtime dependencies and uses the standard Plugin Hub build.

## Safety and data handling

- No credential collection or storage.
- No reflection, JNI, subprocesses, or runtime code downloads.
- External requests are HTTPS-only, identified, rate-limited, cached, and size-bounded.
- Local files are limited to exported cards, league archives, and optional user-provided comparison data under the RuneLite directory.
- The compact `!vs` command only displays local console results and does not automatically alter outgoing chat.

## Validation

- Java 11 Gradle build and test workflow passes on the submitted plugin commit.
- Repository, manifest, icon, README, and BSD-2-Clause license follow the Plugin Hub checklist.
- The repository and full Git history were checked for secrets and unsafe executable behavior.

## Reviewer note

`Private comparison data` is disabled by default. When explicitly enabled, it reads user-supplied local properties and may display PB times, detailed collection totals, and a CA tier when values exist for both compared players. These values are labeled unverified and are excluded from `!vs` output and Monthly League scoring. If this narrow local-only display is considered within the rejected PB-hiscore category, I am happy to remove it before approval.

Plugin repository: https://github.com/hakimbalestrieri/RuneVersus

Submitted commit: `89f95cc41f24514ece706bdd487a560d93488f7f`
