### PR TITLE
Added flati boss tracker plugin.

### DIFF
--- a/plugins/flati-boss-tracker
+++ b/plugins/flati-boss-tracker
@@ -1,2 +1,3 @@
 repository=https://github.com/Flati/Flati-Boss-Tracker.git
 commit=89bc1a55bc601969a45ef98c075cc26fbde3310e
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/flati-boss-tracker
+++ b/plugins/flati-boss-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Flati/Flati-Boss-Tracker.git
-commit=2582e362257b333bd8452fe8e4cb0c01546bc3c3
+commit=89bc1a55bc601969a45ef98c075cc26fbde3310e

--- a/plugins/flati-boss-tracker
+++ b/plugins/flati-boss-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Flati/Flati-Boss-Tracker.git
+commit=b5341b679b23bd47436083b08a7cb36d20e486ce

--- a/plugins/flati-boss-tracker
+++ b/plugins/flati-boss-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Flati/Flati-Boss-Tracker.git
-commit=2ef2e04da4f1ae537a592977e798e43591ac2a47
+commit=2582e362257b333bd8452fe8e4cb0c01546bc3c3

--- a/plugins/flati-boss-tracker
+++ b/plugins/flati-boss-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Flati/Flati-Boss-Tracker.git
-commit=b5341b679b23bd47436083b08a7cb36d20e486ce
+commit=2ef2e04da4f1ae537a592977e798e43591ac2a47


### PR DESCRIPTION
The plugin tracks boss kills and posts the KC to an endpoint hosted at flati.is/osrs (configurable for custom backends).
Allows friend groups to keep boss KC data with each other and makes a visual graph to show boss trips with kill timers.
Also tracks agility laps and other counters kept by Grace.
Includes information to set up your own server but creating a new group on flati.is is also available by request.

<img width="1129" height="769" alt="image" src="https://github.com/user-attachments/assets/1b5aed88-f37a-4d5e-b2ef-00b414727665" />

<img width="1248" height="1235" alt="image" src="https://github.com/user-attachments/assets/12e9639c-ef6f-42e5-895e-672a5429c786" />

<img width="1240" height="1164" alt="image" src="https://github.com/user-attachments/assets/7d92e692-2892-46d6-95b0-6c2e2a9f53a4" />

<img width="1219" height="273" alt="image" src="https://github.com/user-attachments/assets/40d641c3-b650-4a89-9fc6-7a0171c75436" />

<img width="1236" height="276" alt="image" src="https://github.com/user-attachments/assets/1d26fc2a-e975-47c6-8078-7516059ec1e1" />

<img width="1336" height="277" alt="image" src="https://github.com/user-attachments/assets/4ee715f4-f155-4fdd-8b71-a5d20d24fd2f" />
