### PR TITLE
drop-rate-properties: notification config, GE filter fix, tooltip caching

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=7220fa0a63d80dd13d4e5e16f3e36d8a32d0c1a6
+commit=76da02f6c6126a34dc03003b9f146e9b096210b9


### PR DESCRIPTION
Update `drop-rate-properties` to `76da02f6c6126a34dc03003b9f146e9b096210b9`.

### Changes

- **Notifications now use the `Notification` config type** instead of a plain boolean, so users get the standard tray/sound/flash/focus controls. The old `notifyOnRareDrops` value is migrated once so nobody loses their setting.
- **Fixed the minimum GE value filter.** `ItemManager.getItemPrice()` returns `0` for untradeables, so any non-zero threshold silently hid every pet, jar and Unsired — and suppressed the rare-drop notification with them. Untradeables now bypass the filter, and stacks are valued as a whole rather than per unit.
- **Collection Log tooltip is no longer rebuilt every frame.** It was re-parsing every rate of the hovered item ~50x a second (some items have 260+ sources). Memoised per item, invalidated on config change. The hidden-filler CSV was likewise re-parsed per item per drop; also cached.
- **Kill counter now shows the average kills a drop takes**, which the config description had always promised but the code never emitted.
- **Data:** stripped wiki section anchors from 11 item names (`Fishbowl#Water`, `Coin pouch#Hero`, `Bird nest (egg)#Blue egg`). Lookups are exact string matches, so those entries could never match anything in game.
- Moved off the fully deprecated `net.runelite.api.InventoryID` to `gameval.InventoryID.WORN`.
- `README.md` now documents the Collection Log tooltip, kill counter, notifications and GE value filter.
- Plugin hub description rewritten; it contained a UTF-8 em dash that came through the manifest as mojibake (`\xe2\x80\x94` as three separate characters). The file is pure ASCII now.

No new third-party dependencies.
