### PR TITLE
Add varlamore-distraction-tracker

### DIFF
--- a/plugins/varlamore-distraction-tracker
+++ b/plugins/varlamore-distraction-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/jdkrupajk/varlamore-distraction-tracker.git
-commit=c011310544b3f0f227ce917f026fe896b9995a32
+commit=719990cc670ed5546cfc28c03abbc674649b538d

--- a/plugins/varlamore-distraction-tracker
+++ b/plugins/varlamore-distraction-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/jdkrupajk/varlamore-distraction-tracker.git
-commit=730185db4187fdcdf72502f4172019b8b98c6b16
+commit=c011310544b3f0f227ce917f026fe896b9995a32

--- a/plugins/varlamore-distraction-tracker
+++ b/plugins/varlamore-distraction-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/jdkrupajk/varlamore-distraction-tracker.git
+commit=730185db4187fdcdf72502f4172019b8b98c6b16


### PR DESCRIPTION
Adds **Varlamore Distraction Tracker**.

Pickpocketing wealthy citizens in Civitas illa Fortis is gated by an urchin distraction that fires every 84–99 seconds. Joining one that is already running earns nothing — the game deliberately penalises it with a slow auto-pickpocket and the message *"Your hands are sweaty and keep dropping the items in the Citizen's pockets."* So the only way world hopping pays is to arrive on a world shortly **before** its next distraction, which means knowing each world's phase.

The plugin keeps a per-world timer for every world you visit, colour-banded and sorted most-urgent-first, with click-to-hop. Existing Varlamore thieving plugins time a single world and reset on leaving the region; this one keeps the worlds you have left, which is the whole point.

### Notes for review

**Third-party server, opt-in and disabled by default.** There is an optional sharing feature that pools distraction timings between users. It ships off, and its `@ConfigItem` carries the required warning:

> This feature submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers

Only a world number is ever transmitted. Nothing about the local player or any other player is sent, and the server logs and stores nothing beyond an in-memory map of world numbers to timestamps that expires after 120 seconds. Server source is public: https://github.com/jdkrupajk/varlamore-distraction-service

**World hopping** uses `client.hopToWorld` / `client.changeWorld` via `WorldService`, following the same sequence as the built-in World Hopper plugin, and only ever from an explicit click on a panel row.

**Notifications** are off by default.

**No scene scanning.** Wealthy citizens are tracked from `NpcSpawned` / `NpcDespawned` into a small set, rather than iterating cached NPCs each tick.

**Tests**: 36 unit tests. All timing and merge logic lives in a class with no RuneLite imports that takes the clock as a parameter, so it is covered by plain JUnit without a mocked client.
