### PR TITLE
Update Lending Tracker: loan roles, one-time lends & piece-by-piece returns

### DIFF
--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=3970adfbd47f3748593c8acf99cc2c8202195125
+commit=c0dff397ccc84b44fb04f99dd33acaab4afe0b7e

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=5e146cdaf408f45499ee3d3dbe8274805841f02e
+commit=2cfbf040510796c555e8f0b95d83610d07df2798

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=c0dff397ccc84b44fb04f99dd33acaab4afe0b7e
+commit=f7c91f7c01e0cafd9a5cec6f58d70a9dc49e714c

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=f801f354390e2aed39b7a4f2717cda911dcb947c
+commit=3970adfbd47f3748593c8acf99cc2c8202195125

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=f7c91f7c01e0cafd9a5cec6f58d70a9dc49e714c
+commit=5e146cdaf408f45499ee3d3dbe8274805841f02e


### PR DESCRIPTION
Quality of life update for how loans and collateral get captured from the trade window, plus a big fix to how returns settle.

- Added a Collat button under the Loan button on the trade screen. The borrower taps it to mark their items as a collateral deposit, so a deposit can never get recorded like they were lending those items out. They also get their own proof screenshot of the deposit now.

- The Loan button now cycles OFF / LIST / 1-TIME — the lender picks per loan whether the item goes back on the group marketplace when returned, or is a one-time lend that never gets listed.

- Returns now settle piece by piece on both sides. Partial returns record progress and sync live to the group instead of counting for nothing, and a loan only closes when the lent items AND the collateral have both gone home. A "return" where the collateral doesn't come back no longer counts as settled.

- The guards now understand duplicates. If you're holding someone's item as collateral but also own your own copy, carrying or trading yours no longer trips warnings — what matters is that your total copies still cover what you owe. (Uses your bank contents once you've opened the bank that session; stays cautious before that.)

- Collateral can never leak onto the marketplace, raw GP can't be recorded as a lent item, and returning a borrowed item can't be mistaken for a new loan.

- Overdue reminders no longer point at the borrower once their side is fully returned, and the loan tooltip shows exactly what each side still needs to hand back.

- No new servers, no new permissions — same sync, same opt-in. Just making the lending flow behave the way people expect. Thanks!