### PR TITLE
Overhaul update to Faux Bingo plugin

### DIFF
--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,3 +1,3 @@
 repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
-commit=66e2414b98fbe91118e6847d050490578199a9d6
+commit=88ddc978759290098e23d85b024d8d43ce2315ba
 authors=ThatOhio

--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,3 +1,3 @@
 repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
-commit=88ddc978759290098e23d85b024d8d43ce2315ba
+commit=027faa042942720d676c31421f90a3599642bfc9
 authors=ThatOhio


### PR DESCRIPTION
We have an event coming up at the end of September and are overhauling how we run our bingo events.

In summary of the changes, we have drastically "dumbed down" the responsibility of this plugin in favor of streaming data to our API, where we can make similar determinations (if an item is bingo related, etc) without requiring updates to this plugin, or any form of client side logic at all.

There has been a lot of work done as well to better identify drops from NPCs, players, and activities with this update. Largely building off of changes other loot plugins have made to better support all the various ways loot is detected in this game.

The plugin still functions without the API enabled, just with severely limited functionality (primarily related to clan overlay and Wise old Man updating).