### PR TITLE
Update Photoscape

### DIFF
--- a/plugins/photoscape
+++ b/plugins/photoscape
@@ -1,2 +1,2 @@
 repository=https://github.com/Viralmoment123/photoscape.git
-commit=7b43ef595782d7ce77c6950687246d979eb13ce5
+commit=1591880ce787c8946b85aa83b2644d8a9cb82ff8


### PR DESCRIPTION
rebuilding for the RuneLite 1.12.30 camera API change from double to float.