### PR TITLE
Update 07flip to 886ca0a

### DIFF
--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=886ca0a4fd7cb4e9b60da3ce1a831b3672303671
+commit=0480bcda157819aa1046bf377c9e62064c717547
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/07flip
+++ b/plugins/07flip
@@ -1,3 +1,3 @@
 repository=https://github.com/UserD40/Runelite07Flip.git
-commit=594d1714f3984070da795d4873f3760a83bb0f19
+commit=886ca0a4fd7cb4e9b60da3ce1a831b3672303671
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Update 07flip plugin to commit 886ca0a.

This update adds a small readout on your Grand Exchange offer slots so you can see at a glance how much of an offer has filled and how recently that item last traded, with colour and on/off options in the settings. It also fixes a bug where the plugin could fill a price into the quantity box when you set the quantity before the price.

The rest is reliability work on the buy/sell price lock: the target you were shown when you bought now survives a client restart, so the profit you were quoted is the profit you get when you come back to sell. Internally a number of small model files were merged into one, which cuts the plugin's source size noticeably.