### PR TITLE
Add SlayerAIO

### DIFF
--- a/plugins/slayeraio
+++ b/plugins/slayeraio
@@ -1,0 +1,2 @@
+repository=https://github.com/Kiyogitpy/SlayerAIO.git
+commit=c0fc0ac9ff6144f69d1b1508575e2fbdc5ad076f

--- a/plugins/slayeraio
+++ b/plugins/slayeraio
@@ -1,2 +1,2 @@
 repository=https://github.com/Kiyogitpy/SlayerAIO.git
-commit=76097b63ab9bb28bb5724d6266146e9ab39265be
+commit=78a81fe0562cc7ca0a8926ee51b656f3989e240a

--- a/plugins/slayeraio
+++ b/plugins/slayeraio
@@ -1,2 +1,2 @@
 repository=https://github.com/Kiyogitpy/SlayerAIO.git
-commit=c0fc0ac9ff6144f69d1b1508575e2fbdc5ad076f
+commit=76097b63ab9bb28bb5724d6266146e9ab39265be


### PR DESCRIPTION
SlayerAIO is a Slayer task assistant that shows, for your current task: monster names/locations, best melee/ranged/magic combat style (from wiki defence data), required items (e.g. mirror shield for basilisks, facemask for smoke devils), monster-exclusive unique drops with drop rate, cannon-immunity warnings, on-scene highlighting of task monsters (and superior spawns, with a configurable alert), GP/hr and kills/hr efficiency with an optional skip suggestion, an opt-in live progress/ETA display, and per-master bracelet/extend usage tips.

It also has a soft integration with the Shortest Path plugin: it posts a `PluginMessage` on the shared EventBus (same handshake Quest Helper uses) to set/clear a path to the current task location, with no compile-time dependency on shortestpath. If Shortest Path is not installed, these calls are harmless no-ops.

Repo: https://github.com/Kiyogitpy/SlayerAIO
License: BSD-2-Clause