### PR TITLE
update voiced-dialogue

### DIFF
--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=987515897ecf3a98be7883604c0706a5e4034393
+commit=94dde035ef125e7331b770502c07e5a23070ad0f
 authors=grabartley
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=94dde035ef125e7331b770502c07e5a23070ad0f
+commit=daabe5325140220e690fc6ead32eb492442b1036
 authors=grabartley
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates voiced-dialogue to [v0.6.0](https://github.com/grabartley/runelite-voiced-dialogue/releases/tag/v0.6.0). The pinned commit is the `v0.6.0` release tag commit.

This PR originally targeted v0.5.0 and has been repointed, so it now takes the Hub from v0.4.0 straight to v0.6.0.

**Note on third parties:** this version adds Google AI Studio as a second cloud TTS provider alongside OpenRouter, so the plugin can talk to one of two third-party services depending on the user's chosen provider. Whichever they pick is named in the plugin's settings and its first-run notice, and dialogue text is only ever sent to that one.

Highlights since v0.4.0:

- **Dialogue starts speaking in well under a second.** Google AI Studio streams audio as it is generated, so a line begins playing on its first fragment instead of after the whole clip exists. Measured against the same lines, time until a line starts speaking went from 1.7s to 0.7s on short lines, 6.3s to 0.8s at 100 characters, and 19.5s to 0.8s at 400 characters. Unlike the previous behaviour, that figure no longer grows with the length of the line, so long quest speeches start just as quickly as one-liners.
- **Long lines are no longer dropped.** Lines past roughly 400 characters could exceed the request timeout, retry, time out again, and end up never voiced. Each request now gets a budget sized to the line it is voicing, so those lines play in full.
- Google AI Studio is the provider new installs use, and is documented as the recommended one. Anyone already set up with an OpenRouter key keeps OpenRouter untouched.
- The cloud connection is established ahead of the first line of a session and kept warm between conversations, removing a handshake from the first thing a player hears.
- Learned NPC voice data is saved more robustly, preventing rare data loss on interrupted writes.
