### PR TITLE
Release Xtreme Tasker v2.2.1: Minor Bug fixes + Task Updates 

### DIFF
--- a/plugins/xtreme-tasker
+++ b/plugins/xtreme-tasker
@@ -1,2 +1,2 @@
 repository=https://github.com/AmTrollin/xtreme-tasker-osrs.git
-commit=5999c503bdd14128536ce99161ac6c4f9348e5ff
+commit=fb1791fe4be07c45b94d9b14e9a5e1bd3cc3648e


### PR DESCRIPTION
Bug fixes:

Fixes task tracking and synchronization regressions - 
- Keeps completed Achievement Diary tasks in the sync review candidate list.
- Restores the Review button when CA/AD sync finds completed tasks.
- Runs the full Collection Log scan while the log setup context is active, preventing oversized clue reward entries from being partially captured.
- Displays task durations over 24 hours as cumulative hours instead of days across task rows and descriptions.

Task Updates: 
- Moves “Get an Echo pearl” from Hard to Medium.
- Removes the Pandemonium quest prerequisite from “Get Ray barbs”
