### PR TITLE
Add BlueLog

### DIFF
--- a/plugins/bluelog
+++ b/plugins/bluelog
@@ -1,0 +1,2 @@
+repository=https://github.com/Lanielm/BlueLog.git
+commit=332928728babf8260588d8ec2cb510234e21a3ba


### PR DESCRIPTION
Adds BlueLog, which colours a Collection Log section blue once the only items you are still missing from it are ones you have chosen to ignore — so a section you consider "done" reads as done at a glance.

Repository: https://github.com/Lanielm/BlueLog

- There is an ignore list textbox where ignored items are listed, comma-separated, so it can be edited by hand.
- Unobtained items in the collection log gain a right-click entry, "Ignore item", to add them to the ignore list. There is also a right-click entry to remove them from the list if they are already in it.
- Ignored items get a small blue corner marker (configurable to top-left/top-right/bottom-left/bottom-right).
- Sections where all missing items are ignored turne blue. Green sections do not get recoloured.
- There is a checkbox to ignore all Pets, and another one to ignore all Jars. They are both checked by default. Neither checkbox adds their items to the ignore list textbox, they are tracked separately.
- Implements code from WikiSync and RuneProfile to read the collection log.