### PR TITLE
Update Zeah RC Helper to 1.0.1

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=fc0d4cbf55b9dc17bbe6787333c6c556b8386f16
+commit=070dcc25deea3271842c5075388f696bd98e8fc2

--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=070dcc25deea3271842c5075388f696bd98e8fc2
+commit=5a4b321c366d9f2a3b2a50ff228026808ae87453


### PR DESCRIPTION
## Summary
- Updates Zeah RC Helper to `070dcc25deea3271842c5075388f696bd98e8fc2` (v1.0.1)
- Fixes blood altar pathing, auto blood-essence charge tracking, jeweller's chisel recognition
- Bundles chisel/pickaxe/lantern under a single Gear reminders toggle

## Test plan
- [ ] Plugin Hub CI build passes
- [ ] Install updated plugin and verify gear reminders / blood path / essence charges
