### PR TITLE
Add OSRS Media Hub

### DIFF
--- a/plugins/media-hub
+++ b/plugins/media-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/Reynolds1121/OSRS-Media-Hub.git
-commit=f2a0ed7516292e21d604445b0cd42069af21cc74
+commit=a5ccd19c0bd410ebbb22d9e4ff77788c12731301

--- a/plugins/media-hub
+++ b/plugins/media-hub
@@ -1,0 +1,2 @@
+repository=https://github.com/Reynolds1121/OSRS-Media-Hub
+commit=59ab166fde9aaada617b5ea17a4de93e59dc4841

--- a/plugins/media-hub
+++ b/plugins/media-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/Reynolds1121/OSRS-Media-Hub
-commit=59ab166fde9aaada617b5ea17a4de93e59dc4841
+commit=f2a0ed7516292e21d604445b0cd42069af21cc74

--- a/plugins/media-hub
+++ b/plugins/media-hub
@@ -1,2 +1,2 @@
-repository=https://github.com/Reynolds1121/OSRS-Media-Hub
+repository=https://github.com/Reynolds1121/OSRS-Media-Hub.git
 commit=f2a0ed7516292e21d604445b0cd42069af21cc74


### PR DESCRIPTION
Adds OSRS Media Hub, a RuneLite plugin that lets users view media information and control playback directly from RuneLite.

The plugin can work as a standalone RuneLite plugin with VLC and does not require any separate application for that functionality. It can also optionally connect to the separately installed open-source OSRS Media Hub Bridge over 127.0.0.1:8765 for Windows system media integration.

The bridge is a separate open-source application that I developed for OSRS Media Hub. It provides access to the media session Windows currently considers active, allowing the plugin to work with supported system media sources beyond VLC. The bridge source code and releases are available here: https://github.com/Reynolds1121/OSRS-Media-Hub-Bridge

The RuneLite plugin does not download, install, launch, start, or update the bridge. If the bridge is not installed or running, the plugin still loads normally and bridge-dependent features are simply unavailable.

The RuneLite plugin does not use JNI, Java reflection, subprocesses, external program execution, or runtime-downloaded code. Communication with the optional bridge is limited to the local 127.0.0.1 connection.

OSRS Media Hub does not automate, control, or interact with Old School RuneScape gameplay. Its RuneLite functionality is limited to displaying and controlling media through a top-level media overlay, so users can manage their media without having to leave RuneLite or switch to another application.

I kept the RuneLite side separate and reviewable so the optional system integration does not require the plugin itself to execute or manage an external application.