### PR TITLE
Create keybind-tile-highlight

### DIFF
--- a/plugins/keybind-tile-highlight
+++ b/plugins/keybind-tile-highlight
@@ -1,0 +1,2 @@
+repository=https://github.com/Jin-Jiyunsun/jins-plugins.git
+commit=1a4d0fa7a01a1b2daaf65ab1abf495fffaea8d20


### PR DESCRIPTION
The plugin allows you to set a key bind which upon pressing will highlight the tile currently under the cursor/mouse, with a configurable color.

Key bind is unset by default and must be configured by the user.