### PR TITLE
bank-templates: 2.3.0

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=771f370200d574062509c9bfc0cb98d86f5a9115
+commit=b9625d93b9d49114dd3e0863e602629372338a8e


### PR DESCRIPTION
Bank value now counts worn and carried items alongside the bank.

Gear kept equipped used to drop out of the total the moment it left the bank, so a synced value understated what the player actually owned. Equipment and inventory are now included in the snapshot. A held item merges into the placeholder its withdrawal left behind, so it keeps the slot the player arranged it in and a rendered bank still matches the game; anything with no slot to merge into is appended to the main tab. Noted stacks resolve to their unnoted id so they land on the same entry rather than creating a duplicate.

The existing privacy gate is unchanged: snapshots are only ever sent for characters the player has linked to an Exchange Insights account, and the setting's description has been updated to say that equipment and inventory are included.