### PR TITLE
Add Fairy Ring Organizer

### DIFF
--- a/plugins/fairy-ring-organizer
+++ b/plugins/fairy-ring-organizer
@@ -1,0 +1,2 @@
+repository=https://github.com/YaBoiStery/Fairy-Ring-Organizer.git
+commit=3b9859094f8340b6e7efe5d53dbdcf012d39d10e


### PR DESCRIPTION
Adds Fairy Ring Organizer to the Plugin Hub.

Fairy Ring Organizer adds local organization and presentation controls to the existing Fairy Ring interface, including independent sorting/manual ordering, local custom destination names, search integration, menu presentation options, and optional per-physical-ring Favorite defaults.

The plugin reuses existing RuneLite/Jagex widgets and menu actions and does not synthesize teleports or input. Preferences are stored through RuneLite's ConfigManager.

The repository includes reviewer-focused implementation notes, automated verification, and a manual regression checklist.