### PR TITLE
Update commit hash for ruthless-clan plugin for 1.0.3

### DIFF
--- a/plugins/ruthless-clan
+++ b/plugins/ruthless-clan
@@ -1,4 +1,4 @@
 repository=https://github.com/Orinite/ruthless-plugin.git
-commit=2e968a9c9950af96a52f172d3e734111f2bd3a2f
+commit=f53e327305e2bde2de1c876032c7c63be7bbba10
 warning=This plugin submits your username and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.
 authors=Orinite


### PR DESCRIPTION
- Fixed bug with kc being off by one when submitting loot message to API
- Added port to the development configuration when developing locally