### PR TITLE
Update Poison Dynamite

### DIFF
--- a/plugins/poison-dynamite
+++ b/plugins/poison-dynamite
@@ -1,2 +1,2 @@
 repository=https://github.com/yonnski/poison-dynamite.git
-commit=6207fc16fa13b0ef81fcecfbe508ba95d016ca81
+commit=6a1325588b471e35cb19b0f6f93a35493065e073

--- a/plugins/poison-dynamite
+++ b/plugins/poison-dynamite
@@ -1,2 +1,2 @@
-repository=https://github.com/itskolja/poison-dynamite.git
-commit=25713577bb8b33dca955a5b0a349fde123559640
+repository=https://github.com/yonnski/poison-dynamite.git
+commit=6207fc16fa13b0ef81fcecfbe508ba95d016ca81

--- a/plugins/poison-dynamite
+++ b/plugins/poison-dynamite
@@ -1,2 +1,2 @@
 repository=https://github.com/yonnski/poison-dynamite.git
-commit=6a1325588b471e35cb19b0f6f93a35493065e073
+commit=b4f5e5223fa9767cf68acea6fad2a84b759b325c


### PR DESCRIPTION
Changes since the previous pin:
- Multiple concurrent poison timers (one per NPC), with cleanup on despawn/death and stale-attempt timeouts
- Attack style resolved from the selected combat stance, including stance and prayer accuracy bonuses
- Poison immunity shown from wiki data; fixed wiki stats parsing and added retry with backoff
- New config toggles (info panel, dynamite count, session stats, proc notification) and unit tests