### PR TITLE
Update TCG Locked

### DIFF
--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=d6d648234c08c1f12a532c18d0420e3f85e6857b
+commit=45f9d1d512fa428e73bd8864856bc7c315c970e1


### PR DESCRIPTION
Bumps TCG Locked to 45f9d1d (1.2.1).

Adds a Discord link in the side panel footer, under a "Bugs and feature requests" row, opened in the system browser via LinkBrowser. Nothing in the plugin previously said where to report a problem, so issues ended up as hub reviews or nowhere at all.

The README gains a matching section, including a note that the plugin is unofficial and not affiliated with the OSRS TCG plugin or its developers.

No functional changes.