### PR TITLE
update dvd-bounce

### DIFF
--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=aa6805284586d579706ec2ef0d144efe73906e96
+commit=0b4db94d50c594874e2a722026355e180b466f27


### PR DESCRIPTION
Updates DVD Bounce v1.1.1 -> v1.4.

Since v1.1.1: judder-free speed presets replacing the speed slider, FPS mode toggle (Adaptive/Crisp/Smooth) with sub-pixel rendering at high fps, custom image loading moved off the render path, and a one-time chat notice after updates.