### PR TITLE
Update protect-item-notifier to 1.0.2

### DIFF
--- a/plugins/protect-item-notifier
+++ b/plugins/protect-item-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/cubeee/protect-item-notify.git
-commit=302770a3fe4d374ff504f68b8e3d11f0179e750d
+commit=ebc09e065077adfd1ce8a2272cd4cb95c878fb21


### PR DESCRIPTION
No longer show icon when protect item is on and "pvp only" is unchecked