### PR TITLE
update unskulled-notifier to 1.0.1

### DIFF
--- a/plugins/unskulled-notifier
+++ b/plugins/unskulled-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/willzero123/Unskulled-Notifier.git
-commit=e2ebbdf414e764bf720856e2797083a31f524b66
+commit=b09f46125eb1f74537d596cf57e9a7aef2802bc7


### PR DESCRIPTION
Adopts the current Plugin Hub build format and reduces overlay rendering allocations.