### PR TITLE
update wilderness-loadouts

### DIFF
--- a/plugins/wilderness-loadouts
+++ b/plugins/wilderness-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/DenisSa/wilderness-loadouts.git
-commit=f65b66da2d642e82bc61d6c108369163b01862db
+commit=ba0781c42a181c24be88c394aa77a9b07c680b1b

--- a/plugins/wilderness-loadouts
+++ b/plugins/wilderness-loadouts
@@ -1,2 +1,2 @@
 repository=https://github.com/DenisSa/wilderness-loadouts.git
-commit=ba0781c42a181c24be88c394aa77a9b07c680b1b
+commit=0b1d63d63b51edc6430fc3ac88ac0267b7267051


### PR DESCRIPTION
Updates Wilderness Loadouts to `0b1d63d63b51edc6430fc3ac88ac0267b7267051`.

- Preserve viable two-handed loadouts during optimizer candidate pruning.
- Keep the current slot item visible and preselected in the alternatives dialog.
- Stop recommending Trouver parchment use for legacy items that remain ineligible.
- Replace the technical Hub listing with a concise, user-focused description.

Validation: `./gradlew clean test --no-daemon` (42 tests passed).