### PR TITLE
Update penguin-crushers to 2.0

### DIFF
--- a/plugins/penguin-crushers
+++ b/plugins/penguin-crushers
@@ -1,2 +1,2 @@
 repository=https://github.com/hyperslab/penguin-crushers.git
-commit=540d736a094ebeb44cae46de474fdf5e0c1ae11c
+commit=e74d4e85869966045f0e335f41b3ea65bfca7e01


### PR DESCRIPTION
The most impactful change here is that the plugin can now tell when you begin to move through the crushers with correct timing and will play a pleasant sound with color changes.

Other new features:
- The plugin can tell when you begin to move with incorrect timing and will play an unpleasant sound with color changes.
- If you are knocked down to the south row, the plugin can highlight a nearby safe tile in the north row to return to.
- The plugin can display a graphical countdown timer over the exit indicating when the tick for safe movement will end.

Everything new can be disabled in config. The timer is off by default.

I imagine this would be too powerful in a combat situation but for a single obstacle in an unpopular agility course we can surely go a little overboard.