### PR TITLE
Drop Rate: add Maggot King, fix bad drop data

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=bdcd4c9bcd94b88c57392002e35bf4213a42eb4a
+commit=5e2e3844f6b02b8e3ceecd87f84618d355ac5f39

--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=5e2e3844f6b02b8e3ceecd87f84618d355ac5f39
+commit=7220fa0a63d80dd13d4e5e16f3e36d8a32d0c1a6


### PR DESCRIPTION
Update to the Drop Rate plugin. Data only, no code changes.

**New**

- Support for the **Maggot King**, the boss added with The Blood Moon Rises on 30 June 2026. Its full drop table is included, along with the three collection log items: Elder venator fang (1/340), Crimson kisten (1/520) and the Maggot marquess pet (1/3500).
- The Maggot marquess pet can be obtained two ways, either by looting the boss or by taking its eggs. Both chances are now listed, so players can see that taking eggs is roughly 2.3x better.
- Venator tooth and Venator fang now show a rate in the Slayer collection log.

**Fixed**

- Removed 57 entries that were never real items. Text from wiki footnotes was being mistaken for item names, so things like "Clue rates tweet}}" were showing up as drops.
- Fixed around 70 drops that could never appear in game. Some monsters and items were stored under their wiki page title instead of their in-game name, for example "Rock Golem (monster)" rather than "Rock Golem", so the plugin never matched them.
- Removed Bloodthirst rockslug. It was taken out of the game in January 2024 but was still listed with 12 drops.
- Renamed "Araxyte venom sack" to "Araxyte venom sac" to match the current item name.

All rates come from the OSRS Wiki. Every rate in the plugin was checked to make sure it displays correctly, and the in-game messages were confirmed on a live Maggot King kill.

No new permissions and no new dependencies.
