### PR TITLE
Update Farming Patch Advisor

### DIFF
--- a/plugins/farming-patch-advisor
+++ b/plugins/farming-patch-advisor
@@ -1,2 +1,2 @@
 repository=https://github.com/Seadeadmeat/farming-patch-advisor.git
-commit=454fa7248741b579f5cb2b2c747d7c8837ac7db9
+commit=385b074f051d77ccdb27777e94ba0375714b2bcd


### PR DESCRIPTION
Updates Farming Patch Advisor to commit 385b074f051d77ccdb27777e94ba0375714b2bcd.

Changes:
- adds a configurable bank and seed-vault checklist
- adds patch-location exclusions and side-panel filtering
- fixes Varrock white-tree and Farming Guild redwood classification
- corrects seaweed seed quantities

Validation:
- `./gradlew clean test --no-daemon`