### PR TITLE
update ge-uncut to 1.5.0

### DIFF
--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,3 +1,3 @@
 repository=https://github.com/uzia35/ge-uncut.git
-commit=7d22063cdc43696729a5b8168b98a4515a3c1365
+commit=ab8882e884258455d7c84397a6a354a7ca66f8a7
 warning=This plugin submits your IP address and various account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates GE Uncut to 1.5.0.

New: the History tab labels each trade as flipped or a regular trade, shows profit after tax and the GE tax paid, and sorts newest first. The GE offer price and quantity prompts gain a clickable line that enters the suggested value for suggested or tracked flips, with an off switch in the plugin settings.

Also includes minor fixes: unlinked installs no longer poll the server, plus small label and tooltip cleanups.