### PR TITLE
update keybind tile highlight

### DIFF
--- a/plugins/keybind-tile-highlight
+++ b/plugins/keybind-tile-highlight
@@ -1,2 +1,2 @@
 repository=https://github.com/Jin-Jiyunsun/jins-plugins.git
-commit=1a4d0fa7a01a1b2daaf65ab1abf495fffaea8d20
+commit=d6c52b5e6dc1e671e8a1a78dd71cfbc31defbb36


### PR DESCRIPTION
Fixes an issue where the tile highlight wouldn't appear if you had the key set to a modifier key (ctrl shift alt) and were already holding one of those keys when trying to use the plugin

Add a RGB rainbow cycle mode, for fun

Add icon and example of plugin usage to readme