### PR TITLE
Grimy Herblore Levels plugin

### DIFF
--- a/plugins/grimy-herblore-levels
+++ b/plugins/grimy-herblore-levels
@@ -1,0 +1,2 @@
+repository=https://github.com/DjilanoS/osrs-grimy-herblore-levels.git
+commit=5b2b59213a27130e299d7eaf113dae14d36fd539


### PR DESCRIPTION
For those who cannot remember or keep track of the Herblore level requirements to clean grimy herbs, this is for you!
A simple plugin that keeps track if you're level is too low to clean grimy herbs, if so it shows a red time with the lvl requirement.