### PR TITLE
Add show-friends-on-login plugin

### DIFF
--- a/plugins/show-friends-on-login
+++ b/plugins/show-friends-on-login
@@ -1,0 +1,2 @@
+repository=https://github.com/robisa693/runelite-show-friends-on-login.git
+commit=ba7fa6db24736641aac150b97ff4e6ce709b2b04


### PR DESCRIPTION
Shows an overlay on login with online friends, clan chat members, and friends chat members, including their worlds and rank icons. Configurable auto-hide timer, max players per category, sort modes, and per-category toggles makes it replace multiple other similar plugins in one.