### PR TITLE
Add Station's AFK Button

### DIFF
--- a/plugins/stations-afk-button
+++ b/plugins/stations-afk-button
@@ -1,2 +1,2 @@
 repository=https://github.com/StationEarthxo/Stations-AFK-Button.git
-commit=d5e3b2e6b5a62d5b727f2726f726e5cd3aec6a07
+commit=bd1a2620648f1fa5b1c7d3aa4f1229df0a5b09d1

--- a/plugins/stations-afk-button
+++ b/plugins/stations-afk-button
@@ -1,0 +1,2 @@
+repository=https://github.com/StationEarthxo/Stations-AFK-Button.git
+commit=d5e3b2e6b5a62d5b727f2726f726e5cd3aec6a07


### PR DESCRIPTION
Adds Station's AFK Button, a playful visual reminder for when a sustained skilling action stops.

Features:
- Dims the game and displays a flashing pixel-art emergency button
- Consumes the dismissing click so it cannot accidentally move the player
- Supports verified skilling animations, including Motherlode Mine ore veins
- Includes configurable timing, sounds, dimming, and a preview hotkey
- Bundles a custom 48x48 pixel-art alarm-button icon for Plugin Hub discovery

Testing:
- `gradlew test` passes
- Confirmed in the development client

The plugin does not send game actions, inspect packets, or communicate with external services.