### PR TITLE
Add AFK Hider plugin

### DIFF
--- a/plugins/afk-hider
+++ b/plugins/afk-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/Filofteia/FilosPlugins.git
-commit=d7cc9d0022955d9a3611820aee2e18351d95f97c
+commit=59f0c2c95701520fd0743c80cb9498745e85fbfe

--- a/plugins/afk-hider
+++ b/plugins/afk-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/Filofteia/FilosPlugins.git
+commit=d7cc9d0022955d9a3611820aee2e18351d95f97c

--- a/plugins/afk-hider
+++ b/plugins/afk-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/Filofteia/FilosPlugins.git
-commit=59f0c2c95701520fd0743c80cb9498745e85fbfe
+commit=d1e0d52e8ac5a6f33702567c6158f3c7204bd3bf


### PR DESCRIPTION
Adds the AFK Hider plugin.

This plugin changes the opacity of the client when clicking an action specified by the user.

It behaves quite similarly to click-to-minimize. However, because it uses opacity so clicks shouldn't go through the client unless I have missed something (maybe other desktop environments).

I understand if this is too close to the removal of click-to-minimize, or if it's too similar to accept. But I feel like it's solved the big issue of its abuse.