### PR TITLE
Add OSRS Advisor

### DIFF
--- a/plugins/osrs-advisor
+++ b/plugins/osrs-advisor
@@ -1,0 +1,2 @@
+repository=https://github.com/JustinTiano/osrsadvisor.git
+commit=51a037068fd39747c8e49ed240203c7bdb9c9524

--- a/plugins/osrs-advisor
+++ b/plugins/osrs-advisor
@@ -1,2 +1,2 @@
 repository=https://github.com/JustinTiano/osrsadvisor.git
-commit=51a037068fd39747c8e49ed240203c7bdb9c9524
+commit=f45390a34fc40e3e736a3367731682eb8a574f5e


### PR DESCRIPTION
Adds **OSRS Advisor** — the in-game front end of a personal account-planning
server: quest cards for the Optimal quest guide with gates diffed against live
stats, costed Fastest/Balanced/AFK training routes for each skill gate, and a
merged GE shopping list.

**Data disclosure, up front:** the plugin pushes account state (player name,
skill xp, quest/diary completion, bank, inventory, equipment, GE offers) to a
**user-configured server URL**, defaulting to `http://localhost:8777` — the
player's own machine. There is no third-party service; nothing is sent anywhere
unless the user changes the URL, and the plugin description plus the Ingest URL
config description both state exactly what is sent. Game data flows one
direction only (client → server); the plugin never sends input to the game.

Without a companion server running, the panel shows a "companion server not
reachable" notice and the pushes go nowhere; the README states this requirement
prominently.

Code notes for review: all HTTP is the injected `OkHttpClient` via `enqueue()`,
JSON is the injected `Gson`, no reflection, no extra dependencies beyond the
template's, no input injection, resources via `ImageUtil.loadImageResource`.
(An earlier private build integrated with Quest Helper reflectively; that was
removed before this submission for the no-reflection rule.)
