### PR TITLE
Update corp-boosting-qol

### DIFF
--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/pet-boosting-qol.git
-commit=2b4494d27f05ba3004085fd5313be999944b11bb
+commit=4bdf218658f596269a9e7831d33814aa24f8ca82


### PR DESCRIPTION
Added Scorpia support: movement lock, prayer regeneration indicator, low prayer indicator, poison indicator, and special attack indicator — each with independent icon/overlay toggles matching the existing per-boss pattern.

Added a low HP threshold alert for Kalphite Queen, with its own icon/overlay/color toggles.

Added a "Low CPU mode" toggle that makes the fullscreen alert overlays blink instead of drawing solid every frame, cutting their average rendering cost roughly in half.

Added rendering caching for the alert and warning overlays (cached rect fills, cached scaled icons, cached warning box background) to reduce per-frame CPU cost.