### PR TITLE
better-monster-examine: update to v1.5.2

### DIFF
--- a/plugins/better-monster-examine
+++ b/plugins/better-monster-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/prettyrocket/better-monster-examine.git
-commit=08572691e142ce5fadc0b6bb296a0618e723d0c6
+commit=354a6a6a4313edd134f235b7925bba0fc9e35be2


### PR DESCRIPTION
Updates **Better Monster Examine** to [`354a6a6a4313edd134f235b7925bba0fc9e35be2`](https://github.com/prettyrocket/better-monster-examine/commit/354a6a6a4313edd134f235b7925bba0fc9e35be2).

Released as **Better Monster Examine v1.5.2 — Drop-table accuracy & recovered stats** — https://github.com/prettyrocket/better-monster-examine/releases/tag/v1.5.2

---

## 🐛 Drop-table accuracy & recovered stats

A correctness release. The headline fix: drop tables that the wiki splits by **location or combat level** are no longer merged together, so a drop from one spot is never shown as a drop from everywhere.

**Drops**
- **Location/level tables stay separate** — a monster whose wiki page splits its drops (Cyclops' Warriors' Guild top floor vs. basement, Abyssal demon's Catacombs vs. Wilderness Slayer Cave) now keeps those tables apart, each under a band naming its location or level. Previously they were flattened together, which is what made the basement-only **Dragon defender** read as a drop from *every* Cyclops.
- **Collapsible sections** — location bands *and* the sections inside them can be collapsed, with collapse-all / expand-all per band and disclosure triangles to show state, so a long drop list is easy to skim.
- **Rarity shown as the wiki shows it** — odds now render in the wiki's own `1/x` form rather than the raw source fraction.
- **Redirects followed** — a monster whose page name is a redirect (e.g. `Hill giant` → `Hill Giant`) now resolves instead of coming back empty.

**Stats**
- **Vardorvis' Strength and Defence now show** — they previously rendered as a dash. The wiki writes his HP-scaling levels as ranges (`270-360`), which the wiki's structured-data store can't hold in a numeric column, so the values never reached the plugin. They're now recovered from the page itself, with the wiki's own footnote as a tooltip — a Defence that counts *down* (215→145) is the mechanic, not a bug.

**Full changelog:** https://github.com/prettyrocket/better-monster-examine/compare/v1.5.1...v1.5.2