### PR TITLE
green-log-reorder: bump to b4f7f87 (v1.1.0)

### DIFF
--- a/plugins/green-log-reorder
+++ b/plugins/green-log-reorder
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/GreenLogReorder.git
-commit=9cf879144d3048138de0e3b388155c5635a657d3
+commit=b4f7f870b22d57aa2c4648ff9934fffe32420023


### PR DESCRIPTION
Adds reordering of the Combat Achievements boss list — bosses that still have tasks left sort first, fully-completed (green) ones drop to the bottom — alongside the existing collection log item and category reordering. Nothing is hidden, and entries keep the game's own order within each group.

Also collapses the three per-list on/off toggles into a single multi-select config item, with a one-time migration so existing users' settings carry over rather than resetting to the default.

Changes: https://github.com/SFranciscoSouza/GreenLogReorder/compare/9cf8791...b4f7f87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
