### PR TITLE
Update blast-mine-improved to 1.0.2

### DIFF
--- a/plugins/blast-mine-improved
+++ b/plugins/blast-mine-improved
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/blast-mine-improved.git
-commit=3e7b1ff5fddc8e7753c26d8f9ecebf21001ba212
+commit=59d93e294a7cc3e72d75622081019f88a8637acc


### PR DESCRIPTION
## Summary
- Updates **blast-mine-improved** to `1.0.2` (`59d93e294a7cc3e72d75622081019f88a8637acc`)
- Blasted ore inventory timers now start at ground spawn (include floor time) and follow ores when inventory slots are rearranged

## Test plan
- [x] Plugin Hub CI build passes
- [x] Leave ore on the floor ~30–60s, pick up — pie should already be partly depleted
- [x] Drag / swap ore in inventory — pie moves with the ore
- [x] Deposit / disintegrate — timers clear with the ores