### PR TITLE
the-birdhouse: update to 1.0.1

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=6fed423323cffd5fce6caa521b6b8fcec6632a00
+commit=9f4b5f1145002bd4d76b69dce77b08702ce2f834
 warning=This plugin submits your IP address, RSN, and in-game screenshots to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates The Birdhouse to 1.0.1. The only change is the pinned commit hash.

This release routes board polling to a dedicated read-only cache host
(api.thebirdhouse.games) with automatic fallback to the existing backend,
reducing backend load. No new permissions; the existing warning line is
unchanged.