### PR TITLE
Update compact-orbs to v1.9.4

### DIFF
--- a/plugins/compact-orbs
+++ b/plugins/compact-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/its-cue/compact-orbs.git
-commit=f2aee3e43671d15d23a664085aa345a4f8d77ff0
+commit=8a6f6f77087628a8596ca830c83f4dfb75ee270c


### PR DESCRIPTION
- add a config option to hide the compact layout when the side panel tab is hidden - [#42](https://github.com/its-cue/compact-orbs/issues/42)
- update README.md (table to markdown and highlight new feature)

maintainability:
- refactor widget lookup in WidgetManager (getMapParent(), getOrbParent(), etc)
- determine isClassicResizable() from the stone arrangement varbit
- track cutscene status when the varbit changes

bugfixes:
- fix NPE on plugin shutdown by clearing slots last on reset
- fix NPE when closing edit-mode if the parent widget is hidden