### PR TITLE
Update target-true-tile

### DIFF
--- a/plugins/target-true-tile
+++ b/plugins/target-true-tile
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/runelite-target-true-tile.git
-commit=1e6a91ec9908290c811f97b0165a003b03ccc64b
+commit=c20c412959e8595d3ec785effb2025b072d59a34
 authors=Notloc

--- a/plugins/target-true-tile
+++ b/plugins/target-true-tile
@@ -1,3 +1,3 @@
 repository=https://github.com/Notloc/runelite-target-true-tile.git
-commit=0d802e6894c1db46560496ce2b0170c4e06a96e9
+commit=1e6a91ec9908290c811f97b0165a003b03ccc64b
 authors=Notloc

--- a/plugins/target-true-tile
+++ b/plugins/target-true-tile
@@ -1,4 +1,3 @@
 repository=https://github.com/Notloc/runelite-target-true-tile.git
-commit=efe38d1089ed318bdf75d94b695494ac62f6a4c3
+commit=0d802e6894c1db46560496ce2b0170c4e06a96e9
 authors=Notloc
-unavailable=This plugin is unavailable due to destabilizing the client


### PR DESCRIPTION
Move the list clears to the top of render to prevent memory leakage when the render loop is failing.