### PR TITLE
Add Rune Count

### DIFF
--- a/plugins/rune-count
+++ b/plugins/rune-count
@@ -1,0 +1,2 @@
+repository=https://github.com/vaeryn-uk/rune-count.git
+commit=9278d54cd4324db1ae808b2456710956e26bb717


### PR DESCRIPTION
Adds Rune Count, a plugin that displays currently available runes from inventory, rune pouch, and equipment sources.