### PR TITLE
Update Slayer Best in Bank to V1.82

### DIFF
--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=cbf9a4fe8fe3ef3ceb78afd60a8fa6e9b395691a
+commit=3c7040b525643993dd9e6e57bc7246d2e0d55333

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=655e93ea1fd972f46879a77aa8fd10102646ab8d
+commit=e5d1cdbbccedfbd693226e3a9ab4826218cd40f5

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=e5d1cdbbccedfbd693226e3a9ab4826218cd40f5
+commit=cbf9a4fe8fe3ef3ceb78afd60a8fa6e9b395691a

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=32b63790df5d3397dde334a999741fe82fb936c1
+commit=655e93ea1fd972f46879a77aa8fd10102646ab8d

--- a/plugins/slayer-best-in-bank
+++ b/plugins/slayer-best-in-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/FreeArcanes/slayer-best-in-bank.git
-commit=4b9baf98ef95e4f3c4ea56bf020f4d15c092b32a
+commit=32b63790df5d3397dde334a999741fe82fb936c1


### PR DESCRIPTION
## Summary

Updates Slayer Best in Bank from the current Plugin Hub marker (4b9baf9) to public release V1.82 (3c7040b). This combines all changes from the current review batch:

- fixes Fossil Island wyvern methods and ranged weapon/ammo matching, including Dizana quiver and specialty variants
- adds target-aware Melee, Ranged, and Magic DPS with live boosts/prayers, combat effects, readable tier comparisons, TTK, and kills per hour
- adds Why? explanations and task-aware Objectives with comparisons, one-click switching, restore support, and objective-aware supply policies
- adds conservative charge-state handling, validated task presets, modeled trip and GP-per-kill costs, and observed task-consumption summaries
- redesigns the embedded Plugin Hub README around seven current screenshots and removes the duplicated plugin masthead
- adds a concise once-per-update V1.82 chat notice while preserving mandatory Slayer safety and manual preferences

## Validation

- full suite: 304 tests passed, zero failures, zero errors
- all seven README image references resolve at the pinned source commit
- Java 11 main-source compilation remains enforced with deprecation warnings treated as errors
- no new dependencies
- no gameplay automation, menu-action invocation, networking, or filesystem mutation

Source PR: https://github.com/FreeArcanes/slayer-best-in-bank/pull/11