### PR TITLE
Add Green Log

### DIFF
--- a/plugins/green-log
+++ b/plugins/green-log
@@ -1,0 +1,2 @@
+repository=https://github.com/420kc/green-log.git
+commit=66e7c971f8f475c0613720995a5423072cc79f91


### PR DESCRIPTION
Sidebar collection log with search, filters, and completion tracking.
Local-only and self-only: captures your own log from the in-game interface, tracks new unlocks from chat messages, and stores everything under .runelite on the player's machine. The plugin makes no network requests; drop-rate data is bundled at build time from the OSRS Wiki (CC BY-NC-SA, attribution kept with the dataset).
Repository: https://github.com/420kc/green-log