### PR TITLE
Update plugin to v1.1.0 for more options for clan announcements

### DIFF
--- a/plugins/ruthless-clan
+++ b/plugins/ruthless-clan
@@ -1,4 +1,4 @@
 repository=https://github.com/Orinite/ruthless-plugin.git
-commit=f53e327305e2bde2de1c876032c7c63be7bbba10
+commit=bdaaf204c2c1adddd5a0bb345b02220df925bf5e
 warning=This plugin submits your username and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.
 authors=Orinite


### PR DESCRIPTION
Update plugin to v1.1.0 for more options for clan announcements
- added broadcast limit, 0 being default meaning unlimited. If set, it only displays the broadcast in the client for the logged in user x amount of times.
- added broadcast type. Defaults to Broadcast, but can set to Game Message instead.