### PR TITLE
Update Slayer Best in Bank: quiver and bank interaction hotfix

### DIFF
--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=02932daafab80d7829aa13a452e250d28f546ae2
+commit=251cf8c396abf442dc6708a9b648e832968e5783


### PR DESCRIPTION
## What changed

- Detect loaded Dizana's quiver ammunition and recommend the strongest owned Prayer blessing when the loadout retains the quiver.
- Keep cannon parts, cannonballs, and other preparation supplies stable during sequential withdrawals.
- Add explicit Isle of Stone and Waterbirth Dagannoth cannon methods.
- Prevent Best-in-Bank from rewriting active Bank Tags or Inventory Setups layouts.

## Why

This hotfix addresses duplicate ammunition recommendations, shifting cannon withdrawal entries, a missing Dagannoth route, and conflicts with externally owned bank layouts.

## Validation

- Clean full Gradle test suite passes.
- Plugin Hub manifest points to merged source commit `251cf8c396abf442dc6708a9b648e832968e5783`.
- Manifest diff validation passes.