### PR TITLE
Add lazybones

### DIFF
--- a/plugins/lazybones
+++ b/plugins/lazybones
@@ -1,0 +1,3 @@
+repository=https://github.com/Mitchole/lazybones.git
+commit=f3f8318e9ffe2164ce768afd0f323daba556c994
+authors=Mitchole


### PR DESCRIPTION
LazyBones adds quality-of-life helpers for all four Mage Training Arena rooms: click counts and cast prompts in the Creature Graveyard, free-item marking in the Alchemist's Playground, and bonus-shape tracking in the Enchanting Chamber.
It is built to run alongside the core Mage Training Arena plugin and never draws over anything that plugin shows.
Source: https://github.com/Mitchole/lazybones