### PR TITLE
update drop-rate-properties

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=76da02f6c6126a34dc03003b9f146e9b096210b9
+commit=6da410698c44e6dd658bb61c02a54715cdcc3e10


### PR DESCRIPTION
Updates `drop-rate-properties` to `6da410698c44e6dd658bb61c02a54715cdcc3e10`.

The plugin's drop feed showed a kill count that was only ever a per-session counter — it reset whenever the plugin loaded, but it was printed as `KC:` next to the average kills a drop takes, so it read as the real in-game kill count.

It now reads the count RuneLite already tracks from the `Your X kill count is:` message. Sources that never print that message have no real count, so they keep the session counter and are explicitly labelled `KC: 8 this session`.

No new dependencies. No changes to the manifest, licence or icon.