### PR TITLE
Update PvM Toolkit to 1.2.1

### DIFF
--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=dbbbc88333186a494f8f34c4cefc439a26e07abc
+commit=09bbc82ea360493c9cbf07c7a684a2b6d0d8d28c


### PR DESCRIPTION
## What changed

- fixes saved Drop Highlights showing internal item IDs or remaining on Loading
- makes plugin startup, shutdown, re-enabling, and shared Toolkit tabs more reliable
- redesigns the update scroll without blocking gameplay outside its controls
- shows the correct bundled version in developer builds
- improves compact Top skill text in the statistics panel

## Why

Saved period statistics could render before item definitions were ready, and client state was previously initialized from the plugin startup thread. The update scroll also needed safer heavyweight-canvas rendering and clearer responsive controls.

## Validation

- gradlew clean test`: 20 tests passed
- manually tested in the combined developer client with the normal RuneLite profile
- update flow tested as an upgrade from 1.1.9 to 1.2.1