### PR TITLE
Urgent Update - RaidParty v2.6.0

### DIFF
--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,2 +1,2 @@
 repository=https://github.com/Kalsupes/RaidParty.git
-commit=ad059bc79c694b53770c8dfb572a0d7c36ba4ed8
+commit=1ee321c118bda7061a4e8ffc120c23e12809890e

--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,2 +1,2 @@
 repository=https://github.com/Kalsupes/RaidParty.git
-commit=1ee321c118bda7061a4e8ffc120c23e12809890e
+commit=ea470d7fe20731d3b9d89d45461001c3005d3bad

--- a/plugins/raidparty
+++ b/plugins/raidparty
@@ -1,2 +1,2 @@
 repository=https://github.com/Kalsupes/RaidParty.git
-commit=ea470d7fe20731d3b9d89d45461001c3005d3bad
+commit=dcb5e7f038283b5eb08778b268b13c401b39007b


### PR DESCRIPTION
# RaidParty v2.6.0 Release Notes

**⚠️ DISCLAIMER: Why the plugin is currently broken for older versions**

> If you have experienced issues with party syncing over the last week (where you couldn't see other players' UI updates or the plugin seemingly stopped working), this is due to a recent RuneLite update and changes made by the Hub Party Panel plugin. Those updates modified how the underlying RuneLite Party websocket handles data. As a result, older versions of RaidParty (v2.5.3 and below) are no longer broadcasting or receiving the correct data packets, causing features like the Player Cards, FFA/SPLIT locks, and Raid Status borders to break. 
> 
> **You MUST update to v2.6.0 for the plugin to work again.** Anyone using an older version will not be able to sync their data with players using v2.6.0. Please ensure your entire team updates their plugin!

---

### What's New & Fixed in v2.6.0

This release completely overhauls how Raid Status and Party Syncing is handled to ensure perfect synchronization across all party members, alongside critical compatibility fixes to get the plugin back online.

**1. Reliable "In Raid" Broadcasting & Green Borders**

- Previously, the plugin relied on your local game client trying to guess if other players were in a raid based on whether their 3D character was loaded in your memory. This resulted in cases where a player entering a raid would not get a green border on their teammates' screens if they weren't standing right next to them.

- **Fix:** Raid Status is now a dedicated, broadcasted variable in the network packet! When you enter a raid, your client instantly tells the entire party exactly where you are, guaranteeing your border will turn green for everyone else in the party, regardless of where they are standing.

**2. Instant CoX Lobby Detection & Loot Locking**

- Entering the Chambers of Xeric passage now instantly triggers your "In Raid" status.

- This means your Player Card border will turn green, and your **FFA / SPLIT button will lock immediately** upon stepping into the lobby, preventing people from changing their loot preferences right before the raid starts. (Previously, the plugin waited until the raid officially started, which was too late).

**3. Smarter "Far Away" Indicator (Purple Border)**

- The "Indicate Away Members" (Purple Border) logic has been strictified. 

- It will now **only** trigger if a party member is on a completely different World Number. 

- Additionally, the purple color has been updated to a softer, darker shade (`#6e3c82`) to differentiate it from the bright neon FFA badge, making it much easier on the eyes while still indicating that a player is on another world.

**4. Performance & Network Optimizations**

- The underlying sync data structure has been optimized to only broadcast delta changes (e.g., only broadcasting your prayer points when they change, instead of blasting your entire inventory and equipment on every tick). This significantly reduces the load on RuneLite's party server.