### PR TITLE
Add NPC Health Text plugin

### DIFF
--- a/plugins/npc-health-text
+++ b/plugins/npc-health-text
@@ -1,0 +1,2 @@
+repository=https://github.com/devrat0/npc-health-text-plugin.git
+commit=7dcf050f06a034be26a25cf71d26e2c6a4575c23


### PR DESCRIPTION
Added a simple NPC Health Text display plugin with the option to display raw values, percentage or both. I created this plugin because I was not satisfied with the way existing NPC hp plugins work, or display their text. I use the default runescape fonts scaled to their supported values to ensure its displayed clearly, and added options for a background so its easier to see in certain scenarios. 

<img width="1024" height="699" alt="image" src="https://github.com/user-attachments/assets/913114fa-9ff0-49f9-9213-ff60a054784d" />

<img width="496" height="338" alt="Screenshot 2026-07-22 at 6 41 06 PM" src="https://github.com/user-attachments/assets/0698b25a-5da2-428e-b3f7-9737a6b1fce3" />