### PR TITLE
Update clanwars-countdown

### DIFF
--- a/plugins/clanwars-countdown
+++ b/plugins/clanwars-countdown
@@ -1,2 +1,2 @@
 repository=https://github.com/BloodGateRS/Clanwars-Countdown.git
-commit=bffdd0aef2f5ccbac5ff0e0d9ae16a362507e0ae
+commit=8e8092e3704816ed4b27cff5cb5124eef6817ba0


### PR DESCRIPTION
Updates Clanwars Countdown to include the latest timer-start detection fix.

The plugin now recognizes both battle initiation message variants and starts the wall-drop countdown from chat events.

Validation:
- Plugin source at the referenced commit matches the previously published functional update.
- Plugin Hub manifest changes only the pinned commit SHA.
