### PR TITLE
Create hallowfell-helper

### DIFF
--- a/plugins/hallowfell-helper
+++ b/plugins/hallowfell-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Sacca-1/hallowfell-helper.git
+commit=a8b8fcc75f28f7aa10f96f89e7ba60edc26af78c


### PR DESCRIPTION
Hallowfell Helper highlights nearby NPCs that allow Hallowfell to hit three targets at once. It accounts for larger NPCs, movement, and optional stand-tile suggestions, and only displays guidance while Hallowfell is equipped. The plugin is visual-only and does not perform actions.