### PR TITLE
update dvd-bounce

### DIFF
--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=f3f9304ca2a8bd97b4b8965b2efc6396a50ee7f7
+commit=c3bded9029025eb27b27e9ec34deda1447b467dd

--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=b767a1f4fea957375857d6a880e38e5a8567e4bd
+commit=f3f9304ca2a8bd97b4b8965b2efc6396a50ee7f7

--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=0b4db94d50c594874e2a722026355e180b466f27
+commit=3674f5598fd892c9918addba06eee362073b2054

--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=c3bded9029025eb27b27e9ec34deda1447b467dd
+commit=32cde7d853068819d4c227f77d3348bd187e49ef

--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=3674f5598fd892c9918addba06eee362073b2054
+commit=b767a1f4fea957375857d6a880e38e5a8567e4bd


### PR DESCRIPTION
1.5 makes broken or oversized custom images fall back to the bundled logo instead of failing silently, and stops the overlay from interfering with overlay management. Update max gif to 30

Update Gradle to 8.1, still build=standard