### PR TITLE
Add Trappy Chinchompa

### DIFF
--- a/plugins/trappy-chinchompa
+++ b/plugins/trappy-chinchompa
@@ -1,0 +1,3 @@
+repository=https://github.com/ajkatz/runelite-trappy-chinchompa.git
+commit=6fb6bac461e378272989a7bc6bf4059fd5192934
+authors=ajkatz


### PR DESCRIPTION
Level Old School RuneScape's newest skill: Anti-Hunter!

Trappy Chinchompa is a flappy-style arcade game in the sidebar: you are the chinchompa, the pipes are box traps. Every trap dodged pays more Anti-hunter xp than the last (+5, +15, +25, ...), your lifetime total runs the real OSRS experience curve to an Anti-hunter level, and 88 achievements gate unlockable critters plus an eleven-zone backdrop tour, from Feldip Marsh at level 1 to Prifddinas at 99. Several rewards stay sealed as ?????? until earned.

<img src="https://raw.githubusercontent.com/AKAddons/runelite-trappy-chinchompa/main/docs/screenshot-run.png" width="240"/> <img src="https://raw.githubusercontent.com/AKAddons/runelite-trappy-chinchompa/main/docs/screenshot-kaboom.png" width="240"/> <img src="https://raw.githubusercontent.com/AKAddons/runelite-trappy-chinchompa/main/docs/screenshot-start.png" width="240"/>

Notes for review:
- No Jagex assets are bundled - trap and critter art is loaded at runtime from the player's own client via ItemManager/SpriteManager; the three bundled images are original pixel art.
- EDT-only (the plugin creates no threads), and the game loop runs only while the panel is the active sidebar tab - closed, the plugin is idle.

Repository: https://github.com/AKAddons/runelite-trappy-chinchompa

🤖 Generated with [Claude Code](https://claude.com/claude-code)
