### PR TITLE
Fate Locked Ironman: Travel Guardian update

### DIFF
--- a/plugins/fate-locked-ironman
+++ b/plugins/fate-locked-ironman
@@ -1,2 +1,2 @@
 repository=https://github.com/Nubles/RS3-Fate-Locked-Runelite.git
-commit=4437425ded24b2f85376904d746277e693901dc7
+commit=5cc1ffc4e4f684a99211f12342a69ceb6d16de30


### PR DESCRIPTION
## Update

Pins Fate Locked Ironman to `5cc1ffc4e4f684a99211f12342a69ceb6d16de30`.

- Strict Mode remains one checkbox and defaults off.
- Only fresh, correct-account travel actions proven `LOCKED` are prevented.
- Unknown, stale, malformed, legacy, wrong-account, and unresolved travel is never blocked.
- The 60-second pause applies to every Strict Mode category and resumes automatically.
- RuneLite never activates travel, moves the player, selects an alternative, rolls, or performs gameplay.
- Blocked travel receives a compact banner and deduplicated chat record; alternatives are suggested only when locally verified as available and allowed.

## Verification

- Clean Gradle test and JAR gate passed: 198/198 tests across 34 suites.
- Companion app gate passed: 526/526 tests, TypeScript, production build, and exact mirror check.
- Independent final code review: APPROVED.
- Live RuneLite client matrix confirmed passed, including strict off/on/paused behavior, locked versus Allowed/Unknown travel, supported travel networks and adjacent movement, chat suppression, verified alternatives, and automatic pause resumption.

The manifest diff is intentionally limited to the single `commit=` value.