### PR TITLE
Update ge-companion to v1.2.1

### DIFF
--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=3f4eba4a50ea7c94c306e526ec577b2ddaab06f0
+commit=a1ad626d322cc512b1a75fb7f93aefc9a9144d56


### PR DESCRIPTION
Fix !bank chat command processing for local player only

Previously, when another player with GE Companion typed !bank, 
it would incorrectly process and display that player's own bank 
value instead of ignoring the command. Now the command only 
processes when typed by the local player.