### PR TITLE
update nex-leech-utility

### DIFF
--- a/plugins/nex-leech-utility
+++ b/plugins/nex-leech-utility
@@ -1,2 +1,2 @@
 repository=https://github.com/jakevollkommer/nex-leech-utility.git
-commit=baf77e870f4181fcc711367fd3b5cd42ebb70dc3
+commit=1bb0f46d1ff3384bfebce07fd6b782ad9cfb7739


### PR DESCRIPTION
Follow-up to #12952, which was closed citing the third-party client guidelines (boss-mechanic timing indicators / additional visual indicatorsof a boss mechanic). This update removes the flagged on-screen indicators and ships some other WOL changes

**Removed (per #12952):**
- The on-screen vulnerability countdown (seconds / ticks / HP-to-go) and the "<minion> incoming" pre-announcement
- The blood reaver spawn predictor from #12952 is not included

**Added:**
- "Nex paths": optional overlay painting the open (walkable) tiles outward from Nex until they hit a wall - room collision geometry around her current position, default off. Helps players read which corridors Nex can dash down
- The damage overlay auto-hides a configurable number of seconds after the kill ends (default 5 minutes; 0 = keep it until the next kill)
- The thrall hider now also hides cosmetic thrall skins (league imp and Deadman variants)
- "Disable entry off mass worlds": optional; de-prioritizes left-click entry through the Nex fight barrier unless the current world is in a user-configured list (default 332), so a misclick can't start a fight on a normal world. Right-click still enters.