### PR TITLE
Update Unpotted Reminder to 1.0.6

### DIFF
--- a/plugins/unpotted-reminder
+++ b/plugins/unpotted-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/unpotted-reminder.git
-commit=3e04a9b8f3a438261f8dbb384d3f8f8dd1b60df5
+commit=ad8b2a354961e281e1746a2875e14b199abb5b98

--- a/plugins/unpotted-reminder
+++ b/plugins/unpotted-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/AnkouOSRS/unpotted-reminder.git
-commit=ad8b2a354961e281e1746a2875e14b199abb5b98
+commit=63987672aab7e2f1e33af0f955ae631e3afd8363


### PR DESCRIPTION
- Add the option to set custom alert text
- Add the option to replace overlay text with an empty vial icon
- Add an option to replace the overlay with an infobox
- Add support for Ancient brew, Forgotten brew, Armadyl brew, and Divine battlemage potions, and fix magic potion tracking to check all four doses.
- Migrate item lookups off RuneLite's deprecated ItemID class.
- Shorten default alert overlay text