### PR TITLE
quest-state-exporter

### DIFF
--- a/plugins/quest-state-exporter
+++ b/plugins/quest-state-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/iamthecodeDECODEDORG/runelite-quest-state-exporter.git
-commit=7cba08d55d167460a2631f5e2262da2656280d9e
+commit=bb21746a7f2093f62eeef876428068f5c0f44ea6

--- a/plugins/quest-state-exporter
+++ b/plugins/quest-state-exporter
@@ -1,2 +1,3 @@
 repository=https://github.com/iamthecodeDECODEDORG/runelite-quest-state-exporter.git
 commit=bb21746a7f2093f62eeef876428068f5c0f44ea6
+authors=iamthecodeDECODED

--- a/plugins/quest-state-exporter
+++ b/plugins/quest-state-exporter
@@ -1,0 +1,2 @@
+repository=https://github.com/iamthecodeDECODEDORG/runelite-quest-state-exporter.git
+commit=7cba08d55d167460a2631f5e2262da2656280d9e


### PR DESCRIPTION
Adds Quest State Exporter, a deliberately narrow local-data plugin.

The plugin:
- reads RuneLite's public `Quest.values()` / `Quest.getState(client)` APIs and the quest-points varp;
- writes one account-scoped JSON snapshot under `.runelite/quest-state-exporter/`;
- exports only quest identity, RuneLite quest state, aggregate counts, quest points, display name, and timestamp;
- performs no network access, game input, packet access, process attachment, credential access, configurable-path writes, or broad account-data collection.

Source is pinned to [`bb21746`](https://github.com/iamthecodeDECODEDORG/runelite-quest-state-exporter/commit/bb21746a7f2093f62eeef876428068f5c0f44ea6). The standalone verifier derives the complete current quest catalog directly from `Quest.values()` instead of assuming a numeric total, then rejects missing, unexpected, renamed, and duplicate catalog entries. It also includes future-quest controls, lifecycle tests, source and bytecode capability checks, adversarial mutation controls, fixture schema validation, and deterministic-build verification. The verified local JAR SHA-256 is `64016be22442f92ac7dfba094ead302fd41ce2d6e2e46612d91cfc42a43d4d44`.