### PR TITLE
Add Adaptive Prayer Slots

### DIFF
--- a/plugins/adaptive-prayer-slots
+++ b/plugins/adaptive-prayer-slots
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/Adaptive-prayer-slots.git
-commit=9541bbb27d802510c3acb982ec0d87de89474b57
+commit=c30a9ae00ab7c599276eabe90dfbc6c98bdefa33

--- a/plugins/adaptive-prayer-slots
+++ b/plugins/adaptive-prayer-slots
@@ -1,0 +1,2 @@
+repository=https://github.com/Endrit-alt/Adaptive-prayer-slots.git
+commit=177f2682cabcf07ad8b9cd18c6833afe9e903a34

--- a/plugins/adaptive-prayer-slots
+++ b/plugins/adaptive-prayer-slots
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/Adaptive-prayer-slots.git
-commit=177f2682cabcf07ad8b9cd18c6833afe9e903a34
+commit=9541bbb27d802510c3acb982ec0d87de89474b57


### PR DESCRIPTION
This plugin :

- Swaps prayer position with lower level variant if the higher level variant is not available

Why?

- This solves having prayers in same position for game modes like LAST MAN STANDING, where a different player profile is given to you. In these different player profiles, sometimes you only have access to lower level prayers.

