### PR TITLE
Add quetzal-whistle-charges

### DIFF
--- a/plugins/quetzal-whistle-charges
+++ b/plugins/quetzal-whistle-charges
@@ -1,0 +1,2 @@
+repository=https://github.com/jdkrupajk/quetzal-whistle-charges.git
+commit=e2dacab6533102d8e4a9052365e7c31b27e12ea3


### PR DESCRIPTION
Shows remaining charges on quetzal whistles, the way the built-in Item Charges plugin does for jewellery — the whistle isn't covered by it, so today the only way to know is to right-click Check.

Charges live on the item rather than a varbit, so there is nothing to read; the plugin uses the count the game prints on both Check and teleport, and shows `?` rather than a guess until it has seen one.

It also draws each hunter meat's charge value coloured by what the next recharge at Soar Leader Pitri would do with it (he takes meat in inventory slot order and wastes the overshoot, so ordering matters), and puts your current rumour in the infobox tooltip, read from the whistle's own Rumour option.

Java 11, BSD-2, no network access, no file I/O, no reflection. 22 unit tests.