### PR TITLE
Updates Rune Count to v1.0.1.

### DIFF
--- a/plugins/rune-count
+++ b/plugins/rune-count
@@ -1,2 +1,2 @@
 repository=https://github.com/vaeryn-uk/rune-count.git
-commit=9278d54cd4324db1ae808b2456710956e26bb717
+commit=a86a011d2b7b2165910981991cc3472bd905c2f9


### PR DESCRIPTION
Fixes the low-rune threshold so runes supplied infinitely by an equipped staff or tome are not shown as low.

Updates plugin author metadata.