### PR TITLE
update loot-beams-deluxe

### DIFF
--- a/plugins/loot-beams-deluxe
+++ b/plugins/loot-beams-deluxe
@@ -1,2 +1,2 @@
 repository=https://github.com/miccou/loot-beams-deluxe.git
-commit=f77cb3fe7062067f2b3076526f1ed3d246ea93a3
+commit=76b4175d8a06cf30f79aa732358a534128215cbc


### PR DESCRIPTION
- Add ownership filter (all/takeable/drops) + a ground items synced option
- Fixed an issue where tier resolution was deferred, causing drops in the tick after the plugin is enabled to not have a loot beam 