### PR TITLE
update bank-templates to v2.3.1

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=b9625d93b9d49114dd3e0863e602629372338a8e
+commit=59fb42c1cbcf30306d6289924bd43a1d0f54583c


### PR DESCRIPTION
Bumps bank-templates from v2.3.0 (b9625d9) to v2.3.1 (59fb42c).

**v2.3.1**
- Fix custom bank tab icons being wiped by the account sync. Both places that deserialise a template from the API built an empty `BankTemplate` and called `putTab`, which only carries an icon a tab already has, so the chosen icon was dropped on read. The sync then mirrored that blank over the user's local copy about 1.5s after every change, which read as the icon refusing to change. Community imports lost the uploader's icons the same way. Reported as TheSpryt/bank-templates#40.
- Read the linked account token from one shared config slot rather than each plugin reading its siblings' keys. The slot is owned by no plugin, so it survives uninstalling whichever one created it, and the old keys are still read as a fallback so existing links keep working.