### PR TITLE
Add Zeah RC Helper plugin

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/JamsRepos/zeah-rc-helper.git
+commit=fc0d4cbf55b9dc17bbe6787333c6c556b8386f16


### PR DESCRIPTION
## Summary
- Adds **Zeah RC Helper**, a click-here rotation guide for Arceuus blood and soul runecrafting
- Highlights the next runestone, agility shortcut, or altar; draws floor paths using qualified shortcuts; shows a status panel
- Includes abyssal lantern, blood essence, and idle reminders
- Declares a conflict with Easy Arceuus Runecrafting
- Uses `build=standard` in `runelite-plugin.properties`

## Test plan
- [ ] Plugin Hub CI build passes
- [ ] Enable plugin in dev client at dense essence mine and verify runestone highlighting swaps on depletion
- [ ] Walk Dark Altar → mine and Blood/Soul altar routes; confirm path and shortcut highlights
- [ ] Confirm lantern / blood essence reminders fire as expected
- [ ] Confirm plugin cannot be enabled alongside Easy Arceuus Runecrafting