### PR TITLE
Update no-misclick-repot

### DIFF
--- a/plugins/no-misclick-repot
+++ b/plugins/no-misclick-repot
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/bop-plugins.git
-commit=1d538e4a0a5b6169eb922562d6357643d2c4fbc9
+commit=1df78055099e9f3b4e7f3df024131db78590c355


### PR DESCRIPTION
Addresses https://github.com/bopsec/bop-plugins/issues/7

Added config option for checking attack boost (in addition to strength) before disallowing scb repot