### PR TITLE
Update Combat Achievement Helper

### DIFF
--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=436ddbe7dad83d85b528863bec24a8ac30cb699d
+commit=1e30b47359649fb1b89dfaf1878868c5f229f412

--- a/plugins/combat-achievement-helper
+++ b/plugins/combat-achievement-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/opaf-osrs/combat-achievement-helper.git
-commit=1e30b47359649fb1b89dfaf1878868c5f229f412
+commit=7a1e8857b363aa9c6bb152efd50cd5cf2325d06e


### PR DESCRIPTION
fixes wrong tier progress for anyone with maggot king CAs done. the completion bitfield stopped at 640 bits but the game is up to 646 tasks now, so those six always read as incomplete. also reads the games own points varbit as the source of truth for tier progress so this class of bug cant show a wrong tier again. reported by a user who was told he needed 19 points for master while already having master.