### PR TITLE
loadout-lab: 0.2.4

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=9dd5e2d17b9905a38f16f9cd7f3e8b7cb2211fcc
+commit=da373eeb27603fa1977cfe0023756a4ba52bf82a
 authors=ajkatz


### PR DESCRIPTION
Updates Loadout Lab to 0.2.4 (pin da373ee).

This supersedes #14014, which bundled 0.2.2 through 0.3.4 into a single 205-file diff. The backlog is being released in sequence instead, so each update is reviewable on its own. This is the first of four.

Since the live 0.2.2:

- Equipment wear-requirement data backfilled, so gear an account cannot legally wear is no longer recommended.
- Undo/redo command history over the panel's persistent mutations (bounded 50-entry stacks).
- 8 engine and UX fixes from a player-audit pass.
- The results area refactored into a page of result entries.
- A date-aware mascot loading-animation roster.

No network I/O.
