### PR TITLE
Update combat-logger to v1.7.2

### DIFF
--- a/plugins/combat-logger
+++ b/plugins/combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/SuperNerdEric/combat-logger.git
-commit=8b78554fa9563e1fe4bcee079e09e77eb2c8dec9
+commit=a5c6f304a9a6828e9ab6efa663c6503c98c4aca1


### PR DESCRIPTION
- Use chat messages instead of dialog box when disabling live logging.
- Create live log executor on plugin startUp to fix RejectedExecutionException