### PR TITLE
Add gielinor-guide

### DIFF
--- a/plugins/gielinor-guide
+++ b/plugins/gielinor-guide
@@ -1,2 +1,3 @@
 repository=https://github.com/3Dendeavors/gielinor-guide.git
 commit=a8296558f60b85c059e66b063b7a65318b4edc89
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/gielinor-guide
+++ b/plugins/gielinor-guide
@@ -1,2 +1,2 @@
 repository=https://github.com/3Dendeavors/gielinor-guide.git
-commit=340525ac830bf7a46727809dd08de43ff86a4786
+commit=a8296558f60b85c059e66b063b7a65318b4edc89

--- a/plugins/gielinor-guide
+++ b/plugins/gielinor-guide
@@ -1,2 +1,2 @@
 repository=https://github.com/3Dendeavors/gielinor-guide.git
-commit=14d1c99817b23ff728c64ad0ce96435bf6a5f86b
+commit=340525ac830bf7a46727809dd08de43ff86a4786

--- a/plugins/gielinor-guide
+++ b/plugins/gielinor-guide
@@ -1,0 +1,2 @@
+repository=https://github.com/3Dendeavors/gielinor-guide.git
+commit=14d1c99817b23ff728c64ad0ce96435bf6a5f86b


### PR DESCRIPTION
## Summary

Adds Gielinor Guide, a conversational OSRS guide in the RuneLite side panel.

- Grounds answers in retrieved OSRS Wiki excerpts.
- Uses only locally reviewed or independently Wiki-verified map destinations.
- Offers optional integration with already-enabled Shortest Path and Quest Helper plugins.
- Does not automate gameplay, click, move, interact with menus, or enable/configure other plugins.

## External requests and privacy

External requests and every player-context category are disabled by default. The enabling configuration displays a third-party warning that identifies the OSRS Wiki and OpenAI and describes the transmitted data. Context categories are separately opt-in, the OpenAI API key uses RuneLite's secret configuration field, requests use `store: false`, and the plugin does not read or transmit chat, the account name, or credentials.

## Validation

- `gradlew.bat clean check`
- Secret scan included in `check`
- Live OSRS Wiki catalog check covering 96 canonical pages
- Live acquisition, item-purpose, comparison, quest-requirement, and Slayer grounding checks
- Java 11 release target and `build=standard`
