### PR TITLE
add gauntlet-guard

### DIFF
--- a/plugins/gauntlet-guard
+++ b/plugins/gauntlet-guard
@@ -1,0 +1,2 @@
+repository=https://github.com/TeemSteebs/gauntlet-guard.git
+commit=64d4c0f6aca8b5b1c7c2710331d503f247419d62

--- a/plugins/gauntlet-guard
+++ b/plugins/gauntlet-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/TeemSteebs/gauntlet-guard.git
-commit=64d4c0f6aca8b5b1c7c2710331d503f247419d62
+commit=d08350153ecc9a8b551c018f2398c69e70c9510b


### PR DESCRIPTION
Adds Gauntlet Guard, a plugin that prevents players from accidentally entering the Hunllef or Corrupted Hunllef room with raw paddlefish or unfinished Gyrm potions:

Each warning can be enabled or disabled independently.