### PR TITLE
Add NPC Attack Counter

### DIFF
--- a/plugins/npc-attack-counter
+++ b/plugins/npc-attack-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/taloskiosrs/npc-attack-counter.git
+commit=09b71a5266aa321a16df2ee33c9f43da00a7c529


### PR DESCRIPTION
Adds NPC Attack Counter, a reactive counter for a fixed, reviewed allowlist of ordinary Slayer NPCs.

The plugin:

- Counts completed attacks after combat hitsplats appear on the local player.
- Uses a fixed allowlist of RuneLite NPC constants.
- Does not accept arbitrary NPC IDs.
- Excludes bosses, superior Slayer monsters, restricted encounters, and instances.
- Does not predict attacks, recommend prayers, modify menus, or automate input.
- Provides configurable text appearance and a user-managed enabled-NPC list.