### PR TITLE
Add Mortimer Slayer

### DIFF
--- a/plugins/mortimer-slayer
+++ b/plugins/mortimer-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/Webben91/mortimer-slayer.git
-commit=e5ac4cdf86adfbd615e54ec81af2307de227aeb5
+commit=e5ac4cd622c82fb27c8c3c4e0d8e560bcb0a954b

--- a/plugins/mortimer-slayer
+++ b/plugins/mortimer-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/Webben91/mortimer-slayer.git
-commit=4324565f63552046831a7954b48ada60c828cfc2
+commit=4aa4aa971a304fa9eb770c56d2a1dca6dca8c29d

--- a/plugins/mortimer-slayer
+++ b/plugins/mortimer-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/Webben91/mortimer-slayer.git
-commit=4aa4aa971a304fa9eb770c56d2a1dca6dca8c29d
+commit=e5ac4cdf86adfbd615e54ec81af2307de227aeb5

--- a/plugins/mortimer-slayer
+++ b/plugins/mortimer-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/Webben91/mortimer-slayer.git
-commit=2925501a02628e60ae135f1ffab2fc8ea88a696d
+commit=f9f440e66aa46d70e8d6d26d697ab7ac3f294517

--- a/plugins/mortimer-slayer
+++ b/plugins/mortimer-slayer
@@ -1,0 +1,2 @@
+repository=https://github.com/Webben91/mortimer-slayer.git
+commit=bbfd495c8c2d75148c8675eb2b8a37767912a13e

--- a/plugins/mortimer-slayer
+++ b/plugins/mortimer-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/Webben91/mortimer-slayer.git
-commit=334abdf7a1301668151f4a244d4ecc97a593b8de
+commit=2925501a02628e60ae135f1ffab2fc8ea88a696d

--- a/plugins/mortimer-slayer
+++ b/plugins/mortimer-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/Webben91/mortimer-slayer.git
-commit=72ee5d184619275d7cca067a1d522671d437ff2d
+commit=4324565f63552046831a7954b48ada60c828cfc2

--- a/plugins/mortimer-slayer
+++ b/plugins/mortimer-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/Webben91/mortimer-slayer.git
-commit=bbfd495c8c2d75148c8675eb2b8a37767912a13e
+commit=334abdf7a1301668151f4a244d4ecc97a593b8de

--- a/plugins/mortimer-slayer
+++ b/plugins/mortimer-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/Webben91/mortimer-slayer.git
-commit=f9f440e66aa46d70e8d6d26d697ab7ac3f294517
+commit=72ee5d184619275d7cca067a1d522671d437ff2d


### PR DESCRIPTION
## Summary

Adds Mortimer Slayer, a local RuneLite planner for comparing Mortimer task offers by Imbued Heart chance, Slayer XP per hour, or an equal balance of both.

## Features

- Reads Mortimer offers from the live game interface and active assignments from RuneLite's Slayer service.
- Highlights the recommended offer directly on Mortimer's interface, including Heart, XP, balanced, fast-reroll, and point-skip guidance.
- Calculates task Heart chance, Heart chance per hour, expected superiors, estimated duration, and on-rate time.
- Supports alternate monster variants, task-specific DPS/cannon overrides, and Slayer-cape repeat recommendations.
- Detects the in-game Slayer block list and provides two manual block selectors for routing when needed.
- Recommends Expeditious or Slaughter bracelets and can flash an optional reminder when the suggested bracelet is not equipped.
- Tracks the active task and accumulated Heart chance in the selected RuneScape profile configuration.
- Contains no telemetry, external accounts, highscores, backend service, or RuneScape credential handling. The only optional network request is directly to the OSRS Wiki when a player saves a Wiki DPS share link.