### PR TITLE
Update Tagkeeper

### DIFF
--- a/plugins/tagkeeper
+++ b/plugins/tagkeeper
@@ -1,2 +1,2 @@
 repository=https://github.com/MarkCDavid/runelite-tagkeeper.git
-commit=9418f8ecd4d736cbddc186f09afcc7dead8dd6a8
+commit=e351dca9a14a18f0f8771a1fe7ede8bb9799c48a


### PR DESCRIPTION
Updates Tagkeeper with panel fixes:

- Long tag names no longer push the row buttons out of the visible area (the scroll view now tracks the viewport width; names truncate instead).
- Row tooltips lead with the full tag name, since names can now truncate.
- Slimmer, darker scrollbar.