### PR TITLE
feat: add bank-settings plugin

### DIFF
--- a/plugins/bank-settings
+++ b/plugins/bank-settings
@@ -1,0 +1,2 @@
+repository=https://github.com/idyet/bank-settings.git
+commit=08fa13df72cfb0553b3a54f586744f2b40fd6133

--- a/plugins/bank-settings
+++ b/plugins/bank-settings
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/bank-settings.git
-commit=08fa13df72cfb0553b3a54f586744f2b40fd6133
+commit=44f7a7403c207855e91cca8841ca42bc1af2782b

--- a/plugins/pvp-arena
+++ b/plugins/pvp-arena
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/pvp-arena.git
-commit=44f7a7403c207855e91cca8841ca42bc1af2782b
+commit=ffe70fabc407a5f449b0fbfa9a5ddcf1651e2a1c

--- a/plugins/pvp-arena
+++ b/plugins/pvp-arena
@@ -1,2 +1,2 @@
 repository=https://github.com/idyet/pvp-arena.git
-commit=ffe70fabc407a5f449b0fbfa9a5ddcf1651e2a1c
+commit=44f7a7403c207855e91cca8841ca42bc1af2782b


### PR DESCRIPTION
# Bank Settings

## What it does

Client-side options for the bank and deposit box. It lets you **disable** any of the three deposit buttons (Deposit inventory, Deposit worn items, Deposit loot) in both the bank and the deposit box. A disabled button stays visible but is dimmed and its click op is stripped, so it reads as greyed-out and does nothing — preventing accidental full-inventory / worn / loot deposits without hiding the button entirely.

It also, optionally:
- groups disabled buttons to the left of the strip so the active ones stay together, and
- adds small decorative icons beside the toggle rows on the bank settings page.

## Why "disable" instead of the game's own "hide"

The vanilla bank settings already let you *hide* these buttons (server side setting). This plugin intentionally does the opposite: it keeps the button on screen but inert, without having to switch to the bank settings page.

### Button disable option
<img width="2048" height="1024" alt="disable-button-option" src="https://github.com/user-attachments/assets/8a6d9ce8-8ae2-4435-8533-665eab28a3b2" />

### Button disabled and shifted left
<img width="2048" height="1024" alt="button-disabled" src="https://github.com/user-attachments/assets/8be9aa99-e7a7-4562-ae5b-431092524d16" />

### All button toggle options
<img width="2048" height="1024" alt="all-button-toggle-options" src="https://github.com/user-attachments/assets/1bbc7bde-182b-447f-a38c-505e67bab623" />

### In-game bank settings labels replaced with icons
<img width="2048" height="1024" alt="bank-settings-icons" src="https://github.com/user-attachments/assets/d10b51da-86da-49e5-a583-a86618ad3484" />
