### PR TITLE
osrs-tcg-exchange: new plugin

### DIFF
--- a/plugins/osrs-tcg-exchange
+++ b/plugins/osrs-tcg-exchange
@@ -1,4 +1,4 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Exchange-TheCardExchange.git
-commit=008ebabdb904711cc48baf7ae73da1e1eab16bfe
+commit=a677e41426a93cd24e91f349cb3dd61dbcb31417
 authors=CompilerOfDust
 warning=This plugin opens pages on osrscardexchange.com, a third-party website not controlled or verified by the RuneLite developers. Those page addresses include your RuneScape display name and the display name of the player you choose to trade with.

--- a/plugins/osrs-tcg-exchange
+++ b/plugins/osrs-tcg-exchange
@@ -1,0 +1,4 @@
+repository=https://github.com/CompilerOfDust/OSRS-TCG-Exchange-TheCardExchange.git
+commit=5743d627ee73991f7aa83e5a065f6a2539fce67a
+authors=CompilerOfDust
+warning=This plugin opens pages on osrscardexchange.com, a third-party website not controlled or verified by the RuneLite developers. Those page addresses include your RuneScape display name and the display name of the player you choose to trade with.

--- a/plugins/osrs-tcg-exchange
+++ b/plugins/osrs-tcg-exchange
@@ -1,4 +1,4 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Exchange-TheCardExchange.git
-commit=5743d627ee73991f7aa83e5a065f6a2539fce67a
+commit=008ebabdb904711cc48baf7ae73da1e1eab16bfe
 authors=CompilerOfDust
 warning=This plugin opens pages on osrscardexchange.com, a third-party website not controlled or verified by the RuneLite developers. Those page addresses include your RuneScape display name and the display name of the player you choose to trade with.


### PR DESCRIPTION
Adds **OSRS TCG Exchange** — a plugin for trading OSRS TCG cards with other players and opening the Card Exchange marketplace from in game.

- Right-click another player (beneath the game's *Trade with*) to open a trade page in the browser. Both players deterministically derive the **same** RuneLite Party passphrase from their alphanumerically-ordered RSN pair — no offer, no accept step and no polling.
- Right-click a Grand Exchange Clerk (beneath *Exchange*) to open the Card Exchange marketplace.

The plugin makes **no HTTP/API calls** — it only opens URLs on osrscardexchange.com. Those URLs include the two RuneScape display names, which is disclosed in the manifest `warning` and in the plugin's own UI. Trading is RSN-only: no account, no login, no token.

Repository: https://github.com/CompilerOfDust/OSRS-TCG-Exchange-TheCardExchange
Author: CompilerOfDust