### PR TITLE
Add ground-item-colour-groups

### DIFF
--- a/plugins/ground-item-colour-groups
+++ b/plugins/ground-item-colour-groups
@@ -1,0 +1,2 @@
+repository=https://github.com/ellatonin/runelite-ground-item-colour-groups.git
+commit=a2c258ce6807be756c4affb3de3caafeaaf8dabd

--- a/plugins/ground-item-colour-groups
+++ b/plugins/ground-item-colour-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/ellatonin/runelite-ground-item-colour-groups.git
-commit=a2c258ce6807be756c4affb3de3caafeaaf8dabd
+commit=5d434bd66712aa6f17d0c2212e81dc647e11084f


### PR DESCRIPTION
Simple plugin that adds a side panel which groups items by custom colour from the default Ground Item plugin.

<img width="245" height="761" alt="image" src="https://github.com/user-attachments/assets/05f52c00-3019-4d42-b8e1-61b8ba729e7f" />
<img width="266" height="373" alt="image" src="https://github.com/user-attachments/assets/ba8ddaf1-24b8-4d9a-9316-747dfb70d2e9" />
