### PR TITLE
add ring-of-time

### DIFF
--- a/plugins/ring-of-time
+++ b/plugins/ring-of-time
@@ -1,0 +1,2 @@
+repository=https://github.com/laurenszs/Ring-of-Time.git
+commit=22ea20b5229b7a39c14f5b020cc1121292a6130b


### PR DESCRIPTION
Adds Ring of Time, a configurable set of independent draggable annular timers for temporary skill buffs and debuffs, poison and venom, antipoison, stamina, and antifire.

- Public source: https://github.com/laurenszs/Ring-of-Time