### PR TITLE
Add PoH Teleport Counter

### DIFF
--- a/plugins/poh-teleport-counter
+++ b/plugins/poh-teleport-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/issmirnov/poh-teleport-counter.git
+commit=6b60cf6100f2f1cda55b967afdbfd4de6898ae63


### PR DESCRIPTION
Adds **PoH Teleport Counter** — counts the free teleports from a Player-Owned House (Teleport Nexus, jewellery box, and the mounted amulet of glory / Xeric's talisman / digsite pendant) and the GP they save, priced live from the Grand Exchange.

- Repository: https://github.com/issmirnov/poh-teleport-counter
- Passive & read-only — reads menu clicks and player position only; no input or automation
- Unit-tested; CI runs build + tests + RuneLite Checkstyle on JDK 11