### PR TITLE
Update TickFlow

### DIFF
--- a/plugins/tickflow
+++ b/plugins/tickflow
@@ -1,2 +1,2 @@
 repository=https://github.com/George-API/TickFlow.git
-commit=b63444a8ed52b760e66490b1a808a1119cf2f8f6
+commit=93965b316b2e6f8056fd1b52c72aadd54a124ff2


### PR DESCRIPTION
## Summary
- Bumps TickFlow Hub pin to `93965b316b2e6f8056fd1b52c72aadd54a124ff2`
- Overlay size/opacity + hub icon refresh
- Fix plugin re-enable (client-thread cache refresh on startUp)


Made with [Cursor](https://cursor.com)