### PR TITLE
Add sceptre-translator plugin

### DIFF
--- a/plugins/sceptre-translator
+++ b/plugins/sceptre-translator
@@ -1,0 +1,2 @@
+repository=https://github.com/L3sius/sceptre-translator.git
+commit=44334a4095d34c8283078763f6ba18d0c22a23fe


### PR DESCRIPTION
Adds Sceptre Translator, a plugin that translates the Pharaoh's Sceptre's cryptic teleport menu names (Jalsavrah, Jaleustrophos, etc.) into plain English.