### PR TITLE
Add chatbox-escape-blocker plugin

### DIFF
--- a/plugins/chatboxescapeblocker
+++ b/plugins/chatboxescapeblocker
@@ -1,0 +1,2 @@
+repository=https://github.com/ellatonin/chatbox-escape-blocker.git
+commit=b68ca0c895626947dfb78636fd57770071ad0a47


### PR DESCRIPTION
Add chatbox-escape-blocker plugin. This remaps the escape key based on the chatbox state to prevent escape from closing chat interfaces (as it did before 2024).