### PR TITLE
Runeshare: Fix game screen flicker when switching bank tag tabs

### DIFF
--- a/plugins/runeshare
+++ b/plugins/runeshare
@@ -1,3 +1,3 @@
 repository=https://github.com/kcdragon/runeshare-plugin.git
-commit=94bc765e077b786f18730624727908819258f39e
+commit=f2a14d80c564503cdbbdc706d7b6740a349b1198
 warning=This plugin submits your bank tag tab data and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/runeshare
+++ b/plugins/runeshare
@@ -1,3 +1,3 @@
 repository=https://github.com/kcdragon/runeshare-plugin.git
-commit=f2a14d80c564503cdbbdc706d7b6740a349b1198
+commit=b6f45d6eb4507b0d5e77a4ecc0a3284e80cb47cc
 warning=This plugin submits your bank tag tab data and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
The plugin panel was constructed with super(false), leaving no JScrollPane validate root between it and the frame's root pane. Every panel rebuild on a tag tab change invalidated the entire window, re-validating the container holding the heavyweight game canvas and flashing the game screen while the RuneShare sidebar tab was open. Wrapping the panel (super(true)) contains revalidation to the sidebar.

Also in this path:
- drawPanel() now ends with revalidate()/repaint() instead of leaving stale invalid state for an ancestor repaint
- Panel entry points re-dispatch to the EDT (updateNpc was called from the client thread, redraw() from OkHttp callback threads)
- onGameTick exits early when no tag is active, skipping the per-tick banktags config sweep while idle and fixing an NPE in tabManager.find(null) when closing a tag tab that had a layout, which also left the panel stuck showing the old tag
- autoSave skips tags that have no real tab (find() returns null) instead of NPEing in createRuneShareBankTab
- The invokeLater lambda captures copies instead of reading mutable fields that the next tick can overwrite