### PR TITLE
Add NPC Attack Tick Timer

### DIFF
--- a/plugins/npc-attack-tick-timer
+++ b/plugins/npc-attack-tick-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/DillonMartin00/npc-attack-tick-timer.git
+commit=17cda749a358014aee594a49390c623d5f2f3b6c


### PR DESCRIPTION
Adds NPC Attack Tick Timer, a visual attack-cycle timer for ordinary non-boss NPCs.

The plugin displays an NPC's attack cycle using configurable countdown, progress bar, timer circle, NPC hull, and tile indicators. Known attack speeds are sourced from monster data with live animation cadence monitoring/correction for NPC variants and unknown speeds.

The plugin intentionally excludes PvP/player attack timers and protection-prayer recommendations.

To comply with the third-party client guidelines regarding boss attack prediction, the plugin fails closed for restricted content. Bosses, raid bosses/sub-bosses, Slayer bosses, demi-bosses, and wave-based minigame encounters are excluded. NPCs requiring classification are not provided attack-timing information until they pass the plugin's safety classification.

The plugin does not automate actions or interact with combat on behalf of the player.