### PR TITLE
grand-flip-out: update to 5af290e

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=49786a6c1d45ff3499b782873b91f97163e72a2c
+commit=5af290eacf22d6e4cd1f2ce5bf724819b46e675a

--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=92de193e492cf830bcf90ad8c878ac07769ae8bf
+commit=49786a6c1d45ff3499b782873b91f97163e72a2c


### PR DESCRIPTION
Updates grand-flip-out to 49786a6.

User-reported UX fixes (plugin Discord #feedback):
- The Advisor's "Fill offer" button now shows armed feedback on the button itself (relabels + disables until the next card render) instead of only a game-chat line; when the auto-fill setting is off the label is unchanged and the chat line names the setting.
- The advisor card is pinned while the player enters the armed offer, so another slot's offer event can no longer swap the suggestion mid-entry. Reuses the existing held-for-sell mechanism, bounded by the existing 90s fill-arm TTL; a terminal buy upgrades to the existing unbounded hold; all release paths unchanged.
- A tracker map crossed by the EDT and the client thread is now a ConcurrentHashMap.

No new APIs, no new automation — the fill remains arm-only (player opens the offer and confirms). Tests: 132/0 (`cleanTest test`), incl. a new suite pinning the hold lifecycle and button labels.
