### PR TITLE
Fate Locked Ironman: unified Plugin Hub update

### DIFF
--- a/plugins/fate-locked-ironman
+++ b/plugins/fate-locked-ironman
@@ -1,2 +1,2 @@
 repository=https://github.com/Nubles/RS3-Fate-Locked-Runelite.git
-commit=5cc1ffc4e4f684a99211f12342a69ceb6d16de30
+commit=1e118ec73f5a0fad17fc7b0704461a602d169041


### PR DESCRIPTION
## Update

Pins Fate Locked Ironman from `5cc1ffc4e4f684a99211f12342a69ceb6d16de30` to `1e118ec73f5a0fad17fc7b0704461a602d169041`.

This update consolidates the complete plugin into one sidebar and keeps all retained settings in independently collapsible sections. It also replaces the former online-sync behavior with an explicit inbound-only companion pairing flow:

- RuneLite generates the pairing code and opens the fixed GitHub Pages companion.
- The plugin makes only `GET https://fate-relay.fatelocked.workers.dev/r/<32-lowercase-hex-code>` requests, optionally with `If-None-Match`.
- There is no local server, localhost dependency, gameplay-data upload, request body, or legacy `/events`, `/acks`, `/suggest`, or `/state` route.
- Detected gameplay events remain in a bounded local history and are not transferred to the web Roll Inbox.
- Imported rules must be complete, current, account-bound v4 bundles; invalid, stale, legacy, future, or wrong-account data never replaces the active rules.

The previously approved Travel Guardian behavior remains opt-in and fail-open. It never performs gameplay, selects an alternative, moves the player, rolls, or changes unlocks. A click is consumed only when fresh exact rules prove it Locked; Allowed, Unknown, ambiguous, stale, malformed, and wrong-account cases pass through.

Panel legibility fixes are included: full collapsible header sizing, opaque color previews without text bleed, and separate Keys, Omni Keys, and Chaos Keys rows.

## Verification

- `gradle clean check verifyPluginHubJar --no-daemon`
- 258/258 tests passed across 43 suites; 0 failures, 0 errors, 0 skipped
- packaged-JAR gate rejects shaded RuneLite/runtime dependencies, forbidden write routes, localhost, legacy relay clients, and request bodies
- source audit confirmed one `@PluginDescriptor`, one navigation button, Java 11, standard Plugin Hub build, and no reflection, JNI, subprocesses, dynamic loading, or embedded server
- live same-PC matrix confirmed one sidebar, all retained settings, explicit pairing, valid v4 import, conditional 304 reads, and no legacy route requests

The Plugin Hub manifest diff is intentionally limited to the single `commit=` value.