### PR TITLE
added prayer drain timer plugin

### DIFF
--- a/plugins/prayer-drain-timer
+++ b/plugins/prayer-drain-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/JarateKing/prayer-drain-timer.git
-commit=f3ae35774ccb49c92e505cf59f5f083acd1f1793
+commit=825ffdbbb5e7ff804e62f2b0bd90fe49b9b18bf4

--- a/plugins/prayer-drain-timer
+++ b/plugins/prayer-drain-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/JarateKing/prayer-drain-timer.git
-commit=825ffdbbb5e7ff804e62f2b0bd90fe49b9b18bf4
+commit=ec6c43b23a5a735998d442df6606f12740f23097

--- a/plugins/prayer-drain-timer
+++ b/plugins/prayer-drain-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/JarateKing/prayer-drain-timer.git
+commit=1ff71a2d775081b43416612124b6c6a27e8a658c

--- a/plugins/prayer-drain-timer
+++ b/plugins/prayer-drain-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/JarateKing/prayer-drain-timer.git
-commit=1ff71a2d775081b43416612124b6c6a27e8a658c
+commit=f3ae35774ccb49c92e505cf59f5f083acd1f1793


### PR DESCRIPTION
no AI was used in the making of this plugin

plugin to add a meter around the prayer orb that shows progress towards the next prayer point drain (similar to Regeneration Meter for hitpoint/spec regen). This is just an approximation because this information isn't available to the client, but it's fairly accurate in most situations.