### PR TITLE
exchange-insights-capture: add plugin

### DIFF
--- a/plugins/exchange-insights-capture
+++ b/plugins/exchange-insights-capture
@@ -1,0 +1,3 @@
+repository=https://github.com/TheSpryt/Exchange-Insights-Capture.git
+commit=5e0fe48b27e5df5131763863c284af370c4f8d75
+warning=This plugin can upload your recorded clips and submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/exchange-insights-capture
+++ b/plugins/exchange-insights-capture
@@ -1,3 +1,3 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Capture.git
 commit=5e0fe48b27e5df5131763863c284af370c4f8d75
-warning=This plugin can upload your recorded clips and submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Exchange Insights Capture, an instant replay plugin. It keeps the last few seconds of play in memory and writes an MP4 when you die, kill a boss, or fill a collection log slot. A hotkey saves one whenever you want. Clips land in folders named for your account and what triggered them, the way RuneLite files screenshots.

The plugin has no third-party dependencies. It encodes H.264 and writes the MP4 container itself, so the verification template needs nothing added. An earlier revision of this PR used jcodec, which has since been removed.

**Warning line.** The plugin can upload clips to Exchange Insights, a third-party service, so the entry warns about the upload and the IP address it implies. Linking an account turns that on. Nothing else in the plugin touches the network.

**What it records.** Capture reads the client canvas, falling back to a screen grab of the client window while that window is focused. Clips carry no audio.

**Since review.** Dropped `LinkBrowser::open`, `Desktop`, subprocess execution, `getenv`, `Runtime::availableProcessors` and thread interrupts. Clicking a clip copies its path to the clipboard, now that a plugin cannot open one.