### PR TITLE
Add No GE Inventory Blink plugin

### DIFF
--- a/plugins/no-ge-inventory-blink
+++ b/plugins/no-ge-inventory-blink
@@ -1,2 +1,2 @@
 repository=https://github.com/osrshool222/no-ge-inventory-blink.git
-commit=2c1bba1e1a70e297b6235f999560e40d09ff6672
+commit=4d33a85fc639aa4418a4c9f13437d48d4ff46561

--- a/plugins/no-ge-inventory-blink
+++ b/plugins/no-ge-inventory-blink
@@ -1,0 +1,2 @@
+repository=https://github.com/osrshool222/no-ge-inventory-blink.git
+commit=2c1bba1e1a70e297b6235f999560e40d09ff6672

--- a/plugins/no-ge-inventory-blink
+++ b/plugins/no-ge-inventory-blink
@@ -1,2 +1,2 @@
 repository=https://github.com/osrshool222/no-ge-inventory-blink.git
-commit=4d33a85fc639aa4418a4c9f13437d48d4ff46561
+commit=e460d9b9e1ada3027542b81832f04a35adadcc9c


### PR DESCRIPTION
Adds the 
o-ge-inventory-blink RuneLite plugin which stops the inventory from blinking/flashing while the Grand Exchange window is open. It does this by hiding the pulsing GE glow (GeOffersSide.GLOW) while the GE window is open.