### PR TITLE
add wiki-gear-setups

### DIFF
--- a/plugins/wiki-gear-setups
+++ b/plugins/wiki-gear-setups
@@ -1,0 +1,2 @@
+repository=https://github.com/Jiimbones/wiki-gear-setups.git
+commit=e836b8d156f0f5f9b7e6375bb04c52f21835ac19


### PR DESCRIPTION
Wiki Gear Setups imports the OSRS Wiki's {{Recommended equipment}} tables as Bank Tags layouts, personalised to the gear the player actually owns.

Search a boss or activity from the side panel, pick a combat style, and the plugin reads the wiki's ranked per-slot recommendations, resolves the best item you own for each slot (falling through the alternatives when you don't own the top pick), and writes a ready-to-use tag tab. There's also a "Show wiki BIS" view that ignores ownership, for planning upgrades.

Notes for review:

Writes through the core Bank Tags API only (TagManager, LayoutManager, TabManager); declares @PluginDependency(BankTagsPlugin.class) and refuses to import while Bank Tags is disabled rather than risk corrupting the tab list.
No third-party dependencies - nothing outside what runelite-client already provides.
Network access is read-only requests to the public OSRS Wiki API, off the client thread, with a descriptive User-Agent as the wiki's policy asks. No telemetry, no other endpoints.
Bank contents are read locally and cached per RuneScape profile in the user's own config. Nothing about the player's bank leaves the machine.
257 unit tests, run green from a clean clone of the submitted commit.