### PR TITLE
Add Bronzeman PVP TCG

### DIFF
--- a/plugins/bronzeman-pvp-tcg
+++ b/plugins/bronzeman-pvp-tcg
@@ -1,2 +1,3 @@
 repository=https://github.com/0xG3r4rD/bronzeman-pvp-tcg.git
-commit=6e835041984c6ffd318cf34adee2fc07109e4cf4
+commit=146965399d11038b8bfef80f73db39e75753c25f
+warning=Card artwork is downloaded from the OSRS Wiki, which receives your IP address and the requested image URLs. If you configure a Discord webhook for pull alerts, card pull data is sent to Discord. No collection or account data is sent anywhere else.

--- a/plugins/bronzeman-pvp-tcg
+++ b/plugins/bronzeman-pvp-tcg
@@ -1,0 +1,2 @@
+repository=https://github.com/0xG3r4rD/bronzeman-pvp-tcg.git
+commit=d637d8c9e154fb36e16a5b0522c1b7993ed92b7b

--- a/plugins/bronzeman-pvp-tcg
+++ b/plugins/bronzeman-pvp-tcg
@@ -1,0 +1,2 @@
+repository=https://github.com/0xG3r4rD/bronzeman-pvp-tcg.git
+commit=6e835041984c6ffd318cf34adee2fc07109e4cf4

--- a/plugins/bronzeman-pvp-tcg
+++ b/plugins/bronzeman-pvp-tcg
@@ -1,3 +1,2 @@
 repository=https://github.com/0xG3r4rD/bronzeman-pvp-tcg.git
 commit=146965399d11038b8bfef80f73db39e75753c25f
-warning=Card artwork is downloaded from the OSRS Wiki, which receives your IP address and the requested image URLs. If you configure a Discord webhook for pull alerts, card pull data is sent to Discord. No collection or account data is sent anywhere else.


### PR DESCRIPTION
Adds **Bronzeman PVP TCG**, a PvP-oriented bronzeman challenge mode built on a card collection.

- Equipping an item is blocked until you own its matching card, so gear is unlocked by pulling cards rather than by acquiring the item.
- Credits are earned only from PvP kills. A kill pays for one booster pack; an optional Hard mode pays 250 credits per 100k of loot value instead.
- A Defence level setting (1 / 20 / 30 / 40 / 50 / 60+) removes cards for gear you could not equip at that level, so the roll pool matches a pure or level-restricted build. Equip requirements are sourced from the OSRS Wiki.
- The card pool is curated down to ~1,190 equipable weapons, armour and jewellery.

**Attribution:** this is a fork of [OSRS TCG](https://github.com/Azderi/osrs-tcg) by Azderi (BSD 2-Clause; the copyright notice is retained in LICENSE), and the equip-restriction concept is ported from [Bronzeman TCG](https://github.com/Felmeme/bronzeman-tcg) by Felmeme. Both are credited in the repository README. The upstream OSRS TCG plugin is already on the hub; this fork runs alongside it — its package, config group, storage paths, party message types and chat commands are all namespaced separately so both can be enabled in the same client without conflicting.

Repository: https://github.com/0xG3r4rD/bronzeman-pvp-tcg