### PR TITLE
Update stations-cozy-clutter to 0.3.1

### DIFF
--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=ff0217648f51e78c6b40f87866c96d48c17d344f
+commit=628dc54365565d956bdcdc541208e098875a77a2

--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=628dc54365565d956bdcdc541208e098875a77a2
+commit=840f802a2808e31d4d4c0605e350c20ab3df64a3

--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=840f802a2808e31d4d4c0605e350c20ab3df64a3
+commit=fe08368b8c4d080c3ab13e3c86cfd10632e23f8b


### PR DESCRIPTION
Updates Station's Cozy Clutter to version 0.3.1.

- Adds a sidebar Undo button and Ctrl+Z support while the panel is open
- Adds a placement-counted Delete All button with an explicit confirmation warning
- Makes Delete All recoverable through the existing bounded undo history
- Documents the new build-management workflow

Validated with the Gradle test suite and a normal GPU-enabled development client.