### PR TITLE
Add RS-Bingo

### DIFF
--- a/plugins/rs-bingo
+++ b/plugins/rs-bingo
@@ -1,4 +1,4 @@
 repository=https://github.com/Newrockku/RS-Bingo.git
-commit=ecc7c74dfb1ae63142907461dc7b2291892fe72f
+commit=52edd494a14e0225a623301384e5d50dd86868d7
 authors=Newrockku
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/rs-bingo
+++ b/plugins/rs-bingo
@@ -1,4 +1,4 @@
 repository=https://github.com/Newrockku/RS-Bingo.git
 commit=ecc7c74dfb1ae63142907461dc7b2291892fe72f
 authors=Newrockku
-warning=This plugin sends your IP address and event code to rs-bingo.com, a third-party server not controlled or verified by the RuneLite developers, to load the event board. If you choose to submit a drop it also sends a screenshot of your client and your RSN for verification, and if you link your account it sends a token identifying you. Screenshots are only captured when you press the submit button.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/rs-bingo
+++ b/plugins/rs-bingo
@@ -1,4 +1,4 @@
 repository=https://github.com/Newrockku/RS-Bingo.git
-commit=5f7f29f5f3d462c9271e7ef4db71388e4533aef7
+commit=ecc7c74dfb1ae63142907461dc7b2291892fe72f
 authors=Newrockku
 warning=This plugin sends your IP address and event code to rs-bingo.com, a third-party server not controlled or verified by the RuneLite developers, to load the event board. If you choose to submit a drop it also sends a screenshot of your client and your RSN for verification, and if you link your account it sends a token identifying you. Screenshots are only captured when you press the submit button.

--- a/plugins/rs-bingo
+++ b/plugins/rs-bingo
@@ -1,4 +1,4 @@
-repository=https://github.com/Newrockku/bingo-plugin.git
-commit=14a2c84847c4ef4f162a67d7646271af33ec2ada
+repository=https://github.com/Newrockku/RS-Bingo.git
+commit=43a8d4e7bb713477c1cbeed3155e6b3f59ed7abe
 authors=Newrockku
 warning=This plugin sends your IP address and event code to rs-bingo.com, a third-party server not controlled or verified by the RuneLite developers, to load the event board. If you choose to submit a drop it also sends a screenshot of your client and your RSN for verification, and if you link your account it sends a token identifying you. Screenshots are only captured when you press the submit button.

--- a/plugins/rs-bingo
+++ b/plugins/rs-bingo
@@ -1,4 +1,4 @@
 repository=https://github.com/Newrockku/RS-Bingo.git
-commit=ac95bf06c36462502a32d3a0f8562da4a15d1773
+commit=5f7f29f5f3d462c9271e7ef4db71388e4533aef7
 authors=Newrockku
 warning=This plugin sends your IP address and event code to rs-bingo.com, a third-party server not controlled or verified by the RuneLite developers, to load the event board. If you choose to submit a drop it also sends a screenshot of your client and your RSN for verification, and if you link your account it sends a token identifying you. Screenshots are only captured when you press the submit button.

--- a/plugins/rs-bingo
+++ b/plugins/rs-bingo
@@ -1,4 +1,4 @@
 repository=https://github.com/Newrockku/RS-Bingo.git
-commit=43a8d4e7bb713477c1cbeed3155e6b3f59ed7abe
+commit=ac95bf06c36462502a32d3a0f8562da4a15d1773
 authors=Newrockku
 warning=This plugin sends your IP address and event code to rs-bingo.com, a third-party server not controlled or verified by the RuneLite developers, to load the event board. If you choose to submit a drop it also sends a screenshot of your client and your RSN for verification, and if you link your account it sends a token identifying you. Screenshots are only captured when you press the submit button.

--- a/plugins/rs-bingo
+++ b/plugins/rs-bingo
@@ -1,0 +1,4 @@
+repository=https://github.com/Newrockku/bingo-plugin.git
+commit=14a2c84847c4ef4f162a67d7646271af33ec2ada
+authors=Newrockku
+warning=This plugin sends your IP address and event code to rs-bingo.com, a third-party server not controlled or verified by the RuneLite developers, to load the event board. If you choose to submit a drop it also sends a screenshot of your client and your RSN for verification, and if you link your account it sends a token identifying you. Screenshots are only captured when you press the submit button.


### PR DESCRIPTION
Side panel for following an rs-bingo.com bingo event: the team's board, tile checklists, point rates, per-player progress and standings, with optional in-client drop submission.