### PR TITLE
Update mystix

### DIFF
--- a/plugins/mystix
+++ b/plugins/mystix
@@ -1,4 +1,4 @@
 repository=https://github.com/Dmurph24/mystix-plugin.git
-commit=a1e6692b7b6be1b358508dc352fc1d0e2e8288e1
+commit=d8646e89019009e35c1e08f994a0180e20c949e9
 authors=Dmurph24
 warning=This plugin submits your RSN, skills, bank, equipment, loadouts, farming timers, and loot data to a 3rd-party server (Mystix) not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Mystix to the latest release.

The main fix: the plugin no longer syncs while the player is on a PvP Arena world. Those worlds hand the player a temporary copy of their character whose quest states, diary varbits, and slayer points are not the real account's, and syncing that copy corrupted tracked progression. PvP Arena joins the world types already excluded (Leagues, Deadman, Fresh Start, Tournament, Beta, no-save, Quest Speedrunning), gating every sync path through the existing shared check.

The only other change is a small layout fix in the roadmaps side panel (goal text now wraps beside its icon). No new data source is introduced.