### PR TITLE
Update Lending Tracker: fix leaving a group, multiple owners, Looking For duplicates

### DIFF
--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=523074044e2b535da95afd9cc6ee0a87232c6cc5
+commit=b7092fee82f36a58b017547952ac7e6eba6f1326

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=2ee85c1d2ae984cbca07a4361b680fc14d3c05eb
+commit=523074044e2b535da95afd9cc6ee0a87232c6cc5

--- a/plugins/lendingtracker
+++ b/plugins/lendingtracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Guess34/Lend-Borrow_Tracker.git
-commit=2cfbf040510796c555e8f0b95d83610d07df2798
+commit=2ee85c1d2ae984cbca07a4361b680fc14d3c05eb


### PR DESCRIPTION
Fixes leaving a group (it didn't actually leave, and the departure never reached other members), adds support for multiple owners, and fixes a handful of smaller bugs - duplicate "Looking For" entries on edit, joining failing when the relay is cold, and loans from one group showing under another.

No new data is sent anywhere and no new permissions or APIs are used.