### PR TITLE
update ge-uncut to 1.5.1

### DIFF
--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,3 +1,3 @@
 repository=https://github.com/uzia35/ge-uncut.git
-commit=319bc39926f269b6cce8bbc741204910dfc03de1
+commit=1f89ff60039ab518f6d6fdeb53719eea9488f67f
 warning=This plugin submits your IP address and various account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,3 +1,3 @@
 repository=https://github.com/uzia35/ge-uncut.git
-commit=ab8882e884258455d7c84397a6a354a7ca66f8a7
+commit=319bc39926f269b6cce8bbc741204910dfc03de1
 warning=This plugin submits your IP address and various account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates GE Uncut to 1.5.1. fixes a minor History tab issue and  now shows completed flips and with refresh buttons.