### PR TITLE
Add plugin fire-max-cape-removal

### DIFF
--- a/plugins/fire-max-cape-removal
+++ b/plugins/fire-max-cape-removal
@@ -1,0 +1,2 @@
+repository=https://github.com/petty-mods/fire-max-cape-removal.git
+commit=f796707201f8ffd95d250df5ea444daa6ef5a1f4


### PR DESCRIPTION
A plugin that replaces worn fire max capes with regular fire capes.