### PR TITLE
grand-flip-out: update to 3194620

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=dd2caf2d96abc58768a307ec56d942c154036e16
+commit=31946209411fb446eeb7f63af0c6202261ba757e


### PR DESCRIPTION
Updates `grand-flip-out` from `dd2caf2` to `3194620` — a batch of GE-flipping UX fixes driven by user feedback. All changes are information-only (no automation, no trade execution) and Java 11 / `./gradlew build`-clean.

**Highlights**
- Advisor now defaults to a single next-flip suggestion (multi-slot basket is opt-in).
- First-run setup: one panel action enables the (disclosed, off-by-default) grandflipout.com features; GE offer auto-fill is a separate, explicitly-ticked opt-in.
- Default the price-fill hotkey to `E`, acted on ONLY while a GE numeric price/quantity input is open (never consumes the key elsewhere — verified against the client's `KeyManager`).
- Flip tracker records partial fills on cancelled offers (previously only fully-completed BOUGHT/SOLD offers were tracked).
- Removed the GE item-search auto-fill: it wrote the item name but could not refresh the results list without a forbidden `runScript`. Price/quantity injection (widget text + client var, player confirms) is unchanged.

**Compliance**
- No terminally-deprecated / banned APIs; no reflection, subprocess, or synthetic input.
- All grandflipout.com network access stays behind the `enableServerFunctionality` master switch, whose `@ConfigItem(warning=...)` names the IP and the exact data sent.
- No other players' data and no local player identity are ever sent.
