### PR TITLE
Add new mouse-button-drop plugin

### DIFF
--- a/plugins/mouse-button-drop
+++ b/plugins/mouse-button-drop
@@ -1,2 +1,2 @@
 repository=https://github.com/jakedavison/runelite-mouse-button-drop
-commit=ce7ca5f6764717608a9b66e71293a26f810477ce
+commit=574f66334a6e48db9b41dde36be5264060f609bc

--- a/plugins/mouse-button-drop
+++ b/plugins/mouse-button-drop
@@ -1,2 +1,2 @@
-repository=https://github.com/jakedavison/runelite-mouse-button-drop
+repository=https://github.com/jakedavison/runelite-mouse-button-drop.git
 commit=574f66334a6e48db9b41dde36be5264060f609bc

--- a/plugins/mouse-button-drop
+++ b/plugins/mouse-button-drop
@@ -1,2 +1,2 @@
 repository=https://github.com/jakedavison/runelite-mouse-button-drop.git
-commit=f3665e48d04969dd46718795386934c266ecedb4
+commit=ece8219bbae3908bff56af39fbd04b97823a3aa5

--- a/plugins/mouse-button-drop
+++ b/plugins/mouse-button-drop
@@ -1,0 +1,2 @@
+repository=https://github.com/jakedavison/runelite-mouse-button-drop
+commit=ce7ca5f6764717608a9b66e71293a26f810477ce

--- a/plugins/mouse-button-drop
+++ b/plugins/mouse-button-drop
@@ -1,2 +1,2 @@
 repository=https://github.com/jakedavison/runelite-mouse-button-drop.git
-commit=574f66334a6e48db9b41dde36be5264060f609bc
+commit=f3665e48d04969dd46718795386934c266ecedb4


### PR DESCRIPTION
Hey maintainers!

Very simple plugin here but my first. The plugin tracks the state of an extra mouse button (configurable) and while pressed will allow left click dropping (like when holding shift).

Since this plugin works very similarly to how the built-in Menu Item Swapper works I have thought about adding it as an extra config on that plugin but I thought it's maybe too niche of a use case to warrant a change on the client  repo itself. Probably I will open an issue (and maybe directly a PR since it's trivial enough to just do it even if it will be rejected) on the main repo for this if this plugin become at all popular, at which point it could remove this plugin from here.

AI disclosure: LLM tools were used for some discovery of the runelite client codebase but this was not vibe coded