### PR TITLE
update daily-xp-tracker

### DIFF
--- a/plugins/daily-xp-tracker
+++ b/plugins/daily-xp-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/zachgiaco/daily-xp-tracker.git
-commit=48243861611203b5de19bb2f4ed8a188d9eeecd5
+commit=ce9c8deaddc5ad855db99983f9ed2475654fa0f1


### PR DESCRIPTION
daily-xp-tracker: 1.1.0
Adds a period summary to the panel: total XP across a chosen span of
completed days, with per-day average and best day. The span is picked
from a dropdown that only offers periods the archive can actually fill,
so a selected period is never partial. Can be hidden from config.

Also adds a toggle for the chart's average line, a legend distinguishing
it from the goal line, and a heading showing how many days the chart
covers capping at 14 while the list below shows everything retained.

Fixes: the average line was not being drawn at all, and the summary
period boundary is now measured in UTC when using the UTC-day window.