### PR TITLE
Add Boss KD Tracker

### DIFF
--- a/plugins/boss-kd-tracker
+++ b/plugins/boss-kd-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/FlawedLegacie/Boss-KD-Tracker.git
+commit=f2df859fbe795cb2ea166421c74a98a2e290e3ca

--- a/plugins/boss-kd-tracker
+++ b/plugins/boss-kd-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/FlawedLegacie/Boss-KD-Tracker.git
-commit=f2df859fbe795cb2ea166421c74a98a2e290e3ca
+commit=dc54f47a0750ccd56ea9afca1b19732fd6cf8a47


### PR DESCRIPTION
Adds Boss KD Tracker, a RuneLite plugin for tracking boss kills, deaths, K/D ratios, nemeses, records, and boss encounters.

Features include automatic boss kill and death tracking, historical boss kill-count synchronization from RuneLite profile data, manual kill/death corrections, quest boss support, searchable boss records, and the !KD chat command.

Historical deaths are not inferred or guessed; players can manually add historical deaths when needed.