### PR TITLE
Add Sote-Mazerunner

### DIFF
--- a/plugins/sote-mazerunner
+++ b/plugins/sote-mazerunner
@@ -1,0 +1,2 @@
+repository=https://github.com/ricker312/Sote-Mazerunner.git
+commit=5a1358edbc17a1bdc5f703097150eb7c1f234a5a


### PR DESCRIPTION
## Description

Adds Sote Mazerunner to the RuneLite Plugin Hub.

Sote Mazerunner is a practice plugin for the Sotetseg maze in Theatre of Blood. It features randomized maze generation, multiple practice modes, themes, and online leaderboards to help players improve maze consistency and speed.

Repository:
https://github.com/ricker312/Sote-Mazerunner