### PR TITLE
Update slayer-simplified

### DIFF
--- a/plugins/slayer-simplified
+++ b/plugins/slayer-simplified
@@ -1,2 +1,2 @@
 repository=https://github.com/Wulfic/slayer-simplified.git
-commit=0a1d8ad3c4605749580a0d8a3951845279ba6ca0
+commit=95b4690836fab42beaf767e02819eed395ab6914


### PR DESCRIPTION
fix fremmick locations falsely requiring quest
fix nonslayer master entires from being shown as slyer masters