### PR TITLE
update runeshare

### DIFF
--- a/plugins/runeshare
+++ b/plugins/runeshare
@@ -1,3 +1,3 @@
 repository=https://github.com/kcdragon/runeshare-plugin.git
-commit=b6f45d6eb4507b0d5e77a4ecc0a3284e80cb47cc
-warning=This plugin submits your bank tag tab data and IP address to a server not controlled or verified by the RuneLite developers.
+commit=7de87f8a3a8a63565ef63d5174a51895408f4de6
+warning=This plugin submits your bank tag tab data, in-game location, and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
Add in-game location to the warning; the plugin now sends world map coordinates to osrs.runeshare.app when starting a task session. Sharing them is opt-out via the new "Share Location?" config option, so the default behavior still transmits location.