### PR TITLE
update pb-tracker-sync

### DIFF
--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/0xJeu/pb-tracker-sync.git
-commit=84a19748b8935ffed860b8a628edcaf3e538f880
+commit=b53b3417f7e7c991d44116a1ab3f60ca38211b04
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Summary

- Update PB Tracker Sync from `84a1974` to `b53b341`.
- Limit automatic bulk PB syncing to once per account login session.
- Suppress identical automatic payloads while they are in flight and briefly after a successful sync.
- Preserve immediate changed-PB delivery and explicit manual syncs.

## Why

RuneLite can emit repeated `LOGGED_IN` transitions during startup, world hops, and reconnects. The plugin previously scheduled another full PB upload for each transition, creating unnecessary duplicate traffic. This update prevents that repeated automatic syncing while keeping normal PB updates working.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) gradle test --rerun-tasks` — 85 tests passed.
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) gradle build` — successful.
- The merged plugin commit has the exact tested tree from plugin PR #14.
- The Plugin Hub change only updates `plugins/pb-tracker-sync` to the merged commit.
