### PR TITLE
Add blast-mine-improved plugin

### DIFF
--- a/plugins/blast-mine-improved
+++ b/plugins/blast-mine-improved
@@ -1,0 +1,2 @@
+repository=https://github.com/JamsRepos/blast-mine-improved.git
+commit=32897508e9a5387bf466617223c5da4f5edb7a84

--- a/plugins/blast-mine-improved
+++ b/plugins/blast-mine-improved
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/blast-mine-improved.git
-commit=9e06c5760e871c8b98d1bdbe1f5628922ccb036a
+commit=07e277a246be73546c2be427756cb082b7060847

--- a/plugins/blast-mine-improved
+++ b/plugins/blast-mine-improved
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/blast-mine-improved.git
-commit=32897508e9a5387bf466617223c5da4f5edb7a84
+commit=9e06c5760e871c8b98d1bdbe1f5628922ccb036a


### PR DESCRIPTION
## Summary
- Adds **Blast Mine Improved**, a Plugin Hub replacement for the built-in Blast Mine plugin
- North-east rotation helper (two full 1-8 laps + 1-2/3-4 finale), menu safety (paired Light, off-path hide), ore timers, sack XP estimates
- Conflicts with core **Blast Mine** and **Blast Mine Dynamite Restriction**
- `build=standard` in `runelite-plugin.properties`

## Test plan
- [ ] Plugin Hub CI build passes
- [ ] Install from Hub side panel in a client
- [ ] Enable plugin and confirm core Blast Mine disables
- [ ] NE rotation helper, deposit at 20, bank chest, and paired Light safety behave as described in the plugin README