### PR TITLE
Update Slayer Best in Bank: scoring and live refresh fixes

### DIFF
--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=9d2cfedac4e04ad36af921247e4d420eac68a921
+commit=175dc0f709d5e00b33798207fad51e515ab3cfed


### PR DESCRIPTION
Updates **Slayer Best in Bank** with the latest tested fixes.

### Scoring engine
- Monster-specific weapon effects now scale a whole-attack proxy instead of only the weapon's visible item stats.
- Fixes Emberlight ranking below Abyssal whip on Black demons.
- Preserves dynamic Golembane, Demonbane, Dragonbane, Keris, Ratbane, Shade, Vampyre and Wilderness-weapon behavior.
- Prayer First and Balanced use the same combat-optimal weapon ranking.
- Attack speed scales the whole weapon offence proxy.
- Preferred item names are tie-breakers rather than pseudo-BiS overrides.

### Live refresh fixes
- Balanced / Prayer First refreshes while the bank remains open.
- Change Method runs on RuneLite's client thread.
- Change Method refreshes immediately with the bank closed.
- Change Method refreshes an open Best-in-Bank view in place.
- Rapid bank-tab / Slayer-helmet transitions remain debounced.

### Existing intelligence retained
- Full combat and weakness catalog.
- 81 location-aware cannon routes.
- Smoke Devil cannon + Ancient AoE handling.
- Mandatory protection, ammo, 2H/off-hand and target legality checks.

### Display name
User-facing name is **Slayer Best in Bank**.

### Validation
gradlew.bat clean test was run on:
1. the exact local tested development tree;
2. a fresh publication clone immediately before the source push.

The plugin remains advisory only and does not automate gameplay.