### PR TITLE
card-exchange-highscores: bump to 0.3.0

### DIFF
--- a/plugins/card-exchange-highscores
+++ b/plugins/card-exchange-highscores
@@ -1,3 +1,3 @@
 repository=https://github.com/CompilerOfDust/osrs-tcg-highscores-thecardexchange.git
-commit=db86fe03e9fdd2720a693c2a57ec0dd9eb1b4d12
+commit=71371f8fe8951b4dcb3066200a22c6003e933ae3
 authors=CompilerOfDust


### PR DESCRIPTION
Side panel with View highscores / Setup guide CTAs, a "recent changes not showing" troubleshooting note (::tcg-save), hard-coded exchange URL, and skipping uploads for empty (0-card) collections.