### PR TITLE
Add GE Trends Portfolio

### DIFF
--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,0 +1,2 @@
+repository=https://github.com/kbosch2000/ge-trends-portfolio.git
+commit=eefabff76c383c2e44d9f08df2b54f61a2723f59

--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,2 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
 commit=eefabff76c383c2e44d9f08df2b54f61a2723f59
+warning=This plugin submits your IP address and your Grand Exchange offer data to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
Adds **GE Trends Portfolio**, an opt-in read-only plugin that synchronizes the user's own Grand Exchange offer snapshots with their private portfolio at https://ge-trends.vercel.app.

## Data and consent
- Cloud synchronization is disabled by default.
- Enabling it shows the required third-party-server warning.
- The fixed HTTPS endpoint receives only slot, item ID, offer state, filled/requested quantities, cumulative spent/received coins, offer price, observation time, and a revocable portfolio-only token.
- It does not submit RSN, account hash, RuneLite identity, inventory, bank, equipment, location, chat, or other-player data.
- Privacy details: https://github.com/kbosch2000/ge-trends-portfolio/blob/main/PRIVACY.md

## Security and implementation
- Fixed HTTPS destination; no configurable URL.
- Uses RuneLite-injected OkHttp and Gson.
- No extra dependencies, reflection, native code, subprocesses, input, overlays, or game actions.
- Java 11 CI and unit tests pass.

The PR is draft while final in-game partial-fill/relog verification is completed.