### PR TITLE
update mirror-tabs

### DIFF
--- a/plugins/mirror-tabs
+++ b/plugins/mirror-tabs
@@ -1,2 +1,2 @@
 repository=https://github.com/romulofelipe21/mirror-tabs.git
-commit=4f083e3da527f249ecf6019c159c8cb7aeadbb3f
+commit=12681cb121a1a4dbd3777d09bc6247d2bb042f6a


### PR DESCRIPTION
## What changed
Updates Mirror Tabs to version 1.1.0. Mirrored inventory and equipment slots now display known item charge and dose counts, including equipped charged items.

## Why
The native inventory/equipment widgets showed charge counts, while the read-only mirrored slots only rendered the item sprites.

## Impact
This is a visual, read-only update. It adds no click handling, menu actions, input injection, automation, or third-party dependencies.

## Validation
- `./gradlew.bat clean build`
- unit tests for charge parsing
- manual in-game validation with charged equipment