### PR TITLE
Disable Combat Lab

### DIFF
--- a/plugins/combat-lab
+++ b/plugins/combat-lab
@@ -1,0 +1,3 @@
+repository=https://github.com/arbeerby-pixel/combat-lab.git
+commit=1ca7452879198a1f03d969da2db1248ae22f066e
+disabled=Removed at plugin owner's request

--- a/plugins/combat-lab
+++ b/plugins/combat-lab
@@ -1,2 +1,0 @@
-repository=https://github.com/arbeerby-pixel/combat-lab.git
-commit=1ca7452879198a1f03d969da2db1248ae22f066e


### PR DESCRIPTION
## Summary

Disables Combat Lab in the RuneLite Plugin Hub at the plugin owner's request.

## Impact

The `disabled` manifest flag removes the plugin from active Plugin Hub distribution while preserving its audit history. The source repository is intentionally left intact.

## Validation

- The branch is based on the latest `runelite/plugin-hub` `master`.
- The only effective change is adding the official `disabled` flag to `plugins/combat-lab`.
- `git diff --check` passes.
