### PR TITLE
Update GearForge

### DIFF
--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,2 +1,2 @@
 repository=https://github.com/marcushill13/gearforge.git
-commit=6a204058d535cd9d22d9bff9a95900dbf090602c
+commit=7f5626cff23fc27f8865f576442becaa0e0b633e

--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,2 +1,2 @@
 repository=https://github.com/marcushill13/gearforge.git
-commit=7f5626cff23fc27f8865f576442becaa0e0b633e
+commit=abd313de64e1b506e2607fcb346e710840784e3e

--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,2 +1,2 @@
 repository=https://github.com/marcushill13/gearforge.git
-commit=abd313de64e1b506e2607fcb346e710840784e3e
+commit=b7d9e3196e4e48e78bbd6192cf05112ad5bc474f


### PR DESCRIPTION
Updates GearForge to `7f5626c`.

Since the last update:

- **Best-in-slot correctness.** The optimiser's per-slot candidate filter was too narrow, and DPS ties were broken by item name. Measured against an exhaustive search it fell short on 15 of 15 test banks, by up to 4.16%. Breadth raised from 5 to 20, where it matches exhaustive, and ties now break on defence.
- **Special attack recommendations.** A new section on the BiS tab suggests which spec weapon to bring, scored against the recommended setup and the selected target. 55 weapons, with mechanics taken from the wiki calculator's own implementation. Damage specs, guaranteed-hit specs and defence-reduction specs are compared in one currency: damage added to the kill.
- **Bank tag fix.** Saved setups tagged every variant of a charged item, so the layout reserved a slot for each charge state.
- **Target list.** Collapsed from 2858 entries to 1273 — one row per monster rather than one per NPC id, with boss forms preserved.

Tests: 170, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)