### PR TITLE
Update Slayer Best in Bank for Mortimer

### DIFF
--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=014c0ea19f3204e3b6173cfae391800aca8a2850
+commit=eabf212eeac010c1bc1f0ce56e3a0a2762c5b098

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=c9a509391a30066e1f4483429f6ea70c26cfae43
+commit=fd43350935008bbd017a1f972157779c72756f2c

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=b69b9c8ff9d54dbf0ceb761943bad0f92fddef82
+commit=014c0ea19f3204e3b6173cfae391800aca8a2850

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=fd43350935008bbd017a1f972157779c72756f2c
+commit=b69b9c8ff9d54dbf0ceb761943bad0f92fddef82


### PR DESCRIPTION
## Summary

Updates the Slayer Best in Bank Plugin Hub pin to source commit `fd43350935008bbd017a1f972157779c72756f2c`.

The source update:

- adds Mortimer's complete launch assignment pool and the new Venators task
- adds dedicated Blisterwood-stakes and Sunspear/Vampyre recommendations for Venators
- improves system-wide armour scoring and task-specific defensive weighting
- expands preparation requirements, protection supplies, task tools, travel, and quantities across the Slayer catalog
- gives clearer feedback when method changes require rebuilding the locked bank plan

## Why

Wyrmscraig introduced a new Slayer master and assignment that were absent from the plugin. The same release also resolves reported scoring and preparation gaps that could produce unintuitive hybrid armour choices or incomplete trip plans.

## User impact

Players receive current Mortimer/Venators support, more coherent gear rankings, and more complete task preparation recommendations.

## Validation

- source suite passes with `./gradlew test --no-daemon` (175 tests)
- Plugin Hub change is limited to `plugins/slayer-best-in-bank`
- `git diff --check` passes

Source PR: https://github.com/FreeArcanes/slayer-best-in-bank/pull/9
