### PR TITLE
clan-management: fix client resize, condense tabs, profile card

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=5de562019a8fd78a150ec3eee5c1897ad22a8f53
+commit=28e09022feb4a78f631cbe936e5c7c7954f3c01c
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates clan-management to `28e09022feb4a78f631cbe936e5c7c7954f3c01c`.

Highlights since the last version:
- **Fixes a panel sizing bug that could resize the RuneLite client window.** The side panel now pins its width and tracks the viewport height instead of growing with content, so it can never push the game window larger.
- Speed Times / Drops / XP are condensed into a single **Leaderboards** tab with a selector.
- Members view shows a member's profile card (bio, favourite boss/skill, goal) above their sections.
- "Sync Roster" now reads clan settings on the client thread (it previously no-opped).
- Removed an in-progress Event tab that wasn't ready for release.
