### PR TITLE
Add Card Locked plugin

### DIFF
--- a/plugins/card-locked
+++ b/plugins/card-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/Kbeeptest/card-locked.git
-commit=2405e9f4ebe1238cf5e1e32321b11d4c2c64739f
+commit=37b98e09b98b04ad99e7016c362f069714559dcf

--- a/plugins/card-locked
+++ b/plugins/card-locked
@@ -1,2 +1,3 @@
 repository=https://github.com/Kbeeptest/card-locked.git
 commit=448364964ac7b3dfb13670eb944af79c163bdce3
+warning=This plugin downloads its artwork bundle from GitHub. Your IP address and standard HTTP request metadata are sent to GitHub, which is not controlled or verified by the RuneLite developers. No RuneScape account or gameplay data is sent.

--- a/plugins/card-locked
+++ b/plugins/card-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/Kbeeptest/card-locked.git
-commit=37b98e09b98b04ad99e7016c362f069714559dcf
+commit=448364964ac7b3dfb13670eb944af79c163bdce3

--- a/plugins/card-locked
+++ b/plugins/card-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/Kbeeptest/card-locked.git
-commit=816a005f33481f80539de4ba4bc25fe24edd7033
+commit=2405e9f4ebe1238cf5e1e32321b11d4c2c64739f

--- a/plugins/card-locked
+++ b/plugins/card-locked
@@ -1,0 +1,2 @@
+repository=https://github.com/Kbeeptest/card-locked.git
+commit=816a005f33481f80539de4ba4bc25fe24edd7033


### PR DESCRIPTION
Adds Card Locked, a RuneLite plugin that turns OSRS progression into a collectible card based challenge. Players unlock access to tracked items and NPCs by obtaining their corresponding cards through gameplay and card packs.