### PR TITLE
Update Combat Achievement Helper

### DIFF
--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=3f64c6589452c592f8a8396e6cf446248335ef8c
+commit=49f64f66269a4c8e009f4d9c3edc8623dd07f537

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=6327aa33c579ef54e3b072da1b6907a86170b1bb
+commit=3f64c6589452c592f8a8396e6cf446248335ef8c

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=e9cb289ad6c8d06f7440f62d54c2dfd85aa5d5ce
+commit=436ddbe7dad83d85b528863bec24a8ac30cb699d

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=49f64f66269a4c8e009f4d9c3edc8623dd07f537
+commit=e9cb289ad6c8d06f7440f62d54c2dfd85aa5d5ce


### PR DESCRIPTION
few small things in this one:

- feedback link in the panel footer and a suggest fix button on a task page. both are plain constant urls opened with LinkBrowser, nothing is sent from the client and no data is collected
- shortened the name on the hub card to CA Helper so the author fits next to it. the plugin is still Combat Achievement Helper once its installed
- sharper icon, redone from the full size art instead of scaling the small one up
- stripped some leftover wiki markup that was showing in a few task descriptions

bumped to 1.1