### PR TITLE
Add GOTR Progress Bar

### DIFF
--- a/plugins/gotr-progress-bar
+++ b/plugins/gotr-progress-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/rstubbs94/gotr-progress-bar.git
-commit=e5445dc530fc85a35a459921d4effcb85c71b5e3
+commit=42125bb225c49d8c33bacb0105a66c7c3bc528a6

--- a/plugins/gotr-progress-bar
+++ b/plugins/gotr-progress-bar
@@ -1,0 +1,2 @@
+repository=https://github.com/rstubbs94/gotr-progress-bar.git
+commit=e5445dc530fc85a35a459921d4effcb85c71b5e3

--- a/plugins/gotr-progress-bar
+++ b/plugins/gotr-progress-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/rstubbs94/gotr-progress-bar.git
-commit=42125bb225c49d8c33bacb0105a66c7c3bc528a6
+commit=4da82524679f247ea5e85a5ad76f5927a2efc0b6


### PR DESCRIPTION
Adds **GOTR Progress Bar**, a passive overlay for Guardians of the Rift that renders a
round as a single scrolling timeline bar: the mining countdown, crafting progress, live
and predicted portal sections, and a configurable fragment/energy goal sub-bar. All state
is read from the game's own HUD update script and chat messages — nothing is automated and
no data leaves the client.


<img width="1080" height="311" alt="mining" src="https://github.com/user-attachments/assets/c19b2504-bbdc-480d-9ba4-0f48f8a82769" />

<img width="1047" height="304" alt="crafting" src="https://github.com/user-attachments/assets/bdb19ab8-34a2-4fde-9447-dc1a0d73c223" />


**Not a duplicate of "Guardians of the Rift Helper":** that plugin does altar highlights,
essence/cell tracking, and notifications. This one deliberately does none of that — it is
only the at-a-glance timeline bar. The two are complementary; users who want the helper
features should use that plugin.

Compliance: passive display only — no input automation, no "stand here" tile indicators,
no menu-entry changes, no chatbox injection, no external HTTP. The next-portal window is
always shown as an estimate, never a directive.

Source: https://github.com/rstubbs94/gotr-progress-bar