### PR TITLE
Add Protect Item Alarm

### DIFF
--- a/plugins/protect-item-alarm
+++ b/plugins/protect-item-alarm
@@ -1,2 +1,2 @@
 repository=https://github.com/adamstz/protect-item-alarm.git
-commit=1d5e58d27000ca04a1ce2ce6353b708fc49f3f45
+commit=44d8b7ee7ad4b7a9179ef4aa973a9ede068427bb

--- a/plugins/protect-item-alarm
+++ b/plugins/protect-item-alarm
@@ -1,2 +1,2 @@
 repository=https://github.com/adamstz/protect-item-alarm.git
-commit=44d8b7ee7ad4b7a9179ef4aa973a9ede068427bb
+commit=9fa559f698bb1aaa0a1c485da75f58dc4996427f

--- a/plugins/protect-item-alarm
+++ b/plugins/protect-item-alarm
@@ -1,0 +1,2 @@
+repository=https://github.com/adamstz/protect-item-alarm.git
+commit=1d5e58d27000ca04a1ce2ce6353b708fc49f3f45


### PR DESCRIPTION
## What it does

Flashes the screen (a continuously strobing overlay, styled after Wilderness Player
Alarm's approach rather than a one-shot flash) for as long as you're in a PvP-risk
area — the Wilderness, or a PvP/High Risk world outside the safe zone — without the
Protect Item prayer active.

Two things this adds on top of the existing Protect Item Notify plugin, which shows
a static, silent overlay icon in the same situation:
- An actual repeating visual alarm instead of a silent icon.
- An "only alarm when skulled" option, to restrict the alarm to the highest-stakes
  moments instead of any time you're unprotected in the Wilderness.

Configurable flash speed/color, an "ignore High Risk worlds" toggle, no network
calls, no third-party dependencies beyond runelite-client.