### PR TITLE
loadout-lab 0.3.4

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=f6e71cf94cf351f430cfa82e99f24d65642dbce2
+commit=e2df216b409ec07a03e193c7712e94297ad798d6
 authors=ajkatz


### PR DESCRIPTION
Updates Loadout Lab to 0.3.4.

Highlights since 0.3.0:
- Multi-mob roster upgrades: kit-backed per-mob rows, roster style coverage fixes, per-mob lens dps
- New per-monster mechanics: the Abyssal Sire's respiratory systems (demonbane one-shot + melee walk), Kalphite Queen's prayer-pierce via Verac's set, Salarin the twisted (flat Strike damage), the Inferno nibblers' barrage lock, and the ToA Wardens' core spec-dump phase (melee always-max)
- ToA invocation scaling with an on-card control - verified to 0.0% against the wiki DPS calculator's open-source engine on both sides of the bowfa/blowpipe ranking flip
- BiS set upgrade cost + ownership borders, divine potion chips, curated bring-recommendations (barrage runes, DK antipoison), wilderness rune-pouch rules
- Engine fixes (golembane pool, twinflame spell dominance, spec-sim ownership) verified against the official calculator harness
- No network I/O: the plugin remains fully local

🤖 Generated with [Claude Code](https://claude.com/claude-code)
