### PR TITLE
update ironkin clan plugin

### DIFF
--- a/plugins/ironkin-clan-plugin
+++ b/plugins/ironkin-clan-plugin
@@ -1,2 +1,2 @@
 repository=https://github.com/garryhuang1/ironkin-clan-plugin.git
-commit=9d9b3155ec928d4db91f91e82afd4300ca7490a7
+commit=a5f3003697fb7551df22258aaac5c97be1f006ed


### PR DESCRIPTION
Updates ironkin clan plugin with the following changes

- Removed bingo ID from config in favor of a generic event list returned from API
- Refactors submissions to use an updated event entry submission
- Refactors code base + added unit testing
- Adds overlay for clan event passwords to verify screenshot submissions
- Adds logic for 'pvm-entry' items, which require a certain number of clan mates to be present.