### PR TITLE
Update Station's Cozy Clutter artwork

### DIFF
--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=9d5925636d2a5ab4ac086763ac56b1dda67b23d2
+commit=1a693147346dc962b56aa2d0185e37f5b8258bf6


### PR DESCRIPTION
Adds a RuneLite-sized icon to the plugin repository and updates the pinned source commit. No plugin behavior changes.