### PR TITLE
Adding hash for ruthless plugin 1.2.0

### DIFF
--- a/plugins/ruthless-clan
+++ b/plugins/ruthless-clan
@@ -1,4 +1,4 @@
 repository=https://github.com/Orinite/ruthless-plugin.git
-commit=5fc198b3c39cba94828e86965f6c0be6223f1c11
+commit=96ec478feac034e54e80719b9c383f2fdcd3fe68
 warning=This plugin submits your username and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.
 authors=Orinite

--- a/plugins/ruthless-clan
+++ b/plugins/ruthless-clan
@@ -1,4 +1,4 @@
 repository=https://github.com/Orinite/ruthless-plugin.git
-commit=bdaaf204c2c1adddd5a0bb345b02220df925bf5e
+commit=5fc198b3c39cba94828e86965f6c0be6223f1c11
 warning=This plugin submits your username and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.
 authors=Orinite


### PR DESCRIPTION
- Added Clan webhook fetching. Can be used to grab webhooks dynamically. This polls on a 5 minute interval and will also grab on startup of the plugin.
- When a valid loot that matches whitelist happens, it will send a screenshot to our #logs channel with the items received in the message.
- Opt-in deaths sending. Defaults to off. If enabled, will send death screenshot to our #deaths channel with custom message defined in the plugin settings. defaults to "$name has died", and replaces $name with logged in character.
- Added custom webhooks for deaths and loots. If a discord url is put in here (comma separated values), it will send to each url defined as well as our channel.
- defaulting clan broadcast limit to 1