### PR TITLE
the-birdhouse: update to 1.0.8

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=c3c69bf013a30a05cb2cd6fd5613a6cd7fba4b39
+commit=a5955f402532f72c85971e9e3d77839998367373
 warning=This plugin submits your IP address, RSN, and in-game screenshots to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates The Birdhouse to 1.0.8.

Adds support for clue scrolls the loot tracker cannot report, all of which were previously invisible to the plugin:

- **Impling jars.** Catching an impling into a jar loots nothing, and opening the jar later has no handler, so only no-jar catches were ever seen. The catch is now reported from the game message and the clue is read from the inventory change when the jar is opened.
- **Skilling.** Mining, Fishing and Woodcutting emit no loot events, so a scroll box, geode, bottle or nest simply appeared unannounced. These are now credited when gathering experience arrives in the same tick.
- **Clue turtles.** The Sailing encounter hands the clue over directly with nothing broadcast. Shipwreck salvaging already worked via the salvage message handler and is explicitly de-duplicated against.

Ground pickups are never credited, which keeps monster drops from being counted twice and closes the drop-and-repickup loop.

Also sends the Grand Exchange value and item id with each proof, since the backend has no price data of its own.

Changes: https://github.com/birdandworm/TheBirdhouse/pull/5 and https://github.com/birdandworm/TheBirdhouse/pull/6
