### PR TITLE
Update ge-companion - bank scan debounce hotfix

### DIFF
--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=a1ad626d322cc512b1a75fb7f93aefc9a9144d56
+commit=10b841fcf5eb7f9308617a4adb7c1ff2cd58d48f


### PR DESCRIPTION
Hotfix for micro-stutters during rapid bank clicking

Added a 500ms debounce to the bank item container scan so it no 
longer fires on every individual click when rapidly moving items 
in the bank. The scan now waits until the user has stopped 
clicking before processing, eliminating the performance issue.

Fixes: bank tag loadout zig-zag clicking causing micro-stutters