### PR TITLE
Add Charged Ring Reminder

### DIFF
--- a/plugins/charged-ring-reminder
+++ b/plugins/charged-ring-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/BNOC/charged-ring-reminder.git
+commit=d81be9296673f187621e03a8646a18c956e87713

--- a/plugins/charged-ring-reminder
+++ b/plugins/charged-ring-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/BNOC/charged-ring-reminder.git
-commit=8e2ea71b3f00c945007049949485d8a4c7a91888
+commit=8f86baf077c52487c58c3c67959a12b6a4f4c705

--- a/plugins/charged-ring-reminder
+++ b/plugins/charged-ring-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/BNOC/charged-ring-reminder.git
-commit=8f86baf077c52487c58c3c67959a12b6a4f4c705
+commit=c3629848444e00a304ba342430d5340007489227

--- a/plugins/charged-ring-reminder
+++ b/plugins/charged-ring-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/BNOC/charged-ring-reminder.git
-commit=d81be9296673f187621e03a8646a18c956e87713
+commit=8e2ea71b3f00c945007049949485d8a4c7a91888


### PR DESCRIPTION
Adds **Charged Ring Reminder**.

Several rings run out of charges and are destroyed mid-activity, and it is easy
to carry on for a while without noticing. This shows an on-screen icon for each
enabled ring that is not currently equipped.

Supported rings, with the item IDs used:

| Ring | Item ID | Charges |
| --- | --- | --- |
| Efaritay's aid | 21140 | 200, vampyric targets only |
| Ring of recoil | 2550 | 40 damage reflected |
| Ring of forging | 2568 | 140 iron smelts |

Every ring is opt-in and **off by default**, so a player who only cares about one
is never told the others are missing. Icons are resolved from the game's item
sprites via `ItemManager`, so no images are bundled. There is one other setting,
an integer scale for the icons.

### Overlap with existing plugins

Flagging this up front rather than leaving it to be found in review.

This started as a fork of [delps1001/recoil-plugin](https://github.com/delps1001/recoil-plugin),
which is already on the hub as `ring-of-recoil-notifier`. There is also
`ring-of-recoil-helper` and `ring-of-forging-helper`. So two of the three rings
here are already covered by published plugins.

What is new is Efaritay's aid, which as far as I can tell nothing on the hub
covers, and consolidating the rings into a single opt-in plugin rather than one
plugin per ring. It also differs from the built-in Item Charges plugin, which
reports charges remaining on an item you are wearing, whereas this fires when
the ring is absent from your equipment entirely.

If maintainers would prefer this narrowed to Efaritay's aid only, or would
rather see it as a contribution upstream to `ring-of-recoil-notifier`, I am
happy to do either.

### Licence

The upstream project is BSD 2-Clause. The original notice and copyright are
retained in `LICENSE`, the overlay retains Devin French's notice in its source
header, and both are reproduced inside the built jar to satisfy clause 2.
