### PR TITLE
Create massiefgoud

### DIFF
--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,0 +1,2 @@
+repository=https://github.com/JOUW-GEBRUIKERSNAAM/massief-goud-runelite-plugin.git
+   commit=f05b932afe7827e3cace3bf7781bbe9d3a1e635b

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-   commit=f05b932afe7827e3cace3bf7781bbe9d3a1e635b
+   commit=b51634fd6bf4fa6b3094377cdc1f2e59b7baa33a

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
-repository=https://github.com/JOUW-GEBRUIKERSNAAM/massief-goud-runelite-plugin.git
+repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
    commit=f05b932afe7827e3cace3bf7781bbe9d3a1e635b


### PR DESCRIPTION
Deze plugin meldt automatisch item-drops (via LootReceived) aan een externe
   website, voor het bijhouden van team-verzameldoelen tijdens community-events
   (Bingo/Ganzebord). De plugin verzendt alleen data, voert geen automatische
   in-game acties uit.