### PR TITLE
Add Newer Style HitSplats

### DIFF
--- a/plugins/newer-style-hitsplats
+++ b/plugins/newer-style-hitsplats
@@ -1,0 +1,2 @@
+repository=https://github.com/stadtehrsoftware/newer-style-hitsplats.git
+commit=1406318b6aed93486ca100da461552f97b39f413


### PR DESCRIPTION
## New plugin: Newer Style HitSplats

Newer Style HitSplats is a cosmetic, client-side plugin that redraws native circular hitsplats in a compact 2010-inspired rectangular style.

### Features

- Context-aware Attack, Strength, Defence, Ranged, and Magic icons.
- Direct spellbook casts are detected as Magic independently of the equipped weapon style.
- Combined icons for Controlled, Longrange, and Defensive Casting.
- Antipoison and Anti-venom item icons for poison and venom hitsplats.
- Matching treatment for healing, prayer drain, burn, bleed, disease, and other special hitsplats.
- Configurable visibility, scale, opacity, smooth fading, and optional x10 damage numbers.

The plugin performs no network requests, file I/O, input automation, or game-state modification and has no third-party production dependencies.

### Testing

- Six automated tests pass with Java 11.
- The plugin launches successfully in the RuneLite development client.

Although the Hub contains broader hitsplat-customization plugins, this submission is intentionally focused on a fixed newer-era visual style with combat-style-aware multi-icon hitsplats and poison/venom potion indicators.