### PR TITLE
Shinigami Eyes - Gauntlet

### DIFF
--- a/plugins/shinigami-eyes
+++ b/plugins/shinigami-eyes
@@ -1,2 +1,2 @@
 repository=https://github.com/Kiwamasi/shinigami_eyes.git
-commit=c350427f9307cbf84638116fff01fcb31bd6818b
+commit=0d942f63d81fff513f3864c3b0de15dc7948c133

--- a/plugins/shinigami-eyes
+++ b/plugins/shinigami-eyes
@@ -1,0 +1,2 @@
+repository=https://github.com/Kiwamasi/shinigami_eyes.git
+commit=aa665b8144c4a2e5c44b8e477fb7aa6c82ca4d98

--- a/plugins/shinigami-eyes
+++ b/plugins/shinigami-eyes
@@ -1,2 +1,2 @@
 repository=https://github.com/Kiwamasi/shinigami_eyes.git
-commit=9e669a88e5810ee012d0de8787f88c059f9dccb2
+commit=c350427f9307cbf84638116fff01fcb31bd6818b

--- a/plugins/shinigami-eyes
+++ b/plugins/shinigami-eyes
@@ -1,2 +1,2 @@
 repository=https://github.com/Kiwamasi/shinigami_eyes.git
-commit=aa665b8144c4a2e5c44b8e477fb7aa6c82ca4d98
+commit=9e669a88e5810ee012d0de8787f88c059f9dccb2


### PR DESCRIPTION
A plugin enabled exclusively within the Gauntlet lobby to display a persons Killcount above their characters head, akin to Shinigami eyes.
Each unique players Hi-Scores is polled once every 300ms (A maximum of once per player) and cached until closure of Runelite so a poll is not required again. 