### PR TITLE
Update no-misclick-repot

### DIFF
--- a/plugins/no-misclick-repot
+++ b/plugins/no-misclick-repot
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/bop-plugins.git
-commit=66e68784357b9fe30f5072fab3cdc97b093b220d
+commit=1d538e4a0a5b6169eb922562d6357643d2c4fbc9


### PR DESCRIPTION
Added config option to timer overlay to allow for showing time till effect expires instead of time till repot allowed