### PR TITLE
Update slayer-streak

### DIFF
--- a/plugins/slayer-streak
+++ b/plugins/slayer-streak
@@ -1,2 +1,2 @@
 repository=https://github.com/nw51/slayer-streak-plugin.git
-commit=cefd80c695e5722e699e6d7794e00cf2062878ba
+commit=4f026ea29ad0c4e591e6f876bc83b6239a2c9d7a


### PR DESCRIPTION
removed last-contact menu options for restricted slayer masters via casting NPC contact when at milestone interval