### PR TITLE
update `taskman` (pre-removal)

### DIFF
--- a/plugins/taskman
+++ b/plugins/taskman
@@ -1,4 +1,4 @@
 repository=https://github.com/OSRS-Taskman/taskman-plugin.git
-commit=ba69eadc9af9533e5587b24e50d99c911fa2f1d3
+commit=7202b8033975a787c5b1324059e9a26085e55e3a
 authors=ImTedious,rmobis
 warning=This plugin submits your ingame name, Taskman credentials, and your IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This update simply adds a warning that the plugin will soon be removed form the plugin hub in favor of our other plugin Collection Log Master.

We'll submit another PR by the end of August to effectively do that.