### PR TITLE
Add Rune Panel

### DIFF
--- a/plugins/rune-panel
+++ b/plugins/rune-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/tristan7303/rune-panel-plugin.git
-commit=da99a9fd158787e2874a9cb054a9e5b6b22d5f5f
+commit=1b8ca859e57b6e2de4d1f5f1284c9d7edd0cb3e8

--- a/plugins/rune-panel
+++ b/plugins/rune-panel
@@ -1,0 +1,2 @@
+repository=https://github.com/tristan7303/rune-panel-plugin.git
+commit=da99a9fd158787e2874a9cb054a9e5b6b22d5f5f


### PR DESCRIPTION
Companion plugin for [Rune Panel](https://github.com/tristan7303/rune-panel), an OSRS wiki desktop app for Windows.

Recreates the Wiki plugin's minimap orb lookup and equipment-screen View DPS button (widget wiring adapted from the core wiki plugin, BSD-2, attribution in file headers), but opens them in the Rune Panel app instead of a browser. The plugin's only network egress is POSTs to 127.0.0.1 on the user's click; the DPS shortlink call is made by the desktop app, not the plugin. When the app isn't running, every action falls back to the exact stock Wiki plugin behaviour. Declares conflicts=Wiki since both wire the same orb widget. Data sent is disclosed in the plugin description and config panel.