### PR TITLE
Add initial Collection Log Exporter RuneLite plugin

### DIFF
--- a/plugins/collection-log-exporter
+++ b/plugins/collection-log-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/collection-log-exporter.git
-commit=8ccb84cf156d626b90fc802cc92f19c6960784ef
+commit=fe29cb7f1dfe152de90aa549f6da111eae3d346f

--- a/plugins/collection-log-exporter
+++ b/plugins/collection-log-exporter
@@ -1,0 +1,2 @@
+repository=https://github.com/xboxnuker-rgb/collection-log-exporter.git
+commit=8ccb84cf156d626b90fc802cc92f19c6960784ef

--- a/plugins/collection-log-exporter
+++ b/plugins/collection-log-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/collection-log-exporter.git
-commit=fe29cb7f1dfe152de90aa549f6da111eae3d346f
+commit=bec511632404abbf3c0c615a523ca930d4f8735a

--- a/plugins/collection-log-exporter
+++ b/plugins/collection-log-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/collection-log-exporter.git
-commit=bec511632404abbf3c0c615a523ca930d4f8735a
+commit=efa560ba867cfd8a078127ad5e53b7b3606fe43f


### PR DESCRIPTION
Initial public repository for the Collection Log Exporter plugin.

- Syncs and deduplicates Collection Log items
- Uses KC data from page headers, Jagex hiscores and local cache
- Exports sortable XLSX, ODS and CSV reports with ETA calculations
- Includes GSVS branding, toolbar icon and tests
- Documents bundled estimate data and third-party attribution