### PR TITLE
Update Station's Inspect Details artwork

### DIFF
--- a/plugins/stations-inspect-details
+++ b/plugins/stations-inspect-details
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Inspect-Details.git
-commit=654b6b9b1720e3c43f0e06173685d5937dae5ddd
+commit=326d96d6c8ffb36935dbe6c81694d7b2cb5f1393


### PR DESCRIPTION
Submitting this update by itself after the previous artwork update was merged, following the one-open-PR-at-a-time workflow.

This adds the root icon.png artwork and updates the pinned source commit. There are no plugin behavior changes.