### PR TITLE
clan-management: parsing fixes, live clog, event tab

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=eff72ba3dd91e6e5279efd603e4200fb7d47731f
+commit=5de562019a8fd78a150ec3eee5c1897ad22a8f53
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates clan-management to `5de562019a8fd78a150ec3eee5c1897ad22a8f53`.

Highlights since the last version:
- Speed-time parsing hardened: Gauntlet/Corrupted Gauntlet completions no longer mis-file onto the Chambers of Xeric board; "total completion time" lines for ToB/ToA are ignored (room time only); ambiguous "Challenge duration" lines are disambiguated by the following count message instead of guessed. Backed by a 25-case parsing test suite.
- Duplicate pets now post correctly (via the "funny feeling" chat line).
- Collection log quantities update live from loot events.
- New in-game Event tab (clan Boss/Skill-of-the-Week race view + countdowns).
- Ranks tab collapses already-held ranks; admin panel layout fixes.
- Solo times are treated as clan-verified regardless of source.
