### PR TITLE
Update goat-pit-indicators to 1.2.0

### DIFF
--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
-commit=18f610b28218232c0eff25b22cb4e3a31a76e08f
+commit=c6484c261f92da9725d80032b29ac378b7c55c81

--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
-commit=048b130177ef7d3ab36d0cb4ff8445aeef8f153b
+commit=18f610b28218232c0eff25b22cb4e3a31a76e08f


### PR DESCRIPTION
Updates goat-pit-indicators from 1.1.1 to 1.2.0.

- `commit=18f610b28218232c0eff25b22cb4e3a31a76e08f` (tag `R-1.2`)
- Release: https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin/releases/tag/R-1.2

Highlights: pit progress-bar style, in-transit goat count (lured + cattle-prodded), menu swaps near a full pit / while prodding, telegrab line-of-sight + Dark Lure support, lifetime total-caught formatting options, and several bug fixes (install/toggle without restart, world-hop double-count, banked rune pouch).