### PR TITLE
goat-pit-indicators: 1.3.1

### DIFF
--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
-commit=db17fd2ed615bd5ba59ed58847c16e4d81eb8c72
+commit=71825f68ae280bde5beb54c41298a9451d387efc


### PR DESCRIPTION
Update goat-pit-indicators to 1.3.1 (commit 71825f68ae280bde5beb54c41298a9451d387efc, tag R-1.3.1).

Changes since 1.3.0: "Clear Goat Pit" now stays as the left-click default once no pit can still catch (clear-out phase) instead of only when full, and singularised settings/README copy that referred to multiple pits.