### PR TITLE
Add Bestiary plugin

### DIFF
--- a/plugins/bestiary
+++ b/plugins/bestiary
@@ -1,0 +1,2 @@
+repository=https://github.com/iTheFish/RuneLite-Bestiary-Plugin.git
+commit=4b39c49c14427df8b55371d8357a702143a1d6ee

--- a/plugins/bestiary
+++ b/plugins/bestiary
@@ -1,2 +1,2 @@
 repository=https://github.com/iTheFish/RuneLite-Bestiary-Plugin.git
-commit=4b39c49c14427df8b55371d8357a702143a1d6ee
+commit=d642742b3f1048d7af9380e98e90c2027980879a


### PR DESCRIPTION
Adds **Bestiary** — a card-collection / bestiary layer for Old School RuneScape. Every monster you kill rolls a chance to be "captured" as a collectible card with rolled stats, a rarity (Common→Mythic) and an independent shiny roll. Includes an album/catalogue of 200+ monsters, a Capture Level with XP and achievements, per-account collections, an in-plugin credits shop, and a shareable card export.

**Repo:** https://github.com/iTheFish/RuneLite-Bestiary-Plugin

Notes for review:
- **Pure Java, no extra runtime dependencies** — no reflection, JNI, native libs, process execution or bundled jars. Storage is local JSON.
- **External network:** the only outbound request is an **optional, off-by-default** fetch of monster artwork from the OSRS Wiki (`oldschool.runescape.wiki`). Only the monster's name is sent — no account or personal data — and images are cached to disk. This is disclosed in the plugin's config.
- **Chat** output uses `GAMEMESSAGE` only (no input insertion / no automation).
- The credits/rarity/reroll systems are purely cosmetic and live entirely inside the plugin: they have **no real-world or in-game value** and can't be traded for money, GP or items. A no-real-world-value disclaimer is shown in the UI.

BSD 2-Clause licensed. Thanks for reviewing!