### PR TITLE
Add pet-battles

### DIFF
--- a/plugins/pet-battles
+++ b/plugins/pet-battles
@@ -1,0 +1,3 @@
+repository=https://github.com/osrs-petbattle-gm/osrs-pet-battles.git
+commit=8345033fc373edecbd49af65a51b98bfac9e25eb
+authors=osrs-petbattle-gm


### PR DESCRIPTION
**Pet Battles** — a turn-based battle minigame between the pets in your collection log.

- **What it does:** Pit your unlocked collection-log pets against NPCs in
  turn-based battles, with per-pet progression (levels/XP), moves, and a type chart.
  Purely cosmetic fun — no gameplay advantage.
- **External connections:** None. The plugin runs entirely client-side and makes no
  HTTP/network requests, so no data leaves the client. Pet progression is saved locally.
- **License:** BSD 2-Clause.

Plugin source: https://github.com/osrs-petbattle-gm/osrs-pet-battles
