### PR TITLE
Update inf-colo-additions

### DIFF
--- a/plugins/inf-colo-additions
+++ b/plugins/inf-colo-additions
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/bop-plugins.git
-commit=80293772d232b6119551ed2ab02be911955336b1
+commit=6ce8337b496bbd97d8ad2e1a65c4fb15b8908e59


### PR DESCRIPTION
Check for worldView changes to better know when to reload scene on entering/leaving colosseum

Fixed so that entering with only "hide colo pillars" enabled would still reload scene