### PR TITLE
Add multi-tagger plugin

### DIFF
--- a/plugins/multi-tagger
+++ b/plugins/multi-tagger
@@ -1,2 +1,2 @@
 repository=https://github.com/KeithIsSleeping/multi-tagger.git
-commit=2eebd6aea707049dd0f709a3706713308de8c888
+commit=32bc3aa9b896090ae872123d7bcda8d87979acd0

--- a/plugins/multi-tagger
+++ b/plugins/multi-tagger
@@ -1,2 +1,2 @@
 repository=https://github.com/KeithIsSleeping/multi-tagger.git
-commit=3d22afbe88d7f039c0aab99520bf498a400d0f46
+commit=2eebd6aea707049dd0f709a3706713308de8c888

--- a/plugins/multi-tagger
+++ b/plugins/multi-tagger
@@ -1,2 +1,2 @@
 repository=https://github.com/KeithIsSleeping/multi-tagger.git
-commit=32bc3aa9b896090ae872123d7bcda8d87979acd0
+commit=ace27f5c07495dde50c1ec932f5813046b138288

--- a/plugins/multi-tagger
+++ b/plugins/multi-tagger
@@ -1,2 +1,2 @@
 repository=https://github.com/KeithIsSleeping/multi-tagger.git
-commit=ace27f5c07495dde50c1ec932f5813046b138288
+commit=fe4e16ab38bab785234128894cce0a55607f7d18

--- a/plugins/multi-tagger
+++ b/plugins/multi-tagger
@@ -1,0 +1,2 @@
+repository=https://github.com/KeithIsSleeping/multi-tagger.git
+commit=3d22afbe88d7f039c0aab99520bf498a400d0f46


### PR DESCRIPTION
Adds **Multi Tagger**: while in a multi-combat area, highlights *untagged* NPCs of the type you're currently fighting (skipping ones already `*`-tagged, your current target, dead, or out of range) so you can tag each for drop credit when barraging / doing group Slayer. Optionally shows each NPC's HP in the right-click menu (estimated hitpoints, percentage, or both, colour-coded), remembering the last-seen HP for NPCs in a large stack that lose their health bar.

Unlike NPC Indicators / better-npc-highlight (static, name-configured highlighting), this is dynamic and combat-triggered; and unlike autotags (gear/item tags) or aggro-tag (aggression warnings) it targets the multi-combat tagging workflow specifically.

Repo: https://github.com/KeithIsSleeping/multi-tagger
