### PR TITLE
Update custom-hp-bar

### DIFF
--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=97d68a77e8e97bf681a814b9e81fe9fe7f7f6d96
+commit=0c38280ee5279b7e8fe66e5c0065797c2ccda9ae

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=0c38280ee5279b7e8fe66e5c0065797c2ccda9ae
+commit=b40c1b541fb50b21e140557a278804abb0d618c5

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=b40c1b541fb50b21e140557a278804abb0d618c5
+commit=6e23d2f4309529efa4db5ef8317a541e737e926b

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,0 +1,2 @@
+repository=https://github.com/waitstepbro/custom-hp-bar.git
+commit=97d68a77e8e97bf681a814b9e81fe9fe7f7f6d96

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=6e23d2f4309529efa4db5ef8317a541e737e926b
+commit=91fe900114d5df691a8cb19f2ed30f666a39c4f7

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=e6c742155ddbc9dc7231c038daacd65c71ced69a
+commit=b6463556da35ebcf43e5c942ae8d83e1d0553521

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=87f2891b3d935b18d578fca5755c9656e9c1f935
+commit=158e0bc8e7663930d5828876e412cd4f9b9294c8

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=91fe900114d5df691a8cb19f2ed30f666a39c4f7
+commit=87f2891b3d935b18d578fca5755c9656e9c1f935

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=e765475876765335c2d2faad106490f1eda409cc
+commit=7d87af93d6523cf3a7663c9c4b1448180acc8fd5

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=b6463556da35ebcf43e5c942ae8d83e1d0553521
+commit=e765475876765335c2d2faad106490f1eda409cc

--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=158e0bc8e7663930d5828876e412cd4f9b9294c8
+commit=e6c742155ddbc9dc7231c038daacd65c71ced69a


### PR DESCRIPTION
## New features
- Special attack bar (own colour, hide-while-full, combat only)
- Configurable bar order — 4 position pickers for HP/Prayer/Special/Run
- NPC combat level suffix on name
- NPC name truncation (length limit)
- HP colour gradient (full → mid → low, per profile)
- Aggressive NPC bar colour (shared with name colour)
- Prayer bar colour configurable
- HP text spacing (Both mode); dropped parentheses around player %
- Grey out NPC names on loot-tainted kills
- Bar opacity slider (target/player, independent)
- Run Energy bar — restore preview, Stamina colour, drain timeout
- Other players' names + fully independent bar styling
- Same-tile stacking for bars/names (NPCs and players)
- NPC/Player same-tile stack limits
- Prioritize Self on Same Tile
- Hotkeys to toggle names/HP bars
- Per-bar Always Show toggles (HP/Prayer/Special/Run)
- Prayer tick timer
- Text alignment (Left/Center/Right)
- Loot-key-carrying PK skull variants
- Config sections collapsed by default
- Self's HP bar now stays visible while actively dealing damage, not just while taking it.

## Fixes
- Bleed tint: fires on-apply, clears on cure (was up to ~19s late)
- Disease tint now matches core's varplayer (clears with Relicym's)
- Prayer bar no longer flickers mid-tick
- Loot-taint detection also reads Ironman warning messages
- Precise HP could stick at 0 on a living NPC — fixed
- Verzik Pillars / Whisperer Columns weren't tracked — fixed
- Zero-damage hits from others now grey the bar
- Corrected NPC max-HP data (Gauntlet demis, Amoxliatl, Yama, Doom of Mokhaiotl)
- ToA/ToB region detection fixed (broke Ironman loot exemption + ToA grey-out/HP%)
- NPC HP bar/name no longer lingers through the death animation
- Player HP bar no longer lingers through the death animation
- Same-tile stacking no longer drifts/staggers with camera angle
- Same-tile stack no longer snaps when a newcomer joins
- "Always Show Name" no longer ignored when "Always Show Bar" was on
- Other players' vertical offset now moves the name too
- Overhead icon no longer drifts during heavy stacking
- Overhead chat text uses its real vanilla anchor, not the bar stack
- PK skull icon now actually renders
- Skull/prayer icon now shows correctly with no bar/name present
- Run Energy bar no longer tied to the combat timer
- Solo bar now respects its configured vertical offset
- NPE crash fix (chat text / script hook)
- Self's own HP bar could snap onto — or render at — another actor's position (e.g. a boss's) whenever their tiles coincided, instead of always tracking the player's own character.
- Other players' names no longer float above self's whole bar stack when sharing self's tile — they anchor above their own head again.

## Other
- Config reorganised into Style/Info sections — keys unchanged, profiles carry over
- Removed: other players' Display Mode (always %), "Replace Overhead Icon" toggle (always on)
- README/TODO docs cleaned up