### PR TITLE
Create party-pete-ai

### DIFF
--- a/plugins/party-pete-ai
+++ b/plugins/party-pete-ai
@@ -1,0 +1,2 @@
+repository=https://github.com/Bill21099/party-pete-ai.git
+commit=3544940918c51956067cf938d484c0d6eed29761


### PR DESCRIPTION
Adds Party Pete AI, a read-only OSRS assistant for RuneLite.

The plugin accepts user-provided API keys and sends questions to the selected AI provider. Optional account context, OSRS Wiki grounding, and Grand Exchange lookups are disabled by default and clearly disclosed in the configuration.

It does not click, type, move the player, or automate gameplay.

<img width="1064" height="1012" alt="New Project" src="https://github.com/user-attachments/assets/0f18255d-14c7-4bab-9ff3-d9a78af940d4" />
