### PR TITLE
Add inventory-click-highlighter plugin

### DIFF
--- a/plugins/inventory-click-highlighter
+++ b/plugins/inventory-click-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/nick-michael/rl-inventory-click-highlight.git
+commit=620efb2f79453b43e957cc341580f938b127a83c

--- a/plugins/inventory-click-highlighter
+++ b/plugins/inventory-click-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/nick-michael/rl-inventory-click-highlight.git
-commit=9de89ada6b7dfe578fa7c2096083fadca26a28e7
+commit=1cdc0a29ad078992412e91962d0a152578ea3841

--- a/plugins/inventory-click-highlighter
+++ b/plugins/inventory-click-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/nick-michael/rl-inventory-click-highlight.git
-commit=620efb2f79453b43e957cc341580f938b127a83c
+commit=9de89ada6b7dfe578fa7c2096083fadca26a28e7

--- a/plugins/inventory-click-highlighter
+++ b/plugins/inventory-click-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/nick-michael/rl-inventory-click-highlight.git
-commit=1cdc0a29ad078992412e91962d0a152578ea3841
+commit=e5eb52993a65aee98eddd17849be11445d576093


### PR DESCRIPTION
A new plugin which will highlight clicks on items in the inventory. You can customise the highlight colour, outline colour, fade duration and exclude any specific actions.


https://github.com/user-attachments/assets/443c1f03-7350-45c1-ae94-cd8a82cd9c78

