### PR TITLE
Update goat-pit-indicators to 1.3.0

### DIFF
--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
-commit=a84b40adec1396d83475e2b3fc4d5dd2a13b9609
+commit=db17fd2ed615bd5ba59ed58847c16e4d81eb8c72


### PR DESCRIPTION
Bumps goat-pit-indicators to release 1.3.0 (tag `R-1.3`, commit `db17fd2ed615bd5ba59ed58847c16e4d81eb8c72`).

New since 1.2.1: telegrab highlight near/far color gradient, spike-supply highlight with a "Take Spike" prompt, animated leaping-goat total icon, and a right-click reordering section to guard against misclicks.