### PR TITLE
Update golem-crafting

### DIFF
--- a/plugins/golem-crafting
+++ b/plugins/golem-crafting
@@ -1,3 +1,3 @@
 repository=https://github.com/Hampo/golem-crafting.git
-commit=e6fcfaa40bf57c37c618d8edf15e6007d608759b
+commit=2705775dfd43c2c294ea5431a81cae3c9a983c2a
 authors=Proddy

--- a/plugins/golem-crafting
+++ b/plugins/golem-crafting
@@ -1,3 +1,3 @@
 repository=https://github.com/Hampo/golem-crafting.git
-commit=246883aa93bc23cb45501b1a9df9208f4f40e263
+commit=e6fcfaa40bf57c37c618d8edf15e6007d608759b
 authors=Proddy


### PR DESCRIPTION
Adds support for both golems
Fixes fur pouch overlay displaying everywhere rather than locally to golem crafting