### PR TITLE
Add GPU v2

### DIFF
--- a/plugins/gpu-v2
+++ b/plugins/gpu-v2
@@ -1,0 +1,2 @@
+repository=https://github.com/koso313/gpu-v2.git
+commit=42258aeded0f3d9f48836ca456d6bd934ecc8086


### PR DESCRIPTION
Adds GPU v2, a standalone GPU renderer with a light suite of graphical
enhancements: a continuous day/night sky, six weather conditions, automatic
dynamic lighting from fires and torches, distance fog and ground mist, and
post-processing.

Repository: https://github.com/koso313/gpu-v2

Notes for review:

- This bundles its own copy of the GPU renderer rather than building on the
  core GPU plugin. The enhancements hook the render passes directly, which
  the core plugin does not expose. Only one renderer can hold the draw
  callbacks, so the plugin detects and refuses to start alongside the stock
  GPU plugin or 117HD.
- Licensed BSD 2-Clause, matching the source it was ported from.
- Requires OpenGL 3.3.