### PR TITLE
word-of-the-day: add plugin

### DIFF
--- a/plugins/word-of-the-day
+++ b/plugins/word-of-the-day
@@ -1,0 +1,2 @@
+repository=https://github.com/jumpshot7/wordoftheday.git
+commit=e1fd49333cc74dd15af864a1d8a990cb1171903e


### PR DESCRIPTION
Created a plugin that displays a word of the day with its definition in the chat box on login. The word list is bundled locally. I also included a option to limit the message to once per day.