### PR TITLE
update exchange-insights to v1.1.5

### DIFF
--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,3 +1,3 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=bc0fcb49f67a232ba37c875326bec99c1d32f3be
+commit=a7d61046f88895390c3cf849ed5981f6c1ccffc5
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps exchange-insights from v1.1.4 (bc0fcb4) to v1.1.5 (a7d6104).

**v1.1.5**
- Read the linked account token from one shared config slot rather than each plugin reading its siblings' config keys directly. The slot is owned by no plugin, so it does not appear as a setting and does not disappear when whichever plugin created it is uninstalled. The old keys are still read as a fallback and promoted into the shared slot on first use, so existing links keep working.

The matching change ships in bank-templates v2.3.1 (#15041); both use the same slot, so they need to agree.