### PR TITLE
Update 1.3.0 for trouble-brewing-highlighter

### DIFF
--- a/plugins/trouble-brewing-highlighter
+++ b/plugins/trouble-brewing-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/trouble-brewing-highlighter.git
-commit=c17f5d281d6a1d897d03bc2fb21f24c9d7ede607
+commit=e6d37462b2b27568aae4053cdfc8c7b0087fb460


### PR DESCRIPTION
Adds Pieces of Eight tracking with an in-match expected total, monkey dialogue guidance, Join-crew prioritisation, configurable flashing, orange active conveyors, improved route colours, and updated inventory highlighting. Removes ground-item highlighting and updates documentation and tests for version 1.3.0.