### PR TITLE
Add tcg-exporter plugin

### DIFF
--- a/plugins/tcg-exporter
+++ b/plugins/tcg-exporter
@@ -1,0 +1,2 @@
+repository=https://github.com/kolox-/tcg-exporter.git
+commit=5f85faa2239acdc0b84c62b997e26cf1e8b45a87


### PR DESCRIPTION
This is a very simple plugin to allow exporting the player's osrs-tcg data to their location of choice.

The purpose is to allow users to create their own tools using their (or their group's) collection, for example a shared log web UI (see [example](https://github.com/kolox-/tcg-pool-template)).

Player provides a webhook, an API key, and the period for checking for updates to the checkpoint.

Uses hybrid update method:
- live updates triggered by osrs-tcg plugin with bare minimum info
- per-period checkpoint scanning: the checkpoint is only updated on logout and `::tcg-save` commands, but contains foil info and more accurate found timestamp

Without webhook provided, the plugin does nothing. Warnings are enabled on the plugin settings.

For disclosure, AI was used when creating this plugin, but I have manually tested and reviewed, and it is extremely simple.