### PR TITLE
Add Motherlode Profit Tracker Fixed

### DIFF
--- a/plugins/motherlode-profit-tracker-fixed
+++ b/plugins/motherlode-profit-tracker-fixed
@@ -1,0 +1,2 @@
+repository=https://github.com/juhadisti/Motherlode-Profit-Tracker-Fixed
+commit=HEAD

--- a/plugins/motherlode-profit-tracker-fixed
+++ b/plugins/motherlode-profit-tracker-fixed
@@ -1,2 +1,2 @@
-repository=https://github.com/juhadisti/Motherlode-Profit-Tracker-Fixed
+repository=https://github.com/juhadisti/Motherlode-Profit-Tracker-Fixed.git
 commit=HEAD

--- a/plugins/motherlode-profit-tracker-fixed
+++ b/plugins/motherlode-profit-tracker-fixed
@@ -1,2 +1,2 @@
 repository=https://github.com/juhadisti/Motherlode-Profit-Tracker-Fixed.git
-commit=HEAD
+commit=52bf57929cb3032b87c36291458d59f644bed196

--- a/plugins/motherlode-profit-tracker-fixed
+++ b/plugins/motherlode-profit-tracker-fixed
@@ -1,2 +1,2 @@
 repository=https://github.com/juhadisti/Motherlode-Profit-Tracker-Fixed.git
-commit=52bf57929cb3032b87c36291458d59f644bed196
+commit=c569e90f69fed9676ab2a2897d5efec04bf0f13c


### PR DESCRIPTION
Fixes the issue where the first inventory withdrawn from the Motherlode Mine sack may not be counted.

Based on the original plugin by Smeety.