### PR TITLE
add live-on-clan

### DIFF
--- a/plugins/live-on-clan
+++ b/plugins/live-on-clan
@@ -1,2 +1,3 @@
 repository=https://github.com/MilicoOSRS/live-on-clan.git
 commit=ce282d7f8ba1aa826a71b9d82b39eb588ae277cc
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/live-on-clan
+++ b/plugins/live-on-clan
@@ -1,0 +1,2 @@
+repository=https://github.com/MilicoOSRS/live-on-clan.git
+commit=63d7e6754212c4ed74086fcd0ed4a7560e2994d1

--- a/plugins/live-on-clan
+++ b/plugins/live-on-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/MilicoOSRS/live-on-clan.git
-commit=a5a140fda8df32af5b6ce5978c85aa9b154e4b5d
+commit=ce282d7f8ba1aa826a71b9d82b39eb588ae277cc

--- a/plugins/live-on-clan
+++ b/plugins/live-on-clan
@@ -1,2 +1,2 @@
 repository=https://github.com/MilicoOSRS/live-on-clan.git
-commit=63d7e6754212c4ed74086fcd0ed4a7560e2994d1
+commit=a5a140fda8df32af5b6ce5978c85aa9b154e4b5d


### PR DESCRIPTION
Adds the Live On Clan plugin.

Features clan announcements, rank requests, monthly MVP rankings, and Twitch live status for members of Wise Old Man group 1945.

Third-party integrations are opt-in and disabled by default. The plugin connects to the clan API only after the user accepts RuneLite's third-party warning.

Validated with Java 11 using `./gradlew clean test jar`.