### PR TITLE
Add Wilderness Loadouts

### DIFF
--- a/plugins/wilderness-loadouts
+++ b/plugins/wilderness-loadouts
@@ -1,0 +1,2 @@
+repository=https://github.com/DenisSa/wilderness-loadouts.git
+commit=f65b66da2d642e82bc61d6c108369163b01862db


### PR DESCRIPTION
Adds Wilderness Loadouts, a defensive gear optimizer that builds Wilderness loadouts only from items physically present in the player's bank, inventory, or equipped gear.

- Optimizes Magic, Overall, Ranged, or Melee Defence under a configurable replacement-risk budget.
- Supports 0, 1, 3, or 4 protected/core items and Auto, Locked, or Empty slot states.
- Accounts for market prices, source-validated reclaim values, and current Trouver repair costs.
- Provides a toggleable virtual Bank Tags layout without moving real bank positions.
- Uses `build=standard` with no additional runtime dependencies or runtime network requests.

Validation:
- `./gradlew build`: 34 tests passed.
- Manually tested in RuneLite using the Jagex Launcher.
- Generated replacement-value tables validate against cited Jagex, RuneLite, and OSRS Wiki sources.

AI disclosure: Development used OpenAI Codex for implementation assistance. The author directed the design and manually tested the plugin in RuneLite; the repository includes automated tests and reproducible, source-validated pricing generators.