### PR TITLE
update voiced-dialogue

### DIFF
--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=45bdafb8b7211ed68b7d6472eea8a6fe8b026fef
+commit=987515897ecf3a98be7883604c0706a5e4034393
 authors=grabartley
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates voiced-dialogue to [v0.4.0](https://github.com/grabartley/runelite-voiced-dialogue/releases/tag/v0.4.0). The pinned commit is the `v0.4.0` release tag commit.

Highlights since v0.3.0:

- The Wyrmscraig Island cast now has full voice coverage, so the whole area speaks in-character.
- Added the Icyene race with its own distinct voices for a more fitting sound.
- Child NPCs now speak from a youthful, gender-correct voice pool, so kids actually sound like kids.

Thanks for taking a look!
