### PR TITLE
EMERGENCY BUG FIXES: Update TCG Locked

### DIFF
--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=d6d648234c08c1f12a532c18d0420e3f85e6857b
+commit=45f9d1d512fa428e73bd8864856bc7c315c970e1

--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=77cbe1b8f51f0ed1e749143e2de26fa2401f174a
+commit=b6a928c0367181068f318a73eaacf51d4cdbc0f1

--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=45f9d1d512fa428e73bd8864856bc7c315c970e1
+commit=77cbe1b8f51f0ed1e749143e2de26fa2401f174a

--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=b6a928c0367181068f318a73eaacf51d4cdbc0f1
+commit=d1671d49b0bcd7b8438cd81d645209a78f58c0f4


### PR DESCRIPTION
Emergency TCG Locked update.\n\n- Fixes item-use and activity-locking bypasses and false requirements.\n- Hardens collection refresh, pending unlocks, party consent, lifecycle, and malformed payload handling.\n- Restores the Shared Cards catalog with RuneLite-local item sprites.\n- Uses OSRS TCG's persistent image cache for NPC portraits, preventing duplicate Wiki downloads between the plugins.\n- Updates the Discord invite.\n\nSource commit: 630931e76999051f6998506125cb31ec49ffe789