### PR TITLE
Update clogman-mode

### DIFF
--- a/plugins/clogman-mode
+++ b/plugins/clogman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/mozjay/clogman-mode.git
-commit=3f37fcc73abe609129676a0816291ef0d319b16a
+commit=f626b8c12e910716ac89fc773bd11c3d9fac8918


### PR DESCRIPTION
Refreshed clog_restrictions.json:
- Added new item restrictions from maggot king release
- Pruned restriction list from quest item variants and untradeable-only dependency chains