### PR TITLE
update ospulse

### DIFF
--- a/plugins/ospulse
+++ b/plugins/ospulse
@@ -1,4 +1,5 @@
 repository=https://github.com/jonathanavis96/ospulse.git
-commit=0d75444c7066d7f13804917bfab30b2887251814
+commit=72b07fc818a72d61fc412df1ea24f6ac75608436
 authors=jonathanavis96
 warning=The optional, off-by-default price-trend feature requests item price history from the OSRS Wiki price API (prices.runescape.wiki), sending only an item id. No account name or player data is sent.
+


### PR DESCRIPTION
Updates the ospulse pin to `72b07fc` (0.2.2).

User-reported fixes: the expensive-item risk cap was unreachable in ironman owned-only mode, it applied to targets outside the Wilderness, and its settings reset on every client restart. Also adds a right-click prayer picker so accounts without Piety/Rigour/Augury can simulate the prayer they actually have.

On size, per the ruling on #13797: `src/main/java` measures ~196.7k LLM tokens against the 200k reviewbot limit (comment-stripped, tiktoken `o200k_base`). A `tokenBudget` Gradle task now fails the build before that limit can be crossed again.
