### PR TITLE
clan-management: bump to 036e012

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=612a3e9b5cb75e012f93f54baba34a4d1455f19a
+commit=423f52f36e038aa3552cb420b5847e73546e4ffa
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=03c70f78ee01a617f9e839da9767a371cd46dd5f
+commit=612a3e9b5cb75e012f93f54baba34a4d1455f19a
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=423f52f36e038aa3552cb420b5847e73546e4ffa
+commit=036e012c11472ea327730157e1b63e68434014ae
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update clan-management to 036e012.

Changes since the current version (03c70f7):
- Achievement Diary and Quest tracking: reads diary tier completion (varbits) and quest states on login, syncs the summary to the clan server, and re-syncs when a quest or diary completion message appears in chat. Change-detected via a config-stored signature so routine logins are a no-op. Quest count excludes miniquests and the Recipe for Disaster subquests so it matches the in-game quest list.
- Account type reporting: reads the player's own account type (varbit 1777) and includes it in the same sync, so the clan server can label irons/group irons correctly.
- Group Ironman team detection: when a group iron opens the in-game Group side panel, the plugin reports the panel's member names to the clan server so the clan's team pages populate automatically (server-side the names are matched against the clan roster; non-member strings are discarded).
- Members panel: a Diaries & Quests section (per-region diary tiers, remaining quests); account-type helm icons (from the client's mod icons) shown before names like in chat; account type + EHB shown on member profiles.
- Leaderboard panel: a Gained/Records view selector (records = best-ever gain in a day/week/month/year window, served by the clan server from Wise Old Man data); tab title reworded.
- In-game confirmation messages for collection log and combat achievement syncs; all chat messages now use a consistent [Solus] prefix.

Manifest bump only; warning line preserved.