### PR TITLE
grand-flip-out: update to 92de193

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=fa2e57cc64510e37f826c1c2ceb81b7d94eba82e
+commit=92de193e492cf830bcf90ad8c878ac07769ae8bf


### PR DESCRIPTION
Updates grand-flip-out to 92de193.

Fixes an advisor request-amplification bug: the intelligence badge fetch was issued from per-card rendering with no in-flight guard, so one render pass over N cards issued N requests and overlapping passes re-issued them. Failures also cached nothing, so a persistently failing item re-fired on every repaint with no backoff.

- in-flight claim taken before dispatch, released in a finally
- failures cached with their own longer TTL so they back off
- regression cover: AdvisorFetchDedupeTest, red-green verified (3/3 fail pre-fix)

Build: gradle JDK-11, 128 tests / 33 suites, 0 failures. No new dependencies, no banned APIs.