### PR TITLE
Add Bank Tag Loot

### DIFF
--- a/plugins/bank-tag-loot
+++ b/plugins/bank-tag-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/skossan/BankTagLoot.git
-commit=ffde88e0bed758cac87b82051791df09209492ca
+commit=8cf9d36c83e58897405d76d35f251e8b430d6cc1

--- a/plugins/bank-tag-loot
+++ b/plugins/bank-tag-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/skossan/BankTagLoot.git
-commit=46c45a105e352580fc3b259fe5a4184f08fe277c
+commit=ffde88e0bed758cac87b82051791df09209492ca

--- a/plugins/bank-tag-loot
+++ b/plugins/bank-tag-loot
@@ -1,0 +1,2 @@
+repository=https://github.com/skossan/BankTagLoot.git
+commit=46c45a105e352580fc3b259fe5a4184f08fe277c

--- a/plugins/bank-tag-loot
+++ b/plugins/bank-tag-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/skossan/BankTagLoot.git
-commit=8cf9d36c83e58897405d76d35f251e8b430d6cc1
+commit=6744573d140e5b147dfc7700e3d0aa82748f4b32


### PR DESCRIPTION
## What it does

Pick a boss from a searchable side panel and instantly create a Bank Tags tab pre-filled with everything that boss can drop. Each tab gets its own icon (the boss's pet where available). Drop data is sourced from the OSRS Wiki.

Repo: https://github.com/skossan/BankTagLoot