### PR TITLE
Update Slayer Best in Bank: preparation QoL and trip lifecycle

### DIFF
--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=ae65dc4d597c609d0d323e4e1817fea200b011b5
+commit=eaaa991f29437404cad61ecb7bd6d3385399d037

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=eaaa991f29437404cad61ecb7bd6d3385399d037
+commit=5796c0e05b9327e10a0e9ab40ad2be1753b0e553

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=175dc0f709d5e00b33798207fad51e515ab3cfed
+commit=ae65dc4d597c609d0d323e4e1817fea200b011b5


### PR DESCRIPTION
## Summary

Updates Slayer Best in Bank to the consolidated preparation and trip-planning
release candidate.

- adds All, Missing, Gear, and Supplies focus views
- locks the active bank-session loadout behind an explicit Refresh action
- adds conservative 28-slot inventory-capacity fitting
- keeps Tier 2/3-only ammunition and off-hand swaps out of Tier 1 preparation
- recognizes Island of Stone as the Jormungand's Prison Dagannoth cannon route
- silently treats consumed supplies and deployed cannon parts as used for the
  prepared trip until the next bank opening
- replaces the invalid Discord support invite with a verified invite
- retains stable manual withdrawal positions and click-only behavior

## Player control and safety

The plugin remains advisory. It does not withdraw, equip, move, attack, pray,
or automate input. The Discord destination is opened only after the sidebar
icon is clicked; no background networking or diagnostics were added.

## Validation

- 128 tests passed, zero failures
- Java 11 main compilation with warnings-as-errors passed
- no filesystem writes, process execution, reflection, runtime downloads,
  sockets, clipboard access, or automated input behavior added

Source commit: `5796c0e05b9327e10a0e9ab40ad2be1753b0e553`
