### PR TITLE
Add Daily CA Picker

### DIFF
--- a/plugins/daily-ca-picker
+++ b/plugins/daily-ca-picker
@@ -1,0 +1,2 @@
+repository=https://github.com/NickTechRepo/daily-ca-picker.git
+commit=87b4739a52db5beccf2632ae4b4f0f120d712dfc


### PR DESCRIPTION
Adds **Daily CA Picker**, a local-only daily Combat Achievement recommendation plugin.

### What it does
- deterministically selects one unfinished CA per account/day
- supports configurable current and goal tiers
- uses combat stats and coarse locally observed equipment/bank capability
- excludes completed, above-goal, and heuristically infeasible tasks
- refreshes at date rollover with no same-day reroll

### Safety and privacy
- no gameplay automation
- no background networking or telemetry
- no account, bank, equipment, stat, or CA data leaves RuneLite
- only an explicit user click can open a strictly allowlisted official OSRS Wiki HTTPS URL
- persists only coarse profile-scoped melee/ranged/magic capability scores and bank-scan state

### Verification
- Java 11 clean test/build: 38 tests, 0 failures
- Plugin Hub standard replacement package passed against RuneLite 1.12.35
- development-client startup smoke test passed against RuneLite 1.12.36
- independent model/lifecycle/security reviews passed

This is intentionally narrower than full CA helper/tracker plugins: it provides one progression-aware daily recommendation and no encounter overlays, automation, or tracking dashboard.