### PR TITLE
Add Stymphike AFK Timer

### DIFF
--- a/plugins/stymphike-afk-timer
+++ b/plugins/stymphike-afk-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/silly-build/stymphike-afk-timer.git
+commit=d3449a5c45bab4fa78a23f6e24d6f35785d79526


### PR DESCRIPTION
Adds Stymphike AFK Timer.

This plugin dims the scene while hidden during stymphike hunting, highlights baited stymphike trees, shows a configurable ETA countdown, warns when no spear is found, and can undim on the expected Hunter XP drop.