### PR TITLE
card-exchange-highscores: bump to 0.3.1

### DIFF
--- a/plugins/card-exchange-highscores
+++ b/plugins/card-exchange-highscores
@@ -1,3 +1,3 @@
 repository=https://github.com/CompilerOfDust/osrs-tcg-highscores-thecardexchange.git
-commit=71371f8fe8951b4dcb3066200a22c6003e933ae3
+commit=1febfde0fe16afa940bdd9fe78f291121113a251
 authors=CompilerOfDust


### PR DESCRIPTION
Icon redesign, dropped-IP upload disclosures, and a 15-minute save-and-sync cycle that runs ::tcg-save (only on a collection change) before uploading.