### PR TITLE
Add Character Stats plugin

### DIFF
--- a/plugins/character-stats
+++ b/plugins/character-stats
@@ -1,0 +1,2 @@
+repository=https://github.com/tailored-data/OSRSCharacterStatsDisplays.git
+commit=ee3c14f287d5739a188e679cdb92b7b18eabaa9d


### PR DESCRIPTION
Adds a sidebar plugin for displaying character stats, providing quick access to stat information without needing to open the standard Worn Equipment inventory section. Settings for this plugin are available and can customized to the user's preference.

EDIT: I have included images in this edit to provide an idea of what this looks like in real-time.

<img width="225" height="597" alt="panel_unpopulated" src="https://github.com/user-attachments/assets/6a4d36f7-2a8b-483c-ab5d-7389b3392768" />
<img width="225" height="615" alt="panel_populated" src="https://github.com/user-attachments/assets/f45ceeb4-ac1b-41e3-90d9-fb3d816019f7" />
<img width="471" height="621" alt="full_populated" src="https://github.com/user-attachments/assets/405d30f8-23d2-41fa-97cf-2a520db169ac" />
