### PR TITLE
Add Mirror Tabs

### DIFF
--- a/plugins/mirror-tabs
+++ b/plugins/mirror-tabs
@@ -1,0 +1,2 @@
+repository=https://github.com/romulofelipe21/mirror-tabs.git
+commit=4f083e3da527f249ecf6019c159c8cb7aeadbb3f


### PR DESCRIPTION
## Summary

- Adds Mirror Tabs, a read-only overlay that mirrors equipment while inventory is active and inventory while equipment is active.
- Uses RuneLite's native movable and resizable overlay support.
- Provides opacity, initial scale, label, and enable settings.

## Safety and behavior

- Mirrored items are visual only and do not handle clicks.
- The plugin does not inject input, modify game menus, automate actions, or communicate with third-party services.

## Validation

- `gradlew.bat clean build`
- Manually verified in the RuneLite development client: automatic inventory/equipment switching, live item updates, overlay movement, and overlay resizing.
