### PR TITLE
Add Skill Rank Tooltip

### DIFF
--- a/plugins/skill-rank-tooltip
+++ b/plugins/skill-rank-tooltip
@@ -1,0 +1,2 @@
+repository=https://github.com/YonwiPlugins/skill-rank-tooltip.git
+commit=9bf636fe3288c000324afb30ab393bada64eb05a


### PR DESCRIPTION
Adds Skill Rank Tooltip to the Plugin Hub.

The plugin adds global hiscore ranks to individual skill and Total level tooltips. It selects the matching normal, Ironman, Ultimate Ironman, Hardcore Ironman, or supported world-specific hiscores.

Validated with the Gradle test suite and in-game tooltip testing across RuneLite layout modes.
