### PR TITLE
Update compact-orbs to v1.9.1

### DIFF
--- a/plugins/compact-orbs
+++ b/plugins/compact-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/its-cue/compact-orbs.git
-commit=4a53cfcec25c07d52de939dde6ab5db514ecd9a1
+commit=4ee6849b44615aa2adb461c5841126124efb362d


### PR DESCRIPTION
- fix hotkey not working because `isCutsceneActive()` was not being called on the client thread