### PR TITLE
update dvd-bounce to 1.6

### DIFF
--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=32cde7d853068819d4c227f77d3348bd187e49ef
+commit=d6ea7e203cadcc1794bb7b5ab6e17d41b76703f0

--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=d6ea7e203cadcc1794bb7b5ab6e17d41b76703f0
+commit=7dd8f46bdef406ee9e6f2c7f261082d81a05827f


### PR DESCRIPTION
DVD Bounce 1.6:
The bouncing picture can now be an in-game item sprite, set by item ID and defaulting to the rubber chicken.
A user image file can bounce alongside it or instead of it, and each picture has its own size, opacity, speed and colour shift.
The bundled placeholder image is removed, so the plugin ships no image assets.
An image file that cannot be read now bounces a notice drawn at runtime.

Sorry for the giant change, I added the support for ingame items and transparency/opacity,
And while I was at it decided to have an agent nitpick on it and fixed its complains of the code.   
This resulted in lots of changes of bad code it complained on and changes to reduce cpu load & frametime load. 

Should be final state, unless something breaks or I get a bug report or pull request for a new feature.