### PR TITLE
Update TCG Locked

### DIFF
--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=d6d648234c08c1f12a532c18d0420e3f85e6857b
+commit=45f9d1d512fa428e73bd8864856bc7c315c970e1

--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=45f9d1d512fa428e73bd8864856bc7c315c970e1
+commit=77cbe1b8f51f0ed1e749143e2de26fa2401f174a


### PR DESCRIPTION
Bumps TCG Locked to 77cbe1b (1.2.2).

Fixes enforcement and account-state issues:

- Warn-only now reports every gated item and monster interaction without blocking it
- Menu removal targets the exact RuneLite entry instead of assuming it is last
- Profile changes clear pending unlocks and withdraw the previous account's shared cards
- Queued client-thread and panel updates cannot repopulate state after shutdown
- Lock icons and carrying warnings now follow the selected difficulty preset

Group collection syncing now uses a compact, versioned catalog bitmap with strict size and format validation. Sharing disable, shutdown, profile changes and unsync all retract previously shared cards, while current clients remain compatible with the prior party message field.

The side panel has been redesigned as a compact dashboard with clearer status and progress cards, conditional activity and warning sections, cleaner group rows, accurate update age, and a four-column lockbook that no longer clips its rightmost cells. Lockbook snapshots are cached so routine inventory events do not repeatedly rebuild and sort the full collection.

Adds regression coverage for catalog versioning, malformed payloads, exact bitmap lengths and legacy party-key validation.

Verified with ./gradlew clean build.