### PR TITLE
Add Facette Companion plugin

### DIFF
--- a/plugins/facette-companion
+++ b/plugins/facette-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/ethanmonlux/facette-osrs.git
-commit=c3b7c0e09b525276dbf9094b26bc717fbbee56fe
+commit=ff5a38770b43ceaffa2dbd5c0e6abb56de73889a

--- a/plugins/facette-companion
+++ b/plugins/facette-companion
@@ -1,0 +1,2 @@
+repository=https://github.com/ethanmonlux/facette-osrs.git
+commit=6350b4b4209a07484d5ab60a6b659c738cdfcfe0

--- a/plugins/facette-companion
+++ b/plugins/facette-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/ethanmonlux/facette-osrs.git
-commit=6350b4b4209a07484d5ab60a6b659c738cdfcfe0
+commit=c3b7c0e09b525276dbf9094b26bc717fbbee56fe


### PR DESCRIPTION
Facette Companion is a read-only RuneLite plugin that exports a bounded view of the local player's live game state to one documented local JSON file.

The plugin performs no gameplay input, makes no network requests, and does not require Facette or any other external application. Facette is an optional reader of the exported file.