### PR TITLE
Update Slayer Best in Bank: boss planning and scoring fixes

### DIFF
--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=9ef184e945426412ab2aca90cc95aed59e00c2bd
+commit=70a022b44cc545aec615807a21242330b76da1b5

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=eabf212eeac010c1bc1f0ce56e3a0a2762c5b098
+commit=9ef184e945426412ab2aca90cc95aed59e00c2bd

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=aa31d3677ca671b66b5bc5ce5c79a72af5571be3
+commit=4b9baf906ee3fb2ffef211f1f221f6c2afd3b786

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=4b9baf906ee3fb2ffef211f1f221f6c2afd3b786
+commit=4b9baf98ef95e4f3c4ea56bf020f4d15c092b32a

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=70a022b44cc545aec615807a21242330b76da1b5
+commit=0b76b1653b35a6ec00ef2c7e6318d7c3f01cb724

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=0b76b1653b35a6ec00ef2c7e6318d7c3f01cb724
+commit=aa31d3677ca671b66b5bc5ce5c79a72af5571be3


### PR DESCRIPTION
## Summary

Updates Slayer Best in Bank to source commit `4b9baf98ef95e4f3c4ea56bf020f4d15c092b32a`.

### Boss Slayer planning

- adds a manual boss selector with assignment-aware boss choices
- adds owned defence-reduction, damage-special, spawn, and phase weapon switches to boss bank preparation
- includes boss switches in inventory-capacity planning and the tiered bank layout
- adds optional Thralls with Book of the dead, rune pouch, and Arceuus spellbook readiness checks
- expands encounter-aware boss profiles and standard-task boss mappings

### Weapon and method corrections

- prevents Voidwaker from being selected as Araxxor's Crush main hand
- counts loaded darts when comparing Toxic blowpipe with ammunition-based ranged packages
- makes Toxic blowpipe the primary owned Jad method with a compatible ranged fallback
- follows the curated Thermonuclear Smoke Devil weapon order
- retains the coherent loadout, Venator, Turael/Aya, supply, and preparation fixes already included in this PR

## Why

Boss assignments need encounter-specific loadouts and switches rather than a generic boss fallback. The prior candidate also allowed weapons without a Crush style into Araxxor's main-hand comparison and undervalued self-ammo ranged weapons because RuneLite's visible equipment stats omit their loaded ammunition.

## User impact

Players receive assignment-aware boss choices, applicable weapon switches, optional Thrall preparation, and corrected main-hand rankings for Araxxor, Jad, Thermy, and Blowpipe-based methods.

## Validation

- source PR: https://github.com/FreeArcanes/slayer-best-in-bank/pull/11
- full `./gradlew test` suite passes
- `git diff --check` passes in both repositories
- regressions cover boss mappings, bank lookup, inventory preparation, Thralls, Blowpipe loaded darts, Venator enforcement, Jad fallback behavior, Thermy ordering, and Araxxor rejecting Voidwaker for Crush
- Plugin Hub change remains limited to `plugins/slayer-best-in-bank`
