### PR TITLE
update Station's Cozy Carts icon

### DIFF
--- a/plugins/stations-cozy-carts
+++ b/plugins/stations-cozy-carts
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Cozy-Carts.git
-commit=7ad20580a2fb759c15666fc94f5e10120f68fa45
+commit=d5e235277efcca26701875c0f8d260f4af662c35


### PR DESCRIPTION
Updates Station's Cozy Carts to use its intended pixel-art Plugin Hub icon.\n\nThe plugin code is unchanged; the source commit only replaces the root 48x48 icon.png.\n\nSource commit: https://github.com/StationEarthxo/Stations-Cozy-Carts/commit/d5e235277efcca26701875c0f8d260f4af662c35