### PR TITLE
add player-compass

### DIFF
--- a/plugins/player-compass
+++ b/plugins/player-compass
@@ -1,0 +1,2 @@
+repository=https://github.com/BloodGateRS/player-compass.git
+commit=5388dc5ae44151df66d9818d44feba522bdc16f5


### PR DESCRIPTION
Player Compass is a RuneLite plugin that displays a small, static compass above the local player's head.

The compass remains screen-facing with north at the top, east on the right, south at the bottom, and west on the left. Its offset, size, font, colors, and shadow can be configured in RuneLite.