### PR TITLE
update slayer-task-logger

### DIFF
--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=59e5bb220c30aa890ec21ec6ca37d84778ea486e
+commit=2ade48ec203bbcdc913fd32c1db164e26605af9e
 warning=This plugin can send slayer event data to an external webhook URL configured by the user. The webhook is disabled by default.


### PR DESCRIPTION
Adds support for the Mortimer slayer master.

Mortimer's chat messages differ from the existing masters, so neither of its events was being logged:

- The task completion message names the master and tracks a per-master task count: `You've completed 1 Mortimer task and received 30 points, giving you a total of 1,619; return to a Slayer master.` The old pattern required `N tasks` with nothing in between, so these completions matched nothing. The master name is now an optional capture group.
- The task assignment message may append a bonus point line: `Your new task is to kill 184 Aquanites.<br>Completing this task will award 30 bonus Slayer Points.` `Text.removeTags` strips `<br>` without a replacement, so the lines arrive concatenated and the greedy monster group captured the trailing sentence as part of the monster name. That group is now lazy.

Existing masters, including Konar, are unaffected. Plugin version bumped to 1.1.0. Verified in-game.