### PR TITLE
waypoint-sync: multiple characters, sea charting, ironman detection

### DIFF
--- a/plugins/waypoint-sync
+++ b/plugins/waypoint-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Xiodrade/waypoint-sync.git
-commit=4f83e84811a9acbe74cbb2763628a6f931ebbc72
+commit=ccee06fd0dacf801262f0900f0a7aa5b059a73aa
 warning=This plugin submits your IP address, display name, quests, diaries, and combat achievements to a third party server not controlled or verified by Runelite developers.

--- a/plugins/waypoint-sync
+++ b/plugins/waypoint-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Xiodrade/waypoint-sync.git
-commit=2cb2d561b94d19dd957fade6d05b445fd0c071f3
-warning=This plugin submits your IP address, display name, quests, diaries, and combat achievements to a third party server not controlled or verified by Runelite developers.
+commit=1c351d0e73c18f21a35fb9ad40bcfa6e8e3b76af
+warning=This plugin submits your IP address, display name, account mode, quests, diaries, combat achievements, skills, collection log, and Sailing charting progress to a third party server not controlled or verified by Runelite developers.

--- a/plugins/waypoint-sync
+++ b/plugins/waypoint-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Xiodrade/waypoint-sync.git
 commit=1c351d0e73c18f21a35fb9ad40bcfa6e8e3b76af
-warning=This plugin submits your IP address, display name, account mode, quests, diaries, combat achievements, skills, collection log, and Sailing charting progress to a third party server not controlled or verified by Runelite developers.
+warning=This plugin submits your IP address, display name, quests, diaries, and combat achievements to a third party server not controlled or verified by Runelite developers.

--- a/plugins/waypoint-sync
+++ b/plugins/waypoint-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Xiodrade/waypoint-sync.git
-commit=ccee06fd0dacf801262f0900f0a7aa5b059a73aa
+commit=2cb2d561b94d19dd957fade6d05b445fd0c071f3
 warning=This plugin submits your IP address, display name, quests, diaries, and combat achievements to a third party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
 ### What changed

  - **Multiple characters on one account.** The plugin now sends RuneLite's account hash
    alongside the display name, so a main, an ironman and a pure can be tracked separately
    under a single key. Previously a second character's sync overwrote the first.
  - **Sea charting.** Reads the Sailing charting completion varbits, a category nothing else
    covered.
  - **Ironman detection.** Sends the account-type varbit so money-making suggestions can drop
    Grand Exchange methods for ironman accounts.
  - **Failed syncs explain themselves.** The panel showed only an HTTP status code; it now
    shows the reason the server returned.
  - **Cheaper interface polling.** Collection-log and combat-achievement capture is now driven
    by `WidgetLoaded` instead of probing up to 80 widget children per group every other tick,
    with a slow poll retained as a safety net. No change to what is captured.