### PR TITLE
update lendingtracker

### DIFF
--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=c96a5f7dee8120112a8f626cc311c9eb1aece54b
+commit=e02caf3b01fecfaf1b4cb561c4362495818c5223


### PR DESCRIPTION
Add multi-use group code with open/close joins
Onboarding a batch of members (a clan or an event group) no longer needs
one invite per person. A new "Group Code (multi-use)" section in Settings
lets invite-permitted members:

- Open Joins: publish one code any number of players can join with, on
  any machine (same relay publish/lookup as single-use codes; the code
  simply isn't consumed after a join)
- Close Joins: the code stops working everywhere immediately but is
  KEPT, so it can be reopened later for stragglers
- Custom codes (6-20 chars, validated) with a warning that guessable
  codes are usable by anyone while joins are open
- Copy button and a live status line (OPEN with use count / closed)

While joins are open the code is re-published on the periodic sync so it
doesn't age out of the relay's 24h invite expiry. Same-machine joins via
the shared config key follow the same multi-use rules. Permission gate is
the existing invite-code rule (owner always; co-owner/admin/mod per group
settings). Single-use invite codes are unchanged.