### PR TITLE
Create massiefgoud

### DIFF
--- a/plugins/Massiefgoud
+++ b/plugins/Massiefgoud
@@ -1,0 +1,2 @@
+repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
+   commit=f05b932afe7827e3cace3bf7781bbe9d3a1e635b


### PR DESCRIPTION
Deze plugin meldt automatisch item-drops (via LootReceived) aan een externe
   website, voor het bijhouden van team-verzameldoelen tijdens community-events
   (Bingo/Ganzebord). De plugin verzendt alleen data, voert geen automatische
   in-game acties uit.