### PR TITLE
bis-gear: 0.3.0

### DIFF
--- a/plugins/bis-gear
+++ b/plugins/bis-gear
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/bis-gear-plugin.git
-commit=82fd0cb212baa40f5a201509bb3b55b27ac5fce7
+commit=2aa61a455c7656313caf8ca189f001c8a621663e


### PR DESCRIPTION
Bumps BiS Gear to 0.3.0 (`2aa61a4`).

Scores the 2026 Summer Sweep-Up combat changes that the plugin models:

- **Tonalztics of ralos** — the Division special's Defence drain (12.5% of the target's Magic level per hit) is now applied; this input previously did nothing.
- **Sanguinesti staff** — base max hit raised by 1 (floor(Magic/3)), and the heal's new +8 damage proc (1 in 5 hits) is modelled as a DPS contribution like the enchanted-bolt procs.
- **Inquisitor** — the set bonus moved onto the individual pieces and the mace no longer triples it; the plugin no longer over-values an Inquisitor's mace setup.

Also refreshes the Soulreaper axe's test data for its +4 strength (live CDN data the calculation already used) and fixes a dev-only data test to skip when its local dataset is absent.

Licence unchanged (BSD-2). No new dependencies. `./gradlew clean build` is green with 70 tests.