### PR TITLE
Update PvM Tools to 1.1.1

### DIFF
--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=a379fe075b205000138750a04772a99286f254eb
+commit=4e66dd4e972c50cf0b39fb8848b99131d6b69cc7


### PR DESCRIPTION
## Summary
- replace properties-based plugin version lookup with `ExternalPluginManager.getDisplayData(...)`
- use the Plugin Hub `DisplayData` version as the runtime source of truth
- bump PvM Tools to 1.1.1

This addresses @coopermor's review feedback on #14191.

## Verification
- `./gradlew clean test` (JDK 21)