### PR TITLE
TCG Gamemode for TheCardExchange - tcg-online 

### DIFF
--- a/plugins/osrs-tcg-online
+++ b/plugins/osrs-tcg-online
@@ -1,0 +1,2 @@
+repository=https://github.com/CompilerOfDust/OSRS-TCG-Online.git
+commit=daabd5c5bba612ac0182d63a479d15dcfe48db80


### PR DESCRIPTION
TCG Online (TheCardExchange) turns Old School RuneScape into a trading card game, backed by osrscardexchange.com (https://www.osrscardexchange.com). Open packs, build a collection of ~7,000 cards drawn from the game's items and NPCs, and trade duplicates with other players in game.

  Fully interactive, drawn on the game canvas

  Every surface is painted directly onto the game canvas in an Old School-styled skin — there are no pop-out Swing frames:

  - Pack opening — a card-by-card reveal with its own sounds, opened from a minimap orb.
  - A collection view with search, sorting and filters, and a per-card detail window showing gem tier, what the card unlocks and how many copies you hold.
  - A credits banner and orbs for balance and pack state. Credits are earned by playing — skill levels, quests, achievement diary tiers and boss kills all pay (how credits work (https://www.osrscardexchange.com/guide/credits)).
  - Mouse capture — while an interface is up, every mouse event inside its bounds is consumed, so clicking, dragging or scrolling never leaks through to the game underneath. No walking to the tile behind the window, no stray right-click menus, no camera zoom.

  The full card catalogue is browsable at https://www.osrscardexchange.com/cards, and the boards at https://www.osrscardexchange.com/highscores.

  A real trade window, over a WebSocket

  Right-click another player → Trade Cards. The offer and incoming stages are chat lines; once both sides accept, a full two-sided trade window opens — two 4×3 grids modelled on the Old School trade interface. Both sides put up duplicates only, and any change to either offer resets both accepts, exactly as the native interface behaves. On confirmation one copy of each offered card moves across in a single step. A network
  badge beside other players running the plugin shows who you can trade with; it can be turned off, which also stops others offering to you.

  The transport is a persistent authenticated WebSocket, not polling. The plugin holds one socket to the API (/api/v1/plugin/trade/ws), authenticated by the plugin token in the handshake header; offers, accepts, declines and cancels are pushed in both directions in real time.

  The API runs as two regional deployments, and which one a client connects to is a pure function of the OSRS world, not of the player's location or latency. Trading in Old School requires standing next to each other, which requires being on the same world — so a world→region mapping puts both sides of every possible trade on the same instance, with no shared store and no message bus between regions.

  Cards can also be traded asynchronously on the site at https://www.osrscardexchange.com/exchanges.

  Two built-in game modes

  The mode is chosen once per character, in the plugin's side panel — the plugin never picks for you, and the choice is final in the same way an account type is. Eligibility is decided server-side (ironman family, untouched account, what the hiscores say); the plugin only records the answer. Cards trade only between characters on the same mode.

  - Normal — collect, open and trade cards alongside ordinary Old School RuneScape, with nothing about the account verified or monitored.
  - CardMan — Cardcore rules: the collection is the progression. It requires an ironman account (any of the six types) and a completely fresh one (every skill at 1, Hitpoints at 10); training anything at all takes CardMan off the table for that character. CardMan has its own highscores board.

  The item lock — items you hold no card for are greyed out and cannot be worn, eaten or used — is a config toggle, on by default, independent of the chosen mode. Picking up, banking, dropping and all skilling stay unrestricted, so you play normally and earn your way into your own gear. Players who want the collection without the restriction turn off Lock uncollected items.

  Full rules: https://www.osrscardexchange.com/guide/game-modes

  Account linking

  The plugin never sees your password. Linking is a device-pairing handshake shaped like the OAuth 2.0 Device Authorization Grant (RFC 8628): the panel shows a short code, you confirm it while signed in on the website, and the plugin — polling with a private device secret it never transmits in the clear — is handed a token. That token is sent as Authorization: Bearer octp_…, is stored server-side only as a hash, and can
  be revoked per device from the panel's Unlink button or from your profile. You never type a RuneScape name anywhere.

  Standalone

  The collection, pack opening, the item lock and trading are one ruleset rather than four features, so no companion plugin is needed. The plugin does not depend on, modify, or read state from any other plugin.

  For full disclosure of the one place it touches the plugin list at all: ClashingPlugins reads installed plugins' descriptor names and packages so it can print a chat warning when another plugin covering the same ground (a second collection tracker or item lock) is installed. It only warns — it never disables or refuses to start, and it reads no data belonging to those plugins.

  Assets and licensing

  All assets — the ~7,000 cards, card art, pack art, sounds and icons — were developed and sourced independently. The repository is BSD 2-Clause licensed in full, covering the code and those assets.

  Setup guide, in the plugin panel and at https://www.osrscardexchange.com/getting-started

  We have retained development records, supporting documentation and a complete changelog. These materials are kept private but can be provided to the RuneLite maintainer team on request, and handled in accordance with applicable privacy and data-protection laws.