### PR TITLE
Update TCG Locked

### DIFF
--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=7507e65dbb039de449646ee899970481f5920ff4
+commit=d6d648234c08c1f12a532c18d0420e3f85e6857b


### PR DESCRIPTION
Bumps TCG Locked to d6d6482 (1.2.0).

**Group play now needs consent, and shows what it is doing.** Party pooling applied automatically to anyone in your RuneLite party — which are also raid parties — so raiding with strangers silently pooled your challenge with them, and a player with no cards could inherit a finished collection just by joining. None of it was visible, and the unsync control did not actually take anything back.

- Pooling requires approval, per person, remembered across sessions and revocable
- Your collection is addressed to exactly the people you have synced, so one undecided player no longer stops sharing with everyone else
- Unsync asks their client to drop what you shared, rather than only stopping future updates
- The panel reports it: pooled items carry a blue corner and name the partner, a Group filter shows only borrowed unlocks, and the Group section leads with how many cards are pooled in and what they open, broken down per partner

**Also disables the unlock reveal.** It was still spoiling pack openings: cards enter the collection the moment a pack is opened rather than as each one is flipped, so the reveal named them before the player had turned them over. The quiet-period delay added in 1.1.0 only postpones that. Commented out rather than deleted, with the setting hidden and stored values untouched, so it returns if OSRS TCG either commits the cards when the reveal interface closes or publishes a pack-reveal signal.

Smaller fixes: party state is cleared properly on leaving, approved partners stay listed after a restart even before their cards arrive, and the stray border PluginPanel's scroll pane draws around the panel is cleared.