### PR TITLE
Update Varrock Bank Ruby Rings

### DIFF
--- a/plugins/varrock-bank-ruby-rings
+++ b/plugins/varrock-bank-ruby-rings
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings.git
-commit=d36a8a70726731ca4e0ef03fdd3445455f9bce97
+commit=256cdb4813f20a997fed49b85fe1c81c21aa46a2


### PR DESCRIPTION
Adds an icon and fixes README/tag wording that inaccurately implied the ring comes from Crafting (it's actually loot from the Crack the Clue III vault in the basement).

Repository: https://github.com/andrew-friedman-phd/varrock-bank-ruby-rings