### PR TITLE
better-monster-examine: update to v1.7

### DIFF
--- a/plugins/better-monster-examine
+++ b/plugins/better-monster-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/prettyrocket/better-monster-examine.git
-commit=ab31e2791247f9bc841d25d4a575bfad3d076e75
+commit=aba64421cda11fd26754a6710bb30e36a6adcaf9


### PR DESCRIPTION
Updates **Better Monster Examine** to [`aba64421cda11fd26754a6710bb30e36a6adcaf9`](https://github.com/prettyrocket/better-monster-examine/commit/aba64421cda11fd26754a6710bb30e36a6adcaf9).

Released as **Better Monster Examine v1.7 — Not Enough Runes** — https://github.com/prettyrocket/better-monster-examine/releases/tag/v1.7

---

## 🔗 Drops that open in Not Enough Runes

A drop row could always take you to the OSRS Wiki. If you also run [Not Enough Runes](https://runelite.net/plugin-hub/Hannah-GBS), it can now take you there instead — straight to the item, in the sidebar, without leaving the client.

**Integrations**

- **A new Integrations config section** — the home for hand-offs to other plugins. Its first entry is **Not Enough Runes**, and it's **off by default**, so nothing changes unless you turn it on.
- **Click a drop, land in Not Enough Runes** — with the link on, clicking an item in the Drops tab opens it in NER's panel. **Right-click still opens the wiki**, so both are a click away.
- **It degrades quietly** — if Not Enough Runes isn't installed, is disabled, or gets switched off mid-session, clicking a drop just opens the wiki as before. Nothing dead-ends.
- **The tooltip says where you'll land** — *Opens in NER*, *Opens in Wiki*, or *Opens in Wiki (no NER)* when the link is on but that plugin isn't running. A fallback shouldn't be mistakable for a bug.

**The other direction, too**

- **Other plugins can now open a monster here** — Better Monster Examine listens for a `displayMonster` request and opens that monster's card, on the Stats or Drops tab, by name and combat level or by NPC id. It's how Not Enough Runes will send you back the other way once its half lands; **you won't see it do anything until then**, but it ships now so that side has a released version to build against.
- **A name has to match exactly to open a card.** A near-miss goes into the search box with the results listed instead. Coming from another plugin, quietly opening the *wrong* monster is worse than showing you the options.

**Under the hood**

Plugin-hub plugins each load in their own classloader and can't see each other's code, so this goes over RuneLite's `PluginMessage` event — the supported channel for exactly this. The upshot for you: the two plugins update independently, and neither needs the other to be installed.

**Thanks** to **Hannah-GBS**, author of Not Enough Runes, for proposing the link and for the integration notes it was built from.

**Full changelog:** https://github.com/prettyrocket/better-monster-examine/compare/v1.6...v1.7