### PR TITLE
the-birdhouse: update to 1.0.4

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=a8c0b24e74cd9ff048715ca302afbfd97174f563
+commit=c3c69bf013a30a05cb2cd6fd5613a6cd7fba4b39
 warning=This plugin submits your IP address, RSN, and in-game screenshots to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates The Birdhouse to 1.0.4. The only change to this file is the pinned commit hash.

This release fixes kill counting for the Gauntlet. The minigame hands out a consolation chest when you die, and the loot tracker books that chest against whichever boss you last fought, so a failed run was indistinguishable from a completed one. Those kills are now credited from the completion count game message instead of the loot event, and every other source still counts from loot as before.

No new permissions and no new network activity; the existing warning line is unchanged.
