### PR TITLE
PvM Toolkit 1.4.1

### DIFF
--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=cb12d28ec42be5a85e279e054ed4ebf6928ed1e7
+commit=aada0a732d4d09e497d4b4c74ccafc397caef065


### PR DESCRIPTION
## PvM Toolkit 1.4.1

- Match direct coin pickups against RuneLite's exact NPC loot data
- Charge Goading potion supply cost per dose instead of per full potion
- Correct Abhorrent spectre superior guidance to Protect from Magic
- Ensure update notes trigger once for each new version unless users opt out

Verification: `clean test shadowJar` passed with 44 tests and the 1.4.1 artifact.