### PR TITLE
clan-management: game-mode filter, rank-requirement fixes, diary/quest sync

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=036e012c11472ea327730157e1b63e68434014ae
+commit=15648c1ab4ecb2e7a72aa4c5b2644e34356230a1
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=15648c1ab4ecb2e7a72aa4c5b2644e34356230a1
+commit=6f4495a09e38d35e819b8b2e7591d0570e31c77c
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Manifest bump for the Solus clan-management plugin.

Changes since the current build:
- Game-mode (account type) filter on the Members and Leaderboards panels
- Rank-requirement fixes: item detection for upgraded/variant gear, TzKal additions; ownership is current-possession based
- Diaries & Quests sync + a profile section for it
- Automatic GIM team detection; GIM teams shown as one shared-account row
- Fixed-mode panel scroll fix so the lower nav is reachable
- Real in-game helm icons and account-type badges in the member list

Still calls only https://api.solusosrs.com (no new external hosts). The existing data-collection warning line is preserved.