### PR TITLE
add osrs-farming-webhook

### DIFF
--- a/plugins/osrs-farming-webhook
+++ b/plugins/osrs-farming-webhook
@@ -1,0 +1,2 @@
+repository=https://github.com/guid-ooo/osrs-farming-webhook.git
+commit=e9a0be23dadea8c08c64e26b769d0eaee8b0c955


### PR DESCRIPTION
Adds **Farming Webhook**.

The plugin sends the state of your farming patches to a webhook of your choosing — the crop, whether it's growing, ready, diseased or dead, and how many growth ticks are left — so you can be reminded to replant by whatever you already use. It doesn't notify you itself and has no UI beyond its config.

It reports state rather than plant/harvest events, so a varbit resync on login is simply a restatement of what's already known rather than a false event.

Patch varbits only decode per patch type and RuneLite's decoder for them is package-private, so seven files from `timetracking.farming` are vendored under `com.farmwebhook.runelite.farming`, unmodified apart from their package and the visibility of three classes, with their BSD-2-Clause headers intact. Same approach as `quest-helper`, `homeassistant`, `time-tracking-reminder` and `mystix`.

Repo: https://github.com/guid-ooo/osrs-farming-webhook
