### PR TITLE
Add mahogany-homes-notifier plugin

### DIFF
--- a/plugins/mahogany-homes-notifier
+++ b/plugins/mahogany-homes-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/staticvoid07/mahogany-homes-notifier.git
+commit=7a6d77e6e6372da405c3796ef68cd6bd8b485a86

--- a/plugins/mahogany-homes-notifier
+++ b/plugins/mahogany-homes-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/staticvoid07/mahogany-homes-notifier.git
-commit=7a6d77e6e6372da405c3796ef68cd6bd8b485a86
+commit=fe0674cab327946cf44cef53747636bc05360891


### PR DESCRIPTION
Notifies you when a new Mahogany Homes contract needs more planks/steel bars than you're carrying