### PR TITLE
Update Slayer Best in Bank: advisor and preparation fixes

### DIFF
--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=251cf8c396abf442dc6708a9b648e832968e5783
+commit=26bcce14e61bb1d421f5971c7c68addcfc36ee9c

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=26bcce14e61bb1d421f5971c7c68addcfc36ee9c
+commit=c9a509391a30066e1f4483429f6ea70c26cfae43


### PR DESCRIPTION
## Summary

Updates Slayer Best in Bank with the manual advisor switch plus three reported preparation fixes:

- restrict blighted food recommendations to confirmed Wilderness tasks
- suppress Rada's blessing unless the selected setup uses a compatible loaded Dizana's quiver
- show prominent refresh-or-reopen feedback when a method or setting change invalidates the locked bank plan
- add regression coverage for the context-aware supply rules

## Root cause

Generic substring matching treated blighted food as ordinary food, Kourend travel matching did not account for the ammunition-slot conflict, and method changes only surfaced a small status line at the bottom of the panel.

## User impact

Non-Wilderness loadouts no longer suggest unusable blighted food, Venator setups no longer pair ordinary ammunition requirements with Rada's blessing, and bank-plan changes now provide immediate actionable feedback.

## Validation

- Source test suite passes with `./gradlew clean test`.
- Plugin Hub entry points to source commit `c9a509391a30066e1f4483429f6ea70c26cfae43`.
- `git diff --check` passes.
