### PR TITLE
Update mystix

### DIFF
--- a/plugins/mystix
+++ b/plugins/mystix
@@ -1,4 +1,4 @@
 repository=https://github.com/Dmurph24/mystix-plugin.git
-commit=39bd4684a4d9299ccf990de1a36377836c0c2e97
+commit=fe31ac67e0574831f9943235f03794d71186b1d6
 authors=Dmurph24
 warning=This plugin submits your RSN, skills, bank, equipment, loadouts, farming timers, and loot data to a 3rd-party server (Mystix) not controlled or verified by Runelite developers.

--- a/plugins/mystix
+++ b/plugins/mystix
@@ -1,4 +1,4 @@
 repository=https://github.com/Dmurph24/mystix-plugin.git
-commit=fe31ac67e0574831f9943235f03794d71186b1d6
+commit=a1e6692b7b6be1b358508dc352fc1d0e2e8288e1
 authors=Dmurph24
 warning=This plugin submits your RSN, skills, bank, equipment, loadouts, farming timers, and loot data to a 3rd-party server (Mystix) not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Mystix to the latest release.

This build fixes slayer task completions from masters that keep their own task streak, which were previously recorded as unknown. The task transition it sends now includes the Wilderness task streak counter and a flag for whether the assignment counted down to zero, alongside the existing slayer task, points, streak and block list sync. Both values come from varbits the plugin already read, so no new data source is introduced.

It also fixes reading the slayer task-offer dialog, where the modifier attached to each offered task was being missed. The dialog's rows are now read from the whole widget subtree under the container rather than a single child list, and ordered by where they draw so rows gathered from different child lists stay with the offer they belong to. Negative modifiers parse alongside positive ones. This is the same widget the plugin already read for the offered task names and amounts, so again no new data source is introduced.