### PR TITLE
clan-management: rank-requirement variant fixes

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=6f4495a09e38d35e819b8b2e7591d0570e31c77c
+commit=38c0bf5d0ed4437bd73017094bc592faf3f69265
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=5d2c6d5448cd74c87726548127ec58b7935f445b
+commit=bc4a68fb1e536323f6debd09cb70aa2810423ae5
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=38c0bf5d0ed4437bd73017094bc592faf3f69265
+commit=5d2c6d5448cd74c87726548127ec58b7935f445b
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=bc4a68fb1e536323f6debd09cb70aa2810423ae5
+commit=7f9552184ff84024219fc08d42b087f97d309b6a
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=1bec152db74a24272f5589ed05907ed8d660172c
+commit=73467a0569ebf5ad3ed07407436aee370f630175
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=7f9552184ff84024219fc08d42b087f97d309b6a
+commit=1bec152db74a24272f5589ed05907ed8d660172c
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps clan-management to `73467a0`.

Changes since the current live commit:
- Occult necklace (or) ornament kit now satisfies the Occult necklace rank requirement
- Completed infernal tools (axe / harpoon / pickaxe) now count as owning a Smouldering stone
- Rune Sword rank: Voidwaker (the full item or any of its three pieces) added as an achieve-pool option
- Void gear (ranger helm / elite top / elite robe / knight gloves) now matches league and locked variants by name prefix
- Imbued god capes (MA2) now match by name prefix, covering Deadman and league cape variants
- Drop rows show the full item name on hover, so long names clipped by the panel stay readable
- Members tab: boss KC shown in the collection-log category header
- Points now support fractional values (parsed as decimals), shown rounded to one decimal place across the panel