### PR TITLE
Update better-clan-broadcasts 1.0.1

### DIFF
--- a/plugins/better-clan-broadcasts
+++ b/plugins/better-clan-broadcasts
@@ -1,2 +1,2 @@
 repository=https://github.com/abristow3/Better-Clan-Broadcasts.git
-commit=ff778193e524e03f652840b984538414229976da
+commit=18f2993cb2f23993452df39affe46e372bb332ce


### PR DESCRIPTION
fixing bug with duplicate icons on clan join and leave messages from chat channel plugin