### PR TITLE
Create dropfinder

### DIFF
--- a/plugins/dropfinder
+++ b/plugins/dropfinder
@@ -1,2 +1,2 @@
 repository=https://github.com/tgoney51/dropfinder.git
-commit=06d81ef1354c9b39b0c3886b73cf15cb911cb736
+commit=05587f41bb032b418911acff4341cf9e5c1b096a

--- a/plugins/dropfinder
+++ b/plugins/dropfinder
@@ -1,2 +1,2 @@
 repository=https://github.com/tgoney51/dropfinder.git
-commit=5246e450a65a43e4a48eef3987baeb122f8d5daf
+commit=67138b967c8e8c7d381ff12152c4adff0c1bf163

--- a/plugins/dropfinder
+++ b/plugins/dropfinder
@@ -1,0 +1,2 @@
+https://github.com/tgoney51/dropfinder
+commit=638fec0510934989ef4ff86a039de1e363177323

--- a/plugins/dropfinder
+++ b/plugins/dropfinder
@@ -1,2 +1,2 @@
-https://github.com/tgoney51/dropfinder
-commit=638fec0510934989ef4ff86a039de1e363177323
+repository=https://github.com/tgoney51/dropfinder.git
+commit=5246e450a65a43e4a48eef3987baeb122f8d5daf

--- a/plugins/dropfinder
+++ b/plugins/dropfinder
@@ -1,2 +1,2 @@
 repository=https://github.com/tgoney51/dropfinder.git
-commit=67138b967c8e8c7d381ff12152c4adff0c1bf163
+commit=06d81ef1354c9b39b0c3886b73cf15cb911cb736


### PR DESCRIPTION
Allows user to search specific items or vague items like chainbody and it will pull results of every chainbody and what npc drops them. Pretty much a inversion of the loot lookup plugin/ may be super helpful for new ironmen looking for what npc drops what item quickly. clicking the npc name will open the wiki, some filter options  such as chest, clue scrolls, events to filter out items that come from chest, clue scrolls, events if you want.