### PR TITLE
grand-flip-out: update to e43bf8a

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=9cf04656764b8011b65bbc2b38d355db14b75d24
+commit=e43bf8a993a87422833fbf0904e78ad671deffa9


### PR DESCRIPTION
Updates grand-flip-out to `e43bf8a`.

Plugin change (one commit) — newest-first flip ordering + larger history caps:

- Active flips were rendered straight from a `HashMap` (arbitrary iteration order) and reshuffled on every refresh; now sorted newest-first by buy time.
- The completed-flips fallback iterated oldest-first (newest at the bottom); now reversed to newest-first, matching the trade-log path.
- Trade-log window/render caps raised 25/40 → 100.

Two pure ordering helpers extracted to `FlipTracker` and unit-tested. `./gradlew clean build`: 28 suites / 109 tests / 0 failures. No new dependencies, no banned APIs, no data-egress change.
