### PR TITLE
Add Hunter Rumour History

### DIFF
--- a/plugins/hunter-rumour-history
+++ b/plugins/hunter-rumour-history
@@ -1,0 +1,2 @@
+repository=https://github.com/mutations-uim/hunter-rumour-history.git
+commit=0cbb4d0aadf86a3939119cfa8b8abb869c70a99e


### PR DESCRIPTION
Adds Hunter Rumour History, a plugin for tracking completed Master Hunter Rumours.

Features:
- Tracks completed Hunter Rumours and catches/KC required for the rare part
- Supports dashing kebbit, moonlight antelope, herbiboar, and red chinchompa, with more tasks planned
- Displays recent completed rumours in a configurable overlay
- Saves rumour history locally to CSV
- Restores recent history after RuneLite restarts
- Does not send or upload player data

The plugin has been tested locally using the RuneLite development client.