### PR TITLE
Adding Vanity ranks to ingame cc for 1.2.0

### DIFF
--- a/plugins/ruthless-clan
+++ b/plugins/ruthless-clan
@@ -1,4 +1,4 @@
 repository=https://github.com/Orinite/ruthless-plugin.git
-commit=abb0772dfdbf83a5ca3d46aecaf8325e165d29d6
+commit=e323d2799b3416a77ddfd59cad3857af01b5f9fa
 warning=This plugin submits your username and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.
 authors=Orinite


### PR DESCRIPTION
- Adding vanity ranks for events. Icons can show up next to users if applicable. Recolors names for the team they belong to.