### PR TITLE
add minimap-zoom-controls

### DIFF
--- a/plugins/minimap-zoom-controls
+++ b/plugins/minimap-zoom-controls
@@ -1,2 +1,2 @@
 repository=https://github.com/miccou/minimap-zoom-controls.git
-commit=aec3addbd13c20e5ab45456676bd381297ebd7be
+commit=e82053760f2b2023cc9f78ce49834f8fad8d7fa6

--- a/plugins/minimap-zoom-controls
+++ b/plugins/minimap-zoom-controls
@@ -1,0 +1,2 @@
+repository=https://github.com/miccou/minimap-zoom-controls.git
+commit=aec3addbd13c20e5ab45456676bd381297ebd7be


### PR DESCRIPTION
Adds the minimap-zoom-controls plugin which provides additional interactions to zoom the minimap, via buttons, a slider, or hotkeys.

The controls can be positioned and scaled.

<img width="210" height="172" alt="screenshot-buttons" src="https://github.com/user-attachments/assets/c0a4ef46-e4a8-452f-8256-27a699a882d1" />
<img width="210" height="172" alt="screenshot-slider" src="https://github.com/user-attachments/assets/9a83c56d-3abf-4e74-ac69-bb1b923e306b" />

