### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=26642d49390608bf40a8633261720252294f6799
+commit=1b6dd8a52ef8e4d5c54991f559bedc851e162325
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=e38b2b1361b81b287f5e97b2fcc54ed54ca3619b
+commit=26642d49390608bf40a8633261720252294f6799
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=2659f1156a2e6f3f8b0283d961e2bbb02cf17b1e
+commit=e38b2b1361b81b287f5e97b2fcc54ed54ca3619b
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=028f9215c5161a94d6b5317f36552d6da9d2a066
+commit=2659f1156a2e6f3f8b0283d961e2bbb02cf17b1e
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary

- **New: a 4-hour buy limit cooldown timer on the Grand Exchange buy offer screen.** Shows the time remaining until an item's buy limit resets, so the limit state is visible at a glance instead of being tracked by hand.
- **New: the Grand Exchange item info override can be turned off.** A config setting restores the vanilla offer description for players who prefer it.
- **Fixed the offer screen layout.** The Buy/Sell label is aligned to the slot's left border and the elapsed timer moved into its own right-aligned field, so a long duration grows leftward instead of overlapping the label.
- **Fixed Grand Exchange slot borders flickering** when the cached price data turned over.
- **Fixed History reports matching a sell against the wrong offer** by comparing on net price rather than gross.
- **Fixed webhook requests being sent unauthenticated on the first attempt**, which relied on a retry to succeed.
- **The Exchange Viewer overlay is now always compact**, with item names and icons always shown. The config options that toggled these were removed.
