### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=6d2bdab1d168fb913d5fddfcbac8d2695c22dfe9
+commit=e992357f594b2a8d1b4775a0c870b863c0f98c60
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=e992357f594b2a8d1b4775a0c870b863c0f98c60
+commit=028f9215c5161a94d6b5317f36552d6da9d2a066
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary

- **Grand Exchange fills are no longer silently dropped.** Offer identity now carries a slot generation that advances on slot turnover, so two consecutive orders in the same slot are tracked as distinct orders instead of the second one being discarded as a duplicate.
- **Offline fills are captured reliably.** Offers that fill while logged out are now classified correctly: the sync waits for the GE snapshot to load before deciding anything, no longer marks itself complete prematurely, and no longer misclassifies held positions as collected.
- **Fixed duplicate flip records** caused by offer IDs being recycled after a world hop or relog.
- **Fixed the Trade Station push service staying dead** after the plugin was toggled off and on again.
- **Removed the in-plugin message-of-the-day feature** entirely, along with two config settings that were read by nothing.
- **Clicking a recommendation now toggles focus**, replacing the previous hint text.
- Panel UI icons ship as static image assets rather than being drawn at runtime.
