### PR TITLE
update lendingtracker

### DIFF
--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=e02caf3b01fecfaf1b4cb561c4362495818c5223
+commit=b27ff2309a4a04a8edebb269cc68c80eeb03a16f

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=b27ff2309a4a04a8edebb269cc68c80eeb03a16f
+commit=8ebbb58320d2ad2df6948dd94554353ce048b117

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=8ebbb58320d2ad2df6948dd94554353ce048b117
+commit=f801f354390e2aed39b7a4f2717cda911dcb947c


### PR DESCRIPTION
Updates Lending Tracker with cloud sync reliability fixes and a rework of online status.

-Fixed the relay connection silently dying a few minutes after login. It only recovered from hard failures, not the server closing an idle connection, so sync just stopped working until the client was restarted. It now reconnects properly and keeps the connection warm.

-New group members are announced the moment they join, so the rest of the group sees them instantly instead of waiting on a periodic push that could skip them entirely.

-Online status in the roster now comes from who is actually connected to the sync relay instead of the friends list, and shows what world they're on. You no longer need people friended or in your friends chat to see them online.

-The group code use counter now counts joins made from other machines instead of staying at 0.

-Kicks now stick across machines. A kicked member can't be re-added by another client that still had an older roster, but re-inviting them works normally.

-Various thread safety hardening around the reconnect logic and replay protection.