### PR TITLE
add tcg-assistant

### DIFF
--- a/plugins/tcg-assistant
+++ b/plugins/tcg-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/Sneugler/tcg-assistant.git
-commit=0c7f089085c4bb025b45d399381c4a82375ea54c
+commit=b275e9b85597ebd6b0292007e21001fb0b7e7c59

--- a/plugins/tcg-assistant
+++ b/plugins/tcg-assistant
@@ -1,0 +1,2 @@
+repository=https://github.com/Sneugler/tcg-assistant.git
+commit=7f69937b865d4a55461b90b6bf4f2c815c0f14a1

--- a/plugins/tcg-assistant
+++ b/plugins/tcg-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/Sneugler/tcg-assistant.git
-commit=7f69937b865d4a55461b90b6bf4f2c815c0f14a1
+commit=0c7f089085c4bb025b45d399381c4a82375ea54c


### PR DESCRIPTION
Adds `tcg-assistant`, a new plugin.

**What it is:** a read-only advisor for the OSRS TCG "CardLocked" gamemode. It
reads your card collection from the existing TCG plugins over the
`PluginMessage` bus and answers, in a sidebar and a window: what you can do
right now, what opens up as you train, what you are one card away from, and
which card is worth hoping for.

Things that should make review quicker:

- **No automation of any kind.** It never sends input to the client. It reads
  varbits, skills, quest states and item containers, and draws Swing panels.
- **No network calls.** Every dataset is generated at build time and bundled
  under `src/main/resources`; the plugin itself talks to nothing.
- **No third-party dependencies.** `build=standard`, and the only imports
  outside runelite-client are Gson, Guice, Lombok (`@Slf4j` only) and SLF4J,
  all of which are transitive dependencies of the client.
- Resources are read with `getResourceAsStream`, per the note in the README
  about jar-URLs.
- BSD 2-Clause licensed.

Repo: https://github.com/Sneugler/tcg-assistant
