### PR TITLE
Add optional task-completion superiors summary in chat.

### DIFF
--- a/plugins/superior-slayer-tracker
+++ b/plugins/superior-slayer-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/superior-slayer-tracker.git
-commit=fdd0708d08f4b70873921002acf538a7bab953a8
+commit=20d9d98afcb064a1048d8cc109795d92464619d5


### PR DESCRIPTION
Track actual kills (bracelet-aware) and superiors per task so players can see killed superiors vs expected after finishing a slayer assignment.