### PR TITLE
Add Ring of Time

### DIFF
--- a/plugins/ring-of-time
+++ b/plugins/ring-of-time
@@ -1,0 +1,2 @@
+repository=https://github.com/laurenszs/Ring-of-Time.git
+commit=fc25dc31c2bc36bc52397d73ea34e8ec55be41af


### PR DESCRIPTION
Adds Ring of Time, a visual timer plugin that displays buffs, debuffs, poison, venom, antipoison, stamina, and antifire as shrinking, independently draggable rings.