### PR TITLE
gauntlet-recorder 0.5.0

### DIFF
--- a/plugins/gauntlet-recorder
+++ b/plugins/gauntlet-recorder
@@ -1,2 +1,2 @@
 repository=https://github.com/lsmith090/gauntlet-recorder.git
-commit=eafa397bbb572268dc0d8aa137a0570c16ede842
+commit=4647c8397508d76388772d72d4a94eee2260f6f6


### PR DESCRIPTION
Adds four raw observation streams: hitsplats (HIT), local-player animation changes (PANIM), player HP/prayer levels on change (STAT), and per-tick prayer toggle deltas (PRAYER). Damage, attack method and prayer usage are now recorded by the plugin itself. Disk log only, as before - no overlay, nothing shown in-game.