### PR TITLE
Add Time Served

### DIFF
--- a/plugins/time-served
+++ b/plugins/time-served
@@ -1,4 +1,4 @@
 repository=https://github.com/vandevkieboom/osrsclanplugin.git
-commit=c4d2ca8e99b11a6672fd0c4b2125c8474c41cb84
+commit=18d5d812ea1f2688b2746651ca832f96ae27ca5f
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.
 authors=vandevkieboom

--- a/plugins/time-served
+++ b/plugins/time-served
@@ -1,3 +1,4 @@
 repository=https://github.com/vandevkieboom/osrsclanplugin.git
 commit=c4d2ca8e99b11a6672fd0c4b2125c8474c41cb84
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.
 authors=vandevkieboom

--- a/plugins/time-served
+++ b/plugins/time-served
@@ -1,0 +1,3 @@
+repository=https://github.com/vandevkieboom/osrsclanplugin.git
+commit=cc995164d42604baf460e378d0312a7826db0b1d
+authors=vandevkieboom

--- a/plugins/time-served
+++ b/plugins/time-served
@@ -1,3 +1,3 @@
 repository=https://github.com/vandevkieboom/osrsclanplugin.git
-commit=cc995164d42604baf460e378d0312a7826db0b1d
+commit=7fe17d037a204fa30bd17f66404bcd7421494233
 authors=vandevkieboom

--- a/plugins/time-served
+++ b/plugins/time-served
@@ -1,3 +1,3 @@
 repository=https://github.com/vandevkieboom/osrsclanplugin.git
-commit=7fe17d037a204fa30bd17f66404bcd7421494233
+commit=c4d2ca8e99b11a6672fd0c4b2125c8474c41cb84
 authors=vandevkieboom


### PR DESCRIPTION
## Plugin

General clan tooling for the Time Served OSRS clan: automatic bingo tile proof submission (screenshot + upload on a matching drop, verified server-side), plus `!rank`/`!verify`/`!needed`/`!live` chat commands for rank/eligibility lookups and Twitch live status, live-stream/broadcast/Wise-Old-Man-competition chat notifications, and a sidebar panel showing the caller's board/goals/leaderboard.

Repo: https://github.com/vandevkieboom/osrsclanplugin

All network calls and what they send are documented in the plugin's README under "What it sends, and when".