### PR TITLE
add tombs-of-arbitrage

### DIFF
--- a/plugins/tombs-of-arbitrage
+++ b/plugins/tombs-of-arbitrage
@@ -1,2 +1,2 @@
 repository=https://github.com/exisrick/TombsOfArbitrage-RuneLite.git
-commit=23eac1dcbb4e15cd17b692363f64865ac6780396
+commit=6a753f6367e73e7c4cc4007bd8ba85b267d71b42

--- a/plugins/tombs-of-arbitrage
+++ b/plugins/tombs-of-arbitrage
@@ -1,0 +1,2 @@
+repository=https://github.com/exisrick/TombsOfArbitrage-RuneLite.git
+commit=5630857d8bcb11ba11d937cd91be58cad3c9eb6e

--- a/plugins/tombs-of-arbitrage
+++ b/plugins/tombs-of-arbitrage
@@ -1,2 +1,2 @@
 repository=https://github.com/exisrick/TombsOfArbitrage-RuneLite.git
-commit=5630857d8bcb11ba11d937cd91be58cad3c9eb6e
+commit=23eac1dcbb4e15cd17b692363f64865ac6780396


### PR DESCRIPTION
## Summary
- adds Tombs of Arbitrage, a passive Grand Exchange flip journal and advisory companion
- provides local Trade, Ideas, Stats, and recovery views without automating game actions
- keeps optional paired Ideas read-only, user-initiated, and disabled by default

## Test plan
- [x] Public Java 11 CI: 697 tests, check, and build
- [x] Plugin Hub manifest points to the verified public commit