### PR TITLE
Add RuneLite completion notifications

### DIFF
--- a/plugins/wyrm-agility-afk-progress
+++ b/plugins/wyrm-agility-afk-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/mrfox-1/runelite-wyrm-agility-progress.git
-commit=9f8fd309b7c5cc0e4e3d38af7e7dabdfa1702662
+commit=733e81176ec5b30118a60f2c0f2ad983a853217d


### PR DESCRIPTION
## What changed

Updates Wyrm Agility AFK Progress to plugin commit `733e81176ec5b30118a60f2c0f2ad983a853217d`.

- Adds an optional native RuneLite notification when the next obstacle should be clickable.
- Uses RuneLite's global notification behavior, including tray notifications, request focus, and taskbar flashing.
- Keeps the plugin-specific completion sound as a separate option.
- Applies the minimum notification-length threshold to both notification types.
- Refreshes the README and settings screenshot.

## Validation

- `gradlew.bat clean build` passes with Java 21 while targeting Java 11.
- The native notification was tested with RuneLite minimized; configured request-focus behavior worked.
- The Plugin Hub change updates only the existing plugin manifest commit hash.
- No new dependencies were added.
