### PR TITLE
bank-skill-sorting: bump to 68e7b41c

### DIFF
--- a/plugins/bank-skill-sorting
+++ b/plugins/bank-skill-sorting
@@ -1,2 +1,2 @@
 repository=https://github.com/Frailrain/Bank-Skill-Sorting.git
-commit=bd224101a3fa7b2764bb6e77ed3aa842dad1ae15
+commit=68e7b41c0a9889a8384beb74888602ed6b66f423


### PR DESCRIPTION
Bumps bank-skill-sorting to 68e7b41c. Ships three bug fixes:

- **#5 — chunk-load stutter (#9 from @v-t-r-gg):** `onWidgetClosed(BANKMAIN)` was firing on every scene unload (the cached bank widget group is torn down at load lines even when the bank is closed), rebuilding all 22 skill-tab layouts on the client thread — a multi-frame hitch on every region load. Now gated on a `bankInterfaceOpen` flag set by `WidgetLoaded(BANKMAIN)` and cleared on `LOADING`/`HOPPING`/`LOGIN_SCREEN`.
- **#6 — user-tag collision (herb tag clobber):** a user's manually-created "herb" bank tag was being written to when the plugin seeded a bare "herblore" tab (Bank Tags standardization collapses both). Every install now auto-migrates to the `(auto)` suffix scheme at startup, so plugin tabs can never share a bare name with a user tag.
- **#7 — trimmed Amulet of Glory missing from combat tabs:** clue-reward Amulet of Glory charge variants (t/t1-t5) share base id 1704 with the untrimmed family via ItemVariationMapping; the combat tab item lists relied on that base-expansion, which silently under-tagged the trimmed variants. Trimmed ids 10360, 10358, 10356, 11966, 11964 are now enumerated explicitly in Melee/Range/Mage Neck sections.

Build + tests pass locally on JDK 11. Manually verified the stutter fix in a dev client against a live account before merging.

The plugin remains passive: no automation, no network access, no file I/O outside the RuneLite config dirs it already uses.
