### PR TITLE
Update paint-overlays to 1.2.0

### DIFF
--- a/plugins/paint-overlays
+++ b/plugins/paint-overlays
@@ -1,2 +1,2 @@
 repository=https://github.com/vahnx/paint-overlays.git
-commit=c4c54ca06640f03552f05e8550755195c21e920f
+commit=ce3291089eb0fe1d605c5302017f9a0fbdee9c1a


### PR DESCRIPTION
Update Paint Overlays to release 1.2.0.

- Added more stamps
- Minor UI tweaks
- Fix to ESC while erasing