### PR TITLE
Update Slayer task loot

### DIFF
--- a/plugins/slayer-task-loot
+++ b/plugins/slayer-task-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/slayer-task-loot.git
-commit=0ffbc88b27379490cd6ccb935ca33d3eea7d9812
+commit=6a2f04f4977670e43fc4cbed658ed7f9c6995b2c

--- a/plugins/slayer-task-loot
+++ b/plugins/slayer-task-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/slayer-task-loot.git
-commit=489de7de323603b36213e961d411e57fb7904a34
+commit=797e60d8b9dee67ab55691ba518f5fc1bf578fa7

--- a/plugins/slayer-task-loot
+++ b/plugins/slayer-task-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/slayer-task-loot.git
-commit=f87a8a22bd092fa53e66dbc000732010e6ce128a
+commit=489de7de323603b36213e961d411e57fb7904a34

--- a/plugins/slayer-task-loot
+++ b/plugins/slayer-task-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/Sintry1/slayer-task-loot.git
-commit=797e60d8b9dee67ab55691ba518f5fc1bf578fa7
+commit=0ffbc88b27379490cd6ccb935ca33d3eea7d9812


### PR DESCRIPTION
- Fixed an issue where death reclaimed items were counting to supply costs.
- Added the ability to Exclude items from the task loot list.
   - Exclusions can be done per-task or for all tasks.