### PR TITLE
Create npc-kill-counter

### DIFF
--- a/plugins/npc-kill-counter
+++ b/plugins/npc-kill-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/PieterPost043Productions/npc-kill-counter.git
+commit=172786af4ea0ff7a5bbb49090964d1d8a5ae9cf4


### PR DESCRIPTION
Simple npc kill counter, so that you can keep track of how many npc's to kill left for getting drop (statistically)