### PR TITLE
Fate Locked Ironman: guardian update

### DIFF
--- a/plugins/fate-locked-ironman
+++ b/plugins/fate-locked-ironman
@@ -1,2 +1,2 @@
 repository=https://github.com/Nubles/RS3-Fate-Locked-Runelite.git
-commit=f450bbd87cee74d26d24061d034368ad9f0c0c86
+commit=4437425ded24b2f85376904d746277e693901dc7


### PR DESCRIPTION
Updates Fate Locked Ironman from `f450bbd87cee74d26d24061d034368ad9f0c0c86` to `4437425ded24b2f85376904d746277e693901dc7`.

This update:

- consumes the web app's canonical v4 rules and shows a compact, category-first chunk panel;
- keeps banks and shops to name plus inline status, quests to tick/circle/cross, and combat to tick/cross;
- adds one opt-in Strict Mode checkbox, off by default, with Unknown-safe prevention, a 60-second pause, and a bounded local audit log;
- adds durable observation and queueing for Slayer tasks, diary tasks, pet drops, Pest Control completions, and mapped boss kills; and
- keeps every new detector confirmation-first until real playtest evidence meets the documented promotion gate.

RuneLite never rolls, awards keys, chooses unlocks, or performs gameplay. The player reviews detections and presses the only **Roll** button in the web app. Online sync remains explicit opt-in and defaults off.

Validation:

- `gradle clean test jar --no-daemon`
- complete web-app suite: 525 tests
- production web-app build
- byte-for-byte standalone/mirror consistency check
