### PR TITLE
add sailing-bad

### DIFF
--- a/plugins/sailing-bad
+++ b/plugins/sailing-bad
@@ -1,2 +1,3 @@
 repository=https://github.com/YonwiPlugins/sailing-bad.git
 commit=6827a9e312a23da08c4a318d55cd47b34dc30567
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/sailing-bad
+++ b/plugins/sailing-bad
@@ -1,0 +1,2 @@
+repository=https://github.com/YonwiPlugins/sailing-bad.git
+commit=6827a9e312a23da08c4a318d55cd47b34dc30567


### PR DESCRIPTION
Adds Sailing Bad, a RuneLite plugin that hides the Sailing tile and shows the original 2277-era total level in the Skills tab.

Its optional community HiScores submission is disabled by default, carries RuneLite's third-party-server warning, and only sends the current character name after the player enables it and clicks the opt-in button.

Source: https://github.com/YonwiPlugins/sailing-bad

Tested with: \\.\\gradlew.bat clean test --no-build-cache --rerun-tasks