### PR TITLE
Update Kill Clog to 1.6.5

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=3b28d6083efd39538e3c7cf16bc8fdb117ad95b7
+commit=074a557ba7b5f579ee1bbafc0fd1c122338f541c
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill Clog 1.6.5

* fixes boss kcs showing empty after today's update: the hiscores added Mad Angel and reshuffled the boss order, this release tracks the new order
* Mad Angel kc parses and works in !kclog today, its panel cell lands once RuneLite ships the new HiscoreSkill entry
* boss tooltips now say when boss data is unavailable during a hiscore format change instead of showing a blank grid