### PR TITLE
Add Spoon Tracker

### DIFF
--- a/plugins/spoon-tracker
+++ b/plugins/spoon-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/spoon-tracker.git
-commit=f5f058c0ce9a1a285874c99e9b7636d0f43876fe
+commit=174d51899c2fbbaaad2953a1822b4295df35e309

--- a/plugins/spoon-tracker
+++ b/plugins/spoon-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/spoon-tracker.git
-commit=e3501d4392742e364496ae5efae0b5bf421015cf
+commit=f5f058c0ce9a1a285874c99e9b7636d0f43876fe

--- a/plugins/spoon-tracker
+++ b/plugins/spoon-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/spoon-tracker.git
-commit=174d51899c2fbbaaad2953a1822b4295df35e309
+commit=1dcf043dc6dc334f34a5cceb6fe71678fb3a14ff

--- a/plugins/spoon-tracker
+++ b/plugins/spoon-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/nassarao/spoon-tracker.git
+commit=e3501d4392742e364496ae5efae0b5bf421015cf


### PR DESCRIPTION
## What it does

Spoon Tracker records newly observed Collection Log uniques and grades how lucky each drop was using spoon tiers. It includes Collection Log badges, configurable celebrations and sounds, a sidebar cabinet, and shareable drop cards.

## Implementation

- Tracks earned uniques locally per RuneScape profile.
- Uses a bundled, versioned probability catalog and RuneLite's local game cache.
- Supports boss, raid, clue, minigame, skilling, shop, and miscellaneous Collection Log pages.
- Performs no runtime downloads and does not upload player data.
- Includes BSD-2-Clause licensing and attribution for adapted probability mechanics.

## Validation

- `gradlew.bat clean test build`
- 30 tests passed with zero failures.
- Development client smoke-tested while logged in.
- Resolved 1,710 current Collection Log items from the game cache.
