### PR TITLE
Add kills-to-level

### DIFF
--- a/plugins/kills-to-level
+++ b/plugins/kills-to-level
@@ -1,0 +1,2 @@
+repository=https://github.com/neldra/kills-to-level.git
+commit=e83b1dcd4a70f0730f57699061e6344acab10a6f


### PR DESCRIPTION
Adds **Kills to Level**, an overlay showing how many kills remain until your next combat level, measured from your actual XP per kill.

https://github.com/neldra/kills-to-level — `build=standard`, no third-party dependencies, no network access, CI green on JDK 11 and 21.
