### PR TITLE
anvil: keep the home board visible when federated (+ sidebar/federation/recap update)

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=fb8a8e0fb4394725a096a82829007d57305ec228
+commit=bdff7e8d152b8d4135978d6cdac4a0ed9b33a0a6

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=bdff7e8d152b8d4135978d6cdac4a0ed9b33a0a6
+commit=291aa63df301060bf00e4f8047af07fd5978cbb8

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=c866dc7f3a9d9dda4707c41b62207ba838ea38df
+commit=fb8a8e0fb4394725a096a82829007d57305ec228

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=291aa63df301060bf00e4f8047af07fd5978cbb8
+commit=2ab48dbaffe50ef032b63e14ca4c880222bb7cf4

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=344f362ea0b60a67d8a375e6d03fd512ac719978
+commit=c866dc7f3a9d9dda4707c41b62207ba838ea38df

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=8a01107d5d5afcf0911f8f80c946aac5024c86c2
+commit=344f362ea0b60a67d8a375e6d03fd512ac719978


### PR DESCRIPTION
Updates the Anvil plugin.

Changes since the pinned commit:
- Sidebar: keep the member's own clan board visible when they're federated with other clans (it could previously disappear, leaving only the relayed clans).
- Sidebar: score Leagues/points boards by point weight; exclude optional (bonus) tiles from the point and count totals.
- PvP kill tiles: honour the site-configured minimum loot value before crediting.
- Clearer in-game notice when the account token is rejected or the site is unreachable.