### PR TITLE
Add Varrock Bank Ruby Rings

### DIFF
--- a/plugins/varrock-bank-ruby-rings
+++ b/plugins/varrock-bank-ruby-rings
@@ -1,0 +1,2 @@
+repository=https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings.git
+commit=e66cd57e8264bdb5665a59b634922f561e45f7f8

--- a/plugins/varrock-bank-ruby-rings
+++ b/plugins/varrock-bank-ruby-rings
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings.git
-commit=7362a464f698ac82ab95430e5c93609b90692098
+commit=6537a58e109bfef27f57fd6d1d574e1378f3239b

--- a/plugins/varrock-bank-ruby-rings
+++ b/plugins/varrock-bank-ruby-rings
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings.git
-commit=5dfc4eb734cf83bfd9920b6d4d4018c2655a5b54
+commit=d36a8a70726731ca4e0ef03fdd3445455f9bce97

--- a/plugins/varrock-bank-ruby-rings
+++ b/plugins/varrock-bank-ruby-rings
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings.git
-commit=b173600a70217766c764c36047a719aa5c7c3cb1
+commit=553ebbf70e63d7aa11baf2b147bcc067d2238b5e

--- a/plugins/varrock-bank-ruby-rings
+++ b/plugins/varrock-bank-ruby-rings
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings.git
-commit=e66cd57e8264bdb5665a59b634922f561e45f7f8
+commit=b173600a70217766c764c36047a719aa5c7c3cb1

--- a/plugins/varrock-bank-ruby-rings
+++ b/plugins/varrock-bank-ruby-rings
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings.git
-commit=6537a58e109bfef27f57fd6d1d574e1378f3239b
+commit=5dfc4eb734cf83bfd9920b6d4d4018c2655a5b54

--- a/plugins/varrock-bank-ruby-rings
+++ b/plugins/varrock-bank-ruby-rings
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings.git
-commit=69cf6060d4433dd6ced737cdce7888d970b6d3cf
+commit=91ed9497671ce537d41e605b49e4bb19eece705a

--- a/plugins/varrock-bank-ruby-rings
+++ b/plugins/varrock-bank-ruby-rings
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings.git
-commit=553ebbf70e63d7aa11baf2b147bcc067d2238b5e
+commit=69cf6060d4433dd6ced737cdce7888d970b6d3cf

--- a/plugins/varrock-bank-ruby-rings
+++ b/plugins/varrock-bank-ruby-rings
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings.git
-commit=91ed9497671ce537d41e605b49e4bb19eece705a
+commit=7362a464f698ac82ab95430e5c93609b90692098


### PR DESCRIPTION
## Plugin: Varrock Bank Ruby Rings

Repository: https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings

Shows a configurable overlay with the number of Ruby rings in inventory, and tracks High Level Alchemy profit and Magic XP gained from alching them, while in the Varrock west bank basement. Overlay and tracking are scoped to that location and reset when leaving it.