### PR TITLE
Add mute-magic-trees plugin

### DIFF
--- a/plugins/mute-magic-trees
+++ b/plugins/mute-magic-trees
@@ -1,0 +1,2 @@
+repository=https://github.com/CasperPlate/mute-magic-trees.git
+commit=744d04fec95ece605e75eaf39e2cac2e7551ce91


### PR DESCRIPTION
This is a small plugin that mutes the chimes of magic trees while allowing other ambient sounds to continue playing (like the chopping sound made during woodcutting for example). 

I have manually tested the following scenarios and had them all succeed:

- Enable plugin while logged in near a Magic Tree.
- Disable plugin near a Magic Tree.
- Enable/disable repeatedly.
- Log out/in with the plugin enabled.
- World hop.
- Teleport between Magic Tree and non-Magic Tree areas.
- Verify other ambient sounds continue.
- Verify chopping sounds continue.
- Verify the plugin doesn't produce errors during logout/client shutdown.

PS: this is the first time I have made a plugin, please correct me if I missed anything and feel free to suggest improvements.