### PR TITLE
update bank-templates to v2.0.0

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=52d127c72ab94fab59285780716911b87a563e7d
+commit=19ac850aa252f3ced25834b48d0ce049fc99eb35

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=7dda90925af02ecc358dbfb4fb54fd550d4fd82f
+commit=52d127c72ab94fab59285780716911b87a563e7d

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=19ac850aa252f3ced25834b48d0ce049fc99eb35
+commit=ec2388a3715896648b05a367d3f2f1e353f297de


### PR DESCRIPTION
Updates bank-templates to v2.0.0: repository commit 534252c96f0ab7cb4c2a066d3bef56a12296a5ed.

Changes since the currently published commit (v1.6.6):

v2.0.0
- My Templates and Browse now use the same profile-styled cards. An imported template you have not edited keeps the original uploader's name, icon and card style; editing it makes it yours. The Exchange Insights account link stays opt-in, so without one the cards fall back to default styling and no account data is fetched.
- Capture and New are now a single "+" card at the top of My Templates. It asks whether to start from the current bank or an empty layout, and only offers the bank option when there is a bank to capture. A newly created template is scrolled into view, paging to it if it landed on another page.
- Clicking a card applies it, or previews it in Browse. The icon buttons keep their own actions and the applied template is outlined in red.
- Cards show the template's tab icons, its import and report counts, and how many of its items you already own. The owned count now works while logged out, using the last bank snapshot the account synced.
- The avatar on a card opens that uploader's Exchange Insights profile in the browser.
- Both tabs get sorting, searching, a pager at the top and bottom of the list, an always-visible scrollbar, and a link to the same list on the website.
- Reorganise collapses to a single row and expands on click.
- Visual pass: RuneScape font throughout, rounded input corners, gold dropdown arrows and tab labels, and hover feedback on cards and icons.
- Fixed virtual tabs from an active template disappearing while a Bank Tags tag tab or the Quest Helper bank tab was open.



