### PR TITLE
Update pricecheck-flipping

### DIFF
--- a/plugins/pricecheck-flipping
+++ b/plugins/pricecheck-flipping
@@ -1,3 +1,3 @@
 repository=https://github.com/pricecheckgg/pricecheck-runelite-plugin.git
-commit=f2f6ba00b2f8c7c64a5bd58dcb2005a79390179e
+commit=8f8b5f9261e2dc79b7f8a8b821a02b379a559fcf
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Version bump for pricecheck-flipping.

Since the last release: a TOP MOVERS losers panel alongside gainers, a 1H/24H/7D window toggle for the movers, and flash-on-change on the rows. No new data collection or dependencies; the plugin-key and subscription model are unchanged.