### PR TITLE
Adds the OldSchoolDB Connector plugin.

### DIFF
--- a/plugins/oldschooldb-connector
+++ b/plugins/oldschooldb-connector
@@ -1,4 +1,4 @@
 repository=https://github.com/ortegarod/oldschooldb-runelite-plugin.git
-commit=a7f579e1d959a4f33b1c34e3e40ded2269f11380
+commit=dc3c9fa10f9db3b56e58c9cda340ef2c4f069e74
 authors=ortegarod
 warning=This plugin submits your account data to api.oldschooldb.com, a server not controlled or verified by the RuneLite developers.

--- a/plugins/oldschooldb-connector
+++ b/plugins/oldschooldb-connector
@@ -1,4 +1,4 @@
 repository=https://github.com/ortegarod/oldschooldb-runelite-plugin.git
 commit=dc3c9fa10f9db3b56e58c9cda340ef2c4f069e74
 authors=ortegarod
-warning=This plugin submits your account data to api.oldschooldb.com, a server not controlled or verified by the RuneLite developers.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/oldschooldb-connector
+++ b/plugins/oldschooldb-connector
@@ -1,0 +1,4 @@
+repository=https://github.com/ortegarod/oldschooldb-runelite-plugin.git
+commit=94152a24bf1e5c199c798c98918c5b21b5cdae20
+authors=ortegarod
+warning=This plugin submits your account data to api.oldschooldb.com, a server not controlled or verified by the RuneLite developers.

--- a/plugins/oldschooldb-connector
+++ b/plugins/oldschooldb-connector
@@ -1,4 +1,4 @@
 repository=https://github.com/ortegarod/oldschooldb-runelite-plugin.git
-commit=94152a24bf1e5c199c798c98918c5b21b5cdae20
+commit=a7f579e1d959a4f33b1c34e3e40ded2269f11380
 authors=ortegarod
 warning=This plugin submits your account data to api.oldschooldb.com, a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
It syncs the player's OWN account data (username, bank, inventory, equipment, skills, quests, slayer/prayer unlocks) to their own authenticated OldSchoolDB account at api.oldschooldb.com, only when the user enables it and provides their personal plugin key. Same pattern as Wise Old Man / TempleOSRS — no other players' data, nothing served or exposed over HTTP, HTTPS to prod. Data-sent warning is in the plugin description and the manifest warning field. 