### PR TITLE
Add farming-contract-helper

### DIFF
--- a/plugins/farming-contract-helper
+++ b/plugins/farming-contract-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Leagen312/farming-contract-helper.git
+commit=168b6933f48ad57da11bf87449d36f7d3fbe736b

--- a/plugins/farming-contract-helper
+++ b/plugins/farming-contract-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/Leagen312/farming-contract-helper.git
-commit=168b6933f48ad57da11bf87449d36f7d3fbe736b
+commit=7768cd21ea25ef2692c9facfaa6043bf56cf3397


### PR DESCRIPTION
Adds **Farming Contract Helper**, an informational plugin for the Farming Guild contract.

Repo: https://github.com/Leagen312/farming-contract-helper

### What it does

Shows the player's current Farming Guild contract in a side panel and an optional compact overlay: the assigned crop, which patch it belongs in and where that patch is, the seed or sapling required, the crop-specific gardener protection payment, whether those items are to hand, the patch's crop state, and an estimated completion time.

### Read-only

No automation, no input injection, no menu entries or modifications, no network requests, no analytics, no reflection, no runtime wiki scraping. It reads the NPC dialogue widget, patch varbits and item containers, then draws text and does arithmetic. All crop and payment data is bundled locally.

### Contract detection

There is no farming contract varbit, so the contract is parsed from Guildmaster Jane's dialogue and persisted per RS profile. As a starting value it will also read the contract that the built-in Time Tracking plugin has already stored, via `ConfigManager.getRSProfileConfiguration` — a plain config read, not a dependency on that plugin's classes. A crop merely being planted in the guild is never treated as evidence of a contract.

### Note on vendored code

`src/main/java/com/farmingcontract/farming/` contains `Produce`, `CropState`, `PatchState` and `PatchImplementation` copied from the client's Time Tracking farming package, reproduced under their original BSD-2-Clause licence with the copyright notices retained (© 2018/2019 Abex, © 2018 NotFoxtrot).

`PatchImplementation.forVarbitValue()` and `PatchState` are package-private and the package belongs to another plugin, so there is no supported way for a hub plugin to call them — but those decode tables are the only correct way to turn a farming patch varbit into a crop and growth state. Changes are limited to the package name, removing the `Tab` field, widening `forVarbitValue()` to public, and reducing patch types the Farming Guild does not use to inert stubs. Happy to take direction if you would prefer this handled differently.

### Other

- Java 11, standard build, BSD-2 licence, no committed build artifacts
- Item, varbit and NPC ids use `net.runelite.api.gameval` constants throughout
- Patch objects are tracked from spawn/despawn events rather than scanning the scene each frame
- 89 unit tests covering the crop/patch/seed/payment data, dialogue and game-message parsing, tick arithmetic, contract state transitions and account switching