### PR TITLE
Add OSRS Bingo plugin

### DIFF
--- a/plugins/osrs-bingo
+++ b/plugins/osrs-bingo
@@ -1,3 +1,4 @@
 repository=https://github.com/OSRS-Bingo-Plugin/runelite-plugin.git
 commit=a211759cef2516929f8f33ac11b3b52a2a0a47ed
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.
 authors=austin-baker2

--- a/plugins/osrs-bingo
+++ b/plugins/osrs-bingo
@@ -1,0 +1,2 @@
+repository=https://github.com/OSRS-Bingo-Plugin/runelite-plugin.git
+commit=bddd27c50dea195474f3a1467d58a0ac376743e8

--- a/plugins/osrs-bingo
+++ b/plugins/osrs-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/OSRS-Bingo-Plugin/runelite-plugin.git
-commit=d1ecf26df82960308e3b7ca41675481841ead7e1
+commit=a211759cef2516929f8f33ac11b3b52a2a0a47ed

--- a/plugins/osrs-bingo
+++ b/plugins/osrs-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/OSRS-Bingo-Plugin/runelite-plugin.git
-commit=bddd27c50dea195474f3a1467d58a0ac376743e8
+commit=d1ecf26df82960308e3b7ca41675481841ead7e1

--- a/plugins/osrs-bingo
+++ b/plugins/osrs-bingo
@@ -1,2 +1,3 @@
 repository=https://github.com/OSRS-Bingo-Plugin/runelite-plugin.git
 commit=a211759cef2516929f8f33ac11b3b52a2a0a47ed
+authors=austin-baker2


### PR DESCRIPTION
**OSRS Bingo** — shows a clan's bingo board in-game and auto-logs on-board drops to the event for a human admin to approve. Backed by the OSRS Bingo service, which any clan can sign up for and run an event on.

**External connection (disclosed):** the plugin contacts exactly one host and nothing else, and is fully opt-in — with no board code entered it makes no network requests. Once a board code is set, it fetches the board and reports drops that match a board tile (item id + quantity, drop source, board code), optionally with a proof screenshot (toggleable). Every outbound request lives in a single class; details are in the repo's `SECURITY.md`.

**Jagex rules:** detection uses only RuneLite loot events (NPC kills, reward chests) — never the inventory or bank, so bank items can't create fake entries. PvP loot is never reported. The plugin never completes a tile itself; a human approves every submission. No automation.

**License:** BSD 2-Clause.
