### PR TITLE
Add Gauntlet Tornado Timer

### DIFF
--- a/plugins/gauntlet-tornado-timer
+++ b/plugins/gauntlet-tornado-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/MakeDawn/hunllef-tornado-timer.git
+commit=c4c076acd381caa031db43e37e2b20374ab08fe2


### PR DESCRIPTION
Adds Gauntlet Tornado Timer, which displays the remaining lifetime beneath
active tornadoes during regular and Corrupted Hunllef encounters.

Features:
- Tracks each tornado independently
- Supports regular and Corrupted Hunllef
- Displays the remaining lifetime in ticks or seconds
- Configurable timer and final-five-ticks colors
- Removes the indicator when the tornado despawns

The plugin has been tested successfully in both encounters.

I initially proposed this feature to the existing The Gauntlet plugin, but
have not received a response from its maintainer. I am submitting it
separately for RuneLite's Plugin Hub review.

Plugin repository:
https://github.com/MakeDawn/hunllef-tornado-timer

Tested commit:
c4c076acd381caa031db43e37e2b20374ab08fe2