### PR TITLE
Add TCG Collection Sync

### DIFF
--- a/plugins/tcg-collection-sync
+++ b/plugins/tcg-collection-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/Akicha-S/tcg-collection-sync.git
+commit=4a15495152c91eab905d0b15787e6d1832808910


### PR DESCRIPTION
Adds "TCG Collection Sync" — uploads a player's [OSRS TCG](https://github.com/Azderi/osrs-tcg) collection progress to a companion tracking site (defaults to tcg.sayver.net, configurable to any compatible server implementing the same API). Off by default; enabling shows RuneLite's required third-party data-submission warning. Not affiliated with the OSRS TCG plugin itself.

Repo: https://github.com/Akicha-S/tcg-collection-sync