### PR TITLE
Add Life Tracker

### DIFF
--- a/plugins/life-tracker
+++ b/plugins/life-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/WoodyCode23/runelite-life-tracker.git
+commit=2df857e6ed1bddb3d109ad51df18e21ca2fadc1c

--- a/plugins/life-tracker
+++ b/plugins/life-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/runelite-life-tracker.git
-commit=2df857e6ed1bddb3d109ad51df18e21ca2fadc1c
+commit=fb0c8a5f711f2f29061bc768978bc4936a062775

--- a/plugins/life-tracker
+++ b/plugins/life-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/runelite-life-tracker.git
-commit=fb0c8a5f711f2f29061bc768978bc4936a062775
+commit=477ee130e0470b86dbbc757fb7703ec4ccc0aa4c

--- a/plugins/life-tracker
+++ b/plugins/life-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/runelite-life-tracker.git
-commit=477ee130e0470b86dbbc757fb7703ec4ccc0aa4c
+commit=62ed3ebddad3d50f81e4e0ebdc5d5000b0cf0492


### PR DESCRIPTION
Adds Life Tracker, a personal activity tracker for your account.

It records what you actually did while playing and shows it over time: tiles walked, ran and sailed; potion doses and foods by individual type; calories; prayer uptime per prayer; playtime split into active and idle; and damage, deaths, kills, specials and alchemy. Everything is broken down by day, week, month, year and all time, with best-day records, login streaks and milestone messages.

The panel has two pages: a summary of colour-coded category cards, and a tracking page for choosing which stats appear on it.

Repository: https://github.com/WoodyCode23/runelite-life-tracker

### Notes for review

No network access whatsoever. The plugin makes no HTTP calls and has no server component. Nothing about the player leaves the machine.

Storage is a RuneLite config value rather than a file, which I want to flag up front as the least conventional thing here. History is serialised to JSON, gzipped and base64'd into one config key per character. A file under `~/.runelite/` would be the more usual choice, but config values are what profile sync carries between machines, and following your own account's stats across installs is the point of the plugin. To keep that value a sane size, per-day detail is pruned after 90 days while monthly totals and lifetime totals are kept exactly and forever.

Characters are keyed by display name, not account hash, so no identifier is derived or stored beyond the name already visible in game.

Heal values come from the client's own `ItemStatChanges`, injected directly rather than through `ItemStatChangesService`, since that interface is bound inside the Item Stats plugin's own injector and is not available to an external plugin.

There is an optional support link at the bottom of the second page. It is a plain `LinkBrowser.browse` call, sends nothing, and is easy to drop if you would rather it were not there.

BSD 2-Clause licensed, `icon.png` at the repository root, `build=standard`.