### PR TITLE
Add better-object-highlight plugin

### DIFF
--- a/plugins/better-object-highlight
+++ b/plugins/better-object-highlight
@@ -1,0 +1,2 @@
+repository=https://github.com/jakevollkommer/better-object-highlight.git
+commit=89dc79b4fde7a44a183f7a5abe54da9616039b75


### PR DESCRIPTION
Adds [better-object-highlight](https://github.com/jakevollkommer/better-object-highlight): highlight game objects by ID or name with per-style lists (hull, outline, clickbox, tile), preset colors selectable per entry, and an entity hider that removes objects from the scene. Object-side counterpart to better-npc-highlight.