### PR TITLE
create Station's Creature Collector

### DIFF
--- a/plugins/stations-creature-collector
+++ b/plugins/stations-creature-collector
@@ -1,0 +1,2 @@
+repository=https://github.com/StationEarthxo/Stations-Creature-Collector.git
+commit=31d3c62c99ff81114c818bee393fe28cfa6c0548

--- a/plugins/stations-creature-collector
+++ b/plugins/stations-creature-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Creature-Collector.git
-commit=31d3c62c99ff81114c818bee393fe28cfa6c0548
+commit=d49365a44443eadf1f59557fd4625a116c5858a8

--- a/plugins/stations-creature-collector
+++ b/plugins/stations-creature-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Creature-Collector.git
-commit=fa4e4a34e2addb403d0114793e0aa84ad0fcd23d
+commit=c89cf75697f62d1b5086288a6a2453027f94ac74

--- a/plugins/stations-creature-collector
+++ b/plugins/stations-creature-collector
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-Creature-Collector.git
-commit=d49365a44443eadf1f59557fd4625a116c5858a8
+commit=fa4e4a34e2addb403d0114793e0aa84ad0fcd23d


### PR DESCRIPTION
## Summary

Adds Station's Creature Collector, a local-only cosmetic creature collection plugin.

- Earn capture balls through XP and credited boss kills
- Catch eligible non-humanoid creatures with a client-side animation
- Browse a regional collection catalogue with rendered portraits and silhouettes
- Call, resize, dismiss, and interact with caught cosmetic companions
- Protect official OSRS pets and their source bosses from catchability

All companion models, capture effects, rewards, and transformations are client-side only. The plugin does not automate actions or send interactions to the game server.

## Verification

- Clean Gradle test and jar build passed against latest RuneLite
- Plugin started in the development client without plugin-specific errors
- Plugin Hub icon is 48x48