### PR TITLE
Add GIM Discord Tracker

### DIFF
--- a/plugins/gim-discord-tracker
+++ b/plugins/gim-discord-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JackBexo/gim-tracker-plugin.git
-commit=1371bb761cc0f43a224447c57a34c08882fd153c
+commit=6936631ea3ae42075101c38dedd11a9ca1c51129

--- a/plugins/gim-discord-tracker
+++ b/plugins/gim-discord-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/JackBexo/gim-tracker-plugin.git
+commit=1371bb761cc0f43a224447c57a34c08882fd153c


### PR DESCRIPTION
Adds GIM Discord Tracker, a Group Ironman tracker for private groups.

Features:
- In-game side panel showing group members, online status, activity, skills and shared bank value
- Discord dashboard (auto-updating embed) and a two-way chat bridge between GIM clan chat and a Discord channel

Disclosure: this plugin sends game data (presence, location, skills, milestones, bank contents and GIM clan chat messages) to an external server hosted by the user's own group. The server URL and group token are configured by the user and nothing is sent until both are set. This is disclosed in the plugin description and README.

Source: https://github.com/JackBexo/gim-tracker-plugin