### PR TITLE
Fix task summary kill count when using expeditious bracelets.

### DIFF
--- a/plugins/superior-slayer-tracker
+++ b/plugins/superior-slayer-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/superior-slayer-tracker.git
-commit=20d9d98afcb064a1048d8cc109795d92464619d5
+commit=12fdcfff2b1228e390528de3b165141cbedc8cc1


### PR DESCRIPTION
Use the game's completion-message kill total instead of Math.max with the tracked assignment-sized count, which overstated expected superiors.