### PR TITLE
Create pot-stash plugin.

### DIFF
--- a/plugins/pot-stash
+++ b/plugins/pot-stash
@@ -1,0 +1,2 @@
+repository=https://github.com/Zorga0/pot-stash.git
+commit=37edc425f4c08f042ef912b56896475491360660

--- a/plugins/pot-stash
+++ b/plugins/pot-stash
@@ -1,2 +1,2 @@
 repository=https://github.com/Zorga0/pot-stash.git
-commit=b812a25476ddbe05ff06f4cdd09086ad6b749840
+commit=12f7c58f29f88d9de2aea5c73a78ba4efc76fd40

--- a/plugins/pot-stash
+++ b/plugins/pot-stash
@@ -1,2 +1,2 @@
 repository=https://github.com/Zorga0/pot-stash.git
-commit=37edc425f4c08f042ef912b56896475491360660
+commit=b812a25476ddbe05ff06f4cdd09086ad6b749840


### PR DESCRIPTION
Use default Bank Tags instead of the Potion Storage.

- Clicking the Potion Storage button opens a "potstash" Bank Tags tab instead of the Potion Storage interface.
- Right-click potions to set their withdraw dose (uses the same technique Bank Tags uses to withdraw potions from storage).

Almost everything relies on the existing Bank Tags plugin or mirrors it:
- The Potion Storage internals mirror `net.runelite.client.plugins.banktags.tabs.PotionStorage`:
  - same scripts (`POTIONSTORE_DOSES` / `POTIONSTORE_WITHDRAW_DOSES`)
  - same potion matching across dose variants (`matches()` / `findPotion()`)
  - same hidden widget preparation (`PotionStorage.prepareWidgets()`)
  - fires menu action 1007 at that widget (same mechanism Bank Tags uses to withdraw potions from storage)

Everything is 1:1 and goes through the same scripts and menu actions that Bank Tags already uses.