### PR TITLE
Update barracuda-trials-pathfinder

### DIFF
--- a/plugins/barracuda-trials-pathfinder
+++ b/plugins/barracuda-trials-pathfinder
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/barracuda-trial.git
-commit=6734e68437c1248827f04e12f4813dec2d02504c
+commit=b05a9f833d59e6b60db0ed3cc1a9265e6d5573cf


### PR DESCRIPTION
Bumps the plugin to the latest release.

The main change here is a pathfinding rework: waypoints are now constraints the path grazes rather than points each search stops at, so a run of waypoints plans as one continuous search. This improves pathing on all three trials, and fixes Jubbly Jive pathing breaking partway through a lap (NathanVegetable/barracuda-trial#13, NathanVegetable/barracuda-trial#11).

Also:

- Improve wind catcher behavior
- Fix path display outside of viewable scene
- Configs for showing crate and toad pillar radius
- Other minor fixes
