### PR TITLE
Add Morty's Ledger

### DIFF
--- a/plugins/mortys-ledger
+++ b/plugins/mortys-ledger
@@ -1,0 +1,2 @@
+repository=https://github.com/ruffensteint/Mortys-Ledger.git
+commit=4627b074975a10ff1e36d3fe1a3ee9bb3df14a6d


### PR DESCRIPTION
## Plugin summary

Morty's Ledger records Mortimer Slayer assignments, task history, Slayer XP, superior and clue drops, and user-selected gear notes in a RuneLite side panel.

Optional third-party features are disabled by default. Users may opt in to OSRS Wiki thumbnails or anonymous Discord webhook announcements after accepting RuneLite's third-party warning. The plugin does not transmit the player's character name.

## Validation

- Built with Java 11 against `latest.release`
- `./gradlew clean test build`
- 20 tests passed
- Verified in game by the plugin author
