### PR TITLE
Update traducao-osrs-br for remote translations

### DIFF
--- a/plugins/traducao-osrs-br
+++ b/plugins/traducao-osrs-br
@@ -1,2 +1,2 @@
 repository=https://github.com/walterrezende12-tech/Traducao-OSRS-BR.git
-commit=892ad133739b29a8db5bc7ff4c1b8789325c2297
+commit=6fa00a56352e98d88fd15125945640d256663411

--- a/plugins/traducao-osrs-br
+++ b/plugins/traducao-osrs-br
@@ -1,2 +1,2 @@
 repository=https://github.com/walterrezende12-tech/Traducao-OSRS-BR.git
-commit=40115ca7942ffd1ffededbfa01d19d99c5e87db3
+commit=892ad133739b29a8db5bc7ff4c1b8789325c2297

--- a/plugins/traducao-osrs-br
+++ b/plugins/traducao-osrs-br
@@ -1,2 +1,2 @@
 repository=https://github.com/walterrezende12-tech/Traducao-OSRS-BR.git
-commit=f500eae92fff76b9abc57e9cb3fdbf89af9050da
+commit=40115ca7942ffd1ffededbfa01d19d99c5e87db3


### PR DESCRIPTION
## Summary
- update the plugin to load versioned translation dictionaries from a HTTPS manifest
- add language selection and PT-BR/Spanish configuration localization
- preserve the last valid cached translation release when remote updates fail
- remove bundled translation JSON files from the plugin artifact
- include only the translation runtime; no collector code is published

## Validation
- ran `.\gradlew.bat clean build jar` successfully in the public release repository
- inspected the generated JAR: 54,621 bytes and no collector classes/resources
- checked source and bytecode for reflection and disallowed APIs
- verified the public repository master points to `40115ca7942ffd1ffededbfa01d19d99c5e87db3`
- Plugin Hub diff changes only `plugins/traducao-osrs-br`