### PR TITLE
Update Gustav's Helper (diary auto-sync, attribution, logo)

### DIFF
--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=2fa55707b6b7ac66c2884610c09757b5fd64f166
+commit=70d7d8b961ef650c8e209f4bacb95a9cd1aad16d


### PR DESCRIPTION
Bumps the pinned commit for the already-merged Gustav's Helper plugin. Changes since the last build:

- Achievement-diary steps now auto-complete like skills/quests (each resolves to that tier's completion varbit; Karamja excluded).
- - Community alt guides re-credited to their author's handle (heboxjonge); NOTICE updated.
- - New plugin icon (a "G"); the description now invites guide suggestions via a GitHub issue.
- - Refreshed bundled route data.
No dependency or permission changes; no reflection/network; builds green.