### PR TITLE
Update STASH Tracker

### DIFF
--- a/plugins/stash-tracker
+++ b/plugins/stash-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Nearvaas/S.T.A.S.H-Toolkit.git
-commit=7e7952c794e9cc19d570250fbc04ca7f532a61a4
+commit=c32e51bbd53a0b2250a757c08a1a9e1db5c0487b


### PR DESCRIPTION
Updates STASH Tracker: world map markers and the inventory item symbol are now coloured by the STASH's clue tier (easy green, medium blue, hard purple, elite gold, master red) to match the reward caskets. On the map, unfilled STASHes show a solid disc and filled ones a faded disc, so completion stays visible; exact status remains in the tooltip.

Source: https://github.com/Nearvaas/S.T.A.S.H-Toolkit