### PR TITLE
Add Spore Runner

### DIFF
--- a/plugins/spore-runner
+++ b/plugins/spore-runner
@@ -1,0 +1,2 @@
+repository=https://github.com/alexgerdisch/spore-runner.git
+commit=883e48e569db9f9e60c1fb1466bdfa9176e53411


### PR DESCRIPTION
## What it does

Spore Runner highlights safe and dangerous tiles around Nightmare / Phosani's Nightmare spores. Tiles within 1 tile of a spore (which pop the spore, forcing walk and draining prayer) are highlighted in a configurable color; safe tiles beyond that are highlighted in a separate configurable color. Totem tiles and unpathable scenery (walls, arena boundary) are never highlighted, and tiles under the boss are excluded from the safe highlighting. A dropdown lets users show only dangerous tiles, only safe tiles, or both.

Repo: https://github.com/alexgerdisch/spore-runner

## Scope / rule compliance

This only highlights the fixed, already-known hazard area of Spore game objects that have already spawned and are already visible on screen (read directly from `GameObjectSpawned`/`GameObjectDespawned`). It does not predict future spawns or any other boss mechanic, and does not add or modify any menu entries or input. This is the same category as other accepted hazard-tile plugins (e.g. highlighting already-active AoE/poison cloud tiles).