### PR TITLE
Add Goat Pit Indicators Extended

### DIFF
--- a/plugins/goat-pit-indicators-extended
+++ b/plugins/goat-pit-indicators-extended
@@ -1,2 +1,2 @@
 repository=https://github.com/dashing213/osrs-goat-pit-indicators-extended.git
-commit=08186ef5f8037ef6b341db5e089b62276a75312f
+commit=9b902d78a59862d2f8e0e34e8b43380557a9db4c

--- a/plugins/goat-pit-indicators-extended
+++ b/plugins/goat-pit-indicators-extended
@@ -1,0 +1,2 @@
+repository=https://github.com/dashing213/osrs-goat-pit-indicators-extended.git
+commit=08186ef5f8037ef6b341db5e089b62276a75312f

--- a/plugins/goat-pit-indicators-extended
+++ b/plugins/goat-pit-indicators-extended
@@ -1,2 +1,2 @@
 repository=https://github.com/dashing213/osrs-goat-pit-indicators-extended.git
-commit=9b902d78a59862d2f8e0e34e8b43380557a9db4c
+commit=122d95cd71a596c979f947c69c76d46c90c9e97b


### PR DESCRIPTION
## Goat Pit Indicators Extended

Promotes **Telekinetic Grab** to left-click on valid goat targets in the Hunter Goat Pit at Wyrmscraig.

### What it does
- When Telekinetic Grab is selected and a valid goat is under the cursor, the spell cast entry is promoted to left-click position via `PostMenuSort`
- Same mechanism as the official Menu Entry Swapper — reorders existing entries, never removes or creates them

### Safety guards
- Only activates when player can cast Telekinetic Grab (level 33, standard spellbook, has runes)
- Only activates when spiked pit has room for more goats
- Only activates within the goat pit area at Wyrmscraig
- Only affects goat NPCs — all other NPCs, players, objects untouched
- No automation: player still selects spell and clicks target manually

### Source
- Repository: https://github.com/dashing213/osrs-goat-pit-indicators-extended
- License: BSD-2-Clause
- 11 unit tests passing

### Plugin hub marker
- `plugins/goat-pit-indicators-extended` added