### PR TITLE
Update corp-boosting-qol

### DIFF
--- a/plugins/corp-boosting-qol
+++ b/plugins/corp-boosting-qol
@@ -1,2 +1,2 @@
 repository=https://github.com/BPM-OSRS/pet-boosting-qol.git
-commit=4bdf218658f596269a9e7831d33814aa24f8ca82
+commit=2fdef14d909825e9d7e4ff31bdbe873ea33a6e63


### PR DESCRIPTION
Fixed Saturated Heart tracking to use a varbit instead of the animation graphic, since the animation could get overridden by other animations (e.g. combat) and silently fail to detect activation.