### PR TITLE
Add RuneScape Coach

### DIFF
--- a/plugins/runescape-coach
+++ b/plugins/runescape-coach
@@ -1,2 +1,2 @@
 repository=https://github.com/joelbridger/runescape-coach-plugin.git
-commit=5e60b5c2581dfb54d670e2eb5a3fe2f193891158
+commit=87b5a2418f557dc90a9f3b84d609fa7d4e49b049

--- a/plugins/runescape-coach
+++ b/plugins/runescape-coach
@@ -1,2 +1,2 @@
 repository=https://github.com/joelbridger/runescape-coach-plugin.git
-commit=21716092714474d93e07dbd0f8c4f05c5f0fa1ed
+commit=421df643115c06051f5a7ef2abedcaea4ba29577

--- a/plugins/runescape-coach
+++ b/plugins/runescape-coach
@@ -1,0 +1,2 @@
+repository=https://github.com/joelbridger/runescape-coach-plugin.git
+commit=21716092714474d93e07dbd0f8c4f05c5f0fa1ed

--- a/plugins/runescape-coach
+++ b/plugins/runescape-coach
@@ -1,2 +1,2 @@
 repository=https://github.com/joelbridger/runescape-coach-plugin.git
-commit=421df643115c06051f5a7ef2abedcaea4ba29577
+commit=5e60b5c2581dfb54d670e2eb5a3fe2f193891158

--- a/plugins/runescape-coach
+++ b/plugins/runescape-coach
@@ -1,2 +1,2 @@
 repository=https://github.com/joelbridger/runescape-coach-plugin.git
-commit=87b5a2418f557dc90a9f3b84d609fa7d4e49b049
+commit=736ab5f8d093b5f08e9515cdb371e5a225109632


### PR DESCRIPTION
RuneScape Coach shows a local checklist in the RuneLite sidebar, with an optional overlay for the selected step. The idea is to keep a longer goal visible without turning it into an automatic helper.

Plans are read from `.runelite/runescape-coach/plan.json`, and users move between steps with Previous and Next buttons. The plugin does not subscribe to game events or make network requests.

This uses the standard build and has no extra dependencies. The README includes the JSON format and a small example.