### PR TITLE
Add FlipX plugin

### DIFF
--- a/plugins/flipx
+++ b/plugins/flipx
@@ -1,3 +1,3 @@
 repository=https://github.com/JoshiOS-VRY/osrs-flip-plugin.git
 commit=ddcf1b04911871e638b405f7bfd2293194da7319
-warning=This plugin submits your IP address and Grand Exchange activity to FlipX (https://www.flipx.gg) when you opt in to upload or market features. See https://www.flipx.gg/privacy.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/flipx
+++ b/plugins/flipx
@@ -1,3 +1,3 @@
 repository=https://github.com/JoshiOS-VRY/osrs-flip-plugin.git
-commit=a7e403182f3418c755cab8ffbd30760f466970e6
+commit=ddcf1b04911871e638b405f7bfd2293194da7319
 warning=This plugin submits your IP address and Grand Exchange activity to FlipX (https://www.flipx.gg) when you opt in to upload or market features. See https://www.flipx.gg/privacy.

--- a/plugins/flipx
+++ b/plugins/flipx
@@ -1,0 +1,3 @@
+repository=https://github.com/JoshiOS-VRY/osrs-flip-plugin.git
+commit=a7e403182f3418c755cab8ffbd30760f466970e6
+warning=This plugin submits your IP address and Grand Exchange activity to FlipX (https://www.flipx.gg) when you opt in to upload or market features. See https://www.flipx.gg/privacy.


### PR DESCRIPTION
## Summary

Adds **FlipX** — a Grand Exchange flipping companion that syncs manual GE activity to the FlipX web app and browses live flip opportunities inside RuneLite.

- **Repository:** https://github.com/JoshiOS-VRY/osrs-flip-plugin
- **Privacy policy:** https://www.flipx.gg/privacy
- **Web app:** https://www.flipx.gg

## Features

- **Opt-in GE upload** (disabled by default) — syncs offers you place manually for portfolio analytics on flipx.gg
- **Market panel** — tier-scoped opportunity browsing, filters, slot optimizer, watchlist sync
- **Display-only overlays** — GE copilot score/profit overlay, slot highlights, stagnation timers (read-only)
- **GE assist buttons** — optional qty/price helpers that invoke the same clientscripts as native GE controls; user must click and confirm every offer

## Compliance

- **No automation** — does not place offers, auto-confirm, or simulate input
- **All network features opt-in** with RuneLite config warnings on upload, market, overlays, and GE assist
- **Open source** — BSD-2, `build=standard`, no extra runtime dependencies
- **Third-party server disclosed** — fixed production host `https://www.flipx.gg`

## Test plan

- [x] `./gradlew test shadowJar` passes on pinned commit
- [x] Production API live at https://www.flipx.gg
- [x] Privacy policy returns 200 at https://www.flipx.gg/privacy

Made with [Cursor](https://cursor.com)