### PR TITLE
Revert ge-companion debounce - broke bank tracking

### DIFF
--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=94b27fa14825bb3013abd8e553956e333c2dac83
+commit=e2ec50550f1dabf3838f40742e9bfcdc909dea5f

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=4e33e8021a44d944e8e34b21b863fcdc690c3109
+commit=94b27fa14825bb3013abd8e553956e333c2dac83

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=7a8761488e82de3f7f5892d3aadab9cb3fd11fe0
+commit=4e33e8021a44d944e8e34b21b863fcdc690c3109

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=10b841fcf5eb7f9308617a4adb7c1ff2cd58d48f
+commit=7a8761488e82de3f7f5892d3aadab9cb3fd11fe0


### PR DESCRIPTION
Emergency revert - the bank scan debounce introduced in the previous 
hotfix broke bank tracking entirely. Reverting to restore bank 
tracking functionality while we investigate a proper fix.