### PR TITLE
Update PvM Toolkit to 1.2.0

### DIFF
--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=a42a55ede65f1c9e5552d739cf2a2b82837af676
+commit=13fa1dfdee4a4a464a24d022d5a11366a611f8a6

--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=13fa1dfdee4a4a464a24d022d5a11366a611f8a6
+commit=dbbbc88333186a494f8f34c4cefc439a26e07abc

--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=fdc244157176702970db6e6f667481f67d80896e
+commit=a42a55ede65f1c9e5552d739cf2a2b82837af676

--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=4e66dd4e972c50cf0b39fb8848b99131d6b69cc7
+commit=fdc244157176702970db6e6f667481f67d80896e


### PR DESCRIPTION
## Changes
- Rename the visible plugin name from PvM Tools to PvM Toolkit while retaining the existing `pvm-tools` manifest and configuration identity.
- Add per-monster Slayer Log personal bests for task time, profit, and XP, including averages.
- Update the in-game update scroll so users can see the 1.2.0 changes.
- Make the update scroll pass gameplay clicks through everywhere except its own controls.
- Harden plugin startup, shutdown, item-name loading, loot valuation, and ground-item rendering during cache or login transitions.

## User impact
Existing installations, settings, trackers, and statistics remain under the same Plugin Hub entry. The plugin is more reliable when enabling, disabling, logging in, or changing worlds.

## Validation
- `gradlew clean test build --no-daemon`
- 20 tests passed with 0 failures
- Full development client started successfully with the normal plugin profile