### PR TITLE
Expanded bank tags viewer

### DIFF
--- a/plugins/expanded-bank-tabs
+++ b/plugins/expanded-bank-tabs
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=6bb5e068efb7e0d95271518baf565658e407be33
+commit=cb46d08c8b3909f9515be50b9706ece2fe4b5fe1

--- a/plugins/expanded-bank-tabs
+++ b/plugins/expanded-bank-tabs
@@ -1,0 +1,2 @@
+repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
+commit=6bb5e068efb7e0d95271518baf565658e407be33

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=a7c8e941a7f9df13fdd831b8c9f4f8f7b5bba1f4
+commit=764a3870c9e7e6c7bdff84b1cf16e7031d54667f

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=764a3870c9e7e6c7bdff84b1cf16e7031d54667f
+commit=764a38704e3de80d49ee44d20c9e80900e34b2e3

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=2e3fd62fe92888af70910765a2fd7053166df003
+commit=d2d852f840a8b1d07f9dee99e5e3a7d36bac6924

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=e42fbd25dff9225e64fe50d3fcf3d52b7c5d48ba
+commit=75a79aa9121f81060d9649d3afc67f04330fcfe2

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=8ff3fcd12634c9a7b92d95cec66177a617930034
+commit=e42fbd25dff9225e64fe50d3fcf3d52b7c5d48ba

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=764a38704e3de80d49ee44d20c9e80900e34b2e3
+commit=8ff3fcd12634c9a7b92d95cec66177a617930034

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=4306f14f9b2764871f20ba80d46647dcd775b55f
+commit=a7c8e941a7f9df13fdd831b8c9f4f8f7b5bba1f4

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=6a75ef6a4636ada3b6e34f3f3f77a581400ec28f
+commit=6e1cf443250b131c1fefa77854c51d19b175ab62

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=aae02a12fc5a2bc7546926d08bb5d3eb04e9dcf5
+commit=2e3fd62fe92888af70910765a2fd7053166df003

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=75a79aa9121f81060d9649d3afc67f04330fcfe2
+commit=048e405f258d2d6fee91f30d9537ac7e99b873ae

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=048e405f258d2d6fee91f30d9537ac7e99b873ae
+commit=3778077f0bbd55a2cbd4b516cb0f342a605349c1

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=d2d852f840a8b1d07f9dee99e5e3a7d36bac6924
+commit=6a75ef6a4636ada3b6e34f3f3f77a581400ec28f

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=3778077f0bbd55a2cbd4b516cb0f342a605349c1
+commit=b2fe815a9b248dae216aa8f9653999d81e523cdf

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=cb46d08c8b3909f9515be50b9706ece2fe4b5fe1
+commit=4306f14f9b2764871f20ba80d46647dcd775b55f

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=b2fe815a9b248dae216aa8f9653999d81e523cdf
+commit=aae02a12fc5a2bc7546926d08bb5d3eb04e9dcf5

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=33eaeb62edd1cb16247f558cad2657fb9c573dd4
+commit=66e4e36441b6110f336815e7af696124e5a6f5b6

--- a/plugins/expanded-bank-tags-viewer
+++ b/plugins/expanded-bank-tags-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/ThomasScottWhite/expanded-bank-tabs.git
-commit=6e1cf443250b131c1fefa77854c51d19b175ab62
+commit=33eaeb62edd1cb16247f558cad2657fb9c573dd4


### PR DESCRIPTION
This plugin creates an expanded bank tabs viewer to help users view and manage their bank tabs more easily
<img width="732" height="824" alt="image" src="https://github.com/user-attachments/assets/140eac1a-b7fe-4c18-927d-9029e88fab29" />
