### PR TITLE
Change commit hash in RuneAlytics plugin

### DIFF
--- a/plugins/runealytics
+++ b/plugins/runealytics
@@ -1,4 +1,4 @@
 repository=https://github.com/Runescape-Tracking/RuneAlytics-Plugin.git
-commit=4f6da7bcc6f84609c787c435cb53b12fffdf9160
+commit=f06528b9e6d38f3786a22ce0b8de26b7724ae210
 warning=This plugin submits your IP address, in-game name, friends list, members of your clan chat, other player metrics, and optional bank contents, to Runealytics.com which is not maintained or reviewed by RuneLite.
 authors=mrtms,cshunton


### PR DESCRIPTION
# RuneAlytics v2.0.5

## XP Tracker: per-skill detail view refinements

A polish pass over the per-skill detail view, the panel you get when you click into a skill. Still gated behind the `xp_tracker` feature flag.

- **Tabbed profit card** — the two separate "Profit (GE Prices)" and "Profit (High Alch)" cards are now one **Profit** card with **GE Prices** and **High Alch** tabs. Switching tabs instantly re-renders profit/hr, session profit, and the used/spent/today breakdown from the cached snapshot, and the active tab stays highlighted so you always know which valuation you're looking at.
- **Right-click resets** — right-click the skill header and you can **Reset XP/hr**, **Reset session XP**, or **Reset both**. Resetting XP/hr just clears the rate timing; your accumulated session XP stays put.
- **"Actions left" stat** — the old "Est. Time" cell is now **Actions Left**, estimating how many more actions you need to hit the next level based on your session's average XP per action.
- **Near-level highlight** — once you're into the last 25% of a level, the Time to Level, Actions Left, and XP to Next stats turn gold to show you're close, then go back to normal on their own the moment the new level ticks over.
- **AFK badge moved** — the "AFK — Paused" indicator used to live in the main panel's session summary header. It now sits in the top-right corner of the detail view's back link, so you can still see it while you're drilled into a skill.

## Readability and presentation

- Reworked the profit breakdown line: relabeled "Made" to "Used", the values are now muted grey, and the "Today" figure carries its own green or red colour depending on whether you're up or down, while the labels stay white.
- Sub-section headings are now the brand teal, which reads a lot better against the dark background.
- A few main-panel touch-ups: the "XP Earned Today" caption is brighter white, the account line shows your account name in green, the Sync button lost its little refresh glyph, and the button labels are centred with tighter margins.