### PR TITLE
Add No GE Inventory Blink plugin

### DIFF
--- a/plugins/no-ge-inventory-blink
+++ b/plugins/no-ge-inventory-blink
@@ -1,2 +1,2 @@
 repository=https://github.com/osrshool222/no-ge-inventory-blink.git
-commit=00c854a87750ad1bfbd8f855310d09d47df3693c
+commit=4d50fb809843941697b0a30d92576b23339d6d75

--- a/plugins/no-ge-inventory-blink
+++ b/plugins/no-ge-inventory-blink
@@ -1,0 +1,2 @@
+repository=https://github.com/osrshool222/no-ge-inventory-blink.git
+commit=00c854a87750ad1bfbd8f855310d09d47df3693c


### PR DESCRIPTION
Adds the **No GE Inventory Blink** plugin, which stops the inventory from blinking/flashing (yellow pulse) while the Grand Exchange window is open.

It works by hiding the pulsing yellow glow component (GeOffersSide.GLOW) around the inventory grid in the GE window, and keeps the main inventory item layer fully opaque as a safety net. It does not interfere with clicking, dragging, or hovering items.