### PR TITLE
Update default-minimap-zoom

### DIFF
--- a/plugins/default-minimap-zoom
+++ b/plugins/default-minimap-zoom
@@ -1,3 +1,3 @@
 repository=https://github.com/YvesW/default-minimap-zoom.git
-commit=3eababd1173ac9c70a9a51e296b4136ad4ee8641
+commit=68b2651ef0156af95357ea6b9e1d058c16b2e214
 authors=YvesW

--- a/plugins/default-minimap-zoom
+++ b/plugins/default-minimap-zoom
@@ -1,3 +1,3 @@
 repository=https://github.com/YvesW/default-minimap-zoom.git
-commit=254ad8c0790ed26ffe11e3758976507791eb673a
+commit=3eababd1173ac9c70a9a51e296b4136ad4ee8641
 authors=YvesW

--- a/plugins/default-minimap-zoom
+++ b/plugins/default-minimap-zoom
@@ -1,4 +1,3 @@
 repository=https://github.com/YvesW/default-minimap-zoom.git
-commit=cf9d2c1e99fe479d78cd6a212ffd2e0c67e31f71
+commit=254ad8c0790ed26ffe11e3758976507791eb673a
 authors=YvesW
-unavailable=This plugin is incompatible with the latest RuneLite version, and requires its author to update it.


### PR DESCRIPTION
Assuming I still know how to do this...
- Should remove the use of Applet by implementing the solution I'd already come up with 2 years ago apparently (oops)
- Uses gamevals instead of deprecated InterfaceID/ComponentID/Varbits
- Fixes outdated, hardcoded widget references
- Adds activity advisor support
- Adds minimap minimizing/hiding support
- Updated to the latest version of https://github.com/runelite/example-plugin Thus, the actual changes are probably size-s instead of size-m.