### PR TITLE
Update Trouble Brewing Highlighter to 1.4.1

### DIFF
--- a/plugins/trouble-brewing-highlighter
+++ b/plugins/trouble-brewing-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/trouble-brewing-highlighter.git
-commit=8cb581b02edd30299c5677b4d483fd3ba35ab6ce
+commit=b1a0a4a87270a8aa2ce2d457a84b767db1523edb

--- a/plugins/trouble-brewing-highlighter
+++ b/plugins/trouble-brewing-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/trouble-brewing-highlighter.git
-commit=b1a0a4a87270a8aa2ce2d457a84b767db1523edb
+commit=6ac8ab14b9e4aaa2ced7aebc7031ad79ed8ce7ea


### PR DESCRIPTION
Updates Trouble Brewing Highlighter from 1.4.0 to 1.4.1.

Changes:
- Makes remaining-rum and supply targets time-aware, including active brew cycles and a five-second collection/deposit buffer.
- Uses the same remaining-run targets in the Brew Status panel, upstairs station labels and inventory badges.
- Shows bitternut totals on inventory monkeys while preserving their route colours.
- Hides a usable sweetgrub mound highlight while its nearby swarm is active and restores it after the swarm despawns.
- Updates version metadata, README documentation and focused unit coverage.

In-game verification completed in a fresh development-client session: Swarm suppression/restoration, plain-monkey bitternut counts and the conservative remaining-rum estimate all passed.