### PR TITLE
Create default-music-now-playing

### DIFF
--- a/plugins/default-music-now-playing
+++ b/plugins/default-music-now-playing
@@ -1,0 +1,2 @@
+repository=https://github.com/RuneLabDev/default-music-playlist.git
+commit=b2f82665f5b8102a0a503c9d8ab809ca2e7e9114


### PR DESCRIPTION
A plugin that automatically enforces the user's preferred default music playlist and playback mode (Area, Shuffle, Single).
Also providing customisable 'Now Playing' track notifications via chat messages and screen overlay.