### PR TITLE
update impling-finder

### DIFF
--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=ab1e658df7fa7e7d91f4723c6da7e02f865c16ad
+commit=b16384015f0aedce5459f386c1b6447aa0335468
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=b16384015f0aedce5459f386c1b6447aa0335468
+commit=8a3a5a8d28eb9c94422a1e8abb07de0896866617
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=944ad27c281c8395df2cec989efb7d5bb1d3dffb
+commit=ab1e658df7fa7e7d91f4723c6da7e02f865c16ad
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Merges PR #35 (all 12 real impling types, Puro-Puro hide toggle, compass direction, map-click crash fix) and PR #37 (Supabase dual-write, off by default) into impling-finder. Also adds build=standard and refreshes the splash panel text.