### PR TITLE
gustav-helper: bump commit (fold over-complete fix, all-guides coord/NPC sweep, current-route Prifddinas guide)

### DIFF
--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=7145b14f1f330683c9fd8cce659522c5b2ba71b7
+commit=503e8ff36e97c9817c1dea43db2b5687523a11f9

--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=70d7d8b961ef650c8e209f4bacb95a9cd1aad16d
+commit=7e05bb392240ba08ee642305a69f827ba2858feb

--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=950c188f8ee04c8004f8eca8f711b68a356a5ef4
+commit=7145b14f1f330683c9fd8cce659522c5b2ba71b7

--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=7e05bb392240ba08ee642305a69f827ba2858feb
+commit=950c188f8ee04c8004f8eca8f711b68a356a5ef4


### PR DESCRIPTION
Bumps `plugins/gustav-helper` `commit=` to `7e05bb392240ba08ee642305a69f827ba2858feb` (from 70d7d8b).

Changes since the last pinned commit:
- **Fix milestone-fold over-completion.** The fold that auto-completes undetectable "flavour" steps is now keyed only to arrival (position/travel) steps, so a quest done out of order can no longer cascade-complete ~150 steps a mid-progress account hasn't done.
- **108 grounded coordinate + NPC-highlight fixes across all bundled guides** (sourced from the OSRS Wiki / gazetteer, not guessed) — e.g. quest steps that previously pointed at the wrong town/NPC now point at the correct tile.
- **Auto-advance polish:** "start `<quest>`" steps advance when the quest is started (not only when finished); "speak to `<NPC>`" quest steps highlight the correct NPC; steps marked "(Optional)" no longer act as hard gates.
- **New bundled guide:** *UIM Walkthrough to Prifddinas (Current Route)* (OSRS Wiki, CC BY-NC-SA 3.0).
- **Panel:** the step description now scrolls (long text no longer clipped); Reset asks for confirmation.

No reflection, no runtime network, no new runtime dependencies (build-time scrapers live under `tools/`, not shipped). Tests: 54 Java + 49 Python, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)