### PR TITLE
Update Twitch Live Loadout to v2.3.5

### DIFF
--- a/plugins/twitch-live-loadout
+++ b/plugins/twitch-live-loadout
@@ -1,2 +1,2 @@
 repository=https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin.git
-commit=e79b59d073faf6b909851d691b9a04f0235f79e8
+commit=a2917870522cdc7868690fae1156b27eac11bcfa


### PR DESCRIPTION
Added support for Random Events to be set up within RuneLite without Twitch to be triggered on certain game events. This opens up some options for content creators to use the Random Events feature without a Twitch integration for non-streaming content purposes.

See an impression of the basic UI for manual Random Event management:
<img width="221" height="392" alt="Screenshot 2026-08-16 at 22 19 24" src="https://github.com/user-attachments/assets/11c7124d-bf30-490b-a7e1-610edda4ebc8" />
