### PR TITLE
loadout-lab: 0.3.0

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=da373eeb27603fa1977cfe0023756a4ba52bf82a
+commit=c1591dcdd4490e9cc58670686f026acf4540de75
 authors=ajkatz


### PR DESCRIPTION
Updates Loadout Lab to 0.3.0 (pin c1591dc).

Second of the staged updates, following #14564. A single `commit=` line on top of the 0.2.4 that just merged.

Since 0.2.4:

- **Multi-mob rosters.** Any result grows into a list of targets — add a mob, or search a curated group or raid — and the optimizer finds ONE shared set per style across the whole lineup, with each mob as its own row showing its dps, the style that answers it, and a lens that flips every card to that mob.
- **Wyrmscraig (2026-07-29) data.** Refreshed from the wiki team's dataset: the Mad Angel (both the quest and the repeatable post-quest forms) and Hallowfell, plus its 75 Attack requirement.
- **Quest-issue kit is no longer suggested.** The Silvthrill ballista and its javelins carry real combat stats upstream but are destroyed on quest completion, so no account can bring them anywhere.
- **Golembane fix.** The weapon candidate pool is cut by a monster-agnostic score while the granite hammer's +30% accuracy / +30% damage vs golems lives in the dps model, so the hammer was pruned before its bonus could count. Measured at the Mad Angel: owned melee 6.58 -> 8.58 dps.

No network I/O.
