### PR TITLE
Add 99 Studying

### DIFF
--- a/plugins/99-studying
+++ b/plugins/99-studying
@@ -1,3 +1,3 @@
 repository=https://github.com/free-abyzz/99-studying.git
-commit=b1f71268f0677a494b0a036dd0e337ebb30b8241
+commit=fb162ac7accd43cf146ea7d264c62b1e35bb07aa
 authors=free-abyzz

--- a/plugins/99-studying
+++ b/plugins/99-studying
@@ -1,0 +1,3 @@
+repository=https://github.com/free-abyzz/99-studying.git
+commit=b1f71268f0677a494b0a036dd0e337ebb30b8241
+authors=free-abyzz


### PR DESCRIPTION
Hello, submitting a new plugin called 99 Studying.

**What it is**

It shows you spaced-repetition flashcards while you AFK skill or wait between boss kills, so your grind time doubles as study time. The cards come from Anki (the flashcard app) through its AnkiConnect add-on, and answering a card levels up a study "skill" that follows the real OSRS XP curve, 1 to 99. Nothing about it touches or automates gameplay, it is purely a companion overlay plus a side panel.

**How it works**

- On a timer you set (1 to 30 min, or custom), the next due card shows up in the side panel and, if you want, a small popup in a corner.
- You grade it with the normal Anki buttons (Again / Hard / Good / Easy). That answer goes straight back to Anki, so Anki does all the actual scheduling. The plugin does none of it.
- Each answer gives XP on the exact OSRS curve. The XP is the plugin's own, it does not read or change anything in game.
- There is a Snooze button and an optional "pause during combat".

**Network use**

The only network call it makes is to AnkiConnect on `http://127.0.0.1:8765`, which is localhost. It never talks to any external server and no user data leaves the machine. If Anki is not running the plugin just shows a "not reachable" state with setup steps.

**Card images**

Image cards are supported, they are pulled from your local Anki media only (external/web images are skipped).

Happy to make any changes you want. Thanks for taking a look.
