### PR TITLE
Add Mortimer Imbued Heart

### DIFF
--- a/plugins/mortimer-imbued-heart
+++ b/plugins/mortimer-imbued-heart
@@ -1,0 +1,2 @@
+repository=https://github.com/Webben91/mortimer-imbued-heart.git
+commit=629b705bf6a2cd8b7dac9654d75fb8eee2bcca71


### PR DESCRIPTION
## Summary

Adds **Mortimer Imbued Heart**, a local RuneLite sidebar calculator for Mortimer Slayer offers and Imbued Heart progress.

The plugin:

- reads Mortimer's open task-choice interface and compares up to three offers;
- follows the active assignment through RuneLite's Slayer service and in-game messages;
- calculates task Heart chance, expected superiors, Heart chance per hour, and estimated completion time;
- tracks completed tasks and cumulative Heart chance in RuneLite profile configuration with a local fallback;
- supports per-monster DPS and cannon configuration, including optional OSRS Wiki DPS share links; and
- contains no telemetry, external accounts, highscores, or remote backend.

## Verification

- `gradlew.bat --no-daemon clean test`
- Result: `BUILD SUCCESSFUL`
- BSD 2-Clause licensed
- Standard Plugin Hub build
