### PR TITLE
Add OSRS Toolkit Sync

### DIFF
--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=35607926226ad825e3f779de7848abe54260300f
+commit=7eb9f2c8608cd4535aeccf285c8c9dcabc4d95f2

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=7eb9f2c8608cd4535aeccf285c8c9dcabc4d95f2
+commit=85106b412f52fdf6510db150938c118efda07388

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=85106b412f52fdf6510db150938c118efda07388
+commit=104c9ffe34b0faae7613ac918626d503da6862f3

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=104c9ffe34b0faae7613ac918626d503da6862f3
+commit=334ebc0c951149a689ccc5ffbce691a076569228

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=649280b7d087d067f4c0f192d193d4fae15248ce
+commit=676cc2b4400347fe0ea246f22481649d4e8edffb

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=b266d6300b0ddc7fd069f3707277c3dff1c91b6c
+commit=649280b7d087d067f4c0f192d193d4fae15248ce

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=676cc2b4400347fe0ea246f22481649d4e8edffb
+commit=8bda4bd3f1db363f6b678f0a614a7209baa6c5be

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
+commit=b266d6300b0ddc7fd069f3707277c3dff1c91b6c

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=8bda4bd3f1db363f6b678f0a614a7209baa6c5be
+commit=35607926226ad825e3f779de7848abe54260300f


### PR DESCRIPTION
OSRS Toolkit Sync records actual Grand Exchange fill deltas to a durable local queue for the OSRS Toolkit desktop trade journal. It can optionally record completed player-to-player trades; that setting is disabled by default. The plugin uses local files only, makes no network requests, does not access credentials, and does not automate or alter game actions. The clean plugin build and its unit tests pass, and both GE-fill and opted-in player-trade paths were confirmed in game.