### PR TITLE
Add face-swap

### DIFF
--- a/plugins/face-swap
+++ b/plugins/face-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/face-swap.git
-commit=b221f24eeda2ab8b27da92af4350068ef1fbf495
+commit=69d7374d2bd9358be5a46b07e441e9c76dddd429

--- a/plugins/face-swap
+++ b/plugins/face-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/face-swap.git
-commit=9503adc386aed69fc6d32fbac01c59d94196f7e8
+commit=e1122beb4d9b9d75188d41325667aab0dc129fce

--- a/plugins/face-swap
+++ b/plugins/face-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/face-swap.git
-commit=fe023f9cdf3140c64a9354b94c7d11e5299f4496
+commit=9503adc386aed69fc6d32fbac01c59d94196f7e8

--- a/plugins/face-swap
+++ b/plugins/face-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/face-swap.git
-commit=69d7374d2bd9358be5a46b07e441e9c76dddd429
+commit=6e351d05a25d274671607f8bc50cdf70789e8cc3

--- a/plugins/face-swap
+++ b/plugins/face-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/face-swap.git
-commit=e1122beb4d9b9d75188d41325667aab0dc129fce
+commit=b221f24eeda2ab8b27da92af4350068ef1fbf495

--- a/plugins/face-swap
+++ b/plugins/face-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/face-swap.git
-commit=fe023f9a8ec0bca5bd78fc05132c2f4e0359bf45
+commit=fe023f9cdf3140c64a9354b94c7d11e5299f4496

--- a/plugins/face-swap
+++ b/plugins/face-swap
@@ -1,0 +1,2 @@
+repository=https://github.com/vahnx/face-swap.git
+commit=b8c314b6f0c578e53b9538968bdd55031604a28b

--- a/plugins/face-swap
+++ b/plugins/face-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/face-swap.git
-commit=2f33a82f6cf1209016e2ebf282498b911265ad8e
+commit=fe023f9a8ec0bca5bd78fc05132c2f4e0359bf45

--- a/plugins/face-swap
+++ b/plugins/face-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/face-swap.git
-commit=799eb83c4359b951734cf60ce262df7dc76f5b80
+commit=2f33a82f6cf1209016e2ebf282498b911265ad8e

--- a/plugins/face-swap
+++ b/plugins/face-swap
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/face-swap.git
-commit=b8c314b6f0c578e53b9538968bdd55031604a28b
+commit=799eb83c4359b951734cf60ce262df7dc76f5b80


### PR DESCRIPTION
Adds Face Swap, a RuneLite plugin that lets you place faces on you or other in-game characters or NPCs.

Features include:

- Pick from a selection of your favorite content creators
- Target your player, friends, clanmates or anyone around you in-game to apply them
- Apply them a 3D model or mask
- Browse your own creations from your computer