### PR TITLE
Add Tagkeeper

### DIFF
--- a/plugins/tagkeeper
+++ b/plugins/tagkeeper
@@ -1,0 +1,2 @@
+repository=https://github.com/MarkCDavid/runelite-tagkeeper.git
+commit=9418f8ecd4d736cbddc186f09afcc7dead8dd6a8


### PR DESCRIPTION
Adds **Tagkeeper**, a sidebar panel that gives you a centralized place to manage the relationship between bank tags and bank tabs: every tag you have, whether it's a tab in your bank, its icon, item count, and whether it has a layout.

### What it does
- Lists all bank tags, both with a tab and item-only, with search and a compact view.
- Click a tag to open it in the bank (works for tags without a tab); click again to close.
- Add or remove a tag's bank tab from the panel.
- Remembers every tab icon and restores it when a tab is re-added; core Bank Tags otherwise resets it to a spade.
- Rename (with merge), delete, and set icons via the chatbox.
- Export/import tags with layouts, in core Bank Tags and [Bank Tag Layouts](https://github.com/geheur/bank-tag-custom-layouts) formats.

Tabs are managed by editing the `banktags` config group, using the same `useTabs` re-init technique as Bank Tag Layouts.
