### PR TITLE
goat-pit-indicators: 1.4.0

### DIFF
--- a/plugins/goat-pit-indicators
+++ b/plugins/goat-pit-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Goat-Pit-Indicators-Plugin.git
-commit=71825f68ae280bde5beb54c41298a9451d387efc
+commit=4957dc74a8046960a0bebff2954972aa2181a22e


### PR DESCRIPTION
Update goat-pit-indicators to 1.4.0 (commit 4957dc74a8046960a0bebff2954972aa2181a22e, on main just past tag R-1.4).

Changes since 1.3.1: adds a Cattleprod "prodable goat" highlight — while a Cattleprod is equipped, goats you can prod into a spiked, non-full pit are outlined (optionally only those you can prod in from where you stand, judged from the tile a click would walk you to), with their own near/far colors; goats prodded by any player are now suppressed from the lure/telegrab highlight while they walk in; and a style-checker false-positive fix. The pinned commit also documents the prodable highlight in the README.
