### PR TITLE
osrscn: 0.2.1

### DIFF
--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=590487207b2c663acaca16116d4d51deeffd9bf7
+commit=e390c386b37f3fe97a7f2979ac74593dc01dfa72
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=e390c386b37f3fe97a7f2979ac74593dc01dfa72
+commit=568da8ccc8bd857583e718ae56ef1dfa3da21e70
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=1c4d15e090a9519b074ce80b876f82002b3b6637
+commit=590487207b2c663acaca16116d4d51deeffd9bf7
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
This is the upload half of what used to be one PR, split off so the last release carried no network change. It is the only thing in this version.

**What it does.** Players who want to help fix missing translations can let the plugin send the English it could not translate, instead of copying a file into a GitHub issue by hand, which turned out to be unrealistic for most of the people using it.

**Off by default.** Turning it on opens a dialog that spells out what gets sent, and it can be turned off again at any time.

**What is sent:** the untranslated game English the lookup tables missed, plus a random six character install id so repeat contributions from one person can be recognised. No chat, no account data. Player names are replaced with a placeholder before a line is ever recorded, and lines containing CJK are refused outright, since those are player authored.

**Where it goes:** a Cloudflare Worker I run, which forwards to the plugin's translation data repository. The worker holds the write token, so the client never has one. It validates the id format and caps size.

**Pacing:** incremental against a local watermark, at most 400 rows a batch, at most once every 30 minutes, on the injected scheduled executor. If the endpoint is not configured the whole feature sleeps.

Happy to extend the existing warning line to mention the upload, or to change anything about how it is presented.
