### PR TITLE
Add CardCore Party

### DIFF
--- a/plugins/cardcore-party
+++ b/plugins/cardcore-party
@@ -1,0 +1,2 @@
+repository=https://github.com/TheRealMoeG/CardCore-Party.git
+commit=6e0b092ca4b9d7c7d556ff73792a74efee3a7c4f


### PR DESCRIPTION
Adds CardCore Party, a standalone RuneLite plugin that integrates with OSRS TCG's public PluginMessage API.

CardCore Party reads each player's distinct owned-card collection from OSRS TCG and shares collection progress between members of a RuneLite Party.

The plugin does not modify or bundle OSRS TCG.