### PR TITLE
Add instant-replay plugin

### DIFF
--- a/plugins/instant-replay
+++ b/plugins/instant-replay
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/instant-replay.git
-commit=b27fccba827bbc6beecb8fe586e7bf496ef2666f
+commit=b9f90103adca1b4c2c1f6d3230e4e4201c111a21

--- a/plugins/instant-replay
+++ b/plugins/instant-replay
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/instant-replay.git
-commit=b9f90103adca1b4c2c1f6d3230e4e4201c111a21
+commit=eb116dc228a51bdf3ff0e7ee60d42b25c9f4cb4a

--- a/plugins/instant-replay
+++ b/plugins/instant-replay
@@ -1,0 +1,2 @@
+repository=https://github.com/georgeparamore/instant-replay.git
+commit=b27fccba827bbc6beecb8fe586e7bf496ef2666f


### PR DESCRIPTION
## Instant Replay

A rolling-buffer clip recorder for OSRS — like ShadowPlay's instant replay. Keeps the last N seconds of gameplay in memory and automatically saves a video clip on new personal bests, valuable drops, collection log slots, pets, quests, combat achievements, and deaths, or on a manual hotkey.

**How it captures:** via `DrawManager` — the same API the core screenshot plugin uses. It only sees the game's rendered frames (never the desktop or other windows), only runs while logged in, keeps frames in memory only, and writes to disk only on a trigger. Nothing is uploaded anywhere.

**Compliance:** pure JDK — no third-party dependencies, no native code, no external processes, no reflection, no runtime downloads, and no runtime inspection. Clips are MJPEG-in-AVI written by a small hand-rolled muxer. `build=standard`.

**Video only** — capturing game audio from inside the JVM isn't practical under Hub rules; noted in the README.

Repo: https://github.com/georgeparamore/instant-replay

(Fresh PR per the one-open-PR-at-a-time policy — this replaces the earlier #14211, which had already passed review after removing JCodec and all runtime inspection.)
