### PR TITLE
Update ge-companion to v1.2.1

### DIFF
--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=af3c2aefea471e383f9f281629eed0eeed2f679d
+commit=cd9f3aa71464072fd1268ae40dd13ba23fd5b286

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=10b841fcf5eb7f9308617a4adb7c1ff2cd58d48f
+commit=af3c2aefea471e383f9f281629eed0eeed2f679d

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=cd9f3aa71464072fd1268ae40dd13ba23fd5b286
+commit=b22ed3f5d06f919fbf9d31151bd2a909d933ff32


### PR DESCRIPTION
v1.2.1 — Performance & stability update

- Bank history now account-specific (per RS profile) — each account tracks its own wealth history independently
- One-time bank history reset due to account-specific migration
- Fixed rapid bank clicking lag — bank history now records every 5 minutes instead of on every click
- Fixed variant items (charged/ornamented) disappearing from Top Gainers/Losers when removed from bank
- Bank value change tracking optimized — no more config writes during rapid clicking
- Fixed account switching edge cases — world hopping no longer resets bank history state