### PR TITLE
Update Skill Ranks

### DIFF
--- a/plugins/skill-rank-tooltip
+++ b/plugins/skill-rank-tooltip
@@ -1,2 +1,2 @@
 repository=https://github.com/YonwiPlugins/skill-rank-tooltip.git
-commit=9bf636fe3288c000324afb30ab393bada64eb05a
+commit=0350c251c730c0b017f00c6beff6e38de16636cc


### PR DESCRIPTION
## What changed

Updates Skill Rank Tooltip to the latest public commit, including:

- the shorter **Skill Ranks** Plugin Hub name and 48 x 48 icon
- detected Main, Ironman, UIM, or HCIM rank categories with an All players option
- a visible, default-enabled checkbox list for Total level and every skill
- removal of redundant rank options and per-skill setting tooltips

## Why

The update makes rank selection clearer and replaces the previous hidden multi-select with straightforward per-skill controls.

## Validation

- `./gradlew clean test --no-build-cache --rerun-tasks`
- 12 tests passed
- launched and tested in the RuneLite development client
