### PR TITLE
create adaptive-fps

### DIFF
--- a/plugins/adaptive-fps
+++ b/plugins/adaptive-fps
@@ -1,0 +1,2 @@
+repository=https://github.com/cha-ndler/runelite-adaptive-fps.git
+commit=4c07aa4447a74a6aab56cc3015536249bb2c8981


### PR DESCRIPTION
Keeps RuneLite's FPS target just below the refresh rate of whichever monitor the
client window is currently on.

On a variable refresh rate display (G-Sync / FreeSync) the frame rate has to stay a
few frames under the panel's refresh rate — cross it and the display leaves its VRR
window and falls back to V-Sync. A single fixed FPS target cannot satisfy two
monitors with different refresh rates, so dragging the client between them silently
puts you on the wrong side of that boundary with no indication. This reads the
refresh rate of the monitor the canvas is on and re-targets within a couple of
seconds, no restart needed.

Headroom defaults to `refresh - refresh² / 3600`, which reproduces NVIDIA's
documented -1 FPS at 60Hz and -16 FPS at 240Hz exactly, and works out to a constant
~0.3ms frametime margin at any refresh rate. A fixed number is available instead.
Sources are cited in the README.

**It does not write to the GPU plugin's configuration.** The target is applied with
`Client.setUnlockedFpsTarget(int)`, the same call `GpuPlugin.setupSyncMode` makes, so
`gpu.fpsTarget` keeps whatever the user set it to and nothing is persisted. There is
one optional setting, off by default and behind `@ConfigItem(warning = ...)`, that
turns the GPU plugin's vsync off and Unlock FPS on — the two settings a target needs
to work at all. Both are restored when it is switched off or the plugin is disabled.

I checked the hub for an existing plugin doing this before writing it and did not
find one. The natural long-term home is arguably the core GPU plugin, which already
owns `fpsTarget` and `vsyncMode` — happy to propose it there instead if you would
prefer that over a separate plugin.

BSD-2-Clause, no runtime dependencies, 48x72 icon included. README has a short demo
clip of the client moving between a 500Hz and a 175Hz panel.
