### PR TITLE
log-adviser: bump to f21ce3e

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=6ec4df9b9c18a804ae1ac6d5c07f11f9951aa88a
+commit=f21ce3e78073db67bc4b1b20fd082dba223eb8aa


### PR DESCRIPTION
Bumps log-adviser to v1.3.2. Data-only update — no source changes.

Corrects the aerial fishing (Molch pearl) rates for the Summer Sweep-Up 2026 changes:

- Molch pearl chance raised ~50%, so pearls/hr 32 -> 48
- Fish sack: 1,000 -> 500 pearls
- Angler's outfit pieces: 100 -> 50 pearls each

Build and tests pass locally on JDK 11.