### PR TITLE
Update Clan Piano MIDI

### DIFF
--- a/plugins/clan-piano-midi
+++ b/plugins/clan-piano-midi
@@ -1,2 +1,2 @@
 repository=https://github.com/TheOffSeason/clan-piano-midi.git
-commit=2e324d323c2b1aed4304c64390266cf7f05b3a20
+commit=d05245f03e77f0381eb9866af663e5330a6b8cf1


### PR DESCRIPTION
Updates `clan-piano-midi` to add selectable instruments.

Adds an instrument setting with three options: Grand piano, Organ, and a deliberately lo-fi RuneScape piano. Each is a set of harmonic strengths and a decay shape generated at runtime rather than a recording, so nothing is added to the download size. The chosen instrument travels with each note so party members hear the performance as the player intended, with a fallback for senders that do not specify one.

Also caps the generated-clip cache so it cannot grow unbounded as instruments are switched.

No change to how the plugin interacts with the game: it still only reads a MIDI input device, plays audio through `AudioPlayer`, and exchanges note messages with the party.