### PR TITLE
drop-rate: update to gem drop table rate fix

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=fedb3384b1f2702bb16e3729ef71b4c4c0125229
+commit=d73d5f18e4371b794e5c67ef0ebf69c6d2ede092


### PR DESCRIPTION
Update **Drop Rate** to d73d5f18e4371b794e5c67ef0ebf69c6d2ede092.

The plugin shows the wiki drop rate of loot you receive, plus a Collection Log hover tooltip listing every source that drops an item.

This update fixes the rates it reads from the rare drop table. The template takes two access rates:

```
{{RareDropTable|1/128|11/128}}
```

The second is how often the monster rolls the gem drop table, not a ring of wealth rate. It was being read as the latter, so every gem rate was computed from the wrong one - fire giant uncut diamond showed 1/8192 against a true 1/734.3. Four further parsing defects fed the same data, including items reachable by two paths keeping the first instead of summing (key halves were understated up to 35x).

It also adds the shared tables that were never read: the gem table for monsters that reach it without the rare table, plus the Catacombs of Kourend, wilderness slayer, herb, seed, fossil, talisman and superior tables.

Every rate the wiki publishes a figure for was checked against that figure before release.

No dependency or build changes; `build=standard` and no third-party dependencies.