### PR TITLE
Update Bank Tab Organizer to 1.1.1

### DIFF
--- a/plugins/bank-tab-organizer
+++ b/plugins/bank-tab-organizer
@@ -1,2 +1,2 @@
 repository=https://github.com/1504681/BankOrganizerPlugin.git
-commit=9a17b4c2845f3e23931ce46e531ea1fb969c553c
+commit=996676d888ff877d186a0da70aae8de9a2fcec6a

--- a/plugins/bank-tab-organizer
+++ b/plugins/bank-tab-organizer
@@ -1,2 +1,2 @@
 repository=https://github.com/1504681/BankOrganizerPlugin.git
-commit=7a41ad635737c6a24de7a1a3e103facf2e1153bd
+commit=8328caeef9789493c84d5a8bcd168b8bfc565305

--- a/plugins/bank-tab-organizer
+++ b/plugins/bank-tab-organizer
@@ -1,2 +1,2 @@
 repository=https://github.com/1504681/BankOrganizerPlugin.git
-commit=8328caeef9789493c84d5a8bcd168b8bfc565305
+commit=9a17b4c2845f3e23931ce46e531ea1fb969c553c


### PR DESCRIPTION
Bump Bank Tab Organizer to 1.1.1.

- More categorization rules from user feedback (uncut gems, ammo tips, ores, raw food, bones, hides, planks, herblore secondaries -> Materials; adamant/mithril gear -> High Alch; Barrows gear -> Combat; diary cape / ring of wealth -> Teleports)
- Materials tab sorts by tier within every group
- Main tab (All) defaults to Currency
- Version shown in sidebar; profiles record which defaults version they came from and pick up newer defaults automatically while keeping the user's own categorizations