### PR TITLE
bank-templates: point at the current commit hash for v2.0.0

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=ec2388a3715896648b05a367d3f2f1e353f297de
+commit=534252c96f0ab7cb4c2a066d3bef56a12296a5ed


### PR DESCRIPTION
Points bank-templates at commit 534252c96f0ab7cb4c2a066d3bef56a12296a5ed. Same v2.0.0 code as the commit merged in #14173, no plugin changes.

#14173 was merged pointing at ec2388a3715896648b05a367d3f2f1e353f297de. I rewrote the repository's history shortly afterwards (normalising commit authorship), which changed every commit hash, so that hash is no longer reachable from any branch. It still resolves today because GitHub has not collected the object yet, but it will stop resolving eventually and the build would then fail to clone it.

534252c is the same tree on the current default branch. Verified identical: `git diff ec2388a 534252c -- src/ runelite-plugin.properties` is empty.

Sorry for the extra PR - I should have repointed before the rewrite rather than after.
