### PR TITLE
gustav-helper: bump commit (step number, in-plugin step reports)

### DIFF
--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,3 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=1489fb47693e8eb4f10cbb4542899cd10ccaf08b
+commit=088a9a99d0d87666220f22b643e0ea3440a7aee4
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,3 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
 commit=1489fb47693e8eb4f10cbb4542899cd10ccaf08b
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,3 +1,2 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
 commit=1489fb47693e8eb4f10cbb4542899cd10ccaf08b
-warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=858e76fec50cfab284a69c209f0b2aef5d3615f0
+commit=1489fb47693e8eb4f10cbb4542899cd10ccaf08b

--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=d7511433cbd0efb92bf64d207ffd78ee5ca6415f
+commit=858e76fec50cfab284a69c209f0b2aef5d3615f0


### PR DESCRIPTION
Bumps `plugins/gustav-helper` `commit=` to `858e76f` (from `d751143`).

- **Current step number** shown alongside the completed counter (`… — 116 / 960 done · Step 117`).
- **"Report wrong / missing info" button.** Opens a dialog asking what is wrong, shows the exact text that will be sent, and only sends when the user confirms. The report carries the guide, step id and number, step text, the tile the plugin pointed at and the NPC/object/item ids it highlighted — enough to fix a bad coordinate or highlight from the report alone.
  - **No account information** is included (no player name, account hash, or player position) — covered by a test.
  - Never automatic: the only caller is the confirmed dialog. Sent asynchronously off the client thread via RuneLite's injected `OkHttpClient` (no new dependency), rate-limited, and failures surface in a dialog rather than throwing.
  - Reports go to a forwarding endpoint the author controls, which holds the Discord webhook privately and rebuilds the payload (no mentions/embeds/attachments pass through). Users can point it at their own webhook via config.
- Ledger tab scrolls; item-overlay lookup is allocation-free on the per-frame path.

Tests: 79 Java + 28 + 27 Python, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)