### PR TITLE
Add collection log roulette

### DIFF
--- a/plugins/collection-log-roulette
+++ b/plugins/collection-log-roulette
@@ -1,3 +1,3 @@
 repository=https://github.com/Jared-Drake/collection-log-roulette.git
-commit=b66e2bbca201f14881b01b7b1c331218d7cb0ded
+commit=efc9f3bf087a20fb184b21d785fc335085a52cb5
 authors=Smelted

--- a/plugins/collection-log-roulette
+++ b/plugins/collection-log-roulette
@@ -1,0 +1,3 @@
+repository=https://github.com/Jared-Drake/collection-log-roulette.git
+commit=b66e2bbca201f14881b01b7b1c331218d7cb0ded
+authors=Smelted

--- a/plugins/collection-log-roulette.toml
+++ b/plugins/collection-log-roulette.toml
@@ -1,2 +1,0 @@
-repository = https://github.com/Jared-Drake/collection-log-roulette.git
-commit = b66e2bbca201f14881b01b7b1c331218d7cb0ded

--- a/plugins/collection-log-roulette.toml
+++ b/plugins/collection-log-roulette.toml
@@ -1,0 +1,2 @@
+repository = https://github.com/Jared-Drake/collection-log-roulette.git
+commit = b66e2bbca201f14881b01b7b1c331218d7cb0ded


### PR DESCRIPTION
Add Collection Log Roulette plugin. Rolls a random Collection Log activity and tracks it until you unlock a new slot from it. Tracking and display only includes no automation and no network calls.