### PR TITLE
log-adviser: bump to 970b100

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=1c4261a18b23f90e317caa667e99682eab712c1f
+commit=970b100a990091b02357d3fc1359123a95272c5b


### PR DESCRIPTION
Updates Log Adviser to v1.3.0.

Adds the three Wyrmscraig activities from the 29 July 2026 update, with
their six new collection log slots: Golem crafting (Jeweller's chisel),
goat hunting (Mr mcgroot), and the Mad Angel (Hallowfell, Jar of light,
Ardeaglais teleport, Aggy, and the existing Granite dust slot).

Also fixes a chat spam bug: the "collection log isn't fully synced"
warning was guarded by a flag reset on every GameStateChanged(LOGGED_IN),
which re-fires on every teleport, region cross and world hop. It is now
armed only on an actual login and limited to once a day per account.