### PR TITLE
Update custom-hp-bar

### DIFF
--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=97d68a77e8e97bf681a814b9e81fe9fe7f7f6d96
+commit=0c38280ee5279b7e8fe66e5c0065797c2ccda9ae

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=0c38280ee5279b7e8fe66e5c0065797c2ccda9ae
+commit=b40c1b541fb50b21e140557a278804abb0d618c5

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=b40c1b541fb50b21e140557a278804abb0d618c5
+commit=6e23d2f4309529efa4db5ef8317a541e737e926b

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,0 +1,2 @@
+repository=https://github.com/waitstepbro/custom-hp-bar.git
+commit=97d68a77e8e97bf681a814b9e81fe9fe7f7f6d96


### PR DESCRIPTION
- Fix boss HP accuracy at scaled/dynamic encounters — track Doom of Mokhaiotl's HP live per delve level, and prefer the game's native boss HP HUD (CoX, ToA, Gauntlet, Moons of Peril, etc.) as the exact HP source whenever it's active.
- Aggressive NPC name coloring now triggers as soon as a hostile NPC's name becomes visible, instead of only within a fixed tile radius.
- "Always Show NPC Bar" no longer shows bars on non-attackable NPCs (bankers, shop owners, fishing spots, pets), independent of other filter settings.
- Target bar's "Both" display mode drops the parentheses around the percentage (123 45% instead of 123 (45%)).
- Trimmed README and several config option descriptions for clarity/length.
- Aggressive NPC icon + bug fixes — added a badge (later corrected to the real PK skull icon) as an alternative to name-recoloring for aggressive NPCs; fixed "Always Show NPC Bar" resetting to full HP on reappear; switched overhead chat text to the real vanilla positioning call.
- Grey-out shared-damage bars (Ironman) — new option that greys an NPC's bar once another player damages it, gated to Ironman accounts, with exemptions for CoX/ToB/ToA, Hueycoatl, Zalcano, and the rest of the OSRS Wiki's group-loot exemption list. 
- Also a full pass trimming verbose comments across every source file (no behavior change).