### PR TITLE
Update emote-wheel

### DIFF
--- a/plugins/emote-wheel
+++ b/plugins/emote-wheel
@@ -1,2 +1,2 @@
 repository=https://github.com/Zezi-cmd/emote-wheel.git
-commit=00dee4450a40ce577a7b7c3a9e45a6b2d990760f
+commit=06cffdda083548d88203a482da033aca35cd6333


### PR DESCRIPTION
Fixes Skillcape and Relic unlock emote matching. all emotes should work now