### PR TITLE
Update authors list in goal-tracker plugin

### DIFF
--- a/plugins/goal-tracker
+++ b/plugins/goal-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Darkforge317/rl-goal-tracker.git
 commit=93cd9a01c7bbc022fe4363a9456c23b32f8451ff
-authors=Toofifty,cecilia-sanare,AhDoozy
+authors=Darkforge317,Toofifty,cecilia-sanare,AhDoozy


### PR DESCRIPTION
Adding myself as an author as the new owner of the repository. 

Keeping the previous owner, @Toofifty , as an author as well since he's had a large impact on the plugin and I definitely trust his skills, context, and judgement.