### PR TITLE
Add daily xp tracker plugin v1

### DIFF
--- a/plugins/daily-xp-tracker
+++ b/plugins/daily-xp-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/zachgiaco/daily-xp-tracker.git
+commit=a45e5682a5137e90a671c1134b2523036140dfb4

--- a/plugins/daily-xp-tracker
+++ b/plugins/daily-xp-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/zachgiaco/daily-xp-tracker.git
-commit=a45e5682a5137e90a671c1134b2523036140dfb4
+commit=8fb5236981c5a5e499029c86e0a569a9d4e75457


### PR DESCRIPTION
New plugin that tracks daily XP gains in one or more skills over 24 hours or within the last day(starting at midnight). Also has history, trends and limited goals functionality.