### PR TITLE
Add Bounty Sailing Map

### DIFF
--- a/plugins/bounty-sailing-map
+++ b/plugins/bounty-sailing-map
@@ -1,0 +1,2 @@
+repository=https://github.com/jitterbot/bounty-sailing-map.git
+commit=577d2e7e7692688ebfcf42dc02dc2ff40df2028a


### PR DESCRIPTION
Adds Bounty Sailing Map, a plugin that displays Sailing bounty creature locations on the world map.

It can display locations for active bounty tasks or show all known bounty creature locations, with configurable marker colours.