### PR TITLE
Overhaul update to Faux Bingo plugin

### DIFF
--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
-commit=702725d525f44d55b59d5cfa19f6f1a67c1aeb93
+commit=50fb122a7035bda18e995000ca64cf316a00aae7

--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,2 +1,2 @@
-repository=https://github.com/ThatOhio/faux-bingo.git
-commit=012f37352906f81f4a5e5e3debf9dae3e2f73849
+repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
+commit=702725d525f44d55b59d5cfa19f6f1a67c1aeb93


### PR DESCRIPTION
We have an event coming up at the end of September and are overhauling how we run our bingo events. 

In summary of the changes, we have drastically "dumbed down" the responsibility of this plugin in favor of streaming data to our API, where we can make similar determinations (if an item is bingo related, etc) without requiring updates to this plugin, or any form of client side logic at all. 

There has been a lot of work done as well to better identify drops from NPCs, players, and activities with this update. Largely building off of changes other loot plugins have made to better support all the various ways loot is detected in this game. 

The plugin still functions without the API enabled, just with severely limited functionality (primarily related to clan overlay and Wise old Man updating).

Also, we have migrated the repository to an organization specific to our clan. 

Edit:
We do a version stamp on API calls which is why I set build mode to gradle. We also have some test dependencies. We could likely get back to a standard build mode if that is determined to be best, that was just new to me so without refactoring the tests and removing the version stamp it needs to be gradle for now. 