### PR TITLE
Add Waypoint Sync

### DIFF
--- a/plugins/waypoint-sync
+++ b/plugins/waypoint-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/Xiodrade/waypoint-sync.git
+commit=fc740a539e6b586e10e4f2fda1a6b488b507290f

--- a/plugins/waypoint-sync
+++ b/plugins/waypoint-sync
@@ -1,2 +1,3 @@
 repository=https://github.com/Xiodrade/waypoint-sync.git
 commit=1201759a31c98ef70d720253444d6801b3f4e6f3
+warning=This plugin submits your IP address, display name, quests, diaries, and combat achievements to a third party server not controlled or verified by Runelite developers.

--- a/plugins/waypoint-sync
+++ b/plugins/waypoint-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Xiodrade/waypoint-sync.git
-commit=fc740a539e6b586e10e4f2fda1a6b488b507290f
+commit=1201759a31c98ef70d720253444d6801b3f4e6f3


### PR DESCRIPTION
Syncs quests, achievement diaries, combat achievements, skills and collection log to a waypointosrs.com
  account, so the site can suggest what to do next.

  Uploads to a single hardcoded endpoint and does nothing until the user pastes a token. No chat, bank, inventory,
  position, or data about other players is read or sent — the one ChatMessage subscriber matches the game's own 'New
  item added to your collection log' line and returns on anything else. The README documents field by field what is
  sent, what is not, and why the interface scraping is necessary (per-task CA completion and collection log counts are
  not exposed as varbits).