### PR TITLE
Add Clan Piano MIDI

### DIFF
--- a/plugins/clan-piano-midi
+++ b/plugins/clan-piano-midi
@@ -1,2 +1,2 @@
 repository=https://github.com/TheOffSeason/clan-piano-midi.git
-commit=50b9e9cd88e0be623dc1dd5c1cbb9bc1f6929977
+commit=2e324d323c2b1aed4304c64390266cf7f05b3a20

--- a/plugins/clan-piano-midi
+++ b/plugins/clan-piano-midi
@@ -1,2 +1,2 @@
 repository=https://github.com/TheOffSeason/clan-piano-midi.git
-commit=10ba8616c557d599fb5836d113e9e631aece58e4
+commit=50b9e9cd88e0be623dc1dd5c1cbb9bc1f6929977

--- a/plugins/clan-piano-midi
+++ b/plugins/clan-piano-midi
@@ -1,0 +1,2 @@
+repository=https://github.com/TheOffSeason/clan-piano-midi.git
+commit=10ba8616c557d599fb5836d113e9e631aece58e4


### PR DESCRIPTION
Adds **Clan Piano MIDI**.

Lets you play the clan hall piano with a MIDI keyboard, and shares the performance with party members running the plugin.

The in-game piano is limited to 24 keys (C4-B5) and its Entertain mode quantises every note to the game tick, so a performance on it is heavily constrained. This renders the notes locally through the JDK synthesizer instead, giving the full MIDI range, polyphony and velocity, with no tick grid. Notes are shared over the existing party system so a clan hall event can hear the whole piece.

The plugin does not interact with the game. It reads a MIDI input device, plays audio, and exchanges note messages with the party. No input injection, no menu entries, no reflection, no HTTP, no file I/O.

Licensed BSD-2-Clause.