### PR TITLE
update ge-uncut to 1.5.8

### DIFF
--- a/plugins/ge-uncut
+++ b/plugins/ge-uncut
@@ -1,3 +1,3 @@
 repository=https://github.com/uzia35/ge-uncut.git
-commit=04a4b8e5c12e7456bd46ce1c33fea9a285b46a68
+commit=eb106771c02c0ef268beda29879ca7b8446ecefd
 warning=This plugin submits your IP address and various account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Live buy/sell prices on the GE offer screen: a new on-screen overlay shows the item's current buy and sell price and how recently each traded, with an Item details button. Removes the old flips-only quantity autofill.