### PR TITLE
Add GearForge

### DIFF
--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,2 +1,2 @@
 repository=https://github.com/marcushill13/gearforge.git
-commit=ba9b56acf977ed26b92e88ba9411b68e75604a2c
+commit=e25dc518e4a81c04207aef190a171dbed1bdcafd

--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,0 +1,2 @@
+repository=https://github.com/marcushill13/gearforge.git
+commit=ba9b56acf977ed26b92e88ba9411b68e75604a2c


### PR DESCRIPTION
Adds **GearForge**, a best-in-slot plugin that works from the gear you actually own.

Repository: https://github.com/marcushill13/gearforge

### What it does

Reads your bank once, then answers "of the items I own, what's best?" across four surfaces: saved **Setups** (with bank filtering), **Search** (per-slot stat ranking), **BiS** (best setup per combat style), and **Bosses** (scored against a boss's real defensive stats, racing every style so it tells you *which* style to bring).

### Notes for review

- **No automation.** It reads game state, computes and displays. It never withdraws, deposits, equips or clicks. Every action it enables is one the player performs themselves.
- **No network I/O of its own.** All datasets are bundled; equipment stats come from `ItemManager`.
- **Bank filtering goes through the Bank Tags plugin** via `TagManager.registerTag` and `BankTagsService.openBankTag`, registering a private namespaced tag rather than touching the user's own tags.
- **Per-account storage** via `setRSProfileConfiguration`, so alts don't share setups or bank data.
- 4 config options. No reflection, no Java serialization, no external processes.
- 122 unit tests. The DPS engine is cross-validated against the OSRS Wiki calculator's own test fixtures.

### Licensing

Plugin code is BSD 2-Clause. Three bundled resources are generated from third-party datasets (osrsbox-db and weirdgloop/osrs-dps-calc), attributed in the README, with the reasoning recorded in `docs/plugin-hub-submission.md`. The underlying OSRS Wiki content is CC BY-NC-SA, so the plugin is and will remain free and unmonetised.

Happy to adjust anything that doesn't fit the Hub's expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
