### PR TITLE
Update Kill Clog to 2.0.1

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=2496ad195e9a639fa5be83d1bf5ff7d053351eb1
+commit=afc574ac78838fc28456dd99fe1c892c5649d66b
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill Clog 2.0.1

* adds a list view for the boss grid, switched from the hamburger menu
* adds an off switch for chat emojis
* the chat message toggle now covers sync results and warnings too; setup guidance stays on, since a muted user can't know they muted it
* fixes pb lines for turkish locale clients
* fixes the show rank setting in compare mode
* aligns hub search tags with the client search