### PR TITLE
Update ge-companion to v1.2.2

### DIFF
--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=c3d472f860a0eaa61897eea86079bad230d570e2
+commit=db2fd987197aaa5fb921acfaefe46d4d42862869

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=edfccce1f28163b5bce886fd3c18a07d874418f2
+commit=c489f30bf5928b54c5d98609b9a4c62e1a871c80

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=c489f30bf5928b54c5d98609b9a4c62e1a871c80
+commit=f85542e1812bd60252197ed46bafee6af5d6490c

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=b22ed3f5d06f919fbf9d31151bd2a909d933ff32
+commit=edfccce1f28163b5bce886fd3c18a07d874418f2

--- a/plugins/ge-companion
+++ b/plugins/ge-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/xOwip/ge-companion.git
-commit=f85542e1812bd60252197ed46bafee6af5d6490c
+commit=c3d472f860a0eaa61897eea86079bad230d570e2


### PR DESCRIPTION
v1.2.2 — Performance & flipping stats update

- Fixed GE tax not applied to flipping stats (Margin, Profit at limit, ROI)
- Added Margin × Volume stat to flipping stats panel
- Added tooltips to all flipping stats explaining each metric
- Fixed variant item detail panel collapsing when removed from bank
- Added live "Last updated" timer in Bank tab (updates every 10 seconds)
- Fixed "Not yet scanned" truncation in bank context label
- Performance: idToName reverse map eliminates linear searches during bank scans
- Performance: cache variant display names to eliminate repeated getItemComposition() calls
- Performance: conditional bankValue/wealthValue writes — only saves when values change
- Bank history no longer records while logged out
- Updated README flipping stats section with GE tax explanation and new screenshot
- Replaced restricted Desktop.getDesktop().browse() with LinkBrowser.browse()