### PR TITLE
Create massiefgoud

### DIFF
--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,3 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
 commit=df19bfb1c863e3e9f67cf29f5b3ff77af645a578
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-   commit=982295446129a6d4cc114d67b1a011d3d1ba56e4
+   commit=e40c7541a4ffbaa82c798f111fa841a8812cb05a

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-   commit=b51634fd6bf4fa6b3094377cdc1f2e59b7baa33a
+   commit=982295446129a6d4cc114d67b1a011d3d1ba56e4

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-commit=d60f6c834941407d20a505c7652ded94e464a0a3
+commit=f7a343bf19e3d0e309e4c2170726ba56d9bbac1e

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-commit=ea91789276f88faf3a828bc3347d8d598518c214
+commit=d60f6c834941407d20a505c7652ded94e464a0a3

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-commit=f7a343bf19e3d0e309e4c2170726ba56d9bbac1e
+commit=df19bfb1c863e3e9f67cf29f5b3ff77af645a578

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,0 +1,2 @@
+repository=https://github.com/JOUW-GEBRUIKERSNAAM/massief-goud-runelite-plugin.git
+   commit=f05b932afe7827e3cace3bf7781bbe9d3a1e635b

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-commit=9ca864aa65e9183233fce4f859a334bbe669d0a1
+commit=51313dc9abe95eaa097d4c7f4cbc306b578e660f

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-   commit=f05b932afe7827e3cace3bf7781bbe9d3a1e635b
+   commit=b51634fd6bf4fa6b3094377cdc1f2e59b7baa33a

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-commit=51313dc9abe95eaa097d4c7f4cbc306b578e660f
+commit=ea91789276f88faf3a828bc3347d8d598518c214

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-commit=e40c7541a4ffbaa82c798f111fa841a8812cb05a
+commit=fe58710a3aca25914c271d955241d83937433ebf

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
-repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
+repository=https://github.com/JOUW-GEBRUIKERSNAAM/massief-goud-runelite-plugin.git
    commit=e40c7541a4ffbaa82c798f111fa841a8812cb05a

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
-commit=fe58710a3aca25914c271d955241d83937433ebf
+commit=9ca864aa65e9183233fce4f859a334bbe669d0a1

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
-repository=https://github.com/JOUW-GEBRUIKERSNAAM/massief-goud-runelite-plugin.git
-   commit=e40c7541a4ffbaa82c798f111fa841a8812cb05a
+repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
+commit=e40c7541a4ffbaa82c798f111fa841a8812cb05a

--- a/plugins/massiefgoud
+++ b/plugins/massiefgoud
@@ -1,2 +1,2 @@
-repository=https://github.com/JOUW-GEBRUIKERSNAAM/massief-goud-runelite-plugin.git
+repository=https://github.com/TheSetter95/massief-goud-runelite-plugin.git
    commit=f05b932afe7827e3cace3bf7781bbe9d3a1e635b


### PR DESCRIPTION
Deze plugin meldt automatisch item-drops (via LootReceived) aan een externe
   website, voor het bijhouden van team-verzameldoelen tijdens community-events
   (Bingo/Ganzebord). De plugin verzendt alleen data, voert geen automatische
   in-game acties uit.
