### PR TITLE
Update deprioritize-leave

### DIFF
--- a/plugins/deprioritize-leave
+++ b/plugins/deprioritize-leave
@@ -1,2 +1,2 @@
 repository=https://github.com/bopsec/bop-plugins.git
-commit=36dfb4308d9e69332249170f2a05fe4125ec12b4
+commit=12b0bf1d9129c0142c4fdb03c3d81e0d8bb7d643


### PR DESCRIPTION
Added config option to also deprio if NPC is still present
Stops you leaving before loot would arrive (iff the NPC dies same tick the loot appears)


hcim please don't toggle this feature