### PR TITLE
Create fire-max-cape-removal

### DIFF
--- a/plugins/fire-max-cape-removal
+++ b/plugins/fire-max-cape-removal
@@ -1,0 +1,2 @@
+repository=https://github.com/petty-mods/fire-max-cape-removal.git
+commit=9c88855dac53914c1ae543adf48b555be186cdf5


### PR DESCRIPTION
This plugin replaces worn fire max capes with regular fire capes. There are config options to exempt yourself, clan members, friends, and friends chat members.