### PR TITLE
Add ground-marker-variables

### DIFF
--- a/plugins/ground-marker-variables
+++ b/plugins/ground-marker-variables
@@ -1,0 +1,2 @@
+repository=https://github.com/Limy-Monkey/Ground-Marker-Variables.git
+commit=dea84e0b5d94e29ee79f3a85b367bfc78f0ec1e6


### PR DESCRIPTION
Extends current Ground Markers plugin functionality with variable support.

Variables include `{metronome4}` as a 4 tick metronome, `{lvl_attack}` to display your current attack level, and more. Full information about which variables are supported are in the README of the repository.

This plugin does force-remove the Ground Marker overlays while the plugin is active. Re-adds Ground Marker overlays when the plugin is turned off. I would technically prefer if I could simply overwrite the text inside the existing Ground Marker overlay, but unfortunately this appears to be Java-private. For this reason, this plugin reads the data from Ground Markers' configManager so it can accurately recreate the tiles it is force-removing. All data is stored on Ground Markers side.

As a side note: I made this plugin in one afternoon. I have no major interest in maintaining this plugin long term -- I have another larger plugin project in active development. If anyone happens to be interested in what this plugin does and would like to take over this codebase, please reach out to me.