### PR TITLE
Add Aura Tracker

### DIFF
--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Matelaa/aura-tracker.git
 commit=ca36c36b015e5479ec9ed38af66c23edd7560994
-warning=This plugin submits your RSN and Aura total to a server not controlled or verified by the RuneLite developers. If you click "Update 3D Model", your character's 3D model is also submitted.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,0 +1,3 @@
+repository=https://github.com/Matelaa/aura-tracker.git
+commit=be79055ef6f1d02711235895038679fa8ffe509c
+warning=This plugin submits your RSN and Aura total to a server not controlled or verified by the RuneLite developers. If you click "Update 3D Model", your character's 3D model is also submitted.

--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Matelaa/aura-tracker.git
-commit=be79055ef6f1d02711235895038679fa8ffe509c
+commit=ca36c36b015e5479ec9ed38af66c23edd7560994
 warning=This plugin submits your RSN and Aura total to a server not controlled or verified by the RuneLite developers. If you click "Update 3D Model", your character's 3D model is also submitted.


### PR DESCRIPTION
Aura Tracker — a fun, purely cosmetic plugin that tracks how long you stand still on the same tile inside the Grand Exchange.

**Local tracking is always on** and never leaves your machine.

**Online sync is on by default (opt-out)**, same model as [RuneProfile](https://runeprofile.com): your RSN and Aura total sync to a community leaderboard on logout. Your character's 3D model can also be shown on your player page, but only if you click the panel's "Update 3D Model" button — never automatically.

The leaderboard is explicitly labeled unofficial — Aura is calculated entirely client-side, so it can be manipulated by a modified client, same as any other self-reported metric.

Repository: https://github.com/Matelaa/aura-tracker
