### PR TITLE
Add cox-gear-planner

### DIFF
--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=4e0c0dc6d73e1222ea1f894f182b2cd226fd5940
+commit=aa0d1d7a3c6cae00cb87e7feeca12bc41f042b8f
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=4fd94f4d4d41efd2b707da7543480a18b932d6c5
+commit=077ada11455528c4e07c60d9bbf269fa9ad790e4
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=a96f5d6788afc5906bcc34b04fad7c384a0839d6
+commit=261fcd1ec7288304ec7e76c8e2aefeaa7309cbf5
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=1e236096779df741cb43944851fa0f84ff57d3bf
+commit=4fd94f4d4d41efd2b707da7543480a18b932d6c5
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=5d25f95ee0c8100d08ab5fd79dc80f3b300b49d7
+commit=2e75c43b98f5f9466944c2f1478f9fff94eae052
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=077ada11455528c4e07c60d9bbf269fa9ad790e4
+commit=f5521a40eb7af1c31c738ffc3ef0ece8e0c9448e
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=f9caad601b26c16f1afbc48eee7182e7454702f9
+commit=2c1dd56f15ca2719adb6a84de3f0ca2bd89bad44
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=b4fc399ba29df8b0a14cfdf39bb8244b64d213ea
+commit=06f5088d0df04ddfd2b6acb45034c5f3e616914f
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=f5521a40eb7af1c31c738ffc3ef0ece8e0c9448e
+commit=608e370df3a69499cc7b6c02d6ae1ffd90bca358
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=b29d10055970adb5027dd1c593056129c242cccc
+commit=aa0918e4cc716a156d222ae1a3f5d8b30549de29
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=dbba765abed7d603122a5bc01d77e64153d735ec
+commit=36e369000778c872c398aee1bdecc6dcbd5076e7
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=0177d2d539d0dbae7177938090962c8c7a1b49f7
+commit=2d019f604610f88f5f49ea0f979236c32e803eff
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=15342c98c79f2620dd4c0b026912ea6073d7755f
+commit=5d25f95ee0c8100d08ab5fd79dc80f3b300b49d7
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=ba5fdbcea7be0eac07243325ae60973e0d697987
+commit=f9caad601b26c16f1afbc48eee7182e7454702f9
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,0 +1,3 @@
+repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
+commit=8888775a202a2142ad900b507936cf3dca7a781e
+authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=b9a93ca53fd24a7f0d081b2609b823eaccf97a55
+commit=b29d10055970adb5027dd1c593056129c242cccc
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=ecd82b79096c9766323f398b0e27d6e765a04d55
+commit=4e0c0dc6d73e1222ea1f894f182b2cd226fd5940
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=608e370df3a69499cc7b6c02d6ae1ffd90bca358
+commit=0177d2d539d0dbae7177938090962c8c7a1b49f7
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=aa0d1d7a3c6cae00cb87e7feeca12bc41f042b8f
+commit=a96f5d6788afc5906bcc34b04fad7c384a0839d6
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=d41b290de2516a7ceaadeb58715b7a72916e2fe6
+commit=a0bb7c35a784b38f7bf5b630782119cdd574cf86
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=a0bb7c35a784b38f7bf5b630782119cdd574cf86
+commit=af3f9eb2e81e335026c913037f572fa090e5a1cc
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=2e75c43b98f5f9466944c2f1478f9fff94eae052
+commit=65a918bae57116b418f8b8c3bac032c2c89f560a
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=f6a810556dd6aef0973d03a3028b4f2050693f77
+commit=97a6927c5b427118d5b872f7df7f68b23ef0a539
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=af3f9eb2e81e335026c913037f572fa090e5a1cc
+commit=54317ff70ac74a7cc7177fa1967652cab24d09c9
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=65a918bae57116b418f8b8c3bac032c2c89f560a
+commit=beb5a1710cb955bf872c8d3b52bcd1e9317398ad
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=739fd83c804461696da87585818a5e206308a781
+commit=15342c98c79f2620dd4c0b026912ea6073d7755f
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=54317ff70ac74a7cc7177fa1967652cab24d09c9
+commit=b9a93ca53fd24a7f0d081b2609b823eaccf97a55
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=261fcd1ec7288304ec7e76c8e2aefeaa7309cbf5
+commit=739fd83c804461696da87585818a5e206308a781
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=8888775a202a2142ad900b507936cf3dca7a781e
+commit=b4fc399ba29df8b0a14cfdf39bb8244b64d213ea
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=aa0918e4cc716a156d222ae1a3f5d8b30549de29
+commit=ba5fdbcea7be0eac07243325ae60973e0d697987
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=36e369000778c872c398aee1bdecc6dcbd5076e7
+commit=1e236096779df741cb43944851fa0f84ff57d3bf
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=2c1dd56f15ca2719adb6a84de3f0ca2bd89bad44
+commit=f6a810556dd6aef0973d03a3028b4f2050693f77
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=beb5a1710cb955bf872c8d3b52bcd1e9317398ad
+commit=dbba765abed7d603122a5bc01d77e64153d735ec
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=2d019f604610f88f5f49ea0f979236c32e803eff
+commit=d41b290de2516a7ceaadeb58715b7a72916e2fe6
 authors=davidcottrellcoding

--- a/plugins/cox-gear-planner
+++ b/plugins/cox-gear-planner
@@ -1,3 +1,3 @@
 repository=https://github.com/davidcottrellcoding/cox-gear-planner.git
-commit=06f5088d0df04ddfd2b6acb45034c5f3e616914f
+commit=ecd82b79096c9766323f398b0e27d6e765a04d55
 authors=davidcottrellcoding


### PR DESCRIPTION
Adds **CoX Gear Planner**, a Chambers of Xeric loadout planner.

Repository: https://github.com/davidcottrellcoding/cox-gear-planner

### What it does

Given the rooms in your raid layout, it produces one concrete loadout: the 11 slots you wear and what goes in your 28 inventory slots, drawn from gear you actually own across your bank, inventory, worn equipment and Group Ironman shared storage. Room times and gear choices are computed with the standard OSRS DPS formulas using your live boosted stats.

Armour is chosen by reading each owned item's real stats via `ItemManager.getItemStats`, rather than matching a hardcoded item list, so newly released gear works without a plugin update. Effects that aren't expressed in item stats are modelled explicitly and sourced from the wiki (twisted bow scaling, dragonbane, demonbane, salve amulet, crystal armour, void, Inquisitor's, powered staff speeds).

### Notes for review

- **No network access.** The plugin makes no HTTP requests of any kind.
- **No automation.** It only reads client state and renders a side panel; it never sends input, and adds no overlays or menu entries.
- **Storage.** It records item IDs and quantities seen in the bank and shared storage containers so suggestions work without the bank open, persisted via `ConfigManager`. Toggleable, and there is a button to clear it.
- **No third-party dependencies**, so no dependency hashes are needed.
- BSD 2-Clause licensed; 79 unit tests covering the combat maths and item data.
