### PR TITLE
Update adaptive-fps to 1.1.0

### DIFF
--- a/plugins/adaptive-fps
+++ b/plugins/adaptive-fps
@@ -1,2 +1,2 @@
 repository=https://github.com/cha-ndler/runelite-adaptive-fps.git
-commit=4c07aa4447a74a6aab56cc3015536249bb2c8981
+commit=95b5810619595f95a6e9a0c90a6a7c425e60399d


### PR DESCRIPTION
Adds support for 117 HD alongside the core GPU plugin, and fixes two bugs in how the FPS target was handed back when the plugin stops.

Previously the plugin only recognised the core GPU plugin, so anyone running 117 HD got no FPS management and an incorrect message saying no GPU plugin was enabled. It also restored the core GPU plugin's stored target on shutdown without checking which renderer was actually running, which could leave a 117 HD user capped at a value belonging to a disabled plugin.

No new dependencies. Build type is unchanged (`standard`).
