### PR TITLE
Add Seed Box plugin

### DIFF
--- a/plugins/seedbox
+++ b/plugins/seedbox
@@ -1,0 +1,2 @@
+repository=https://github.com/fgillet4/osrs-seedbox-plugin.git
+commit=8510abfab39aca33fe436b713e88b8555565b8b0


### PR DESCRIPTION
Adds a Seed Box plugin that shows seed counts and total GE value on hover.

## Features
- Shows total seed count as a number overlay on the seed box item in inventory
- Hover tooltip showing each seed type and quantity
- Total GE value of all seeds shown in yellow at the bottom of the tooltip
- Counts update live when the seed box UI is open
- Config options to toggle count overlay, hover tooltip, and GE value separately

## Testing
Tested locally via `./gradlew run` with a Jagex account login.