### PR TITLE
Add Gnomeball Plugin

### DIFF
--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
 commit=6bc94e6ce6be605bd1b29496d53c0a40b8673347
-warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=761a5c6d3c3e7742845d0ef4be229b0ba79d30dc
+commit=c673a49624a0cc7130f14a5faeb2b3a68241b2f2
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=f8df03f98df9ba196ac4e7e50e450a193da7b472
+commit=761a5c6d3c3e7742845d0ef4be229b0ba79d30dc
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,0 +1,3 @@
+repository=https://github.com/codycrossley/gnomeball.git
+commit=a7cf501cc5f17158c390df063800da35d6e9225b
+warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=6c3917da5a2f858b0c7c9b3d4c81a210674cea3f
+commit=12d8380dbb223e406b35e1467262905d604a9b17
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=4ddf18794380de3d19899edde0b7c2083b555d5b
+commit=746a739c8c051477b3d9cfaeb4d683f7d29e539a
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=f1336ef85f1a031370f6c2364c9b98702bd3087f
+commit=f8df03f98df9ba196ac4e7e50e450a193da7b472
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=705ee51bfc4b17cfb9f45e898c619eed6dcba3ec
+commit=f0d1b268624377090ec5644d51e6d5b688a2b5d0
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=f0d1b268624377090ec5644d51e6d5b688a2b5d0
+commit=286ef3df202ced5f8b7c5e46f6ad139395fdd1ca
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=746a739c8c051477b3d9cfaeb4d683f7d29e539a
+commit=4f870ae7cda43a120a26e688a337f0d2dd5e2d26
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=12d8380dbb223e406b35e1467262905d604a9b17
+commit=6bc94e6ce6be605bd1b29496d53c0a40b8673347
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=c673a49624a0cc7130f14a5faeb2b3a68241b2f2
+commit=705ee51bfc4b17cfb9f45e898c619eed6dcba3ec
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=a7cf501cc5f17158c390df063800da35d6e9225b
+commit=f1336ef85f1a031370f6c2364c9b98702bd3087f
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=4f870ae7cda43a120a26e688a337f0d2dd5e2d26
+commit=4d1e229f511145e2fbd61bb726c8111ba3bb1aae
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=286ef3df202ced5f8b7c5e46f6ad139395fdd1ca
+commit=4ddf18794380de3d19899edde0b7c2083b555d5b
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.

--- a/plugins/gnomeball
+++ b/plugins/gnomeball
@@ -1,3 +1,3 @@
 repository=https://github.com/codycrossley/gnomeball.git
-commit=4d1e229f511145e2fbd61bb726c8111ba3bb1aae
+commit=6c3917da5a2f858b0c7c9b3d4c81a210674cea3f
 warning=This plugin submits your IP, player name, location, and other data to a 3rd party server not controlled or verified by RuneLite.


### PR DESCRIPTION
# Gnomeball

<img width="1573" height="826" alt="Screenshot 2026-08-05 at 1 20 27 AM" src="https://github.com/user-attachments/assets/eed9edbe-0281-4ae6-a84e-1b5c06d72f74" />

Adds Gnomeball, a plugin for organizing and refereeing a flag-football-style minigame played with the Gnomeball (or F2P-accessible Peaceful handegg). The plugin is a thin client over a companion "Gnomeball API" server (running at https://gnomeball.shrunk.studio) that owns the game state (roster, score, ball possession, timer, tiles, etc.); the plugin observes the game world, reports events to the server, and renders the server's state back to every connected client.

- Setup: host creates/joins a game from the sidebar, marks out a field (built-in preset, custom arena, or saved layout), and enlists players onto Team A / Team B / Referee via right-click.
- Gameplay: pass the ball between teammates, tag the ball carrier to force a turnover, score by carrying the ball into your end zone, with out-of-bounds and post-goal/turnover "obligation" rules enforced.
- Live sync: shared countdown clock, scoreboard, referee whistle/pause/set-clock controls, host announcements/score correction, and a confetti + final-score banner when the clock hits 0:00.
- Overlays: player jersey/ball indicators, field/zone tile rendering with placement previews, timer/scoreboard box, and full-screen event flashes (goals, interceptions, whistles).