### PR TITLE
Retire prayer-time-infobox

### DIFF
--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,0 +1,3 @@
+repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
+commit=9d850e13a757655a6c270f35cac951e438e34962
+disabled=retired by author

--- a/plugins/prayer-time-infobox
+++ b/plugins/prayer-time-infobox
@@ -1,3 +1,0 @@
-repository=https://github.com/arbeerby-pixel/prayer-time-infobox.git
-commit=9d850e13a757655a6c270f35cac951e438e34962
-disabled=freezes client on login


### PR DESCRIPTION
PvM Toolkit has been retired by its author. Keep the historical manifest as required by Plugin Hub policy, but update its disabled reason to mark the plugin as permanently retired. The old source repository has also been removed. A separate replacement plugin may be submitted later as a new review.