### PR TITLE
Update TCG Locked

### DIFF
--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=2f4755510007e5134c3b48d11641a7958186d53e
+commit=7507e65dbb039de449646ee899970481f5920ff4


### PR DESCRIPTION
Bumps TCG Locked to 7507e65 (1.1.0).

**Fixes unlock reveals spoiling pack openings.** Cards land in the collection one at a time as a pack is opened, and every unlock was announced the moment it arrived — the reveal named the card, with the chat line and chime behind it, before the player had turned it over. Reported by a user whose own packs were being given away to them.

Unlocks are now collected and shown together once no new cards have arrived for ~5s: longer than the gap between flips, short enough that a single unlock outside a pack still feels immediate. One chime per batch rather than one per card, since a pack's worth at once gives away the same thing in sound. New Feedback setting, on by default, for anyone who wants the old immediate behaviour back.

**Adds interop with Bronzeman TCG.** That plugin enforces the same locks from its own copy of the collection, so this plugin's party-pooled unlocks had no effect whenever it was running — it blocked the item regardless of what this one decided, and group play quietly stopped working. The pooled cards are now offered over a small PluginMessage API on its side (currently under review at Felmeme/bronzeman-tcg#6), including answering its query when it starts or changes profile, and withdrawn when this plugin is switched off.

This half is inert until that lands: nothing subscribes to the namespace, so with Bronzeman TCG absent or on its current release it is a no-op.

Also corrects two config item position collisions.