### PR TITLE
Fix duplicate Nexling pet tracking

### DIFF
--- a/plugins/nex-loot-tracker
+++ b/plugins/nex-loot-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/JJDeakins1/nex-loot-tracker.git
-commit=5ee31300b09de64049ad74f90c749e13aa588bc2
+commit=0021470e535fde748995eb5196ffa8d5a6df7828


### PR DESCRIPTION
Recognize duplicate-pet and untradeable Nexling chat messages so post-kill region changes do not discard the drop.