### PR TITLE
Update DropTracker to v5.4.2

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=9c259fc2198a736d882c92e160149ea1a68b1950
+commit=45c6bc0f252509dc799fb39877cc030ed645c555
 authors=joelhalen,OSRSKoeppy

--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=7ad6720d1fb55cdd9e039afa328cfd40157f19aa
+commit=9c259fc2198a736d882c92e160149ea1a68b1950
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
Adds a couple of minor fixes to time detection at ToA/ToB that were causing PBs to fail to send accurate times, or send incorrect team sizes