### PR TITLE
Update configurable-slayer-task-overlay

### DIFF
--- a/plugins/configurable-slayer-task-overlay
+++ b/plugins/configurable-slayer-task-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/configurable-slayer-task-overlay.git
-commit=ac6b8c10a957dce52518f774a4b6274d77fa3da2
+commit=9f09e813a19c236f0eef37b840154feca113efa5


### PR DESCRIPTION
Bumps the plugin to the latest release.

Fixes [NathanVegetable/configurable-slayer-task-overlay#1](https://github.com/NathanVegetable/configurable-slayer-task-overlay/issues/1): the overlay timeout now hides the task instead of discarding it, so kills no longer re-trigger it. Also adds Mortimer and corrects Kuradal's spelling.