### PR TITLE
Update goat-pit-indicators to 1.2.1

### DIFF
--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
-commit=c6484c261f92da9725d80032b29ac378b7c55c81
+commit=a84b40adec1396d83475e2b3fc4d5dd2a13b9609


### PR DESCRIPTION
Updates goat-pit-indicators to 1.2.1 (commit a84b40adec1396d83475e2b3fc4d5dd2a13b9609, tag R-1.2.1).

Changes since 1.2.0: refreshed the plugin icon with new leaping-goat-over-spiked-pit artwork. Asset-only change, no code or behaviour differences.