### PR TITLE
Update GearForge

### DIFF
--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,2 +1,2 @@
 repository=https://github.com/marcushill13/gearforge.git
-commit=9640709736f35169e05f9d4c99d38055fd5da7d2
+commit=3e6a3154fbddb83257ff4d1924e07b2a43a89975

--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,2 +1,2 @@
 repository=https://github.com/marcushill13/gearforge.git
-commit=b7d9e3196e4e48e78bbd6192cf05112ad5bc474f
+commit=9640709736f35169e05f9d4c99d38055fd5da7d2


### PR DESCRIPTION
Updates GearForge to `3e6a315`.

Mostly correctness work on the combat model, after checking it against the wiki calculator's own implementation and finding a number of effects missing or wrong.

**Gear effects that were absent**

- Crystal armour, which does nothing without a crystal bow but is worth +30% accuracy and +15% damage with one. Without it the optimiser preferred rune knives with a shield over a bow of faerdhinen.
- Enchanted bolts — all six enchantments and their dragon variants, including the immunities. These cannot be written as a damage multiplier, so the engine now carries a damage distribution.
- Powered staves and tridents, whose maximum comes from the Magic level rather than a spell.
- The salve amulet's plain and enchanted forms, and the Soul Wars and Emir's Arena copies of the imbued ones.
- The vampyre banes, which had never fired: the attribute was a single `VAMPYRE` constant where the data spells three tiers.
- Obsidian set, berserker necklace, amulet of avarice, Efaritay's aid, colossal blade, ratbane weapons, brimstone ring, crystal blessing, chaos gauntlets, twinflame staff, eclipse atlatl.

**Effects that were wrong**

- Darklight and silverlight had a 60% damage bonus the game does not give them; it applies to the attack roll only.
- Best-in-slot ties were broken by item name, so the alphabet decided between items with identical DPS.
- The optimiser kept only five candidates per slot, which fell short of an exhaustive search on 15 of 15 test banks. Raised to twenty, where it matches.

**Magic spell selection**

Magic assumed Ice Barrage for every setup. 1,219 monsters have an elemental weakness worth half again in both accuracy and damage, so the strongest spell was the wrong answer for over a third of the game. The spell is now chosen from the target, which also makes the elemental tomes meaningful.

Tests: 211, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)