### PR TITLE
Add Discord Loot Streamer

### DIFF
--- a/plugins/discord-loot-streamer
+++ b/plugins/discord-loot-streamer
@@ -1,0 +1,2 @@
+repository=https://github.com/acbroache/discord-loot-streamer.git
+commit=596969d65856aecaef88ad1af8e2f8c448ec2b5f


### PR DESCRIPTION
Streams your Loot Tracker drops to a Discord webhook in **batches** — one embed every N kills, every X minutes, or whichever comes first — instead of one message per drop.

The embed attaches an image rendered in the loot tracker panel style: one box per source with kill count and total value, and the item icons with quantity overlays.

Features:
- Batch triggers: every N kills, every X minutes, or whichever comes first
- Big-drop instant post: a single stack over a configurable gp value posts immediately with a highlight
- Filters: source-name blacklist, min item value (excludes cheap stacks), min kill value (kills below it don't count toward the batch or appear)
- Webhook URL is empty by default (opt-in) with the third-party-server warning on the config item
- All HTTP via injected OkHttpClient with enqueue(); JSON via injected Gson

Repository: https://github.com/acbroache/discord-loot-streamer

🤖 Generated with [Claude Code](https://claude.com/claude-code)