### PR TITLE
Add We Do Raids

### DIFF
--- a/plugins/we-do-raids
+++ b/plugins/we-do-raids
@@ -1,0 +1,2 @@
+repository=https://github.com/randytkrx/we-do-raids-plugin.git
+commit=6f2637018cb3a1809276989caad4af34d4b534cc


### PR DESCRIPTION
This is the official We Do Raids community plugin. We've been working with the WDR team to build it — it surfaces their Discord raid recruitment in-game: a live feed of recruiting calls (ToB/CoX/ToA) with one-click world hopping, party-board highlights for WDR teams, hosting your own call with live post editing, auto party hub passphrases with one-click RuneLite party join, KC-based tier gating matching the WDR Discord's structure, and WDR ban-list awareness.

It talks to the community's own bridge (wdr.timecapsule.ink) over HTTPS. Nothing is sent until the user opts in by entering their verification key from the WDR Discord; once connected it sends the player's RSN + key so the bridge can verify them and enforce the WDR ban list — disclosed up-front in the plugin settings and README.