### PR TITLE
Sensum OSRS Companion

### DIFF
--- a/plugins/sensum-osrs-companion
+++ b/plugins/sensum-osrs-companion
@@ -1,0 +1,2 @@
+repository=https://github.com/ADDerallxx/sensum-osrs-companion.git
+commit=d422e6aff57426407136ae916d7b103c7ff3995c


### PR DESCRIPTION
Adds Sensum OSRS Companion to the Plugin Hub.

The plugin is read-only with respect to gameplay and does not automate clicks, movement, menu actions, or any other game action. It can optionally send account progression snapshots to a user-configured HTTPS dashboard endpoint.

Dashboard synchronization is disabled by default. The opt-in configuration carries the required warning that enabling the feature submits the user's IP address to a third-party server not controlled or verified by RuneLite developers.

The referenced plugin commit was built and tested successfully and uses `build=standard`.
