### PR TITLE
Add RunePlan plugin

### DIFF
--- a/plugins/runeplan
+++ b/plugins/runeplan
@@ -1,2 +1,2 @@
 repository=https://github.com/dontbotbro-ux/runeplan.git
-commit=6a5cf8c6c750c33dd31680eabe953d4a61bddc3e
+commit=cc523892d2495083a30eff30221016e65c1c5ed9

--- a/plugins/runeplan
+++ b/plugins/runeplan
@@ -1,0 +1,2 @@
+repository=https://github.com/dontbotbro-ux/runeplan.git
+commit=6a5cf8c6c750c33dd31680eabe953d4a61bddc3e


### PR DESCRIPTION
Adds the RunePlan plugin: a display-only OSRS planner overlay with live skill/inventory tracking and a boss prayer helper (TzTok-Jad). Display-only - no automation.