### PR TITLE
Add boss-fight-log

### DIFF
--- a/plugins/boss-fight-log
+++ b/plugins/boss-fight-log
@@ -1,0 +1,2 @@
+repository=https://github.com/Drypt0/boss-fight-log.git
+commit=5f3122fac3fc8f4108577b194f43c03c4eac3e3f

--- a/plugins/boss-fight-log
+++ b/plugins/boss-fight-log
@@ -1,2 +1,2 @@
 repository=https://github.com/Drypt0/boss-fight-log.git
-commit=e9df265317b6aa3b3a2d0456c64dbab49a4d96cb
+commit=5a8de7546617c874e5d8a0d7901c24487077795c

--- a/plugins/boss-fight-log
+++ b/plugins/boss-fight-log
@@ -1,2 +1,2 @@
 repository=https://github.com/Drypt0/boss-fight-log.git
-commit=5f3122fac3fc8f4108577b194f43c03c4eac3e3f
+commit=e9df265317b6aa3b3a2d0456c64dbab49a4d96cb


### PR DESCRIPTION
**Boss Fight Log** - a side panel that keeps a per-kill record of your boss fights.

Where the Loot Tracker shows you what you got, Boss Fight Log shows you how you did: kill time, DPS, damage taken and accuracy for every kill, with each kill compared against your own previous kills of the same boss.

Two views. All kills lists every fight, most recent first. By boss collapses to one row per boss with its averages and best time, expanding to show the kills behind it. Above both sits a summary of totals — average and best DPS, average and best kill time, damage dealt and taken, accuracy and kill count.

Scope: panel-only and post-kill. It draws nothing in the game world, has no overlay, and surfaces nothing while a fight is in progress - a kill appears only once it has already resolved. Every figure comes from the player's own hitsplats; it never counts or displays the boss's attacks, phases or timings.

<img width="230" height="559" alt="image" src="https://github.com/user-attachments/assets/4b6482b8-34fe-4112-adcb-773f6e7dd6f3" />
