### PR TITLE
Add salvaging afk timer

### DIFF
--- a/plugins/salvaging-afk-timer
+++ b/plugins/salvaging-afk-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/silly-build/salvaging-afk-timer.git
+commit=fd505a76f23e2ab9387b4b0515c635ea99468624


### PR DESCRIPTION
Adds Salvaging AFK Timer to the Plugin Hub.

The plugin provides salvaging and sorting timers, shipwreck lifespan
tracking, cargo tracking, Crystal Extractor status, a distraction dimmer,
and standard and minimalist timer overlays.

Tested locally using the RuneLite development client.