### PR TITLE
Add ToA Wardens Tile Memory

### DIFF
--- a/plugins/toa-wardens-tile-memory
+++ b/plugins/toa-wardens-tile-memory
@@ -1,0 +1,2 @@
+repository=https://github.com/dacluna/toa-wardens-tile-memory.git
+commit=daa564a38065f8d57a58f57cdd6d0261738bd924


### PR DESCRIPTION
Adds a ToA Wardens P3 memory aid that tracks only the player's own manual movement clicks.

The plugin watches three configured floor tiles and keeps the most recently clicked one highlighted until another of the three is clicked. It does not detect Warden attacks, animations, projectiles, timing, or determine a safe tile automatically.