### PR TITLE
Update notification-panel to 2.0.0

### DIFF
--- a/plugins/notification-panel
+++ b/plugins/notification-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/KogasaPls/notification-panel.git
-commit=f9d127674ac87fbb9283b73c8b86babbca4134f6
+commit=352e4d613c14300e1420ac2277e8019d882a0c81


### PR DESCRIPTION
Updates Notification Panel to 2.0.0, from `f9d127674ac87fbb9283b73c8b86babbca4134f6` to `352e4d613c14300e1420ac2277e8019d882a0c81`.

The plugin shows game notifications in a movable overlay panel.

2.0.0 constitutes a substantial rewrite of the plugin's internals:

- Replaces the two parallel config lists of regex patterns and format strings with a sidebar rule editor + clearer config schema.
- Replaces the old regex pattern matching (java.util.regex) with a wildcard matcher. More restrictive but safer and simpler.
- Migrates an existing configuration into the new format on first load. The old values are kept rather than destroyed, and a row that cannot be translated faithfully arrives disabled with an explanation instead of being dropped or silently changed.
- Simplified the visibility model: rules can no longer hide a notification. The two options now are "show all notifications, override via rule matches" and "show only notifications matching a rule".
- Removes the per-notification timers, the static queue and the cached component graph in favor of a deterministic core with no timers, executors or static state.
- Adds tags and an icon for discoverability.

Notes for review:

- `build=standard` with no third-party runtime dependencies.
- No reflection, threads, executors, timers, network access, file I/O or `System.exit`. Gson is injected and customized with `.newBuilder()` rather than constructed.
- The wildcard matcher is a standard two-pointer scan that runs in O(pattern*text), backtracking only as far as the most recent `*`. I intentionally avoided reusing the `WildcardMatcher` util, partly to reduce coupling and partly because it translates the pattern to a regex and calls `String.matches`: these patterns are user-authored and matched on the client thread against whole notification messages, which are much longer than the item and NPC names it was written for, so a bad pattern can backtrack catastrophically. For a pathological example: `*a*a*a*a*a*a*a*a*a*a*b` against 60 `a` characters returns false here in 0.2ms and does not terminate within 10s through `WildcardMatcher`.
- The config group is unchanged and no key is removed or renamed, so nothing collides. 2.0.0 adds `rulesV1` for the structured rules and `showTestNotification` for the preview toggle, and narrows `fontType` from RuneLite's `FontType` to a three-value enum.
- Verified by building `src/main` alone against `standard-build.gradle` with a Java 11 toolchain: it compiles against 1.12.33 and every emitted class is major version 55.

