### PR TITLE
update daily-xp-tracker

### DIFF
--- a/plugins/daily-xp-tracker
+++ b/plugins/daily-xp-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/zachgiaco/daily-xp-tracker.git
-commit=7d6b5ccc672e85d1dc4afb69bea36c6afdc6049c
+commit=836619d6dfa87027c844c530bf803471002251cb


### PR DESCRIPTION
**v1.2.1:**
Fix small bug discovered with temporary disconnect. Remedy by adding 3 minute time limit. If 3 minutes pass before the client detects a game tick, then XP is counted as offline XP. If it is under 3 minutes, then the XP is counted as online XP. Either way, XP gained is attributed towards the day with non-rolling 24hr window selected.
