### PR TITLE
Xarpus Sounds Muter

### DIFF
--- a/plugins/xarpus-sounds
+++ b/plugins/xarpus-sounds
@@ -1,0 +1,2 @@
+repository=https://github.com/MrJaspen/Xarpus-Sounds.git
+commit=9d98522aa809ac98d4fc04d2571d8cd6c49132d8


### PR DESCRIPTION
Mutes selected Xarpus sound effects in ToB so players can isolate the audio cues they care about. Made this to help people learn how to do p2 xarpus with melee but I was hearing from my friends it's hard to hear the spit noise people mention as the audio cue. This plugin helps isolate that noise. No third party dependencies.