### PR TITLE
Add Clan Tenure Ranks

### DIFF
--- a/plugins/clan-tenure-ranks
+++ b/plugins/clan-tenure-ranks
@@ -1,0 +1,2 @@
+repository=https://github.com/Newrockku/Clan-Tenure-Ranks.git
+commit=40659b129f34ab76bc6dee7fb2cdc7f58f3f51e2


### PR DESCRIPTION
Clan Tenure Ranks shows which clan members are due a rank promotion based on how long they've been in the clan.

It reads the same roster data the in-game Clan Settings > Members list shows (name, rank, joined date) for every member, online or not, and compares each member's tenure against a rank ladder configured by the user (two config fields: eligible ranks in order, and the number of days required for each rank).

It's entirely read-only and local — there's no way to change ranks via the API, and no network calls are made. The panel just tells the clan owner/admin who to promote; a human still does the promoting in-game.

Config also supports per-member overrides (manual join dates, for members who left and rejoined; ignored members, for alts), and an optional notification when someone newly becomes due for promotion.

Repo: https://github.com/Newrockku/Clan-Tenure-Ranks