### PR TITLE
Update Combat Lab to 1.0.1

### DIFF
--- a/plugins/combat-lab
+++ b/plugins/combat-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/combat-lab.git
-commit=32673f0a2f587a02f5c71c4dceff9df364991706
+commit=1ca7452879198a1f03d969da2db1248ae22f066e


### PR DESCRIPTION
## Summary

Updates Combat Lab to 1.0.1.

## Fix

Combat Lab previously injected RuneLite's internal `ItemStatChangesService`, which is not bound for Plugin Hub external plugins. The plugin therefore failed during Guice instantiation before its side-panel button could be registered.

The new version:

- only injects public external-plugin bindings (`Client` and `ItemManager`) in the reserve calculator;
- uses a self-contained reserve estimator for common PvM food and restorative potions;
- adds regression coverage for the constructor bindings and restoration estimates;
- correctly counts all remaining potion doses.

## Validation

- Combat Lab CI passed
- `gradlew.bat test build shadowJar --no-daemon`
- 11 tests passed, 0 failures
