### PR TITLE
drop-rate-properties: update to Wyrmscraig drop data

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=6da410698c44e6dd658bb61c02a54715cdcc3e10
+commit=fedb3384b1f2702bb16e3729ef71b4c4c0125229


### PR DESCRIPTION
Updates `drop-rate-properties` to commit `fedb3384b1f2702bb16e3729ef71b4c4c0125229`.

This is a data-only refresh of the bundled wiki drop rates following the Wyrmscraig update (released 29 July 2026). No code changes, no new dependencies.

**New content**
- Mad Angel, the island's repeatable boss — 24 drops including Hallowfell (1/128), Jar of light (1/1000) and the pet Aggy (1/2000), plus 25 Rare Drop Table entries from its 2/150 access rate.

**Corrections picked up by the re-crawl**
- `Desert goat horn` was renamed to `Goat horn` in this update. Lookups are exact string matches, so the old name had been silently unmatchable since 29 July on Corporeal Beast, Locust rider, Scarab Mage and Thermonuclear smoke devil.
- `Blood-starved venator` removed — its only item, Brimstone key, is now documented as an always-drop conditional on a Konar task, so the previously shipped 1/56 was incorrect.
- Rate changes: Sulphur Nagua / Sulphur blades 1/250 to 1/450, Vampyre kraken / Bottled storm 1/300 to 1/350, Vampyre kraken / Dragon metal sheet 1/150 to 1/80.

**Verification**
- 613 NPCs, 26 Rare Drop Table items.
- Every emitted rate parses through the plugin's own rate-parsing logic (13955 rates, 0 failures).
- `gradlew build` passes.
- LICENSE re-diffed against the plugin-hub LICENSE, icon confirmed 48x72, no third-party dependencies.
