### PR TITLE
Manual state tracker

### DIFF
--- a/plugins/manual-state-tracker
+++ b/plugins/manual-state-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/shdshdw/manual-state-tracker-runelite-plugin.git
-commit=047f45036f3da9ec90b21c2b906c55ab4f5a264d
+commit=d533ae804a7b6b99ae2f5f4a4dcc450abec7301d

--- a/plugins/manual-state-tracker
+++ b/plugins/manual-state-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/shdshdw/manual-state-tracker-runelite-plugin.git
-commit=33578b6aaa97db4a04e6a2501b87fcbaa15d03aa
+commit=047f45036f3da9ec90b21c2b906c55ab4f5a264d

--- a/plugins/manual-state-tracker
+++ b/plugins/manual-state-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/shdshdw/manual-state-tracker-runelite-plugin.git
+commit=33578b6aaa97db4a04e6a2501b87fcbaa15d03aa


### PR DESCRIPTION
Manual State Tracker shows a single movable overlay image that you switch yourself with hotkeys. It never reads the game to decide what to display, which is the whole point: it stays clear of the plugin-hub rules around boss mechanic indicators and prediction, because you are the one tracking the state.

You build state sets in a side panel, each holding any number of states. Each state has a name, a hotkey, and an image, which can be:

- Text, drawn as large as it fits, with fill and outline colour pickers. For example: a single character makes a good phase counter.
- A game icon, searchable over every item in the cache plus all 32 prayers, 24 skills and 178 spells, pulled from the client's own sprites.
- A few built-in shape: four arrows, a looping arrow, a cross and a plus, also colourable.
- A custom PNG uploaded by the user
- A flat colour.

Typical uses: counting a phase yourself, remembering which prayer you meant to be on, tracking your place in a rotation, or marking which direction to go next.