### PR TITLE
Add Sunstone Golem Helper

### DIFF
--- a/plugins/sunstone-golem-helper
+++ b/plugins/sunstone-golem-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Yug559/sunstone-golem-helper.git
+commit=f94fd61e1de1c2ecf9d88f5efe2575e00eef5272


### PR DESCRIPTION
ABSOLUTE AI SLOP

This plugin was built with extensive AI assistance and intentionally makes Sunstone Golem Crafting much more dramatic than necessary.

Excessive features

Precisely calibrated progress bars for every chiselling stage

Automatic red/green tracking for all four golem sides

A directional arrow showing which way the golem faces

Fur pouch tracking

A flashing shortage banner when fewer than five furs remain

RuneLite shortage notifications

Inventory-percentage tracking while mining Sunstone

A silver-blue “Honoured in Moonlight” tribute for departing Moonlight-hide golems

Enough visual feedback to make assembling one stone golem feel like launching a spacecraft

Despite the theatrics, the plugin is informational only. It reads normal client state and draws overlays. It does not automate clicks, alter menu entries, send inputs, or perform gameplay actions for the player.

The plugin was tested in the live Wyrmscraig activity and compiled against the current RuneLite release.