### PR TITLE
Add Gielinor Cartography

### DIFF
--- a/plugins/gielinor-cartography
+++ b/plugins/gielinor-cartography
@@ -1,3 +1,3 @@
 repository=https://github.com/jacke9708/Gielinor-Cartography.git
 commit=30a3b974a1ff14e52834f2d52de8ccb55955355c
-warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/gielinor-cartography
+++ b/plugins/gielinor-cartography
@@ -1,0 +1,3 @@
+repository=https://github.com/jacke9708/Gielinor-Cartography.git
+commit=b55a3553710dabd0018609fa19b6bd2d0d0f8a80
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/gielinor-cartography
+++ b/plugins/gielinor-cartography
@@ -1,3 +1,3 @@
 repository=https://github.com/jacke9708/Gielinor-Cartography.git
-commit=b55a3553710dabd0018609fa19b6bd2d0d0f8a80
+commit=30a3b974a1ff14e52834f2d52de8ccb55955355c
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Turf-style territory control for OSRS: in-game locations ("tasks" - a combat kill count, a woodcutting spot, a stand-in-zone landmark, or an agility course) can be claimed and stolen by whichever player last completes them. Ownership, points, and a leaderboard are synced across every player through a backend I run and maintain.

See the repo README for details: https://github.com/jacke9708/Gielinor-Cartography