### PR TITLE
Add PvM Tools 1.1.0

### DIFF
--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=0fe052a695685d5dbe6c1ee3f8e7cdc4265469af
+commit=fc18b1bd78bf2ab001eb9063934ec77d3052f5bd

--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,0 +1,2 @@
+repository=https://github.com/arbeerby-pixel/pvm-tools.git
+commit=0fe052a695685d5dbe6c1ee3f8e7cdc4265469af

--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=fc18b1bd78bf2ab001eb9063934ec77d3052f5bd
+commit=005a24393ab3a1fac24e8090597791b3b17992e5

--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=005a24393ab3a1fac24e8090597791b3b17992e5
+commit=a379fe075b205000138750a04772a99286f254eb


### PR DESCRIPTION
## PvM Tools 1.1.0

This PR adds **PvM Tools**, a clean RuneLite PvM companion rebuilt from the discontinued PvM Toolkit plugin.

**Latest source:** [`a379fe0`](https://github.com/arbeerby-pixel/pvm-tools/tree/a379fe075b205000138750a04772a99286f254eb)

## Features

- Combat potion and prayer timers with shared screen warnings and sounds.
- Cannon empty, reload, and repair alerts.
- Valuable NPC drop alerts and configurable Loot Glow.
- Loot Glow minimum value with full stack and coin-value support.
- Ground-item lifetime text that shrinks from green to red before despawn.
- Loot click-through for visible drops beneath NPCs.
- Wilderness/PvP safety that disables menu-changing helpers in dangerous areas.
- Persistent loot, supply-cost, combat XP, and Slayer XP trackers.
- Dynamic chat-tab trackers and Trade-button clock.
- PvM statistics side panel and permanent Slayer task history.
- Superior Slayer spawn alerts and short examine hints.
- Inventory-space helper and warning popup support.
- Cancelled Slayer tasks are excluded from Slayer Log.

The broken clue-related feature from the previous plugin was not included.

## Validation

- Full test suite passes on Java 11.
- Plugin Hub standard build passes.
- Repeated full developer-client launches load PvM Tools, Skilling Toolkit, and the normal RuneLite profile successfully.
- Tested through normal gameplay for timers, trackers, drops, cannon alerts, Slayer history, plugin enable/disable, and login/logout lifecycle behavior.
