### PR TITLE
Skilling Toolkit 0.4.2 - fix toolkit tab coordination

### DIFF
--- a/plugins/skilling-toolkit
+++ b/plugins/skilling-toolkit
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/skilling-toolkit.git
-commit=8835ac12ec968823c741064a2c4bf8f3045dc670
+commit=fb87b738853a2870aff4491f7079a28f41f0d50d


### PR DESCRIPTION
## Changes
- fixes shared chat-tab ownership with PvM Toolkit
- preserves manual tab selection until the user changes it
- restores tab widgets safely when either plugin is disabled
- fixes Skilling Toolkit disable/re-enable lifecycle handling

## Verification
- `gradlew clean test` passes on Java 21
- tested locally with PvM Toolkit and Skilling Toolkit enabled together
- tested disabling and re-enabling each plugin independently

This is the Skilling Toolkit half of a coordinated two-plugin fix. The plugins remain separate Plugin Hub entries.