### PR TITLE
Add Combat Achievement Helper

### DIFF
--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=ab3a56ec1bf37c4504d6d79dfb0217a66ba0dcf1
+commit=ac08023e2bd591e5ecdf4d8600862e3ee2615a06

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=c643b89648bdb448a74355165f0b0a57823a19bd
+commit=3925405d3b644b45939b20128ef1902684dd9681

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=ac08023e2bd591e5ecdf4d8600862e3ee2615a06
+commit=c643b89648bdb448a74355165f0b0a57823a19bd

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/opaf-osrs/combat-achievement-helper.git
+commit=ab3a56ec1bf37c4504d6d79dfb0217a66ba0dcf1

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=3925405d3b644b45939b20128ef1902684dd9681
+commit=c15f32f72eaaa69d653d0196d98d27732aa97f1a

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=b902ee10951315f66724cf9e3b53c6266974c9e0
+commit=1a6a42b0434702eb5a569fa1450feecfc27e845e

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=c15f32f72eaaa69d653d0196d98d27732aa97f1a
+commit=b902ee10951315f66724cf9e3b53c6266974c9e0

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=1a6a42b0434702eb5a569fa1450feecfc27e845e
+commit=6327aa33c579ef54e3b072da1b6907a86170b1bb


### PR DESCRIPTION
Recommends which combat achievements to actually do next. Reads your completion live from the CA varps, ranks whats realistic for your stats, and plans a route to your next tier. Boss pages, quest unlock suggestions and training goals included.

<img src="https://raw.githubusercontent.com/opaf-osrs/combat-achievement-helper/main/img/cas.png" width="230"> <img src="https://raw.githubusercontent.com/opaf-osrs/combat-achievement-helper/main/img/boss.png" width="230"> <img src="https://raw.githubusercontent.com/opaf-osrs/combat-achievement-helper/main/img/route.png" width="230">

Everything ships bundled with the plugin, no external calls. Kill counts come from the hiscores via the built in client.

Not the same thing as the existing combat achievements tracker plugin, that one tracks and overlays your completion state. This one is about recommending and planning what to do next.

Planned for a later update: a button to open a quest straight in Quest Helper, once Zoinkwiz/quest-helper#2756 lands. Left it out of this submission since it does nothing until then.
