### PR TITLE
Add Private Group Manager

### DIFF
--- a/plugins/private-group-manager
+++ b/plugins/private-group-manager
@@ -1,2 +1,2 @@
 repository=https://github.com/charlie1991cooper-ops/private-group-manager.git
-commit=4894b3bb454494e830480d74c9a32405db6131a5
+commit=8337e70d51c0813d21b39f49d4824c504fa09e9d

--- a/plugins/private-group-manager
+++ b/plugins/private-group-manager
@@ -1,0 +1,2 @@
+repository=https://github.com/charlie1991cooper-ops/private-group-manager.git
+commit=4894b3bb454494e830480d74c9a32405db6131a5


### PR DESCRIPTION
Adds Private Group Manager to the Plugin Hub.

Private Group Manager allows players to create temporary private groups without requiring a Clan Chat or Friends Chat. It includes privacy reminders, group roles, membership controls, shared world calls, tile pings, and optional Entity Hider integration.

Designed for PvM, events, and other organised group activities.