### PR TITLE
Update stockpile to 1.4.1

### DIFF
--- a/plugins/stockpile
+++ b/plugins/stockpile
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Stockpile-Plugin.git
-commit=df7660b16c32a0a28fd1cd66554cfdb12e1ed696
+commit=db36729b0fbd70c714bcac0bf6cbd356ef009b12


### PR DESCRIPTION
Bumps the Stockpile plugin to release 1.4.1 (commit db36729).

Bug-fix release:
- Fired ammunition is valued correctly — ammo destroyed on use is booked at 0, ammo that lands on the ground is recovered instead of written off.
- Rune pouch contents are no longer double-counted as a phantom reward on login.

Release: https://github.com/Oveduumnakal/Stockpile-Plugin/releases/tag/R-1.4.1