### PR TITLE
Update Kill Clog to 2.0.0

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=cb1efd9562d9051d38287f9e25f11355cb156f0e
+commit=a659b0ebbd87209a5e707b75b19d8fc03b4e3504
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers. If you enable "Sync Collection Log to Killclog.com" (off by default), your collection log and personal bests are published to your killclog.com profile.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
 commit=2496ad195e9a639fa5be83d1bf5ff7d053351eb1
-warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers. If you enable "Sync Collection Log to Killclog.com" (off by default), your collection log and personal bests are published to your killclog.com profile.
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=a659b0ebbd87209a5e707b75b19d8fc03b4e3504
+commit=2496ad195e9a639fa5be83d1bf5ff7d053351eb1
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers. If you enable "Sync Collection Log to Killclog.com" (off by default), your collection log and personal bests are published to your killclog.com profile.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=074a557ba7b5f579ee1bbafc0fd1c122338f541c
+commit=d0505c4837472a34f281e9d840e5dcda09c3fe0f
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=d0505c4837472a34f281e9d840e5dcda09c3fe0f
+commit=f5663a3b419074fb0e8ec18e57bd2829c6a26537
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=54f63596fc56cfebe3b1bf8bffe8c2766e71606f
+commit=cb1efd9562d9051d38287f9e25f11355cb156f0e
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers. If you enable "Sync Collection Log to Killclog.com" (off by default), your collection log and personal bests are published to your killclog.com profile.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=f5663a3b419074fb0e8ec18e57bd2829c6a26537
-warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.
+commit=54f63596fc56cfebe3b1bf8bffe8c2766e71606f
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers. If you enable "Sync Collection Log to Killclog.com" (off by default), your collection log and personal bests are published to your killclog.com profile.


### PR DESCRIPTION
Kill Clog 2.0.0

first-party collection log sync, opt-in and off by default:

* a new "Sync Collection Log to Killclog.com" setting publishes your locally tracked collection log and personal bests to your own killclog.com profile. nothing is sent until you turn it on, and opting out at killclog.com deletes everything stored
* player lookups now also read killclog.com alongside TempleOSRS and RuneProfile, so synced players' logs and personal bests show up in lookups and boss tooltips. looking up a never-synced name costs no extra requests
* the README and privacy copy name every endpoint the plugin talks to: TempleOSRS, RuneProfile, killclog.com, and the OSRS Wiki item mapping

also in this release:

* hiscore lookups now use the name-keyed json endpoint, so game updates that reshuffle the hiscores can no longer blank or misalign boss kcs
* personal bests now also come from the adventure log's counters scroll, so times you set before installing show up without having to re-kill anything. the log opens in either the original or the newer menu interface depending on your interface style setting, and both are read
* hovering a pet in the player summary shows its name and links its wiki page
* skill summaries follow the virtual levels plugin when you have it enabled, up to 126 and virtual totals
* new titan prestige for 200m xp in every skill
* mad angel collection log data maps correctly

note on the adventure log: runelite's own chat commands plugin parses personal bests from that same scroll, but it only watches the older menu interface, so for anyone using the newer interface style the parse is silently skipped and no adventure log personal bests are recorded at all. that is why this plugin reads it too rather than relying on the existing parse. i have a fix written for chat commands and will open it against runelite core separately.
