### PR TITLE
Add osrs-flip-desk

### DIFF
--- a/plugins/osrs-flip-desk
+++ b/plugins/osrs-flip-desk
@@ -1,0 +1,2 @@
+repository=https://github.com/klye32/osrs-flip-desk.git
+commit=cabd9b7f6daa9e4b13e541338e13352dce5f0ef2


### PR DESCRIPTION
## Summary
Adds **OSRS Flip Desk**, a RuneLite sidebar plugin that suggests affordable Grand Exchange flips from public wiki market data and tracks your fills into Active/History.

- Competitive buy/sell targets (not raw last-low as a live ask)
- Sizing from GP on hand, buy limits, and recent volume
- Local fill learning and optional tray notifications
- Does **not** automate GE clicks, typing, or offer submission

## Manifest
- repository: https://github.com/klye32/osrs-flip-desk.git
- commit: 4384439da8fb07b4f0360be222a0999574b476eb

## Test plan
- [ ] Plugin Hub CI build passes
- [ ] Review confirms no input injection / automation
- [ ] Install from built artifact and open sidebar panel