### PR TITLE
card-exchange-highscores: bump to 0.3.1

### DIFF
--- a/plugins/card-exchange-highscores
+++ b/plugins/card-exchange-highscores
@@ -1,3 +1,3 @@
 repository=https://github.com/CompilerOfDust/osrs-tcg-highscores-thecardexchange.git
-commit=71371f8fe8951b4dcb3066200a22c6003e933ae3
+commit=1febfde0fe16afa940bdd9fe78f291121113a251
 authors=CompilerOfDust


### PR DESCRIPTION
Side panel with View highscores / Setup guide CTAs, a "recent changes not showing" troubleshooting note (::tcg-save), hard-coded exchange URL, skipping uploads for empty (0-card) collections, and a redesigned plugin icon (card-back frame + gold highscores trophy) that reads clearly on RuneLite's dark side-panel toolbar.