### PR TITLE
Update pricecheck-flipping

### DIFF
--- a/plugins/pricecheck-flipping
+++ b/plugins/pricecheck-flipping
@@ -1,3 +1,3 @@
 repository=https://github.com/pricecheckgg/pricecheck-runelite-plugin.git
-commit=52635de5308f7a917a79f63b11f9a6fa003f9f04
+commit=c334023f4e6312379ad7b55ce8eec80a89d245b2
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Version bump for pricecheck-flipping.

Since the last release: a Language setting, with Japanese as the first supported language. The sidebar panel, the Grand Exchange desk overlays and the price lines the plugin draws inside the GE all translate. Item names, prices and the game's own right-click menus stay exactly as the client provides them, so what you read still matches what you type into the GE.

Japanese only engages when a font that can draw it is installed; otherwise the plugin stays in English, and any string without a translation falls back to English rather than rendering blank.

No new data collection, no new dependencies, no new input paths. 