### PR TITLE
Update GE Trends companion

### DIFF
--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,3 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
-commit=9a0117a7669895c0fa8627a91549d37a89fc4a8c
+commit=87e605d8f0c9662cd8f546109beb73275b9b8c0f
 warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value from inventory-plus-bank coins and platinum tokens to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,3 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
-commit=3511672a3b5389dd0808f74745d92a343ff2d753
+commit=e4420631282d0f7af89365b28e572662de3817c3
 warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value from inventory-plus-bank coins and platinum tokens to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,3 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
-commit=eb73466a1b71f945734d4bf3892dfb0bd0ea1d30
+commit=9d1431553746d47880c8b290c886c6431e546416
 warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value from inventory-plus-bank coins and platinum tokens to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,3 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
-commit=87e605d8f0c9662cd8f546109beb73275b9b8c0f
+commit=ac825f74dbeac0cbd69c9b8d55c016546eb1370a
 warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value from inventory-plus-bank coins and platinum tokens to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,3 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
-commit=2fd9d515d9c3f17aaf7ebcba146c7068539440e2
-warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate inventory-plus-bank coin balance to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.
+commit=9a0117a7669895c0fa8627a91549d37a89fc4a8c
+warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value from inventory-plus-bank coins and platinum tokens to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,3 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
 commit=3511672a3b5389dd0808f74745d92a343ff2d753
-warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value to GE Trends; retrieve your connected portfolio summary; and send item searches to prices.runescape.wiki. These are 3rd-party servers not controlled or verified by RuneLite developers.
+warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value from inventory-plus-bank coins and platinum tokens to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,3 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
-commit=9d1431553746d47880c8b290c886c6431e546416
-warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value from inventory-plus-bank coins and platinum tokens to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.
+commit=3511672a3b5389dd0808f74745d92a343ff2d753
+warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value to GE Trends; retrieve your connected portfolio summary; and send item searches to prices.runescape.wiki. These are 3rd-party servers not controlled or verified by RuneLite developers.

--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,3 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
-commit=ac825f74dbeac0cbd69c9b8d55c016546eb1370a
+commit=eb73466a1b71f945734d4bf3892dfb0bd0ea1d30
 warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value from inventory-plus-bank coins and platinum tokens to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,3 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
-commit=e4420631282d0f7af89365b28e572662de3817c3
+commit=afa57d48ab94e71bca5c3c6c2d8cdb6ae40c1950
 warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate GP value from inventory-plus-bank coins and platinum tokens to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/ge-trends-portfolio
+++ b/plugins/ge-trends-portfolio
@@ -1,3 +1,3 @@
 repository=https://github.com/kbosch2000/ge-trends-portfolio.git
-commit=eefabff76c383c2e44d9f08df2b54f61a2723f59
-warning=This plugin submits your IP address and your Grand Exchange offer data to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.
+commit=2fd9d515d9c3f17aaf7ebcba146c7068539440e2
+warning=This plugin can submit your IP address, Grand Exchange offer data, and an optional aggregate inventory-plus-bank coin balance to GE Trends, a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
Expands the existing read-only tracker into **GE Trends**, a RuneLite companion with:

- a sidebar portfolio summary for the connected token owner;
- live OSRS Wiki item search, high/low prices, spread, buy limit, and a 30-day chart;
- an explicit button opening the GE Trends website; and
- the existing partial-fill, offer, coin, and platinum-token tracking unchanged.

## Data and consent
- Cloud portfolio sync remains disabled by default and retains its third-party warning.
- Market lookup is separately disabled by default and has its own prices.runescape.wiki warning.
- The connection token may retrieve only its owner's summarized portfolio and holdings. It cannot sign in, change account settings, access another user, or interact with the game.
- Wiki requests contain an item ID and normal network metadata, but never the GE Trends token or RuneLite identity.
- Updated privacy details: https://github.com/kbosch2000/ge-trends-portfolio/blob/main/PRIVACY.md

## Security and implementation
- All destinations are fixed HTTPS endpoints disclosed in source and documentation.
- Java 11 only, using RuneLite's injected OkHttpClient and Gson.
- No new dependency, reflection, native code, subprocess, input automation, menu manipulation, or configurable destination.
- Plugin tests and the packaged development build pass.