### PR TITLE
quest-voiceover: update to 1.13.0

### DIFF
--- a/plugins/quest-voiceover
+++ b/plugins/quest-voiceover
@@ -1,3 +1,3 @@
 repository=https://github.com/KevinEdry/runelite-quest-voiceover.git
-commit=81fbc68a68d045f19177462f120099fe068af2b2
+commit=9b9b61c5fe278b57057ba51a62a8f46317cbfe6e
 jarSizeLimitMiB=15


### PR DESCRIPTION
Updates Quest Voiceover to v1.13.0, pointing the manifest at the
release commit e02751a.

Changes since 1.12.1:
- Add a toggle to disable player-character dialogue voiceover, so
  only NPC voices are heard
- Add a "Finish Last Line on Exit" audio option
- Add a Ko-fi donation button to the plugin panel
- Show the release changelog as a chat message once per new version

Release notes: https://github.com/KevinEdry/runelite-quest-voiceover/releases/tag/v1.13.0