### PR TITLE
Update pricecheck-flipping

### DIFF
--- a/plugins/pricecheck-flipping
+++ b/plugins/pricecheck-flipping
@@ -1,3 +1,3 @@
 repository=https://github.com/pricecheckgg/pricecheck-runelite-plugin.git
-commit=8f8b5f9261e2dc79b7f8a8b821a02b379a559fcf
+commit=52635de5308f7a917a79f63b11f9a6fa003f9f04
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Version bump for pricecheck-flipping.

Since the last release: the GE desk now sizes itself to the client window (Auto layout tiers, with on-screen feedback when a fixed layout does not fit), settings simplified from 18 toggles down to 10, and the old floating overlays are removed. No new data collection or dependencies; the plugin-key and subscription model are unchanged.