### PR TITLE
Add wildy-agility plugin

### DIFF
--- a/plugins/wildy-agility
+++ b/plugins/wildy-agility
@@ -1,0 +1,2 @@
+repository=https://github.com/Macko306/wildy-agility.git
+commit=08dc6e44445311d5d3c6bd774368c86d863f32ba

--- a/plugins/wildy-agility
+++ b/plugins/wildy-agility
@@ -1,2 +1,2 @@
 repository=https://github.com/Macko306/wildy-agility.git
-commit=08dc6e44445311d5d3c6bd774368c86d863f32ba
+commit=a95d27c9b22d5a7cf86ec2198bd6c9c0ab35df84


### PR DESCRIPTION
Wildy Agility tracks DD compliance at the Wilderness Agility Course. It flags which friends chat members reach the marked DD tile when a ranked member calls a stack, with location callouts for course obstacles, prayer-call alerts, and a basic gear check for runners. Built for Agility FC.