### PR TITLE
Add Iron Path

### DIFF
--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,3 +1,3 @@
 repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
-commit=fdafb5fbb1e87e778c73bde9b7ee4632a90217af
+commit=c2241dbbdf367bee5021e4f4e1cbc0d67d20279e
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,2 +1,2 @@
 repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
-commit=58285e2d01ccc27d55d21eb09e2519c66f40e1a1
+commit=b9e54f0e3beedca763e0989ed0de7540bdcc61b1

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,2 +1,3 @@
 repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
 commit=b9e54f0e3beedca763e0989ed0de7540bdcc61b1
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,3 +1,3 @@
 repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
-commit=b9e54f0e3beedca763e0989ed0de7540bdcc61b1
+commit=fdafb5fbb1e87e778c73bde9b7ee4632a90217af
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,2 +1,2 @@
 repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
-commit=df962e9f37313eee957c9ff4cd71d15f09297b46
+commit=58285e2d01ccc27d55d21eb09e2519c66f40e1a1

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,2 +1,2 @@
 repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
-commit=70cad83a4e4717cde051debb5a61e958b9a2df82
+commit=66f23e8375db0454ac5b23495fda2e603e80885e

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,2 +1,2 @@
 repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
-commit=91dbd52b10271381e72655fa99dce4dbe6160f01
+commit=70cad83a4e4717cde051debb5a61e958b9a2df82

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,0 +1,2 @@
+repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
+commit=91dbd52b10271381e72655fa99dce4dbe6160f01

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,2 +1,2 @@
 repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
-commit=978292f3ca0d6f4f83ab73f10e8c3c219fd30e96
+commit=df962e9f37313eee957c9ff4cd71d15f09297b46

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,2 +1,2 @@
 repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
-commit=66f23e8375db0454ac5b23495fda2e603e80885e
+commit=53b59bacca07b8cca15ee5c0bfdd325a4da2fd2e

--- a/plugins/iron-path
+++ b/plugins/iron-path
@@ -1,2 +1,2 @@
 repository=https://github.com/ConnorFitzgerald17/iron-path-runelite.git
-commit=53b59bacca07b8cca15ee5c0bfdd325a4da2fd2e
+commit=978292f3ca0d6f4f83ab73f10e8c3c219fd30e96


### PR DESCRIPTION
Adds the Iron Path companion plugin to the Plugin Hub.

Iron Path synchronizes a linked RuneScape character's skills, quests, account mode, equipment and inventory snapshots, bank changes, loot and kill counts, user-triggered Collection Log progress, recent Collection Log items, and goal progress with the Iron Path web application. Per-profile RuneLite storage keeps linked characters and offline queues separate when switching accounts.

The finalized Collection Log flow reads the authoritative account-wide total directly from the full Collection Log title, retries while the interface is loading, syncs every section only when the player presses **Sync full log**, and records the last successful full-log sync. Its configurable sidebar can hide connection status, sync activity, Collection Log controls, recent collections, recent kills, or goals.

Plugin repository: https://github.com/ConnorFitzgerald17/iron-path-runelite

Production application: https://ironpathosrs.com/

Canonical production API origin: https://www.ironpathosrs.com

Pinned commit: `58285e2d01ccc27d55d21eb09e2519c66f40e1a1`

Validation:

- `./gradlew clean test build` passes
- Collection Log uploads are explicitly user-triggered and retry as one batch
- The authoritative Collection Log total is read from the full-log header without double-counting items shared by multiple sections
- Recent Collection Log capture waits for RuneLite's dynamic overview widgets to populate
- Sidebar layout and Collection Log title parsing have regression tests
- Boss and raid KC is read from Hiscores, RuneLite storage, Collection Log headers, and completion messages
- The Plugin Hub branch pins the verified 0.4.2 source commit on plugin `main`
- The custom production domain responds over HTTPS
- An unauthenticated request to `https://www.ironpathosrs.com/api/plugin/v1/goals` returns the expected `401` without a cross-host redirect
- The plugin uses standard build mode
- The repository is public and BSD-2-Clause licensed
- Plugin metadata, link payload, and User-Agent are aligned at version 0.4.2
- The linking setting warns users exactly which RuneScape data is sent to the configured API origin
- The README documents transmitted data and per-character token/queue storage

RuneLite's policy check routes this new plugin to the normal Plugin Hub maintainer review.
