### PR TITLE
Add quick-minimise plugin

### DIFF
--- a/plugins/quick-minimise
+++ b/plugins/quick-minimise
@@ -1,0 +1,2 @@
+repository=https://github.com/YonwiPlugins/quick-minimise.git
+commit=13c0475a03ba0d5f4b29b370a32e7c9b0f40ac83


### PR DESCRIPTION
Adds Quick Minimise, a movable and resizable overlay button with an optional hotkey for minimising the RuneLite window.

Both controls are dedicated user inputs. Unlike Click To Minimize, which was disabled in [`1de785b5`](https://github.com/runelite/plugin-hub/commit/1de785b5c51373f4e769354f540fee16efd7377c), this plugin does not listen to `MenuOptionClicked` or any other gameplay events and cannot attach minimisation to an in-game action.

BSD 2-Clause, no third-party dependencies, `build=standard`, and 22 unit tests.