### PR TITLE
Add Compass Quadrants

### DIFF
--- a/plugins/compass-quadrants
+++ b/plugins/compass-quadrants
@@ -1,0 +1,2 @@
+repository=https://github.com/Puzzle-Drops/compass-quadrants.git
+commit=3e27471b478b532cd5d5cde3437760ee495206ce


### PR DESCRIPTION
Splits the minimap compass into four wedges so that left-clicking a wedge faces that direction, instead of always snapping to north.

The game already provides Look North, Look East, Look South and Look West on the compass's right-click menu. The plugin promotes whichever one matches the wedge under the cursor into the left-click slot on `PostMenuSort`. It adds no menu entries and causes no actions to be sent to the server, as camera yaw is client side. The right-click menu is left as-is.

It optionally replaces the compass sprite with one that has the N erased, so that all four letters can be drawn by the plugin and match each other. This uses `client.setCompass`, the same mechanism the Interface Styles plugin uses, and the original sprite is restored when the option is disabled or the plugin is stopped.

Repository: https://github.com/Puzzle-Drops/compass-quadrants