### PR TITLE
Update GearForge

### DIFF
--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,2 +1,2 @@
 repository=https://github.com/marcushill13/gearforge.git
-commit=4ea3455a3244c10893d2b141a29febc990488e6d
+commit=d5bb84c669abd557c8f85da8305658c415062f1b

--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,2 +1,2 @@
 repository=https://github.com/marcushill13/gearforge.git
-commit=3e6a3154fbddb83257ff4d1924e07b2a43a89975
+commit=4ea3455a3244c10893d2b141a29febc990488e6d


### PR DESCRIPTION
Updates GearForge to `d5bb84c`. Correctness work on the combat model, from player reports.

**Effects that were modelled but never applied**

- The call that computes DPS dropped the spell, so the elemental tomes and the twinflame staff could not fire however the spell was chosen.
- The powered staff wiring had been lost, so tridents were scored as Ice Barrage casts.
- The twinflame staff needs its spell chosen after the weapon is known: it doubles bolt, blast and wave spells only, so choosing the strongest spell first guaranteed it one it could never double.

**Wrong recommendations**

- A whip was offered for crush setups. Its three attack options are all slash. Weapon categories now carry their real attack styles.
- Thrown weapons were credited with ammo they cannot fire — dragon javelins carry 150 ranged strength, so a rune knife plus a javelin dwarfed every honest setup.
- A blowpipe was scored without its darts; both are weapon-slot items, so the two never met in the search.
- The soulreaper axe is scored at five stacks and says so.
- DPS ties broke on defence alone, preferring Dharok's platelegs over the strictly better oathplate legs. Offence settles a tie first now.
- Melee weapons that cannot reach a target are no longer offered for it.

**One scoring path**

Each tab built its own combat context and they drifted; the reach model, spell selection and target hitpoints only ever reached one of them. All three now share a builder. The Bosses tab is retired — it was the second of those paths, and the BiS tab does the same job with a target selected.

**Also**

- Prayers and boosts are multi-select; the strongest of each applies rather than the sum.
- A style offers its top five setups rather than one.
- Monster list cut to what people fight: bosses and slayer creatures at any level, ordinary monsters from level 50.
- Fights searchable by their own name (Royal Titans, DKs, Gauntlet).

Tests: 230, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)