### PR TITLE
Add BA Metronome plugin

### DIFF
--- a/plugins/ba-metronome
+++ b/plugins/ba-metronome
@@ -1,2 +1,2 @@
 repository=https://github.com/rsfost/ba-metronome.git
-commit=2aa2277fade6aa8c7ba5313ac2f5b2c7e8ee397c
+commit=0edf9f5dfb3f5343529d0d523e8355246412bcd3

--- a/plugins/ba-metronome
+++ b/plugins/ba-metronome
@@ -1,0 +1,2 @@
+repository=https://github.com/rsfost/ba-metronome.git
+commit=2aa2277fade6aa8c7ba5313ac2f5b2c7e8ee397c


### PR DESCRIPTION
This plugin automatically plays a metronome sound during specific actions in Barbarian Assault. It currently supports the Healer role only, but other roles may be added if there's demand.