### PR TITLE
Add Chunk Collector

### DIFF
--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=6d298fc3930f5071caecff3ae0f8c2bc1d81504c
+commit=d77aab1333f51421d05d5df04511ff2254952990

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=9fdd187eeeee481cf3e103a90198a5993a4fcacc
+commit=efb862ad6c0d6b4bf5792cdc40bebd6d79e38232

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=2980b2ef60f5b70ea9e4e9f96ee82692720f8737
+commit=c94e77ce3b3ca9a6249df7ef9c7dfc8fe7a1706b

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=42878fef29a4dc86cf17a79f0725109a9bfee801
+commit=9499c2c39c381842b19f2c0c48fb41b9aee5e786

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=1cf992bb2b846834e28e7c2c0c90197f0e9a545e
+commit=a3995575b311ec98e9b82169d3d46bf69525f5b0

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=c94e77ce3b3ca9a6249df7ef9c7dfc8fe7a1706b
+commit=9fdd187eeeee481cf3e103a90198a5993a4fcacc

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,0 +1,2 @@
+repository=https://github.com/theclockblocks/chunk-collector.git
+commit=2980b2ef60f5b70ea9e4e9f96ee82692720f8737

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=efb862ad6c0d6b4bf5792cdc40bebd6d79e38232
+commit=e5ae1b0b5e677f97847739006cec1e712e59892f

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=9499c2c39c381842b19f2c0c48fb41b9aee5e786
+commit=d94a6dd1728a7960de64692f207a37e0bcdd0d12

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=a3995575b311ec98e9b82169d3d46bf69525f5b0
+commit=de1ad4c638598ce78a4938a0da8a0f46062e708c

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=d94a6dd1728a7960de64692f207a37e0bcdd0d12
+commit=1cf992bb2b846834e28e7c2c0c90197f0e9a545e

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=de1ad4c638598ce78a4938a0da8a0f46062e708c
+commit=6d298fc3930f5071caecff3ae0f8c2bc1d81504c

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=e5ae1b0b5e677f97847739006cec1e712e59892f
+commit=42878fef29a4dc86cf17a79f0725109a9bfee801

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=d77aab1333f51421d05d5df04511ff2254952990
+commit=a08090f9785193f344064a58c85f73bc135cc6e6

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=b07dbf9114e99086a50cc0d01971a481de725551
+commit=cfb617595f5428b7b6310dc5e4937967a15aa28d

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=a08090f9785193f344064a58c85f73bc135cc6e6
+commit=c369ccbd509e7ab1ba0e05d846cfa805f6dc6eee

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=c369ccbd509e7ab1ba0e05d846cfa805f6dc6eee
+commit=3a9ae1ab63550ffaf5106a5897f79a744ea3c3fe

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=3a9ae1ab63550ffaf5106a5897f79a744ea3c3fe
+commit=0cfe4e7eb8ce5abce651c0c860af3f3ff39d6a04

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=0cfe4e7eb8ce5abce651c0c860af3f3ff39d6a04
+commit=b07dbf9114e99086a50cc0d01971a481de725551

--- a/plugins/chunk-collector
+++ b/plugins/chunk-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/theclockblocks/chunk-collector.git
-commit=cfb617595f5428b7b6310dc5e4937967a15aa28d
+commit=c22f805da74c337bcd47d0aa978841259cee2369


### PR DESCRIPTION
Adds Chunk Collector, a zone-locked challenge-mode plugin: the map is locked outside your starting zone (64x64 regions, or 8x8 chunks for hardcore), and progression comes from completing the drop tables of the mobs, trees, rocks and fishing spots you sight in each zone. Reaching a configurable share of a zone's collection points earns a token to unlock a frontier zone of the player's choice; 100% completion earns a bonus token.

Details:
- Drop tables are parsed from OSRS Wiki DropsLine wikitext (custom User-Agent, cached to disk in the plugin's .runelite subdirectory, fetched once per NPC)
- Optionally mirrors unlocked/frontier zones into the Region Locker plugin's config for rendering (opt-out toggle; the plugin draws no zone overlays itself)
- Region nicknames and per-zone challenges are bundled from the Chunk Picker community's public data export, credited in the README
- Locked-zone enforcement cancels menu clicks client-side only; no outgoing actions are added
- BSD-2-Clause; inspired by Region Locker, Bronzeman Mode, Hold Your Ground and OSRS TCG (all credited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)