### PR TITLE
grand-flip-out: update to a07015c

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=5af290eacf22d6e4cd1f2ce5bf724819b46e675a
+commit=a07015c04a9125d34ee174fc6459e58c9eae3fe9


### PR DESCRIPTION
Updates grand-flip-out to a07015c.

- After using "Fill order", the pinned advice card now offers an immediate "Next flip" escape, and an expired arm-hold is released on game tick (previously the card could sit stale with no affordance until an offer event fired) — fixes a user-reported flow gap.
- Estimated-fill labels now read as an honest floor ("~Xm+").

No new dependencies, no new data egress; test suite 140/0 at the pinned commit.
