### PR TITLE
Add Required Materials

### DIFF
--- a/plugins/required-materials
+++ b/plugins/required-materials
@@ -1,2 +1,2 @@
 repository=https://github.com/SchauweM/runelite-required-materials.git
-commit=b65f1f33e7d35d5bfe56063692d90298fa2fb5eb
+commit=2ad57ad30647beca8cbd45f2a4416b0c84c2b1a0

--- a/plugins/required-materials
+++ b/plugins/required-materials
@@ -1,2 +1,2 @@
 repository=https://github.com/SchauweM/runelite-required-materials.git
-commit=dbddefd0fc9eb8c629532c39339ecda1f16ec844
+commit=a60b09e0b5b702c909e4168435b364db1f5cdaad

--- a/plugins/required-materials
+++ b/plugins/required-materials
@@ -1,2 +1,2 @@
 repository=https://github.com/SchauweM/runelite-required-materials.git
-commit=2ad57ad30647beca8cbd45f2a4416b0c84c2b1a0
+commit=dbddefd0fc9eb8c629532c39339ecda1f16ec844

--- a/plugins/required-materials
+++ b/plugins/required-materials
@@ -1,2 +1,2 @@
 repository=https://github.com/SchauweM/runelite-required-materials.git
-commit=3b8266d5271e238583426b4d6f28e8313850a96b
+commit=b65f1f33e7d35d5bfe56063692d90298fa2fb5eb

--- a/plugins/required-materials
+++ b/plugins/required-materials
@@ -1,0 +1,2 @@
+repository=https://github.com/SchauweM/runelite-required-materials.git
+commit=3b8266d5271e238583426b4d6f28e8313850a96b


### PR DESCRIPTION
Adds Required Materials, which tracks the materials and skill levels you still need for Sailing and Construction builds, and can regroup your bank around them.

Repository: https://github.com/SchauweM/runelite-required-materials

- Clicking a build in-game starts tracking it. That works from the Sailing and Construction skill guides (both the old and new layouts), the Boat Customisation interface via Build or Check Materials, and the Furniture Creation menu.
- The side panel lists what you're tracking in a collapsible section per skill, showing each material as `have/need` against your bank and inventory, plus the skill levels the build requires, coloured green once you meet them. Bank contents are remembered between sessions, so the counts are there before you next visit a bank.
- A toggle button in the bank rebuilds the item grid so tracked materials come first, grouped per build with a `have / need` label and a tick or cross. It reuses the bank's own item slots rather than drawing an overlay, so withdrawing behaves normally, and toggling it off restores the bank exactly as it was.

Requirements are read from the OSRS Wiki rather than scraped from the game's interfaces. When you click a build, the plugin fetches that item's wiki page through RuneLite's injected OkHttpClient and parses its `{{Recipe}}` template for the materials and level requirements. Only the page name is sent, results are cached per page for the session, and no user or account data leaves the client. A handful of Construction activities have no `{{Recipe}}` on the wiki; for those it falls back to the material list the game already prints to chat, and the levels shown in the skill guide.

The plugin only reads game state and displays information. It does not automate anything, does not act on the player's behalf, and does not alter what the client sends to Jagex.