### PR TITLE
Add Hunllef expected value plugin

### DIFF
--- a/plugins/hunllef-expected-value
+++ b/plugins/hunllef-expected-value
@@ -1,2 +1,2 @@
-respository=https://github.com/greg-tucker/HunleffED.git
+repository=https://github.com/greg-tucker/HunleffED.git
 commit=5930c104ab706653e5ac5115c5fb87be10fff32e

--- a/plugins/hunllef-expected-value
+++ b/plugins/hunllef-expected-value
@@ -1,0 +1,2 @@
+respository=https://github.com/greg-tucker/HunleffED.git
+commit=5930c104ab706653e5ac5115c5fb87be10fff32e


### PR DESCRIPTION
A plugin which shows expected damage given and taken in hunllef fight a bit like the PVP performance tracker plugin. 