### PR TITLE
Update anvil

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=68ea860d59fa6a59a80678daa44b72d77b5c0bb4
+commit=2219cb4310ca44e610027239aba6d948361cb078

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=c844ee81528b845ac8d661239be0c7ad8587295d
+commit=8462fcc39856659c1ef129b8127700168f2ef825

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=b7f1b69ff24a955bda5824cf5f57a6a08d08c337
+commit=0353a8a1c94b2dd2a73915d84d485d3f31cfac2a

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=2219cb4310ca44e610027239aba6d948361cb078
+commit=67d9a5ac2440db8642d345f6ba35511decbac759

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=0084900e5bd372834b4847c0a2caec699731264e
+commit=68ea860d59fa6a59a80678daa44b72d77b5c0bb4

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=0353a8a1c94b2dd2a73915d84d485d3f31cfac2a
+commit=46f45d5f2a9d250f1df89b317f15d6c7696dd727

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=4de86ce7ff6e916c063fc466e9e40a32b267ef24
+commit=0084900e5bd372834b4847c0a2caec699731264e

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=be134604203da7d6f14d672cb648d76656313484
+commit=6fce39800d1ccc0a61538ab2e528903bc6a868ae

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=8462fcc39856659c1ef129b8127700168f2ef825
+commit=be134604203da7d6f14d672cb648d76656313484

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=6fce39800d1ccc0a61538ab2e528903bc6a868ae
+commit=4de86ce7ff6e916c063fc466e9e40a32b267ef24

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=46f45d5f2a9d250f1df89b317f15d6c7696dd727
+commit=c844ee81528b845ac8d661239be0c7ad8587295d

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=3f923dad88cdf3c5bfa7cfb6df29b848adcc7c22
+commit=a417480366e561a88e32d969283851c21fe4a328

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=16c35053a8cc5acd602ff0fac7b4f3022d487dd1
+commit=ec8bdfb6cf661ddc73f7a0f3ea2a91fce3c7bfc2

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=b526e786d543426fe05444e1167356911ed11944
+commit=de2b36892bf2f027569605230391b5c244f4b53b

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=f85b8530eb93a2ed5e881b2af53d0f6940932347
+commit=a4cd005f1917ebd8af551d13db01552eebe9020d

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=e47c605581e2c8fb56494a52c8e8998fbfe9ea3f
+commit=56c8cfa142c00c44f365480cb18d357c732bb48f

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=30249dc0c48bd49de13b3883bc97098c28e4fb20
+commit=b7f1b69ff24a955bda5824cf5f57a6a08d08c337

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=a4cd005f1917ebd8af551d13db01552eebe9020d
+commit=16c35053a8cc5acd602ff0fac7b4f3022d487dd1

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=ec8bdfb6cf661ddc73f7a0f3ea2a91fce3c7bfc2
+commit=e47c605581e2c8fb56494a52c8e8998fbfe9ea3f

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=7a875887eb93ab794f75841f726f91997ba30ae6
+commit=30249dc0c48bd49de13b3883bc97098c28e4fb20

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=56c8cfa142c00c44f365480cb18d357c732bb48f
+commit=7a875887eb93ab794f75841f726f91997ba30ae6

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=de2b36892bf2f027569605230391b5c244f4b53b
+commit=3f923dad88cdf3c5bfa7cfb6df29b848adcc7c22

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=2ab48dbaffe50ef032b63e14ca4c880222bb7cf4
+commit=b526e786d543426fe05444e1167356911ed11944

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=a417480366e561a88e32d969283851c21fe4a328
+commit=f85b8530eb93a2ed5e881b2af53d0f6940932347


### PR DESCRIPTION
Bumps anvil to a417480. Adds the clan's weekly (SotW/BotW) competitions and upcoming events to the side panel, and an in-game 'active missions' strip (with a live countdown and per-mission grow/decay values) for mid-event mission drops on a bingo board. Also fixes the side panel sitting empty for ~15s after signing in, reports a sign-in whose token RuneLite failed to persist instead of silently looking unsigned-in, and surfaces the reason when a cross-clan "share my RSN" is refused rather than rendering a refusal as success.
