### PR TITLE
Re-enable/Update kill-count-viewer

### DIFF
--- a/plugins/kill-count-viewer
+++ b/plugins/kill-count-viewer
@@ -1,2 +1,2 @@
 repository=https://github.com/RedSparr0w/runelite-plugins.git
-commit=5fa0d929f5f30918c6d81bcdf4cb86f7e6cfe62d
+commit=755188349007192aa1376aa982110d28312c929d

--- a/plugins/kill-count-viewer
+++ b/plugins/kill-count-viewer
@@ -1,3 +1,2 @@
 repository=https://github.com/RedSparr0w/runelite-plugins.git
-commit=5e15974a810b5eba4cb27783403305583b93a10c
-disabled=true
+commit=5fa0d929f5f30918c6d81bcdf4cb86f7e6cfe62d


### PR DESCRIPTION
Remove wilderness agility course from plugin detection
Re-enable plugin

Please let me know if there's any other changes required to have this re-enabled.