### PR TITLE
update ge-uncut to 1.5.6

### DIFF
--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,3 +1,3 @@
 repository=https://github.com/uzia35/ge-uncut.git
-commit=3683e7a583aac5bdc24e0c46f388e5739edf514a
+commit=b612d99d48befcc553892f64f36a78d145256f95
 warning=This plugin submits your IP address and various account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
﻿Updates GE Uncut to 1.5.6 (uzia35/ge-uncut@b612d99d48befcc553892f64f36a78d145256f95).

The side panel now follows the account you log into: flips and history scope to that account, a small heading names it, and switching characters switches the view. Also fixes dropdowns not closing when clicked a second time, and adds tooltips to the finder controls.
