### PR TITLE
update pb-tracker-sync

### DIFF
--- a/plugins/pb-tracker-sync
+++ b/plugins/pb-tracker-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/0xJeu/pb-tracker-sync.git
-commit=b53b3417f7e7c991d44116a1ab3f60ca38211b04
+commit=de9bb24ddcea2fa0e2263b177141591235de442e
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
> This Plugin Hub update was prepared by Codex acting as Steph's coding agent.

Updates `pb-tracker-sync` from:

- `b53b3417f7e7c991d44116a1ab3f60ca38211b04`

to:

- `de9bb24ddcea2fa0e2263b177141591235de442e`

## Included plugin changes

- deduplicated and coordinated local My PBs profile loads
- persisted per-account sync fingerprints to skip unchanged automatic payloads across restarts
- automatic install-recovery backoff and scheduled retries
- passive install-mismatch recovery with no recovery page, code, setting, or required player action
- account-isolated retry timers and stale-callback protection

No new plugin dependencies are introduced.

## Validation

- full JDK 17 plugin test/build passed
- the cumulative plugin release was reviewed across PRs 15, 16, 17, and 18
- the corresponding backend release is deployed to production
- production migrations are applied with complete legacy credential backfill
- official-domain and direct-backend installation routes are live and authentication-protected
- the manifest diff contains only the commit-pin update
