### PR TITLE
Update notification-panel to 2.1.0

### DIFF
--- a/plugins/notification-panel
+++ b/plugins/notification-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/KogasaPls/notification-panel.git
-commit=4c0173909a3fe4107d1d09d0175f44153cddffc2
+commit=b656aaf3ccc36212d36d28a3266ada5b5db244e3


### PR DESCRIPTION
Updates Notification Panel to 2.1.0, from `4c0173909a3fe4107d1d09d0175f44153cddffc2` to `b656aaf3ccc36212d36d28a3266ada5b5db244e3`.

- add a Notifications tab to the sidebar, showing recent notifications