### PR TITLE
Add osrs-codex plugin

### DIFF
--- a/plugins/osrs-codex
+++ b/plugins/osrs-codex
@@ -1,0 +1,2 @@
+repository=https://github.com/carlosmaguda/osrs-codex.git
+commit=b048464eb311f3f7da6fe8fb2ca0cff2ef4581c3


### PR DESCRIPTION
Codex writes your account state to JSON under `.runelite/codex/`, so you can read it with your own tools.

RuneLite already knows a lot that no single interface shows you at once — which sea charting tasks you have completed, which combat achievements are ticked, which collection log sections are finished. This writes that out.

**What it writes**

- `skills` — real level, boosted level, exact experience
- `quests` — state of every quest the client knows
- `varbits` — every *named* varbit that is not zero, keyed by name rather than number, using the client's own varbit name table (bundled as a resource)
- `inventory`, `equipment`, `bank` — items, with a `placeholder` flag from `getPlaceholderTemplateId()`
- `killCounts` — parsed from the game messages the client already displays
- `freshness` — when each section was last seen, and how to refresh the ones that are not live

**Notes for review**

- It only ever writes local files under `RuneLite.RUNELITE_DIR/codex/`. It opens no ports, makes no network requests and accepts no commands.
- Every call it makes into the client is a getter — no menu actions, no varbit writes, no scripts.
- No reflection, no JNI, no subprocesses, no code downloaded at runtime.
- Disk and JSON work happens on the executor; the client thread is only used to read.
- Sections that only update on an event (bank, shared bank, kill counts) are remembered across restarts and report their age, so stale data is visible as stale rather than passed off as current.
- The raw varp array is available under Advanced and is off by default.

BSD-2-Clause.