### PR TITLE
Update goat-pit-indicators to 1.1.1

### DIFF
--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
-commit=a86a022f4d57bdd8920bf5dea0781249ead10267
+commit=048b130177ef7d3ab36d0cb4ff8445aeef8f153b


### PR DESCRIPTION
Bumps goat-pit-indicators to release 1.1.1 (tag R-1.1.1, commit 048b130177ef7d3ab36d0cb4ff8445aeef8f153b).

Changes since 1.1.0:
- Attribute in-transit goats to the local player, so other players' telegrabbed goats no longer count toward your two-goat cap 
- Require line of sight for the telegrab highlight, so goats behind terrain are no longer highlighted
- Support Dark Lure alongside Telekinetic Grab as a valid lure spell
- Remove the in-transit cap on the highlight, so all grabbable goats outline even in a busy pit.

Release: https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin/releases/tag/R-1.1.1