### PR TITLE
Update tickflow

### DIFF
--- a/plugins/tickflow
+++ b/plugins/tickflow
@@ -1,2 +1,2 @@
 repository=https://github.com/George-API/TickFlow.git
-commit=93965b316b2e6f8056fd1b52c72aadd54a124ff2
+commit=19c499e039dcb99e4cd673841383364c5fb5e049


### PR DESCRIPTION
## Summary
- Bump TickFlow pin to `19c499e039dcb99e4cd673841383364c5fb5e049`.
- Minimal overlay mode + leaner HUD (no title text).
- Stabilize circular NOW progress tip.
- Regenerate hub icon cropped to fill 48x48.

## Test plan
- [ ] Hub CI builds from the pinned commit
- [ ] Learn / Compact / Minimal modes work
- [ ] Circular NOW progress is smooth
- [ ] Plugin Hub list icon fills the card thumbnail


Made with [Cursor](https://cursor.com)