### PR TITLE
Add superior-slayer-tracker

### DIFF
--- a/plugins/superior-slayer-tracker
+++ b/plugins/superior-slayer-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/JJDeakins1/superior-slayer-tracker.git
+commit=9fd572899373443b3075b8684c95ef6f17f0c72a

--- a/plugins/superior-slayer-tracker
+++ b/plugins/superior-slayer-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/superior-slayer-tracker.git
-commit=9fd572899373443b3075b8684c95ef6f17f0c72a
+commit=19e7cfd991577440662ed91eb11c2e7e9e79b720

--- a/plugins/superior-slayer-tracker
+++ b/plugins/superior-slayer-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/superior-slayer-tracker.git
-commit=19e7cfd991577440662ed91eb11c2e7e9e79b720
+commit=008c0e3502dd54eaf190446da3902899edc37633


### PR DESCRIPTION
Adds the Superior Slayer Tracker plugin.

Tracks superior slayer monster kills and unique drops (imbued heart, eternal gem, mist/dust battlestaff), with per-monster kill counts, dry-streak stats, and drop-rate expectations shown in a side panel.

Repository: https://github.com/JJDeakins1/superior-slayer-tracker