### PR TITLE
Update custom-hp-bar

### DIFF
--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=97d68a77e8e97bf681a814b9e81fe9fe7f7f6d96
+commit=0c38280ee5279b7e8fe66e5c0065797c2ccda9ae

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,0 +1,2 @@
+repository=https://github.com/waitstepbro/custom-hp-bar.git
+commit=97d68a77e8e97bf681a814b9e81fe9fe7f7f6d96


### PR DESCRIPTION
Updated commit to 0c38280ee5279b7e8fe66e5c0065797c2ccda9ae. Changes since the originally submitted commit:

- **Food heal & Prayer restore previews** — hovering a food/potion extends the HP bar
  (or Prayer bar, for Prayer-restoring items) with a translucent preview of where the
  stat would land. Calculated via the core Item Stats plugin's service (added as a
  @PluginDependency), so level/gear-dependent heals are exact.
- **Standalone Prayer bar** — a prayer toggled on outside combat now shows the Prayer
  bar on its own, instead of only during combat (requested via GitHub issue).
- **Replace Overhead Icon** (new toggle) — suppresses the native overhead UI on the
  local player only (RenderCallback) and draws the protection prayer icon just above
  the HP bar, so HP/Prayer/icon move as one unit. Hitsplats and overhead chat text on
  the local player are redrawn to match vanilla exactly (game's own splat sprites,
  native fonts/colors/timing) since they're part of the same suppressed render pass.
- README/screenshot updates.