### PR TITLE
goalplanner: update to 0.5.0

### DIFF
--- a/plugins/goalplanner
+++ b/plugins/goalplanner
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-goal-planner.git
-commit=840b7124af3f65cf0ac9b89cfec2846a6d08b451
+commit=83966f32a445e5afb7bb75bfdcc236e0592cebc1
 authors=ajkatz


### PR DESCRIPTION
Repeatable goals: any custom goal can repeat daily/weekly/monthly, and long-term goals can spawn repeating slices of themselves ("Prayer +10K XP a day", "General Graardor x20 a week") that re-arm each period and size against the player's own progress. Live "resets in" countdowns on every repeatable card.

Per-character plans: goals are now keyed by profile and character (same model as the existing main/leagues split, now including Deadman worlds), so two accounts sharing a RuneLite profile no longer share or endanger each other's goals. Existing plans are adopted by the first character to log in.

Fixes a data-corruption bug where a goal set could be scored against whichever account was logged in, silently completing goals permanently (user-reported); any completed goal can now be reopened for recovery. Share codes carry the repeat fields (additive to the existing wire — older builds import them as one-shots), and re-importing a code you've already imported now warns first.

Full changelog: https://github.com/AKAddons/runelite-goal-planner/blob/main/CHANGELOG.md