### PR TITLE
Adding shrimp-lock package to plugin-hub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shrimp-lock"]
+	path = shrimp-lock
+	url = https://github.com/ErnestDongleheim/shrimp-lock


### PR DESCRIPTION
Adding a quick package that disables the eat option for all food except for shrimps.