### PR TITLE
Update sea-charting-quest-helper

### DIFF
--- a/plugins/sea-charting-quest-helper
+++ b/plugins/sea-charting-quest-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JaredEzz/sea-charting-quest-helper.git
-commit=7de4cf7523a94f18c2b90b2b5d908f60ff8c2a13
+commit=b4ac85ceef6d44db89e5a11cd4491fbf6a1b44a5


### PR DESCRIPTION
## What's new

- Mermaid Guide tasks now show the riddle's required items in the existing task info tooltip (e.g. Pearl Bank → "Riddle answer: 2 woad leaves and 2 onions"), so you no longer have to look the riddle up off-client. Existing task notes are preserved and merged with the riddle answer when a task has both. Contributed by @NicolasLaurent321 (JaredEzz/sea-charting-quest-helper#2), verified in a dev client.
- LICENSE is now a verbatim BSD 2-Clause with both copyright holders; the extra data-attribution notes that used to be appended to it moved to the README.

Commit: JaredEzz/sea-charting-quest-helper@d30d600e1473d6640fab107767b010c9c8dd84db