### PR TITLE
Update NPC Health Text

### DIFF
--- a/plugins/npc-health-text
+++ b/plugins/npc-health-text
@@ -1,2 +1,2 @@
 repository=https://github.com/devrat0/npc-health-text-plugin.git
-commit=1be502021744d1c5106c2db3067b105e6cedc736
+commit=5976e825b0276448ae32d445b12149aadf8c5dc5


### PR DESCRIPTION
- fixed an issue that caused the overlay to disappear on certain oversized npcs
- fixed an issue where the overaly was being incorrectly rendered in doom of mokhaiotl