### PR TITLE
Add Gielinor Profile Sync

### DIFF
--- a/plugins/gielinor-profile-sync
+++ b/plugins/gielinor-profile-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/cwewright/gielinor-profile-sync.git
+commit=c33227968131bc9aef7b2f692a0d4345ffa968f4


### PR DESCRIPTION
## Description

Gielinor Profile Sync writes a versioned, local-only account snapshot for personal dashboards and progression tools.

The snapshot includes the logged-in player's skills, quests, Achievement Diary tier completion, item-container freshness, Grand Exchange offers, and a compact copy of the local player's model for private avatars.

## Privacy and behavior

- Performs no network requests.
- Writes only beneath `.runelite/gielinor-profile-sync`.
- Does not export world, coordinates, FPS, animation state, credentials, Discord data, or other players.
- File writes run on a dedicated executor rather than the client thread.
- Uses the Plugin Hub's standard build mode and adds no third-party runtime dependencies.

## Validation

- Java 11
- RuneLite `latest.release`
- 4 unit tests passing
- Plugin Hub build passing
- Live in-game export confirmed through the Jagex Launcher development flow