### PR TITLE
loadout-lab 0.3.5

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=e2df216b409ec07a03e193c7712e94297ad798d6
+commit=45cf99118e56351549982499413731e620ba40fd
 authors=ajkatz


### PR DESCRIPTION
Updates Loadout Lab to 0.3.5 - documentation and bug fixes, no network changes.

- Documentation overhaul: the README is condensed to a hub-friendly page (the full feature guide moves to docs/GUIDE.md), and the guide's screenshots are reshot on the current UI
- Cross-plugin link-ins resolve monster groups: a "search" message naming a fight (Abyssal Sire, Grotesque Guardians) opens the whole multi-mob roster; single-boss names and npc-id link-ins stay single
- Issue-report fixes: the version string is build-stamped (was a stale constant), the reported dps now matches the on-screen number with thrall/spec folds itemized, and the viewed side (Yours/Best in game) leads the block
- The plugin remains fully local: no network I/O

🤖 Generated with [Claude Code](https://claude.com/claude-code)
