### PR TITLE
Update goat-pit-indicators to 1.1

### DIFF
--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
-commit=a6efcae61c1a624288246ca5923e405a18fc5596
+commit=a86a022f4d57bdd8920bf5dea0781249ead10267


### PR DESCRIPTION
Updates the pinned commit for **goat-pit-indicators** to the Release 1.1 tag (`R-1.1`, commit `a86a022`).

Changes since the current 1.0.1 pin:
- Highlight telegrabbable goats (glow goats you can telekinetic-grab into a spiked, non-full pit).
- Lifetime total-caught counter drawn on the pit, persisted across sessions.
- Settings reorganized into sections and dual-purpose colors split into dedicated outline/fill settings.
- Lower default overlay fill opacity; removed the developer debug-logging option.

Release: https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin/releases/tag/R-1.1