### PR TITLE
Update notification-panel to 2.0.1

### DIFF
--- a/plugins/notification-panel
+++ b/plugins/notification-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/KogasaPls/notification-panel.git
-commit=352e4d613c14300e1420ac2277e8019d882a0c81
+commit=4c0173909a3fe4107d1d09d0175f44153cddffc2


### PR DESCRIPTION
Updates Notification Panel to 2.0.1, from `352e4d613c14300e1420ac2277e8019d882a0c81` to `4c0173909a3fe4107d1d09d0175f44153cddffc2`.

- improve worst-case performance bounds for wildcard matching
- fix text running offscreen
- re-add visibility controls
- add "hide sidebar button" setting