### PR TITLE
Update 420 kc to 1.1.1

### DIFF
--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420kcp.git
-commit=7b2e5212e4787024d637b36345427ef51d05d9f9
+commit=01e6c511a19da76dd2a2bb07e99809560c24ae0f


### PR DESCRIPTION
420 kc 1.1.1

* the 420 message now fires for every wording the game uses: gauntlet completions, raids, wintertodt, sepulchre, rifts closed, hunter rumours, chest openings and more
* previously only kill count messages counted, so a real 420 gauntlet went uncelebrated