### PR TITLE
Update coal-bag to v1.6

### DIFF
--- a/plugins/coal-bag
+++ b/plugins/coal-bag
@@ -1,2 +1,2 @@
 repository=https://github.com/WolffTech/coal-bag-plugin.git
-commit=4db6a7d69eae3b65943508b92b130a5ce9cf6dae
+commit=b432633deedd2c95119ce6e388cae93cb07034c8


### PR DESCRIPTION
Updates Coal Bag to v1.6. This release tracks coal mined directly into an open bag, including eligible bonus ore and bank container-emptying.