### PR TITLE
Add OSRS Copilot

### DIFF
--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,3 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=defe9383d727e0739519a47fe4ada0e8f276d895
+commit=17b4debf4e13cdb828c5dce511199927829d59bc
+warning=This plugin submits your IP address and game state (skills, quests, inventory, equipment, bank) to a 3rd-party server not controlled or verified by the RuneLite Developers: the LLM endpoint you configure.

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=62a4815e20ce99751a4a567124d626b128e7fec4
+commit=67ee0e9b966b00b5ce2da9eb44bb7c356785c5d7

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=b42170f8e4d2dbacba0fffc411c8a3efc42c4e28
+commit=01b379e04f7d511a62e7ae4d2edc1bb64da2ac58

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=01b379e04f7d511a62e7ae4d2edc1bb64da2ac58
+commit=460860dfd0abbb03a4f37f9138ede726e62f5e49

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=fc97dae7e4f4761d4ce7da1c1a5a0435c9bcfd77
+commit=d01a842e25d4b5e459a8ff1eacbe0bda93561159
 warning=This plugin submits your IP address and game state (skills, quests, inventory, equipment, bank) to a 3rd-party server not controlled or verified by the RuneLite Developers: the LLM endpoint you configure.

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=d01a842e25d4b5e459a8ff1eacbe0bda93561159
+commit=f0f49562bee073ec65d39e6e99290d2586351adc
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=f0f49562bee073ec65d39e6e99290d2586351adc
+commit=227cbf55ca0dcc4d85846f1cc971a69d0170265d
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=460860dfd0abbb03a4f37f9138ede726e62f5e49
+commit=62a4815e20ce99751a4a567124d626b128e7fec4

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=9759eeabc8f4c67d195e835a4f3d7b618aa03472
+commit=fc97dae7e4f4761d4ce7da1c1a5a0435c9bcfd77
 warning=This plugin submits your IP address and game state (skills, quests, inventory, equipment, bank) to a 3rd-party server not controlled or verified by the RuneLite Developers: the LLM endpoint you configure.

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/zerofata/osrs-copilot.git
 commit=d01a842e25d4b5e459a8ff1eacbe0bda93561159
-warning=This plugin submits your IP address and game state (skills, quests, inventory, equipment, bank) to a 3rd-party server not controlled or verified by the RuneLite Developers: the LLM endpoint you configure.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,3 +1,3 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=17b4debf4e13cdb828c5dce511199927829d59bc
+commit=9759eeabc8f4c67d195e835a4f3d7b618aa03472
 warning=This plugin submits your IP address and game state (skills, quests, inventory, equipment, bank) to a 3rd-party server not controlled or verified by the RuneLite Developers: the LLM endpoint you configure.

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=67ee0e9b966b00b5ce2da9eb44bb7c356785c5d7
+commit=defe9383d727e0739519a47fe4ada0e8f276d895

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=42cb9cf059a7948c3c709930d5b75eed9e799bd7
+commit=59bfb7405590532140757a786ececa2326306721

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=03c0a63746752aa4e3968433b0c195aafb740fff
+commit=3c5f98b69d28414faaac2d91c5375b7953da36d1

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=6f6860415fabac76f8fb5f9fe278940b080d1ac0
+commit=b42170f8e4d2dbacba0fffc411c8a3efc42c4e28

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=5578906f80b9f98ce1ab8df39fde41afb0da1ea4
+commit=24189ea694e78f37fd80857394f4f9108f4fbd7a

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=5529e8b345f41e2f4ae04bc7c9cfacf5fa3d7014
+commit=006cf71f120402f9438f02e361d31dbfa6ae1795

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=8014e438cef70d3a0bd7615f399fa2f270ccd63f
+commit=54f44bf9f2115a135830ddcbb756ad715f1e9904

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=0d5ca01ab141637ae9aa68279629f96c300fd884
+commit=cf1e91dcc9ccf1e7f4ae8485e2a5cf5e0fb188b4

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=b54a13d9e507cd1bfb54b6bfb70241e3d8696aaf
+commit=03c0a63746752aa4e3968433b0c195aafb740fff

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=35ec212a8c1ab10ef0a81e3b84c14a673da307d9
+commit=0d5ca01ab141637ae9aa68279629f96c300fd884

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=cde1e4a7a3bcf4eaada020d096f8712f4a567e8d
+commit=42cb9cf059a7948c3c709930d5b75eed9e799bd7

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=24189ea694e78f37fd80857394f4f9108f4fbd7a
+commit=8014e438cef70d3a0bd7615f399fa2f270ccd63f

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=54f44bf9f2115a135830ddcbb756ad715f1e9904
+commit=b54a13d9e507cd1bfb54b6bfb70241e3d8696aaf

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=387f9fdaa02a234a740dda7cc5dc4b1af62b26fe
+commit=6f6860415fabac76f8fb5f9fe278940b080d1ac0

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,0 +1,2 @@
+repository=https://github.com/zerofata/osrs-copilot.git
+commit=3f36ba2681cd16ff70d843860f8961e7599ba0f0

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=3c5f98b69d28414faaac2d91c5375b7953da36d1
+commit=cde1e4a7a3bcf4eaada020d096f8712f4a567e8d

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=006cf71f120402f9438f02e361d31dbfa6ae1795
+commit=35ec212a8c1ab10ef0a81e3b84c14a673da307d9

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=3f36ba2681cd16ff70d843860f8961e7599ba0f0
+commit=5578906f80b9f98ce1ab8df39fde41afb0da1ea4

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=cf1e91dcc9ccf1e7f4ae8485e2a5cf5e0fb188b4
+commit=387f9fdaa02a234a740dda7cc5dc4b1af62b26fe

--- a/plugins/osrs-copilot
+++ b/plugins/osrs-copilot
@@ -1,2 +1,2 @@
 repository=https://github.com/zerofata/osrs-copilot.git
-commit=59bfb7405590532140757a786ececa2326306721
+commit=5529e8b345f41e2f4ae04bc7c9cfacf5fa3d7014


### PR DESCRIPTION
Copilot plugin for OSRS, uses integration from runelite and data available from various API's along with a basic regex & grammar routing system.

Requires a user to bring their own LLM endpoint. Primarily tested using an OAI endpoint from Llama.CPP (Qwen3.8 27B / Muse 30B) and an openrouter provider (GLM5.2 / DSv4 Flash 0731).

Effort is taken where possible to cache queries and reduce strain on API's, the largest queries are run once weekly under a Github CI and published on the plugin repo.

APIs used:
- oldschool.runescape.wiki/api.php
- prices.runescape.wiki/api
- secure.runescape.com
- raw.githubusercontent.com - osrs-copilot vocab-data branch, where larger weekly queries get stored and served.
- Whatever OAI endpoint a user configures

Users are required to opt-in and enable functionality before the plugin does anything involving an API.

Uses injected OkHttpClient/Gson throughout, no reflection, file IO confined to .runelite/osrs-copilot/.

Disclosure (although I'm sure it's pretty obvious): Codebase was written entirely by Claude.