### PR TITLE
Add Station's Inspect Details

### DIFF
--- a/plugins/stations-inspect-details
+++ b/plugins/stations-inspect-details
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Inspect-Details.git
-commit=08711a93781940a9052b967b2b4db6b8dd35c16e
+commit=654b6b9b1720e3c43f0e06173685d5937dae5ddd

--- a/plugins/stations-inspect-details
+++ b/plugins/stations-inspect-details
@@ -1,0 +1,2 @@
+repository=https://github.com/StationEarthxo/Stations-Inspect-Details.git
+commit=08711a93781940a9052b967b2b4db6b8dd35c16e


### PR DESCRIPTION
Adds Station's Inspect Details, a cosmetic inventory plugin that spins selected hovered item categories and provides an item inspection viewer with model rotation, zoom, stats, and collection-log inspection. Its Inspect menu can optionally require Shift. The plugin uses the standard build and adds no third-party dependencies.