### PR TITLE
Update custom-hp-bar with full release

### DIFF
--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=97d68a77e8e97bf681a814b9e81fe9fe7f7f6d96
+commit=0c38280ee5279b7e8fe66e5c0065797c2ccda9ae

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=0c38280ee5279b7e8fe66e5c0065797c2ccda9ae
+commit=b40c1b541fb50b21e140557a278804abb0d618c5

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=b40c1b541fb50b21e140557a278804abb0d618c5
+commit=6e23d2f4309529efa4db5ef8317a541e737e926b

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,0 +1,2 @@
+repository=https://github.com/waitstepbro/custom-hp-bar.git
+commit=97d68a77e8e97bf681a814b9e81fe9fe7f7f6d96

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=6e23d2f4309529efa4db5ef8317a541e737e926b
+commit=91fe900114d5df691a8cb19f2ed30f666a39c4f7


### PR DESCRIPTION
New

- Prayer bar: "Hide Prayer Bar While Not Praying" toggle (default off) — restricts the bar to while a prayer is actually draining
- Prayer flicking no longer strobes the bar — was re-sampled every frame, so it vanished for the off-half of each flick

Fixed

- Talk-only NPCs no longer get HP bars — Cam Torum guards carry a combat level but can't be attacked; they keep their name, lose the bar
- Aggression timer now uses the game's real area-scoped tolerance mechanic, so expiry no longer recolors every hostile NPC on screen
- Bars appear immediately after login/teleport instead of waiting for the first hitsplat
- Moons of Peril: Enraged boss forms and Blue Moon tornadoes no longer get phantom bars; Blood jaguar shows percent and never greys out; the Ironman grey-out exemption now survives non-breaking spaces in boss names
- Vasa Normal/Challenge Mode HP read live (shared NPC IDs)
- ToA minions fall back to percent rather than a wrong raid-level-only number
- Bleed no longer tracked for NPCs/other players — it's local-player-only