### PR TITLE
Update stations-cozy-clutter to 0.3.0

### DIFF
--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=f563e522fa1483f52f60b3daaf953d4882e623af
+commit=ff0217648f51e78c6b40f87866c96d48c17d344f

--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=01cdea9b993e492114fe02d48993e26f919e0fb4
+commit=1456dcd21b15ac87f4805a6472e9c8b3859086f1

--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=1456dcd21b15ac87f4805a6472e9c8b3859086f1
+commit=f563e522fa1483f52f60b3daaf953d4882e623af

--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=a5147400c425818d84986f6d70cd2e7c5224697f
+commit=01cdea9b993e492114fe02d48993e26f919e0fb4


### PR DESCRIPTION
Updates Station's Cozy Clutter to version 0.3.0.

- Adds animated object and NPC decorations to the sidebar catalogue and placement workflow
- Persists animation metadata in Tilepacks while remaining compatible with existing Tilepacks
- Keeps catalogue/model caches and imported placements bounded
- Removes the `enabledByDefault` descriptor entry

Validated with a clean `gradlew clean test` build against the latest RuneLite release.