### PR TITLE
Update DropTracker to v6.0

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=45c6bc0f252509dc799fb39877cc030ed645c555
+commit=87d66f3fc93bcc451cf5a6f6cdf59bdb5f74e77e
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
### Features:
- Clan-broadcast relay: two-way discord chat comms + the ability to track drops from non-plugin users, when they appear in clan chat messages.
- Deep sea trawling tracking: chat parsing for attributing loot
- Account progression sync — state synchronization with the backend, allowing for collection log unlocks, combat achievement progress, and a 3D rendered model of the player's gear to be attached to submissions for personal bests and etc. 
### Fixes:
- Raid participants: sends raid-party evidence (not just the roster) for split verification; solo raids no longer read as failed roster captures.
- Deaths: fix killer attribution, region naming, and safe-death flagging.
- PB correctness — a ToB room split can never be submitted as the raid time (fight time at Verzik occasionally overrode player's actual PB)
- Hardened player IDs: prevent a few cases where null player names could be transmitted with a submission
- Screenshots taken at Nightmare/Phosani's Nightmare are now held one game tick so loot renders ([#48](https://github.com/joelhalen/droptracker-plugin/issues/48))
- Side-panel symbols drawn manually to fix MacOS rendering issues
- Config panel condensed from fifteen sections to four (old keys migrated, with the old retired toggles still honored)

- Added attribution for leveraged projects
  <details>
  <summary>View attributed repositories</summary>

  - [TrackScape](https://github.com/fatfingers23/trackscape-connector-plugin) (@fatfingers23) - Discord clan chat sync
  - [RuneProfile](https://github.com/ReinhardtR/runeprofile-plugin) (@ReinhardtR) - 3D models of characters
  - [WikiSync](https://github.com/weirdgloop/WikiSync) (@andmcadams) - Collection log scraping method
  </details>
