### PR TITLE
Update Trouble Brewing Highlighter to 1.4.0

### DIFF
--- a/plugins/trouble-brewing-highlighter
+++ b/plugins/trouble-brewing-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/trouble-brewing-highlighter.git
-commit=e6d37462b2b27568aae4053cdfc8c7b0087fb460
+commit=8cb581b02edd30299c5677b4d483fd3ba35ab6ce


### PR DESCRIPTION
Updates Trouble Brewing Highlighter to version 1.4.0.

Highlights:
- Adds an optional, movable Brew Status overlay with remaining supply targets, production state and context-aware boiler guidance.
- Adds station and inventory quantity guidance, including boiler fuel/tinderbox prompts.
- Adds local-team, cross-floor fire and damage alerts with structure-specific repair guidance and a 3 → 2 → 1 repair countdown.
- Retains Pieces of Eight totals and in-match expected totals, monkey dialogue guidance, Join-crew prioritisation, configurable flashing and colour-coded routes.
- Removes ground-item highlighting and updates documentation and tests.

The plugin remains passive: it does not automate interactions, inject input, access the network or read/write files. It targets Java 11 and uses RuneLite gameval constants.

Manually tested in active Trouble Brewing matches across both teams and floors, including inventory/station guidance, overlays, fire detection and multi-stage repairs.