### PR TITLE
Update raids-death-indicator to a1516d1f2493d922d6069b717572937f450df22a

### DIFF
--- a/plugins/raids-death-indicator
+++ b/plugins/raids-death-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/vikke1234/raids-death-indicator.git
-commit=63229f866bc313c16f716389c6804346b18f9bcb
+commit=a1516d1f2493d922d6069b717572937f450df22a


### PR DESCRIPTION
a1516d1 damagehandler: Fix nightmare totem healing
5c32f09 enemy: add olm mage hand to bosses list
3e176ea enemy: Initialize queued damage to 0
15ad84b ci: Include commits in release notes