### PR TITLE
Add loot-case-opening plugin

### DIFF
--- a/plugins/loot-case-opening
+++ b/plugins/loot-case-opening
@@ -1,0 +1,2 @@
+repository=https://github.com/adnapPanda/loot-case-opening.git
+commit=370bb4ccdf54324019dc4c9a96b2e396652b4f3f

--- a/plugins/loot-case-opening
+++ b/plugins/loot-case-opening
@@ -1,2 +1,2 @@
 repository=https://github.com/adnapPanda/loot-case-opening.git
-commit=1b0ec51130b8dffb10c1216a938493daa3882967
+commit=36bd5dc134b69139be02f623a863340ed81717da

--- a/plugins/loot-case-opening
+++ b/plugins/loot-case-opening
@@ -1,2 +1,2 @@
 repository=https://github.com/adnapPanda/loot-case-opening.git
-commit=370bb4ccdf54324019dc4c9a96b2e396652b4f3f
+commit=1b0ec51130b8dffb10c1216a938493daa3882967


### PR DESCRIPTION
## Loot Case Opening Plugin
Adds a case-opening-style reel animation that plays when you receive loot from supported content. Instead of the item just appearing in your inventory, a reel spins across a row of possible items before landing on the one you actually got.

### Supported content
- Theatre of Blood
- Chambers of Xeric
- Tombs of Amascut
- Corrupted Gauntlet/Gauntlet
- Moons of Peril
- Barrows

### How it works
- Triggers automatically
- Hides the in-game reward widget until the spin and reveal have finished
- Press ESC at any time to skip the spin and jump straight to the result
- Press ESC again to close the result panel
- The colors of the different rarities can be adjusted in the config settings