### PR TITLE
Add Clue Case Opening

### DIFF
--- a/plugins/clue-case-opening
+++ b/plugins/clue-case-opening
@@ -1,0 +1,2 @@
+repository=https://github.com/Ed-joe/CaseOpeningPluginOSRS.git
+commit=4d9b366dccf5064945062a32de602fd9fb4927d5

--- a/plugins/clue-case-opening
+++ b/plugins/clue-case-opening
@@ -1,2 +1,2 @@
 repository=https://github.com/Ed-joe/CaseOpeningPluginOSRS.git
-commit=4d9b366dccf5064945062a32de602fd9fb4927d5
+commit=6a557f739cc7cbfcc1ef1fe6e1ed2c49d7478cbb

--- a/plugins/clue-case-opening
+++ b/plugins/clue-case-opening
@@ -1,2 +1,2 @@
 repository=https://github.com/Ed-joe/CaseOpeningPluginOSRS.git
-commit=6a557f739cc7cbfcc1ef1fe6e1ed2c49d7478cbb
+commit=d6431682f1510ad5f8f73a32980c7f8f4564b6ac


### PR DESCRIPTION
Adds Clue Case Opening, a cosmetic reward-reveal animation for clue caskets.

The plugin:
- Activates from the normal clue-casket Open interaction.
- Reads the actual rewards from the standard trail reward interface.
- Displays a cosmetic case-opening reel without changing game actions or rewards.
- Uses bundled clue loot data for realistic teaser rewards.
- Supports configurable clue tiers, sound effects, and skip/close controls.


https://github.com/user-attachments/assets/4e8062f3-b94a-4b2d-9627-e73a878fa4e4


