### PR TITLE
Update aerial-fishing v1.0.4

### DIFF
--- a/plugins/aerial-fishing
+++ b/plugins/aerial-fishing
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/runelite-plugins.git
-commit=cca83b98a8d8d1b23b6a1b86a37c2e3288ced023
+commit=c4bddef2f933f0bdf410c383116feb90477b4c4f


### PR DESCRIPTION
- Allow multiple frenzied spots to be tracked instead of one