### PR TITLE
create soulflame-horn

### DIFF
--- a/plugins/soulflame-horn
+++ b/plugins/soulflame-horn
@@ -1,0 +1,3 @@
+repository=https://github.com/Scaleee/soulflame-horn-plugin.git
+commit=5b0fe465ac55c7a618e919786d12d151b42409bf
+authors=Scaleee

--- a/plugins/soulflame-horn
+++ b/plugins/soulflame-horn
@@ -1,3 +1,3 @@
 repository=https://github.com/Scaleee/soulflame-horn-plugin.git
-commit=cb915fe8acb7188ae876e55faf405238247fde53
+commit=81849a3b0950b6b4a9120b829df8919e48a19e47
 authors=Scaleee

--- a/plugins/soulflame-horn
+++ b/plugins/soulflame-horn
@@ -1,3 +1,3 @@
 repository=https://github.com/Scaleee/soulflame-horn-plugin.git
-commit=5b0fe465ac55c7a618e919786d12d151b42409bf
+commit=cb915fe8acb7188ae876e55faf405238247fde53
 authors=Scaleee


### PR DESCRIPTION
Adds Soulflame Horn, a plugin for the Soulflame horn's Entice special attack.

Entice lasts 10 ticks and is spent by a single melee hit, with nothing on screen indicating it is running out. This plugin makes the cycle audible and visible:

- A configurable sound for each stage: spec sent, received, utilized, missed, wasted, and when a party member wastes a buff you gave them. All bundled sounds can be replaced with your own files.
- An infobox counting the buff down, in seconds or ticks.
- An optional overlay outlining the tiles the horn reaches, following the radius configured on the horn itself.
- Optional overhead text above players as their buff is applied, spent or wasted.

Detection is driven entirely by the game messages the server sends. Buff expiry uses the game's own "effect fades away" message rather than a tick counter, with the counter kept only as a backstop for a missed message.

Party integration is optional and off by default. When enabled it uses PartyService to share buff status between party members running the plugin, so you can see whether allies used what you gave them. Only buff status and a short configurable text line are sent; incoming text is stripped of markup and length capped before it is drawn.

Repo: https://github.com/Scaleee/soulflame-horn-plugin