### PR TITLE
Add What Could Have Been

### DIFF
--- a/plugins/what-could-have-been
+++ b/plugins/what-could-have-been
@@ -1,0 +1,2 @@
+repository=https://github.com/wchbdotnet/wchb-runelite.git
+commit=e5dfe4a61032a6f6e35ba515a6b59e145740a639

--- a/plugins/what-could-have-been
+++ b/plugins/what-could-have-been
@@ -1,2 +1,3 @@
 repository=https://github.com/wchbdotnet/wchb-runelite.git
 commit=e5dfe4a61032a6f6e35ba515a6b59e145740a639
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## What Could Have Been

Adds the WCHB companion plugin. WCHB rerolls Dink-delivered OSRS drops into a separate, entirely fictional loot profile.

The plugin provides a configurable RuneLite overlay, live recent-reroll sidebar feed, temporary profile onboarding, optional WCHB account linking, and persistent per-character reconnection. Dink remains solely responsible for loot detection; this plugin does not automate gameplay or collect drops itself.

Network access is disabled by default and requires RuneLite's third-party warning. Connections stop while logged out or disabled. The plugin does not access Jagex credentials, chat, nearby players, or gameplay inputs.

Repository: https://github.com/wchbdotnet/wchb-runelite
