### PR TITLE
Add Golems Don't Die plugin

### DIFF
--- a/plugins/golems-dont-die
+++ b/plugins/golems-dont-die
@@ -1,0 +1,2 @@
+repository=https://github.com/Varzeki/golems-dont-die.git
+commit=656d646bf396a183843715af4867b69ee46b45f0


### PR DESCRIPTION
Makes Wyrmscraig golems persist locally and "live forever" instead of dying after 20 ticks.
You can also name them.

Purely cosmetic.

<img width="1600" height="718" alt="golem-island" src="https://github.com/user-attachments/assets/f71b604f-3252-4541-b485-10caa1f66ad7" />
