### PR TITLE
Update Waypoint Sync

### DIFF
--- a/plugins/waypoint-sync
+++ b/plugins/waypoint-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Xiodrade/waypoint-sync.git
-commit=1201759a31c98ef70d720253444d6801b3f4e6f3
+commit=941bd299203fbfe6425eb09f8e0ed3e5a92ab388
 warning=This plugin submits your IP address, display name, quests, diaries, and combat achievements to a third party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Fix: combat achievement tasks could stay marked incomplete if first viewed under a non-"Complete" filter; now keeps the strongest filter value seen.
- Add: capture completed combat tasks live from the in-game "Combat Task Completed!" pop-up notification (no interface scrolling needed).
- Add: an in-client sidebar panel showing last-sync status and what synced, with "Sync now" and "Open Waypoint" buttons.