### PR TITLE
Fix TCG Locked party sharing

### DIFF
--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=630931e76999051f6998506125cb31ec49ffe789
+commit=cb7cdfc90d8acb59442634eb3b8c55204359406f

--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=d1671d49b0bcd7b8438cd81d645209a78f58c0f4
+commit=630931e76999051f6998506125cb31ec49ffe789


### PR DESCRIPTION
Publishes TCG Locked 1.2.4 as a focused party-sharing hotfix. The Shared Catalog has been removed from this update for separate review.

- Fixes asymmetric sharing where one player could see a partner's cards but not receive cards back.
- Stops temporary Party audience omissions from deleting persisted shared collections.
- Resends a complete collection when approved Party member names resolve or the audience changes.
- Retains the last valid collection when a packed payload is malformed or from a different catalog version.
- Adds mixed-version fallback and regression coverage.
- Adds an explicit semantic version so RuneLite displays 1.2.4 instead of a commit prefix.

Source commit: cb7cdfc90d8acb59442634eb3b8c55204359406f