### PR TITLE
Add BIS Loadouts

### DIFF
--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,0 +1,2 @@
+repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
+commit=10d9f7bd0441751665bfaf0e2d839be4d8c82700

--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
-commit=0a871d6e41867856a979e4eed69adeb677d3aca5
+commit=33102f7466f89dff3082505b997f3a9ec2253451

--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
-commit=da1cf0329c7b9013f27bc1c9798a372d55958606
+commit=0a871d6e41867856a979e4eed69adeb677d3aca5

--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
-commit=10d9f7bd0441751665bfaf0e2d839be4d8c82700
+commit=da1cf0329c7b9013f27bc1c9798a372d55958606

--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
-commit=c7a4481abb3cfd1e761adb594d56b9a7cd39873d
+commit=2e77e870ea9e79c69cf363ae7fe1164b27415cfb

--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
-commit=33102f7466f89dff3082505b997f3a9ec2253451
+commit=0429f0a272f04383865ee46416b71b31054a3854

--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
-commit=3fa4125d3d8408091ca6212f1c8050f924c97294
+commit=c7a4481abb3cfd1e761adb594d56b9a7cd39873d

--- a/plugins/bis-loadouts
+++ b/plugins/bis-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/ItMeansBigMountain/bis-loadouts-osrs.git
-commit=0429f0a272f04383865ee46416b71b31054a3854
+commit=3fa4125d3d8408091ca6212f1c8050f924c97294


### PR DESCRIPTION
## Summary
- Adds BIS Loadouts as a single Plugin Hub submission
- Points to immutable plugin commit `10d9f7bd0441751665bfaf0e2d839be4d8c82700`
- Supersedes #13918 after the one-open-PR-per-author rule prevented reopening it

## Previous review feedback
The prior request to remove `Thread.currentThread().interrupt()` usage from `BossDataService` is addressed in the referenced plugin commit.

## Verification
- Clean Java 11 `test assemble` build passes
- This PR changes exactly one file: `plugins/bis-loadouts`
