### PR TITLE
Update scapestack-sync to v0.4.0

### DIFF
--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
-commit=718f5e9e07f0e2e547e14ce6600c98954a3bd1a7
+commit=aeb0e73c1eea87c5100e8ef1cc46fb117b3e3ddd
 warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/scapestack-sync
+++ b/plugins/scapestack-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/laurensbs/scapestack-runelite-plugin.git
-commit=e29f6ac6995ffd8f95c3f71bebeac1d0ea26ebd3
+commit=718f5e9e07f0e2e547e14ce6600c98954a3bd1a7
 warning=This plugin submits your IP address and comprehensive account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Scapestack Sync from v0.3.0 / snapshot contract 3 to v0.4.0 / snapshot contract 4.

## What changed

- Login sync now waits for quest varps with a bounded client-tick readiness poll. If they never become readable, the quest field is omitted instead of sending a false empty list.
- Unread quest and collection-log fields are omitted. Observed empty readings remain explicit, so the server can distinguish “nothing completed” from “not read this sync”.
- The panel reports quests, collection log and bank status in player-facing terms before sync.
- A guarded Full resync action replaces retained quest, diary and collection-log progress only when the plugin has complete readings.
- The collection-log limitation is explicit: RuneLite can read it only after the player opens the in-game widget; the server retains the resulting union for later sessions.

The production Scapestack API already accepts contract 4 before this update ships.

## Review notes

- **External HTTP calls without user opt-in:** `Sync on login` and `Refresh after quests` default off. `Sync now` is an explicit player action. Quest-complete refresh also requires `Sync on login`.
- **Bank privacy:** when bank checks are enabled, Scapestack sends bank item IDs, names and quantities for gear and supply planning. It never sends inventory, equipment, chat, screenshots, clicks, local files, login details or a RuneScape password.
- **Transport:** claim and sync send the raw local install token only as the `Authorization: Bearer` value. The server stores its SHA-256 hash.
- **Threading:** collection processing and HTTP claim/readiness/sync work do not block RuneLite's client thread. Shutdown cancels an active HTTP call.
- **Web handoff:** successful sync directs the player to Scapestack `/next`; the website loads the persisted plugin snapshot and does not reuse stale browser-bank context.
- **Game integrity:** the plugin is read-only. It does not click, type, move the player, change prayers, swap menus or perform game actions.

## Verification

- Standalone source: `aeb0e73c1eea87c5100e8ef1cc46fb117b3e3ddd`
- Release tag: `v0.4.0`
- `./gradlew clean test --offline`
- Monorepo `npm run ci:check`
