### PR TITLE
log-adviser: bump to 6ec4df9

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=970b100a990091b02357d3fc1359123a95272c5b
+commit=6ec4df9b9c18a804ae1ac6d5c07f11f9951aa88a


### PR DESCRIPTION
Bumps Log Adviser to 1.3.1.

Data-only update: corrects three Mad Angel drop rates in the bundled activity
data to match the wiki's post-quest table, which is now backed by a drop-log
project sample of ~3.85M kills.

- Ardeaglais teleport  22.2857 -> 25   (1/25)
- Jar of light             896 -> 1000 (1/1000)
- Aggy                    3000 -> 2000 (1/2000)

No source changes; only a JSON data file, the test that pins those values, and
the version in runelite-plugin.properties / build.gradle.
