### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=036a9cb6936fbce6cabc19e7f2537876394b5a79
+commit=6d2bdab1d168fb913d5fddfcbac8d2695c22dfe9
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=216a9b545104a847c3d92f175052da7be2e362c0
+commit=036a9cb6936fbce6cabc19e7f2537876394b5a79
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=fecb6fcbdfd4b67308f632580161c8ae6188e7ff
+commit=d54eb0be68454bf94f880cf157ef59b39c910040
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=d54eb0be68454bf94f880cf157ef59b39c910040
+commit=216a9b545104a847c3d92f175052da7be2e362c0
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
- Active Flips is now derived from a single authoritative in-plugin offer store, so GE slot highlights, timers, and the Active Flips list survive world hops and other in-game activities instead of blanking or flickering.
- Fixed a bug where a cancelled-but-uncollected Grand Exchange slot could resurrect as a live offer.
- Session Stats: Projected Profit no longer double-counts partially-filled sell offers.
- Active Flips state is now pushed to the FlipSmart backend so the website mirrors what the plugin sees in-game (covered by the existing data-sharing warning below).
