### PR TITLE
update no-run-hotkey to 1.0.1

### DIFF
--- a/plugins/no-run-hotkey
+++ b/plugins/no-run-hotkey
@@ -1,2 +1,2 @@
 repository=https://github.com/willzero123/No-Run-Hotkey.git
-commit=7f3cfcf2c67062aa0ed6895a7e9b6fe3c0f11c44
+commit=a3d7c0a0db5a8fa6dee823198993be876b0d4b13


### PR DESCRIPTION
Adopts the current Plugin Hub build format and improves menu and hotkey handling.