### PR TITLE
Update clue-case-opening

### DIFF
--- a/plugins/clue-case-opening
+++ b/plugins/clue-case-opening
@@ -1,2 +1,2 @@
 repository=https://github.com/Ed-joe/CaseOpeningPluginOSRS.git
-commit=d6431682f1510ad5f8f73a32980c7f8f4564b6ac
+commit=489d9a3e94c8f19db2f35dd350f7d9614873961c


### PR DESCRIPTION
Updates Clue Case Opening to commit 489d9a3e94c8f19db2f35dd350f7d9614873961c.\n\nChanges:\n- Start the case-opening overlay only after the clue reward screen confirms a successful casket open, preventing an empty overlay when the game rejects the action.\n- Refresh the README and add an embedded plugin demonstration.