### PR TITLE
Update pricecheck-flipping

### DIFF
--- a/plugins/pricecheck-flipping
+++ b/plugins/pricecheck-flipping
@@ -1,3 +1,3 @@
 repository=https://github.com/pricecheckgg/pricecheck-runelite-plugin.git
-commit=e4e7bd2798db4facf7dfb06a6af5d6b0812fe600
+commit=f2f6ba00b2f8c7c64a5bd58dcb2005a79390179e
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Version bump for pricecheck-flipping.

Since the last release: the in-GE terminal desk (evidence cards, offer advisor, positions blotter, watchlist, session strip), buy-limit tracking, and click-to-fill prices. This update also completes the in-client data disclosures (the plugin-key description now notes the trial account-bind identifier, and the Contribute market data warning names its full payload) and adds a NOTICE reserving the brand while the code stays BSD-2.