### PR TITLE
Update Gem Sack plugin to 1.3

### DIFF
--- a/plugins/gemsack
+++ b/plugins/gemsack
@@ -1,2 +1,2 @@
 repository=https://github.com/serenibyss/osrs-gem-sack-plugin.git
-commit=632bb4f2d1bf2c563820af87ff9886e1e7181156
+commit=b59be019a89e67392afe9846eb35c54091fbcec9


### PR DESCRIPTION
- Fix empty to bank option on Gem Bags, as the option name was renamed from "Empty" to "Empty-to-bank"
- Add compatibility with the bank's "Empty containers" button