### PR TITLE
update bank-templates to v2.2.0

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=77563b2ce54f565fc4dfba4af72294e0d7a031c8
+commit=90948745486031a2c423492c3416408aa913f131

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=ec2388a3715896648b05a367d3f2f1e353f297de
+commit=77563b2ce54f565fc4dfba4af72294e0d7a031c8

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=22b48422fe119b2147324faaf95a33197f100858
+commit=771f370200d574062509c9bfc0cb98d86f5a9115

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=f824a4058154b4591b0d64bd90242ec6ea91fe95
+commit=9642eae3e02c6cb519f63d6898909eba60e87452

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=9642eae3e02c6cb519f63d6898909eba60e87452
+commit=22b48422fe119b2147324faaf95a33197f100858

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=90948745486031a2c423492c3416408aa913f131
+commit=f824a4058154b4591b0d64bd90242ec6ea91fe95


### PR DESCRIPTION
Updates bank-templates from v2.0.0 (ec2388a) to v2.2.0 (f824a40). This supersedes the earlier v2.1.0 pin on this branch, which had not merged; the range below covers both releases.

**v2.2.0**

- Imported template cards show the original community template's live import and report counts, refreshed in the background, instead of always showing zero.
- Sharing an imported template you have not changed claims it as your own: it uploads under your name and its counts start at zero, so it can never be republished under the original owner's name.
- New Placeholder transparency setting under Layout, from solid to invisible, covering both the template's own placeholders and real bank placeholders (issue #38).
- The search box no longer takes keyboard focus during a background refresh, so it stops pulling the text cursor out of the game mid-action.
- The Link Exchange Insights account button now shows before the community repository is enabled; clicking it asks to enable the repository, then links in the same step.

**v2.1.0**

- Item matching treats a recoloured or upgraded item as the item a template asks for: golden prospector matches ordinary prospector, and likewise the Forestry outfit and lumberjack, spirit angler and angler, the forestry basket and log basket, radiant oathplate, sanguine torva, twisted ancestral, and the corrupted voidwaker. Reported as issue #37. Sets RuneLite already groups are left alone.
