### PR TITLE
add Station's Cozy Carts

### DIFF
--- a/plugins/stations-cozy-carts
+++ b/plugins/stations-cozy-carts
@@ -1,0 +1,2 @@
+repository=https://github.com/StationEarthxo/Stations-Cozy-Carts.git
+commit=2352bb45551d944dce213b310b45325606269993

--- a/plugins/stations-cozy-carts
+++ b/plugins/stations-cozy-carts
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Carts.git
-commit=2352bb45551d944dce213b310b45325606269993
+commit=7ad20580a2fb759c15666fc94f5e10120f68fa45


### PR DESCRIPTION
## Description

Adds Station's Cozy Carts, a cosmetic client-side plugin that lets the local player ride a customizable native OSRS minecart.

## Features

- Separate idle, walk, and run rider animation choices
- Independent cart body, wheel, and wheel-hub colours
- Adjustable cart size, facing, and height
- Optional cape, weapon, and shield hiding while mounted
- Movable and resizable click-to-mount overlay using supplied plugin artwork
- Optional native smoke-poof effect when mounting or dismounting

## Validation

- Uses the standard Plugin Hub build with no third-party dependencies
- Clean Gradle `check` passes against `latest.release`
- Java 11 release target
- Java deprecation and unchecked lint passes without warnings
- Root icon is 48x38 px and README includes an in-game screenshot
- No networking, reflection, subprocesses, file access, or game-input automation