### PR TITLE
Bryophyta's Staff Helper

### DIFF
--- a/plugins/bryophyta-staff-helper
+++ b/plugins/bryophyta-staff-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/maxgauthier12/bryophyta-staff-helper.git
-commit=34b358bc5c97a0444da70463302eae5ffd29aa87
+commit=d623db3e09009d4518034cfbaccbd3597d846257

--- a/plugins/bryophyta-staff-helper
+++ b/plugins/bryophyta-staff-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/maxgauthier12/bryophyta-staff-helper.git
-commit=d623db3e09009d4518034cfbaccbd3597d846257
+commit=07106cde44cb99b363f24a24136adb932f98ae25

--- a/plugins/bryophyta-staff-helper
+++ b/plugins/bryophyta-staff-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/maxgauthier12/bryophyta-staff-helper.git
+commit=34b358bc5c97a0444da70463302eae5ffd29aa87


### PR DESCRIPTION
Adds a RuneLite plugin for tracking Bryophyta's staff charge count and warning when it is running low.

Features:

- tracks the current staff charge in an infobox
- learns the value from the staff’s in-game Check option
- warns when the staff drops below the configured low-charge threshold
- tracks nature rune usage and saved-rune behavior
- alerts when an uncharged Bryophyta's staff is equipped

This plugin is intended for players who want to monitor Bryophyta's staff charge state more reliably.