### PR TITLE
Update repository URL for faux-bingo plugin

### DIFF
--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,2 +1,2 @@
-repository=https://github.com/ThatOhio/faux-bingo.git
+repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
 commit=012f37352906f81f4a5e5e3debf9dae3e2f73849

--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
-commit=012f37352906f81f4a5e5e3debf9dae3e2f73849
+commit=66e2414b98fbe91118e6847d050490578199a9d6


### PR DESCRIPTION
Was asked to update the repo url before I update the commit hash in a previous PR. 