### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=fc62fcdc26e23e9acdffb5a66b41bba0aa6c8d1d
+commit=fecb6fcbdfd4b67308f632580161c8ae6188e7ff
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=fa0f3e469a397d28882fc6b1671fad161b890fa4
+commit=fc62fcdc26e23e9acdffb5a66b41bba0aa6c8d1d
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
- Tracking-accuracy hardening: prevented round-trip-ID poisoning by keying the round-trip ledger per Grand Exchange slot, made the ledger idempotent against re-fed fills on relog, and fixed offer over-counting with a breakeven fallback and a more reliable manual sell-focus retry
- Added a proactive Grand Exchange history auto-backfill so trade history stays complete without manual intervention, backed by a golden-corpus offer-replay test harness and a tax-exempt item list parity check
- New GP/Hour and session earnings display, with a collapsible/hide toggle so players can tuck it away when not needed
- Hardened the plugin's premium status against being clobbered by entitlement updates, with a corresponding gate/cogwheel update fix
