### PR TITLE
add osrs-tcg-highscores (osrsthecardexchange)

### DIFF
--- a/plugins/card-exchange-highscores
+++ b/plugins/card-exchange-highscores
@@ -1,0 +1,3 @@
+repository=https://github.com/CompilerOfDust/osrs-tcg-highscores-thecardexchange.git
+commit=2f72477928e385daaeae8ffec3d8631ed6e99a07
+authors=CompilerOfDust

--- a/plugins/card-exchange-highscores
+++ b/plugins/card-exchange-highscores
@@ -1,3 +1,3 @@
 repository=https://github.com/CompilerOfDust/osrs-tcg-highscores-thecardexchange.git
-commit=2f72477928e385daaeae8ffec3d8631ed6e99a07
+commit=8718630b0f7f63e924e0ea020d83bf37958513f5
 authors=CompilerOfDust


### PR DESCRIPTION
Adds **Card Exchange Highscores**, a community plugin that uploads the card
  collection stored by the `osrs-tcg` plugin to
  [osrscardexchange.com](https://www.osrscardexchange.com).

  Repo: https://github.com/CompilerOfDust/osrs-tcg-highscores-thecardexchange

  **Not affiliated with the `osrs-tcg` plugin or its authors.** This is a separate
  project that reads the collection that plugin saves. Issues with it belong on
  this repo, not theirs.

  ### Why it uploads anything

  The OSRS TCG plugin keeps a collection inside the player's own client, so
  nothing outside RuneLite knows what anyone owns. That upload is what makes the
  site's features possible at all:

  - **Card-collection highscores** — players ranked by unique cards owned,
    alongside an existing total-level board. Without the upload there is no data
    to rank.
  - **A public collection page** per player, grouped by rarity.
  - **Ownership checks while browsing** — cards you already own get marked, and an
    exchange can be shown as backed by a collection that actually contains the
    card being offered, rather than taken on trust.

  ### What it sends, and when

  - **Off by default.** `uploadEnabled` defaults to `false` behind a
    `ConfigItem(warning = ...)`, so the third-party-upload disclosure is shown and
    accepted before anything leaves the client.
  - The payload is the player's **display name and their card names/counts**, plus
    packs-opened and credits. Nothing else — no position, no inventory, no
    equipment, no chat, no other game state.
  - One upload per actual collection change (compared against a stored hash), plus
    a heartbeat at most every 15 minutes. An idle player generates no requests.
    Failures back off; `401`/`403` pause uploads for the session rather than
    retrying every tick.

  ### It reads another plugin's config group

  The one thing that will look unusual in the diff, so stating it plainly: it
  reads `osrs-tcg`'s RSProfile-scoped `osrstcg` config group (`state` and `hash`)
  through the shared `ConfigManager`.

  - Reads are **strictly read-only**. It never calls that plugin's `load()`, which
    has migration side effects that write config keys and disk files.
  - If the blob can't be decoded it falls back to `osrs-tcg`'s own cross-plugin
    `PluginMessage` API (`query-owned-names`), which returns names only, and marks
    the payload as partial.
  - Debug/cheat-spawned copies (`pulledBy` prefixed `DEBUG_`) are stripped before
    upload, matching what `osrs-tcg` excludes from its own public share.

  This is documented in the README, including why the save format is duplicated in
  `TcgStateBlobCodec` — Plugin Hub loads each plugin in its own classloader, so the
  source class can't be imported.

 ### Build

  `build=standard`. No third-party dependencies — only `runelite-client`
  (compileOnly), Lombok and JUnit, so nothing needs dependency verification. 13
  unit tests cover the save-format decoding and the change-detection hashing.