### PR TITLE
Add Bank Item Value plugin

### DIFF
--- a/plugins/bank-item-value
+++ b/plugins/bank-item-value
@@ -1,0 +1,2 @@
+repository=https://github.com/zachgodsell93/osrs-bank-item-value.git
+commit=720ef026964a5e3fa519a1a9e478ffaa641983f8


### PR DESCRIPTION
Adds the Bank Item Value plugin.

Repository: https://github.com/zachgodsell93/osrs-bank-item-value

The plugin overlays each bank item with its value and applies colour-coded highlighting by configurable value tiers. It supports GE and high-alch price sources, several text positions, and value formats. Prices come from RuneLite's built-in ItemManager; the plugin makes no external HTTP calls.

It differs from existing bank value plugins by rendering per-item value text and tier-based colour highlighting directly on bank slots, rather than showing a total or tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)