### PR TITLE
Update osrs-game-session-tracker

### DIFF
--- a/plugins/osrs-game-session-tracker
+++ b/plugins/osrs-game-session-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Golddcaleb/osrs-game-session-tracker.git
-commit=a6ecfa44d4e8d33f014a09381c3ef1f6a96582c4
+commit=e6049c343c208da727e79673e3341ba645ddbfa5
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update osrs-game-session-tracker to 1.2.0
Bumps the pinned commit for OSRS Game Session Tracker to
e6049c343c208da727e79673e3341ba645ddbfa5.

Repository: https://github.com/Golddcaleb/osrs-game-session-tracker
Previous commit: 4578d3e82c585e6c23b7d8bac492f79f9274491f
What changed
Loot is no longer filtered by the plugin's boss list. Previously the plugin only
recorded loot whose source matched a fixed boss list and silently discarded everything else
(slayer tasks, superior spawns, pickpocketing). Boss-list matching is now an enrichment
field rather than a gate — every loot event the local player receives is recorded, and the
companion web tool decides how to group it.

Un-gated the loot handler; the early return on an unmatched source name is gone.
Added source (the raw, unmodified in-game source name) and sourceType
(LootRecordType.name() — NPC / PLAYER / PICKPOCKET / EVENT / UNKNOWN) to the
recorded event. LootReceived already carried the type; the plugin simply was not
reading it.
bossName is unchanged in meaning: still the web tool's display name when the source
matches, still nullable.
Added a "Use dev database paths" config toggle that redirects writes to a separate
database path, so plugin changes can be verified without writing into live data.
Extracted the event payload into a pure static method and added OsgsLootPayloadTest
covering it.
No new subscriptions were added — loot still comes solely from LootReceived, which is a
superset of NpcLootReceived for this purpose; subscribing to both previously caused every
drop to be recorded twice.

Scope of the data change
The disclosure is unchanged in kind — the same categories of data go to the same
user-supplied endpoint — but the volume increases, since loot from ordinary NPCs is now
recorded rather than dropped. Flagging it explicitly:

What is sent: the local player's OSRS display name, boss kill counts, and loot (item
name / quantity / GE value) with its source name and type, plus a periodic presence
timestamp.
Where: a Firebase Realtime Database URL the user supplies in config. No hardcoded
endpoint; nothing is sent until the user enters their own URL, and nothing is sent while
Enable tracking is off. Credentials live only in RuneLite's ConfigManager.
How: Firebase REST over OkHttp, all asynchronous (enqueue); failures are logged,
never thrown.
The disclosure is in the plugin description, at the top of the config panel, and behind a
consent warning on the tracking toggle.
Compliance
No automation of game actions and no modification of game state.
Reads only the local player's own loot, via RuneLite's existing LootReceived event.
No new dependencies; still build=standard.
./gradlew build (compile + tests) passes.

🤖 Generated with Claude Code

https://claude.ai/code/session_01F9emox3mEwdxpqDyaH5ym2