### PR TITLE
Update blast-mine-improved to 1.0.1

### DIFF
--- a/plugins/blast-mine-improved
+++ b/plugins/blast-mine-improved
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/blast-mine-improved.git
-commit=07e277a246be73546c2be427756cb082b7060847
+commit=3e7b1ff5fddc8e7753c26d8f9ecebf21001ba212


### PR DESCRIPTION
## Summary
- Updates **blast-mine-improved** to `1.0.1` (`3e7b1ff5fddc8e7753c26d8f9ecebf21001ba212`)
- Fixes the default ore sack HUD staying visible when entering the mine or enabling the plugin (re-applies `setHidden` every frame)

## Test plan
- [ ] Plugin Hub CI build passes
- [ ] Enter Blast Mine with Show ore sack overlay enabled — stock HUD should stay hidden
- [ ] Toggle plugin off/on inside the mine — stock HUD should hide again when re-enabled
