### PR TITLE
Update GearForge

### DIFF
--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,2 +1,2 @@
 repository=https://github.com/marcushill13/gearforge.git
-commit=d5bb84c669abd557c8f85da8305658c415062f1b
+commit=46253562f0f47a93ffa2b4fedcdea07c2c9997ee


### PR DESCRIPTION
Updates GearForge to `4625356`.

**Slayer gear requirements**

Some slayer monsters cannot be fought without a specific item, and the optimiser had no idea. An aberrant spectre needs a nose peg, so the best-scoring helmet in that slot produced a setup the game will not let you equip — not a worse answer, an unusable one.

Monsters that demand gear now have that slot fixed to something acceptable, preferring a slayer helmet over the bare item when both are owned, since it satisfies the requirement and carries stats. Basilisks are handled separately: a slayer helmet does nothing against the gaze, only a mirror shield or V's shield does.

Items that finish a kill rather than filling a slot are stated in the reasoning instead, because the setup has nowhere to show them — a rock hammer for gargoyles, a bag of salt for rockslugs, fungicide for zygomites, an ice cooler for desert lizards, and leaf-bladed weapons for kurask and turoth. If none of the accepted items is owned, the reasoning says the setup cannot be used as it stands.

**Panel layout**

The damage figure on a spec weapon row was pushed off the panel by long weapon names: BorderLayout will not shrink its centre below the centre's minimum and squeezes the east side to nothing instead. The centre can now shrink and the figure's width is reserved.

The two setup buttons sat outside the strip everything else lines up in, running under the scrollbar and reading as stretched and off-centre.

Tests: 235, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)