### PR TITLE
add item-sync

### DIFF
--- a/plugins/item-sync
+++ b/plugins/item-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/ZachRouan/runelite-item-sync.git
+commit=f0f4feada08e7eade7bf2d31ae8490a52f7aaec0


### PR DESCRIPTION
Item Sync sends the player's bank, worn equipment and inventory to a single HTTP endpoint they configure, so their own tooling can answer "do I have the materials for this?" without checking in game. No public API exposes item contents, so the data has to come from the client.

**Network surface:** one POST of JSON to the one URL set in config, with the user's token in an `X-Sync-Token` header. Nothing is sent while the URL or token is blank, and no other host is ever contacted. It reads no chat, no location and no credentials. This follows the same user-configured-endpoint pattern as dink.

**Behaviour:**
- Syncs on bank and equipment container changes, debounced 3s. Inventory never triggers an upload on its own — it is included alongside those syncs, since it changes every few seconds while playing.
- Bank placeholders are skipped, and noted/un-noted stacks are merged via `ItemManager.canonicalize` so quantities report under the item's real name.
- Skipped entirely on tournament, beta, deadman, PvP Arena, seasonal, fresh start, LMS and quest speedrunning worlds.
- Upload failures are logged and otherwise ignored, so gameplay is never interrupted.

No third-party dependencies beyond what runelite-client already provides (OkHttp, Gson). `build=standard`.