### PR TITLE
Add  - TCG Online (TheCardExchange) - Plugin to RuneLite

### DIFF
--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,2 +1,2 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
-commit=2e904d14893ed98ee390fc17f069c5074fc8071d
+commit=566c2480b230b79d10884241619b86f4b57e6567

--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,2 +1,2 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
-commit=418aa0df483faf8ecfc1887a75cc1be0fa976b4b
+commit=17cd121ce26e52cc1f3ea9a3c89a17ffcce9ada9

--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,2 +1,2 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
-commit=4722b7ef56f0d5ca388866fea57c90d620c14426
+commit=2e32a9b93b8522387210b0e46caa4a081839a858

--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,2 +1,2 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
-commit=commit=2e904d14893ed98ee390fc17f069c5074fc8071d
+commit=2e904d14893ed98ee390fc17f069c5074fc8071d

--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,2 +1,2 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
-commit=17cd121ce26e52cc1f3ea9a3c89a17ffcce9ada9
+commit=4722b7ef56f0d5ca388866fea57c90d620c14426

--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,2 +1,2 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
-commit=eac132e9c6bea9b0acf070409151e75685c886dd
+commit=commit=2e904d14893ed98ee390fc17f069c5074fc8071d

--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,2 +1,2 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
-commit=2e32a9b93b8522387210b0e46caa4a081839a858
+commit=51831cf22c20f0ba63e5357caf99dd54428ea3ec

--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,2 +1,2 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
-commit=566c2480b230b79d10884241619b86f4b57e6567
+commit=a81a5ac70c64cc3ef2056c91c6e169bb8a38a8be

--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,0 +1,2 @@
+repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
+commit=418aa0df483faf8ecfc1887a75cc1be0fa976b4b

--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,2 +1,2 @@
 repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
-commit=51831cf22c20f0ba63e5357caf99dd54428ea3ec
+commit=eac132e9c6bea9b0acf070409151e75685c886dd


### PR DESCRIPTION
RuneLite TCG plugin for OSRSCardExchange.com — a trading card game built inside Old School RuneScape.

Open packs, collect approximately 7,000 independently sourced cards, and trade with other players in-game through a WebSocket API connection. The plugin is fully standalone: it does not require any other plugin and does not access or read data from other plugins. All assets have been developed independently.

A setup guide is available in the plugin panel and at:

https://www.osrscardexchange.com/getting-started

We have retained development records, supporting documentation, and a complete changelog. These materials are kept private but can be provided to the RuneLite maintainer team upon request and handled in accordance with applicable privacy and data-protection laws.