### PR TITLE
Update compact-orbs to v1.9.0

### DIFF
--- a/plugins/compact-orbs
+++ b/plugins/compact-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/its-cue/compact-orbs.git
-commit=fd3678bc9ef569b5912bb707cfe1c38e012f2f0c
+commit=4a53cfcec25c07d52de939dde6ab5db514ecd9a1


### PR DESCRIPTION
- add an edit-mode to reduce config navigation for hiding/showing/swapping widgets
  - can be toggled via the minimap toggle button (or with `Esc` if enabled)
  - supported across vanilla/compact-view and classic/modern resizable
  - can hide/show widgets similar to the config via a menu option
  - can swap orbs similar to the config by dragging onto another orb (indicator will show on the orb that will be swapped)
  - display a background similar to the prayer/spellbook reordering and prevent clickthrough while editing
- add a new custom layout, and while edit-mode is enabled:
  - supports drag and drop positioning
  - shows an indicator for the widget being dragged
  - shows an indicator for a widget that is overlapping or in proximity of the widget being dragged
- refactor HotkeyListener to KeyListener
- refactor Offsets to account for component id and index
- add minimap toggle button to the TargetWidget interface (offsets moved out of the manager class)
- remove the compass toggle button