### PR TITLE
Update guide-overlay to 1.2.0 - Bug Fixes

### DIFF
--- a/plugins/guide-overlay
+++ b/plugins/guide-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/RunelitePlugin/guide-overlay.git
-commit=1968090bd86e2591ba208b28ed17ff0c4029ca96
+commit=f3b87ee5691c416d843e5307455b62b3bad053db

--- a/plugins/guide-overlay
+++ b/plugins/guide-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/RunelitePlugin/guide-overlay.git
-commit=5dc086ef122d55b36abd10cfba3c66a8bc1395a0
+commit=1968090bd86e2591ba208b28ed17ff0c4029ca96


### PR DESCRIPTION
Reworks the BRUHsailer guide display: long paragraph steps are now split
into one action per step, so nothing gets cut off by the step length limit.

Existing saved progress migrates automatically.