### PR TITLE
effective-level: takeover request (clause 3, 60+ days incompatible)

### DIFF
--- a/plugins/effective-level
+++ b/plugins/effective-level
@@ -1,2 +1,2 @@
-repository=https://github.com/XrioBtw/effectivelevel-plugin.git
-commit=7e668ac45e24b8d41ba059c7d616394a9a6415dd
+repository=https://github.com/barkovaz/effective-level.git
+commit=5f07f9d874a40b076c2916e8270391f21d7d7fdf

--- a/plugins/effective-level
+++ b/plugins/effective-level
@@ -1,2 +1,2 @@
 repository=https://github.com/barkovaz/effective-level.git
-commit=5f07f9d874a40b076c2916e8270391f21d7d7fdf
+commit=7e668ac45e24b8d41ba059c7d616394a9a6415dd


### PR DESCRIPTION
## Takeover request

Xrio hasn't touched this plugin or said anything since it broke back in March 2026, when OSRS's "Skill Guide and Level-Up Rework" update landed. That's over 5 months now with an open bug report and other users chiming in (not the author though), so I'd like to take over maintenance: https://github.com/XrioBtw/effective-level/issues/10

This is my first time going through a plugin hub takeover, so bear with me if I get something wrong. This PR only changes `repository=` to point at my fork (https://github.com/barkovaz/effective-level, made by forking the original repo). `commit=` is left untouched, same commit exists in both repos. I already have a working fix plus a couple new features sitting on top of that commit in my fork, planning to send that as a separate follow up PR once the takeover itself goes through.

Issues are enabled on my fork so people have somewhere to report problems.
