### PR TITLE
Update Keybind Tile Highlight

### DIFF
--- a/plugins/keybind-tile-highlight
+++ b/plugins/keybind-tile-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/Jin-Jiyunsun/jins-plugins.git
-commit=1a4d0fa7a01a1b2daaf65ab1abf495fffaea8d20
+commit=78048977a48d25a8bd7d11176e99499f8572cf82

--- a/plugins/keybind-tile-highlight
+++ b/plugins/keybind-tile-highlight
@@ -1,0 +1,2 @@
+repository=https://github.com/Jin-Jiyunsun/jins-plugins.git
+commit=1a4d0fa7a01a1b2daaf65ab1abf495fffaea8d20


### PR DESCRIPTION
Fixes an issue where the tile highlight wouldn't appear if you had the key set to a modifier key (ctrl shift alt) and were already holding one of those keys when trying to use the plugin

Add a RGB rainbow cycle mode, for fun