### PR TITLE
Add Wyrmscraig Goat Hunting Plugin

### DIFF
--- a/plugins/wyrmscraig-goat-hunting
+++ b/plugins/wyrmscraig-goat-hunting
@@ -1,2 +1,2 @@
 repository=https://github.com/claudiodekker/runelite-wyrmscraig-goat-hunting.git
-commit=5c84f6a08776aca3e907ca1fdfd1fc16f02707eb
+commit=76c0fdcbd16fc1543749096655ea9d50d2c980ff

--- a/plugins/wyrmscraig-goat-hunting
+++ b/plugins/wyrmscraig-goat-hunting
@@ -1,0 +1,2 @@
+repository=https://github.com/claudiodekker/runelite-wyrmscraig-goat-hunting.git
+commit=5c84f6a08776aca3e907ca1fdfd1fc16f02707eb

--- a/plugins/wyrmscraig-goat-hunting
+++ b/plugins/wyrmscraig-goat-hunting
@@ -1,2 +1,2 @@
 repository=https://github.com/claudiodekker/runelite-wyrmscraig-goat-hunting.git
-commit=76c0fdcbd16fc1543749096655ea9d50d2c980ff
+commit=f3e8f574abbfffb63676feee6ba35fd66533fcfd


### PR DESCRIPTION
A plugin for the Wyrmscraig goat hunting activity. It shows the pit's state at a glance, marks the single best goat to
telegrab next, tracks which goats are already being captured, and prevents misclicks when not clicking the telegrab spell first.

# What it does

- **Tells you which goat to take.** Stand on one of the twelve tiles around the pit and the goats you can capture from
there are outlined. The nearest one gets its own colour — that is the one to grab.

- **Adapts to the other players.** Your area is a quarter of the pen while someone works the side to your left or right,
and opens up to the whole opposite half when nobody does. A player *opposite* you never narrows it: they are aiming back across the pit at the half you are standing in, so they take nothing you would have taken.

- **Skips goats you cannot actually take.** Goats already being captured by anyone are dropped from the highlight, and goats behind a tree — where telegrabbing makes you run around — are shown in a faded colour but never recommended.

- **Stops you wasting runes.** The game's counter only knows about goats that have already landed. This counts the ones still walking too, so the pit stops asking for casts before the last few arrive rather than after.

- **Shows what the pit needs.** A health-style bar over the pit, plus an outline colour that says what to do rather than
which internal state the pit is in.

- **Keeps a misclick from pulling you out of position.** While you are stood on a capture tile, left-clicking a far-off
goat does nothing instead of walking you over to it.