### PR TITLE
Add repository info and update commit reference for inventory-item-counter

### DIFF
--- a/plugins/inventory-item-counter
+++ b/plugins/inventory-item-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/mfdumile/inventory-item-counter.git
+commit=990752f5e2f3f0a86765b090e9b123b5f3417fb8

--- a/plugins/inventory-item-counter
+++ b/plugins/inventory-item-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/mfdumile/inventory-item-counter.git
-commit=990752f5e2f3f0a86765b090e9b123b5f3417fb8
+commit=1ee310230c90229b39f2ef6a3e1fa06d14e65df1


### PR DESCRIPTION
Displays a count on inventory items that displays the amount you currently have on. Useful for activities where specific amounts of non-stackable items are needed.