### PR TITLE
update jumpscare

### DIFF
--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=920bafd1db71222573900ec26a95d9e550d08469
+commit=60e2da412a7e4d2c3a395c0044154a2234522d6c
 authors=vividflash


### PR DESCRIPTION
Updates Jumpscare v1.1 -> v1.5.

Since v1.1: independent Default/Happy/Custom sources for image and sound, custom assets preloaded off the client thread, default chance changed to 1 in 6000, one-time chat notice after updates, config migration for stale defaults from earlier releases, and a test mode toggle.