### PR TITLE
update daily-xp-tracker

### DIFF
--- a/plugins/daily-xp-tracker
+++ b/plugins/daily-xp-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/zachgiaco/daily-xp-tracker.git
-commit=ce9c8deaddc5ad855db99983f9ed2475654fa0f1
+commit=7d6b5ccc672e85d1dc4afb69bea36c6afdc6049c


### PR DESCRIPTION
**v1.2.0:**
The history chart now covers real calendar days rather than only the days
with recorded XP. Previously a gap in play was closed up, so eleven bars
could span twenty days while still being labelled "past 11 days". Days
with nothing recorded draw as flat grey bars, and the average line counts
them as zero — a per-calendar-day figure matching the period summary.

Fixes XP earned while the client was closed across midnight being absorbed
into the new day's baseline instead of counted. It is now attributed to the
day you next log in, and marked in the day list. Days totalled across the
archive now sum to the XP actually gained.

Also adds a "Last 14 days" summary period, which lines up with the chart's
window, and a toggle for whether offline XP counts toward the daily goal —
off by default, so the bar doesn't fill before you start training. Where a
day's total includes offline XP, the excluded portion is drawn dimmed so
the solid part of each bar reads against the goal line.