### PR TITLE
green-log-reorder: bump to 9fa470f (v1.1.1)

### DIFF
--- a/plugins/green-log-reorder
+++ b/plugins/green-log-reorder
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/GreenLogReorder.git
-commit=b4f7f870b22d57aa2c4648ff9934fffe32420023
+commit=9fa470f9542718652b76a9384af146201583970f


### PR DESCRIPTION
Reverts the config change from v1.1.0. That version collapsed the three per-list checkboxes into a single multi-select, which RuneLite renders as a `JList` that only commits on focus lost — toggling an entry appears to do nothing until you click elsewhere in the panel. The checkboxes are back.

Anyone who never ran v1.1.0 keeps their settings untouched, since the original config keys come back with it. For anyone who did, a one-time migration sets the checkboxes from the multi-select's stored value, so a list they had deselected doesn't come back on.

No change to the reordering behaviour itself.

Changes: https://github.com/SFranciscoSouza/GreenLogReorder/compare/b4f7f87...9fa470f

🤖 Generated with [Claude Code](https://claude.com/claude-code)
