### PR TITLE
Update object-marker-plus

### DIFF
--- a/plugins/object-marker-plus
+++ b/plugins/object-marker-plus
@@ -1,2 +1,2 @@
 repository=https://github.com/Shackin/ObjectMarkerPlus.git
-commit=06ce98e6c76bc7c2d3753c8831c215189b651948
+commit=237ff82b5058b1bbf2fbdeaa5316b9531b232ac0


### PR DESCRIPTION
Added compatibility for importing raw markers not exported by the plugin.

Clean up random backslashes (\: and \#) from the clipboard.
Tweaked it to handle decimals so region integers don't break import.