### PR TITLE
update chance-man to v3.3.3

### DIFF
--- a/plugins/chance-man
+++ b/plugins/chance-man
@@ -1,2 +1,2 @@
 repository=https://github.com/ChunkyAtlas/chance-man.git
-commit=0f746034b9ae3396a43d91c92f71e4a6cf8b5e1c
+commit=89f2823720ab4788efbd9f11bffab105fa5121ec


### PR DESCRIPTION
fix(BlockedItems): prevent blocked items from being restricted, dimmed, or triggering rolls, bump to v3.3.3