### PR TITLE
slayer-codex: bump to 55e8f28

### DIFF
--- a/plugins/slayer-codex
+++ b/plugins/slayer-codex
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/SlayerCodexPlugin.git
-commit=55e8f28f473a0e835c549da083e738974cd2daad
+commit=59737889503f5b1f4976d2741f74a6811942b61e

--- a/plugins/slayer-codex
+++ b/plugins/slayer-codex
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/SlayerCodexPlugin.git
-commit=4b0de406ffac6d9ea1cfb1c009b40b6b160e2158
+commit=55e8f28f473a0e835c549da083e738974cd2daad


### PR DESCRIPTION
Bumps Slayer Codex from `4b0de40` to `55e8f28`.

Slayer Codex is an information-only sidebar panel: it detects your current Slayer assignment and shows wiki-sourced gear tiers per slot next to the best matching gear you already own. All reference data is bundled as a gzipped resource, so there are no runtime HTTP calls.

### Changes since the currently pinned commit

- **Fixes task to monster resolution.** 12 tasks previously resolved to the wrong monster - a "Hydras" task showed Alchemical Hydra gear, "Rats" showed Barbarian Assault, "Ents" showed Ancient Wyvern. Matching is now exact name, then a plural fold, then a small explicit alias table. Anything else resolves to nothing and the panel shows a "no strategy bundled" state with a wiki link, since bad gear advice is worse than none.
- **Revives boss-variant mapping.** 14 of 17 mappings were dead because they keyed off base monster keys with no page in the dataset. Hellhounds/Cerberus, Kalphites/Kalphite Queen, Blue dragons/Vorkath and 11 others now resolve.
- **Scopes the item-name index** to only the names the bundled dataset can actually ask about, rather than retaining name variants for every item in the game.
- **Adds gear data** for Turoth, Cave horrors, Gryphons and Warped creatures, and folds a duplicate dataset entry (`aquanite`/`aquanites`) into one.
- **Adds a regression suite** covering all 115 assignable task names, plus the new Mortimer master's 29 tasks spelled as the game's own SlayerTask table spells them.
- Replaces a non-ASCII character in the hub description with an ASCII hyphen.

### Notes

No new dependencies: `net.runelite:client` remains `compileOnly`, Lombok is compile-time only, and junit is test-only. No reflection, no runtime network access, and the plugin performs no game actions.

15 tests pass on the pinned commit.
