### PR TITLE
Updating ruthless clan to 1.3.1

### DIFF
--- a/plugins/ruthless-clan
+++ b/plugins/ruthless-clan
@@ -1,4 +1,4 @@
 repository=https://github.com/Orinite/ruthless-plugin.git
-commit=572ac4ae317c53bc25d45c09ffbfcc281fc7f931
+commit=49eedbf9b960240e3cd1a8884416fdf2ac25534c
 warning=This plugin submits your username and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.
 authors=Orinite


### PR DESCRIPTION
- Event codeword being added automatically (no WOM needed) during running events.
- bugfix for cox times not submitting