### PR TITLE
Add loot-beams-deluxe to plugins

### DIFF
--- a/plugins/loot-beams-deluxe
+++ b/plugins/loot-beams-deluxe
@@ -1,0 +1,2 @@
+repository=https://github.com/miccou/loot-beams-deluxe
+commit=f77cb3fe7062067f2b3076526f1ed3d246ea93a3

--- a/plugins/loot-beams-deluxe
+++ b/plugins/loot-beams-deluxe
@@ -1,2 +1,2 @@
-repository=https://github.com/miccou/loot-beams-deluxe
+repository=https://github.com/miccou/loot-beams-deluxe.git
 commit=f77cb3fe7062067f2b3076526f1ed3d246ea93a3


### PR DESCRIPTION
A RuneLite plugin for extra customization of loot beams. More value tiers, more styles, two-tone beams, and drop fanfare animations.