### PR TITLE
Upgrade dk-lights version to 2.0.4

### DIFF
--- a/plugins/dorgesh-kaan-lights
+++ b/plugins/dorgesh-kaan-lights
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/dk-lights.git
-commit=67e2397692cc82fc7dee7b96bdeb70119ea10b23
+commit=be0e29c8f9dac481c170f5d9d56035b90eeda327
 authors=andmcadams,tmgdejong

--- a/plugins/dorgesh-kaan-lights
+++ b/plugins/dorgesh-kaan-lights
@@ -1,3 +1,3 @@
 repository=https://github.com/andmcadams/dk-lights.git
-commit=be0e29c8f9dac481c170f5d9d56035b90eeda327
+commit=2d1c049c6085cf19d9cbe068390d9ecdc74cb85c
 authors=andmcadams,tmgdejong


### PR DESCRIPTION
Fixed a bug where the lamp statuses would reset upon the `LOADING` gamestate (https://github.com/andmcadams/dk-lights/issues/15)
