### PR TITLE
Fix Nexling pet tracking and keep unique dry streaks independent.

### DIFF
--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=7d75df528900332aea355e8999b1a4186e4798d5
+commit=5866e77bf1791e54712e7c3766c5e087c49824cd


### PR DESCRIPTION
Route Nexling to petReceiver instead of specialLoot, show it in the panel without split controls, and stop pet drops from resetting unique-table dry streaks as they roll off a tertiary drop table (seperate from uniques).