### PR TITLE
green-log-reorder: bump to a9fc6e9 (v1.1.2)

### DIFF
--- a/plugins/green-log-reorder
+++ b/plugins/green-log-reorder
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/GreenLogReorder.git
-commit=9fa470f9542718652b76a9384af146201583970f
+commit=a9fc6e929ef9e3de0de9ec4a306edeaa19f8cea2


### PR DESCRIPTION
Bumps `green-log-reorder` to a9fc6e929ef9e3de0de9ec4a306edeaa19f8cea2 (v1.1.2).

The plugin's display name changes from **Green Log Reorder** to **Green Reorder** — "Log" undersold it, since the plugin reorders the Combat Achievements boss list as well as the collection log.

This is a display-name-only change. Nothing that identifies the plugin or persists user data moves:

- the manifest filename stays `green-log-reorder`, so this is an update rather than a new plugin;
- `@ConfigGroup` stays `greenlogreorder`, so existing users keep their settings;
- the class stays `GreenLogReorderPlugin`, so the enabled/disabled toggle survives;
- `plugins=com.greenlogreorder.GreenLogReorderPlugin` is unchanged.

Diff against the previous release is 5 lines: the `@PluginDescriptor` name, `displayName`, the version in `runelite-plugin.properties` and `build.gradle`, and the README heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)