### PR TITLE
Add Goat Pit Indicators

### DIFF
--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
-commit=6323a22ab706f2120c0ab1669839cad3618c1e4a
+commit=151a4eda35ec9a20a278dcfee8d826df977dec68

--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
-commit=151a4eda35ec9a20a278dcfee8d826df977dec68
+commit=a6efcae61c1a624288246ca5923e405a18fc5596

--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
+commit=6323a22ab706f2120c0ab1669839cad3618c1e4a


### PR DESCRIPTION
Adds Goat Pit Indicators, a RuneLite plugin that draws a goat pit's fill level (`X / 20`) and a spikes-needed warning directly on the pit.

Repository: https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin
License: BSD 2-Clause