### PR TITLE
Add emotes-remapping plugin

### DIFF
--- a/plugins/emotes-remapping
+++ b/plugins/emotes-remapping
@@ -1,2 +1,2 @@
 repository=https://github.com/maxgauthier12/emotes-remapping.git
-commit=c7e6d0af85df62d8d7f06a0718b490e25fc979a8
+commit=ec0ec318a6f799cfa2a581f8f4bea3e170baa352

--- a/plugins/emotes-remapping
+++ b/plugins/emotes-remapping
@@ -1,2 +1,2 @@
 repository=https://github.com/maxgauthier12/emotes-remapping.git
-commit=ec0ec318a6f799cfa2a581f8f4bea3e170baa352
+commit=6061c1c1681bd102c6e678b9d808e8f05969483a

--- a/plugins/emotes-remapping
+++ b/plugins/emotes-remapping
@@ -1,0 +1,2 @@
+repository=https://github.com/maxgauthier12/emotes-remapping.git
+commit=c7e6d0af85df62d8d7f06a0718b490e25fc979a8

--- a/plugins/emotes-remapping
+++ b/plugins/emotes-remapping
@@ -1,2 +1,2 @@
 repository=https://github.com/maxgauthier12/emotes-remapping.git
-commit=6061c1c1681bd102c6e678b9d808e8f05969483a
+commit=ed81e1730d275bb32cf10cf410239768425fe4bc


### PR DESCRIPTION
Adds the "Emotes Remapping" plugin.

__Repository:__ [](https://github.com/maxgauthier12/emotes-remapping)<https://github.com/maxgauthier12/emotes-remapping>

__What it does:__

- __Emote favorites & reordering__ — right-click any emote in the emote tab to Favorite/Unfavorite it. Emotes can be sorted alphabetically or favorites-first, and there is a "show favorites only" filter. Favorites are persisted per-profile.

- __Crack the Clue 3 vault helper__ — while standing on the tiles in front of the Varrock basement vault gates (region 12697), the plugin:

  - Highlights the next emote to perform in the emote tab and auto-scrolls to it
  - Reorders the emote grid so the upcoming CTC3 sequence emotes appear first, in order
  - Shows a countdown (17 → 0) above the next emote icon
  - Blocks emote clicks between clicking and the animation starting, to prevent misclicks
