### PR TITLE
Add RaidMates

### DIFF
--- a/plugins/raidmates
+++ b/plugins/raidmates
@@ -1,3 +1,3 @@
 repository=https://github.com/JustMippie/raidmates.git
 commit=b53eedb656310791e481310ed3413eadf7a3960b
-warning=This plugin connects to an external third-party server and sends a random installation ID, the locally observed character name, submitted group data, lobby chat, reports, and technical connection data.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/raidmates
+++ b/plugins/raidmates
@@ -1,0 +1,3 @@
+repository=https://github.com/JustMippie/raidmates.git
+commit=b53eedb656310791e481310ed3413eadf7a3960b
+warning=This plugin connects to an external third-party server and sends a random installation ID, the locally observed character name, submitted group data, lobby chat, reports, and technical connection data.


### PR DESCRIPTION
## RaidMates

RaidMates is a fully opt-in group finder for Old School RuneScape raids, bosses, and group PvM activities.

### Features

- Create and browse manually submitted group listings
- Filter by activity, team size, experience/KC, role, language, and region
- Send and manage join requests
- Private accepted-group lobby with members, roles, ready status, and preferred world
- Optional Discord contact
- External lobby chat with reporting and moderation support
- Wilderness activity warning
- Automatic listing refresh and instant chat updates with polling fallback

### Compliance and safety

- RaidMates does not automate, click, or perform any in-game actions
- The external service is disabled by default and requires explicit opt-in
- The enabling setting contains a warning describing all data sent externally
- RSNs are marked as client-observed and are not claimed to be Jagex-verified
- RaidMates never requests or stores Jagex login credentials
- Privacy Policy: https://api.raidmates.nl/privacy
- Community Rules: https://api.raidmates.nl/rules
- Support: support@raidmates.nl

### Testing

- Built and tested with Java 11 and the latest RuneLite release
- Tested with two development clients
- Tested listing, join, lobby, chat, report, moderation, restart, and session-security flows
- Concurrent acceptance testing confirms duo groups cannot exceed their maximum size