### PR TITLE
loadout-lab: 0.3.0

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=da373eeb27603fa1977cfe0023756a4ba52bf82a
+commit=f4b916d2cbdab969b87a87ea7aa6cb1555359c73
 authors=ajkatz

--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=f4b916d2cbdab969b87a87ea7aa6cb1555359c73
+commit=f6e71cf94cf351f430cfa82e99f24d65642dbce2
 authors=ajkatz


### PR DESCRIPTION
Updates Loadout Lab to 0.3.0 (pin f6e71cf).

Re-scoped: this PR previously carried a single small step of a split release. Per reviewer guidance it now carries the whole of that work as one update instead.

### Multi-mob rosters

Any result grows into a list of targets — add a mob, or search a curated group or raid — and the optimizer finds ONE shared set per style across the whole lineup. Each mob is its own row showing its dps, the style that answers it, and a lens that flips every card to that mob. Spec weapons compete across styles and are part of the carried set. The roster objective is HP-weighted, and avoidable curated attacks (Zulrah's magma slam) count zero.

### Result card rework

Style tabs replace the stacked style cards, with the strongest auto-selected. The classic worn-equipment layout becomes the layout, with info tiles filling the grid blanks. Every result owns its parameter zone, which rides the card as chips. New 5x5 gear silhouette plus stat flank. Undo/redo captures entry objects, so parameter zones survive back and forward.

### Engine

Augury and Mystic Vigour no longer stack. Kraken's typeless magic is modelled, and it pierces Protect from Magic (field report, wiki-verified). Dual macuahuitl chained hits and the Bloodrager set. Blue moon and eclipse moon sets. Dominated ornament kits lose dps ties. Per-form protect prayers via version-keyed boss overrides.

### Golembane fix

Golembane weapons were pruned from the weapon candidate pool before their bonus could apply. The pool cuts to the top 24 by a monster-agnostic score, and the granite hammer's raw stats sit below that line — so the +30% accuracy and +30% damage the engine already modelled never got a chance to count. At Dusk this suggested a Noxious halberd for 9.73 dps while the account owned a granite hammer worth 11.05. `candidateScore` already carried the same fix for salve, dragon hunter, arclight, keris and the leaf-bladed battleaxe; golem was missing from the list.

### Wyrmscraig data (2026-07-29)

Corpus refreshed from the wiki team's dataset: the Mad Angel in both its quest and repeatable post-quest forms, and Hallowfell with its 75 Attack requirement. Quest-issue kit is now excluded from loadouts — the Silvthrill ballista and its javelins carry real combat stats upstream but are destroyed on quest completion, so no account can bring them anywhere.

No network I/O.
