### PR TITLE
Update prayer-icons-overlay

### DIFF
--- a/plugins/prayer-icons-overlay
+++ b/plugins/prayer-icons-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/JashyardEngDev75/prayer-icons-overlay.git
-commit=c218fc7675f8f5a4023f667c8521af171481b4fb
+commit=f10547d4bce5b0d7b4c8adcf749d9b0b5f49ed1c


### PR DESCRIPTION
Updates `prayer-icons-overlay` to v1.1.0.

Still a purely visual, read-only overlay. The only client calls in the plugin are `Client#isPrayerActive` and `Client#getVarbitValue`. No input injection, no menu or interface modification, no reflection, no network calls, no new dependencies.

**Changes**

- **Icon size** setting: Small (0.5x), Regular (1x), Large (1.5x). Width and height scale by the same factor, so sprites are never distorted. Scaled copies are cached, so the per-frame render path performs no image resizing.
- **Background colour** picker. Alpha still comes solely from the existing opacity slider.
- Replaced the 31 per-prayer show/hide checkboxes with a single **Include overhead prayers** toggle (default on), covering Protect from Magic/Missiles/Melee, Retribution, Redemption and Smite. This only filters what this overlay draws; the in-game head icon is untouched.
- Optional **Update on game ticks**: refreshes once per tick instead of every frame. This is display timing only. It adds no timers, counters or predictions of any kind.
- Removed a redundant "Enable overlay" config item, since the plugin's own toggle already covers it.
- Added `icon.png` (48x48) for the hub listing.

**Fixes**

- Prayer state is now read on the client thread. Priming the tick snapshot from `startUp()` and `onConfigChanged()` ran on the Swing EDT and tripped the "must be called on client thread" assertion, which aborted `startUp()`.
- The overlay no longer drifts at right- or bottom-aligned anchors. `SnapCorner#getNextDrawPosition` positions via `out.x -= bounds.width` using the previous frame's bounds, so every change in reported size drew one frame at the stale offset. The reported size now only grows, while the panel and icons still paint at their true current size from the overlay origin.

Repo: https://github.com/JashyardEngDev75/prayer-icons-overlay