### PR TITLE
Add ground-focus-items

### DIFF
--- a/plugins/ground-focus-items
+++ b/plugins/ground-focus-items
@@ -1,0 +1,2 @@
+repository=https://github.com/richardverheyen/ground-focus-items.git
+commit=4d4d21b6b2db305dc3b6fb523c2ce8f4db8dce8d


### PR DESCRIPTION
## Ground Focus Items

Ranks the up to 3 item meshes in each ground pile by value, then lets you show, hide, resize, or isolate them individually.

- Ranks each pile slot by value (item #1 = most valuable, #2, #3), using Grand Exchange price or High Alchemy value.
- Per-rank show/hide and scaling (10%–1000%), plus a name-based always-hide list and a minimum-value cutoff.
- A "focus item" concept (by value threshold or by name) that can render alone with the rest of the pile hidden, at its own scale.

Repository: https://github.com/richardverheyen/ground-focus-items