### PR TITLE
Fix stations-cozy-clutter author metadata

### DIFF
--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=fe08368b8c4d080c3ab13e3c86cfd10632e23f8b
+commit=9d5925636d2a5ab4ac086763ac56b1dda67b23d2


### PR DESCRIPTION
Corrects the public author metadata for Station's Cozy Clutter from a personal first name to the creator identity `StationEarthxo`. The source repository's root and packaged `runelite-plugin.properties` files, as well as the LICENSE, have been corrected.

This is a metadata-only privacy correction; the Gradle test suite passes.