### PR TITLE
Add Injury Animations

### DIFF
--- a/plugins/injury-animations
+++ b/plugins/injury-animations
@@ -1,0 +1,2 @@
+repository=https://github.com/xyg123/injury-animations.git
+commit=846219052fbd0973ec66c2a244ef9763e2b07a66


### PR DESCRIPTION
Adds Injury Animations, a local cosmetic plugin that changes the local
player's movement animations when their hitpoints fall below a configurable
threshold.

Features:
- Configurable injured HP threshold
- Injured walk, run, and idle animation replacements
- Restores original animations while actions are active
- Restores original animations after healing, logout, player changes,
  plugin disable, and shutdown
- Optional local-player injury outline

The plugin does not inject input, send server actions, use networking, or
predict combat behaviour.

Tested manually in the RuneLite development client with multiple weapon and
shield configurations. The Gradle test suite contains 25 passing tests.