### PR TITLE
add cox-assistant

### DIFF
--- a/plugins/cox-assistant
+++ b/plugins/cox-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/caasssh/cox-assistant.git
-commit=035784ce77e17eb834f2ad01113b8d0cc9cc7a65
+commit=8c1838420b55094129c28665a0308e475a351e56

--- a/plugins/cox-assistant
+++ b/plugins/cox-assistant
@@ -1,0 +1,2 @@
+repository=https://github.com/caasssh/cox-assistant.git
+commit=035784ce77e17eb834f2ad01113b8d0cc9cc7a65

--- a/plugins/cox-assistant
+++ b/plugins/cox-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/caasssh/cox-assistant.git
-commit=de7b5d3b08177b917c65c9c9e7a8cc85048bb166
+commit=afae3cc8b9a0eece0ef774260d1481ef6813442a

--- a/plugins/cox-assistant
+++ b/plugins/cox-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/caasssh/cox-assistant.git
-commit=1d8ab8ddfd5f1ffff9208d3f999ed95af7359cfd
+commit=de7b5d3b08177b917c65c9c9e7a8cc85048bb166

--- a/plugins/cox-assistant
+++ b/plugins/cox-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/caasssh/cox-assistant.git
-commit=8c1838420b55094129c28665a0308e475a351e56
+commit=1d8ab8ddfd5f1ffff9208d3f999ed95af7359cfd


### PR DESCRIPTION
Adds CoX Assistant, a passive Chambers of Xeric sidebar for raid scouting and planning.

Features include layout and scale display, supported-room point and purple estimates that are explicitly labelled as estimates, preparation tracking, NPC/defence planning, Olm information, and RuneLite Party team data. Named raid summaries remain local. Anonymous point fixtures are opt-in, saved locally, and shared manually by the user.

Validation:

- Java 11 with `build=standard`
- 99 automated tests passing
- Packaged resources load through classpath streams
- No additional production dependencies
- Shared-storage convergence and performance live-tested by the project owner

The feature scope was discussed with RuneLite maintainers before submission; no stable public link to that conversation is available, so this PR is submitted for normal maintainer review without claiming that discussion as formal approval.
