### PR TITLE
Update Wyrm Agility AFK Progress for August 12 course changes

### DIFF
--- a/plugins/wyrm-agility-afk-progress
+++ b/plugins/wyrm-agility-afk-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/mrfox-1/runelite-wyrm-agility-progress.git
-commit=7fc4cc5a1ab01ec5b48b4499274b3c1e94bf42f3
+commit=9f8fd309b7c5cc0e4e3d38af7e7dabdfa1702662


### PR DESCRIPTION
## What changed

Updates Wyrm Agility AFK Progress to plugin commit `9f8fd309b7c5cc0e4e3d38af7e7dabdfa1702662`.

- Recalibrates the hard-coded lower and advanced route timers for the August 12, 2026 Colossal Wyrm course changes.
- Adds an optional minimum obstacle-length threshold for completion sounds, so short obstacles can remain silent.
- Previews the configured sound immediately when the Sound ID is changed.
- Updates the README for the course changes, settings, and Plugin Hub-compatible images.

## Why

The August 12 game update lengthened the basic course by roughly 25% and the advanced course by roughly 40%. The plugin's timers were calibrated against the previous obstacle durations, causing progress and completion notifications to finish early.

## User impact

Progress, overhead countdowns, and completion sounds now align with the updated course. Users may also restrict sounds to longer AFK obstacles without changing the visual timers. The plugin still does not automate movement or input.

## Validation

- `gradlew clean build` passes with Java 21 while targeting Java 11.
- Both Wyrm routes and the updated timings were tested in the RuneLite development client.
- The sound-length threshold and live Sound ID preview were tested in game.
- This Plugin Hub change updates only the existing plugin manifest commit hash.
- No new dependencies were added.
