### PR TITLE
PvP Profit Tracker 1.6.3

### DIFF
--- a/plugins/pvp-profit-tracker
+++ b/plugins/pvp-profit-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/anonyser/runelite-profit-tracker.git
-commit=77a00d3192a15987993cef03836eb6d7c9c389df
+commit=d51cb8261b3b7f0142177c47972a99dbac516bf2


### PR DESCRIPTION
risk fix

items kept on death werent counted right so protect item and skull didnt change the number properly. also fixed the price on some bounty hunter gear, and some inconsistencies in the fight log.