### PR TITLE
create boss-pb-timer

### DIFF
--- a/plugins/boss-pb-timer
+++ b/plugins/boss-pb-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/TrashChiefMoko/boss-pb-timer.git
+commit=4295a97a44d4fadac8e15ffcf1f1e9b4a46e59e1


### PR DESCRIPTION
Adds Boss PB Timer, a draggable tick-based boss fight timer with per-profile personal-best tracking. The plugin uses RuneScape's reported fight duration and personal best when available, with game-tick timing as its live fallback.

Repository: https://github.com/TrashChiefMoko/boss-pb-timer

Tested with ./gradlew clean test jar.