### PR TITLE
lootlette 1.0.12

### DIFF
--- a/plugins/lootlette
+++ b/plugins/lootlette
@@ -1,2 +1,2 @@
 repository=https://github.com/Diogo-G-Dias/lootlette.git
-commit=2680007fd0a1edc087734be27243b073a208bf7b
+commit=1ba5a2fd8686ab62551a7e9c9908d33ec9335100


### PR DESCRIPTION
Three fixes.

**"Cha-ching" firing on ordinary coin drops at the God Wars Dungeon.** Every GWD minion's wiki page files its large Coins drop under the same "Unique" header as the god-item pieces, so `Coins` was being scraped into twelve minions' tagged unique sets and triggering the unique-drop sound on every coin drop. Blocklisted in the build-time unique scraper, the same way Phantom Muspah's Ancient essence was in 1.0.10.

**The Gauntlet and Corrupted Gauntlet had no drop table at all.** Their loot is credited to the Hunllef, but the wiki keeps both difficulties' tables on the shared Reward Chest (The Gauntlet) page, which nothing looked up. The reel fell back to "drops seen this session", so armour seeds, enhanced seeds, Youngllef and dragon halberds never appeared while rolling. The scraper now reads each drop line's section anchor and files the Regular and Corrupted sections under Crystalline Hunllef and Corrupted Hunllef.

**A kill that drops nothing free-spun until the timeout.** No loot event is posted at all for an empty drop, so it's now inferred from the absence of one: a two-tick deadline armed when the corpse despawns (twelve ticks for the Nightmare, Duke Sucellus and the Swamp wallbeast, whose loot is deliberately delayed) lands the reel on "Nothing".

Also: the reel count no longer spoils a unique before the reel stops. A wiki drop table is several sub-tables each rolled its own number of times, so a kill spins the sum of those roll counts rather than only the largest one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrVBnerBY2WpvKcEBstHGG