### PR TITLE
Update Salvaging AFK Timer startup handling

### DIFF
--- a/plugins/salvaging-afk-timer
+++ b/plugins/salvaging-afk-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/silly-build/salvaging-afk-timer.git
-commit=30b97e74e5c096caf6a2fcde1d7e64051fe1cc7b
+commit=c8c835d56ad830b8ad713b441702959cba42116b


### PR DESCRIPTION
Fixes an intermittent startup failure when enabling Salvaging AFK Timer while already logged in.

The plugin previously called client.addChatMessage directly from startUp(). Plugin startup runs outside the RuneLite client thread, causing an IllegalStateException stating that the operation must be called on the client thread.

This could cause the plugin to stop immediately, refuse to re-enable, or appear to require a RuneLite restart after installation.

The direct call has been removed from startUp(). The blue startup message is still displayed through the existing game-state and game-tick event handlers, where the client is ready.