### PR TITLE
add slayer-companion

### DIFF
--- a/plugins/slayer-companion
+++ b/plugins/slayer-companion
@@ -1,0 +1,2 @@
+repository=https://github.com/kolobocode/slayer-companion.git
+commit=694b6d7649ac1d3483a6103352574e4c86b9403c


### PR DESCRIPTION
Adds Slayer Companion.

An information plugin: it reads the assigned Slayer task from the game varps and DB tables, scores every item in the players own bank to work out the best setup for that specific monster, and checks the inventory against that plan before leaving the bank. It also hands a chosen fighting spot to the Shortest Path plugin.

No automation: it never clicks, never sends input, and only reads and displays.