### PR TITLE
Add Items to Text

### DIFF
--- a/plugins/items-to-text
+++ b/plugins/items-to-text
@@ -1,0 +1,2 @@
+repository=https://github.com/itemstotext/items-to-text.git
+commit=ed338e3c0f71885e211dfb3f587e31d8db32708b


### PR DESCRIPTION
## Summary

Adds Items to Text, a small RuneLite sidebar plugin that displays the local player's currently loaded inventory, equipment, bank, and Grand Exchange offers as a readable list with an explicit clipboard copy button.

## Behavior

- Reads RuneLite item containers and Grand Exchange offer state.
- Uses `Unspecified` until a section has been observed during the current session.
- Refreshes Grand Exchange data from the offers screen or collection box.
- Makes no network requests and does not automate gameplay.

## Validation

- `./gradlew clean test`
