### PR TITLE
waypoint-sync: update to 4f83e84

### DIFF
--- a/plugins/waypoint-sync
+++ b/plugins/waypoint-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Xiodrade/waypoint-sync.git
-commit=941bd299203fbfe6425eb09f8e0ed3e5a92ab388
+commit=4f83e84811a9acbe74cbb2763628a6f931ebbc72
 warning=This plugin submits your IP address, display name, quests, diaries, and combat achievements to a third party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update Waypoint Sync: in-client panel now shows real synced totals and a per-session activity log; count miniquests separately and Recipe for Disaster as one quest.