### PR TITLE
Update Station's Cozy Boats artwork

### DIFF
--- a/plugins/stations-cozy-boats
+++ b/plugins/stations-cozy-boats
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Boats.git
-commit=54063a996c8e60bcbdae3627060e14da0bc569d8
+commit=e9c976859cb209c748926cf60c31f34452c6344f


### PR DESCRIPTION
Submitting this update by itself after the previous artwork update was merged, following the one-open-PR-at-a-time workflow.

This adds the root icon.png artwork and updates the pinned source commit. There are no plugin behavior changes.