### PR TITLE
Create wrong-prayer-warning

### DIFF
--- a/plugins/wrong-prayer-warning
+++ b/plugins/wrong-prayer-warning
@@ -1,2 +1,2 @@
 repository=https://github.com/bockscarrasor/wrong-prayer-warning.git
-commit=2a50bbbb9b08acde22b568f4ac6fcf2eff59b472
+commit=4ed82dcc59af32a96f1286407061b863aa3f96b7

--- a/plugins/wrong-prayer-warning
+++ b/plugins/wrong-prayer-warning
@@ -1,0 +1,2 @@
+repository=https://github.com/bockscarrasor/wrong-prayer-warning.git
+commit=2a50bbbb9b08acde22b568f4ac6fcf2eff59b472


### PR DESCRIPTION
Adds Wrong Prayer Warning, a plugin that alerts the player when their equipped weapon's combat style (melee/ranged/magic) doesn't match their currently active offensive prayer. Warns via chat message and/or desktop notification, both toggleable, with an optional setting to also warn when no offensive prayer is active at all.

Source repo: https://github.com/bockscarrasor/wrong-prayer-warning