### PR TITLE
grand-flip-out: update to 9cf0465

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=31946209411fb446eeb7f63af0c6202261ba757e
+commit=2050a9f17a38bdc095e7e959b8ef9050dd024f20

--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=2050a9f17a38bdc095e7e959b8ef9050dd024f20
+commit=9cf04656764b8011b65bbc2b38d355db14b75d24


### PR DESCRIPTION
Updates `grand-flip-out` from `3194620` to `9cf0465` — user-feedback UX fixes plus account-recognition improvements. Information-only (no automation, no trade execution), Java 11 / `./gradlew clean build`-clean (107/0 tests).

**Highlights**
- Advisor card now HOLDS after a collected buy until you place the matching sell offer (+ a "Next flip" button; on by default) — fixes losing the sell price on collect.
- Account tier is now VISIBLE in the footer: a badge shows **Not signed in / Free / Pro** (and a ⚠ "Pro in use elsewhere" state), so a payer gets confirmation their Pro is recognized. Tier-aware CTA ("Upgrade to Pro" for free users).
- A 5-minute entitlement heartbeat keeps the tier/Pro state fresh (it previously only updated on startup/key-change).

**Compliance**
- No terminally-deprecated / banned APIs; no reflection, subprocess, or synthetic input.
- All grandflipout.com network access stays behind the disclosed, off-by-default `enableServerFunctionality` master switch. A new `X-GFO-Instance` header carries only an ephemeral per-launch random token (never the RuneScape account or any player identity) so the server can prevent one paid key running many concurrent instances.
- No other players' data and no local player identity are ever sent.
