### PR TITLE
Update star-afk-timer

### DIFF
--- a/plugins/star-afk-timer
+++ b/plugins/star-afk-timer
@@ -1,2 +1,2 @@
 repository=https://github.com/silly-build/star-afk-timer.git
-commit=8045ea58e7b38d9183c0d452aea11e11a1b7ec1a
+commit=784720fe8c626d960c8c01c5c52f8a5f8a3385a6


### PR DESCRIPTION
Updates star-afk-timer to https://github.com/silly-build/star-afk-timer/commit/784720fe8c626d960c8c01c5c52f8a5f8a3385a6.

Changes:
- Add optional RuneLite notification sound near the end of a Shooting Star layer, disabled by default
- Add configurable warning threshold, defaulting to 30 seconds
- Update plugin icon

Thank you to LeoPalmowski for the additional notifications options.
