### PR TITLE
Update Bounty Sailing Map version

### DIFF
--- a/plugins/bounty-sailing-map
+++ b/plugins/bounty-sailing-map
@@ -1,2 +1,2 @@
 repository=https://github.com/jitterbot/bounty-sailing-map.git
-commit=7c603a5f6196ebb094e489f7bf22ec6896404e0b
+commit=3d06b0d611ae92b2aa3d51b11d98f5b0be37f2dc


### PR DESCRIPTION
Sets the plugin version to 1.0.0.