### PR TITLE
better-monster-examine: update to v1.6

### DIFF
--- a/plugins/better-monster-examine
+++ b/plugins/better-monster-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/prettyrocket/better-monster-examine.git
-commit=354a6a6a4313edd134f235b7925bba0fc9e35be2
+commit=ab31e2791247f9bc841d25d4a575bfad3d076e75


### PR DESCRIPTION
Updates **Better Monster Examine** to [`ab31e2791247f9bc841d25d4a575bfad3d076e75`](https://github.com/prettyrocket/better-monster-examine/commit/ab31e2791247f9bc841d25d4a575bfad3d076e75).

Released as **Better Monster Examine v1.6 — Usable variant lists** — https://github.com/prettyrocket/better-monster-examine/releases/tag/v1.6

---

## 🧹 Variant lists you can actually use

The version dropdown was a mess on common monsters — Guard offered **124** entries, Zombie 80, Hill Giant 14 — because the wiki carries a row per **sprite**, and roughly a quarter of the bestiary's "variants" differed in nothing the plugin renders. This release reduces the bestiary to the variants a player can act on, and fixes two ways the wrong monster could be shown.

**Variants**

- **Only variants that differ** — rows with identical levels, bonuses, max hit, speed, attributes, immunities and size now collapse into one. Across the bestiary that's **3,227 → 2,410 versions (−25%)**: Guard 124 → 26, Zombie 80 → 35, Skeleton 66 → 31, Crystal impling 17 → 1, Hill Giant 14 → 2.
- **Right-click still resolves every spawn** — 1,005 NPC ids lived only on rows that collapse, so the surviving variant absorbs their ids rather than stranding them. Right-click on those spawns is unchanged.
- **Right-click picks the correct row** — when a spawn's id isn't in the dataset the plugin falls back to matching name + in-game combat level, and it used to take the *first* row at that level. In 240 cases those rows have genuinely different stats (Alchemical Hydra's four phases all sit at level 426, likewise Abyssal Sire and Araxxor), so it showed whichever one the wiki happened to list first. It now picks the canonical variant.
- **Removed content dropped, but only when something's left** — `(historical)` NPCs no longer clutter the list, unless the whole name is historical (Barbarian woman), which would otherwise vanish from search entirely.

**Stats**

- **A monster's own article wins over a page reusing its name** — two different wiki pages can emit an infobox with the same name, and with no anchor, no default flag and the same combat level there was nothing to tell them apart. Shellbane gryphon's boss article and its Troubled Tortugans quest fight both became "Level 235" versions, and the plugin defaulted to the *quest* one — showing its real max hit of `22` instead of the boss's `22 / 64 (whirlwinds) / 30 (knockback)`. A bare name now resolves to the monster's own article, and a variant from another page is labelled with that page's qualifier instead of a meaningless `#2`. **33 monsters** had labels found nowhere on the wiki; they now read correctly.

**Drops**

- **Stack quantities are no longer cut off** — item icons were locked to 28×28 while OSRS sprites are 36×32, cropping 2px off the top of every sprite. `ItemManager` draws the stack count into exactly those pixels, so the digits lost their tops.

**Reporting**

- **A visible route to the issue tracker** — a `⚑ Report a bug or request a feature` link anchored at the bottom of the panel (outside the scroll pane, so it doesn't scroll away under a long drop list), plus `Report an issue` on the sidebar icon's right-click menu. Both fixes above came from player reports; nothing in the plugin said where to send one.

**Thanks** to **Hot Melons** (#60) and **Louiziana** (#52) for the reports.

**Full changelog:** https://github.com/prettyrocket/better-monster-examine/compare/v1.5.2...v1.6