### PR TITLE
Add Zero XP Drops

### DIFF
--- a/plugins/zero-xp-drops
+++ b/plugins/zero-xp-drops
@@ -1,0 +1,2 @@
+repository=https://github.com/Webben91/zero-xp-drops.git
+commit=61e0a3c1ccc476ff0e39605630b95bcc585aadf7


### PR DESCRIPTION
Shows a movable MISS or 0 when an attack gives no combat XP.