### PR TITLE
Update Station's Cozy Clutter artwork

### DIFF
--- a/plugins/stations-cozy-clutter
+++ b/plugins/stations-cozy-clutter
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Clutter.git
-commit=9d5925636d2a5ab4ac086763ac56b1dda67b23d2
+commit=1a693147346dc962b56aa2d0185e37f5b8258bf6


### PR DESCRIPTION
Resubmitting this update by itself. I understand now that I should only have one Plugin Hub PR open at a time.

This adds the root icon.png artwork and updates the pinned source commit. There are no plugin behavior changes.