### PR TITLE
add minimalist

### DIFF
--- a/plugins/minimalist
+++ b/plugins/minimalist
@@ -1,0 +1,2 @@
+repository=https://github.com/jakevollkommer/osrs-minimalist.git
+commit=148161eb36ace8c5b3140e44acdf56e5c961f42b


### PR DESCRIPTION
Hides non-interactable scenery, NPCs, and HUD elements at supported content, starting with Guardians of the Rift and the runecrafting altars. 

All hiding is done with hardcoded curated ID sets behind simple toggles (no ID inputs) in response to the comment on my [previous PR to add a Better Object Highlight plugin](https://github.com/runelite/plugin-hub/pull/15124#issuecomment-5330133734)

Object hiding uses the RenderCallback API so hidden objects stay in the scene, clickable, and visible to other plugins; scenery hiding requires a GPU plugin and the plugin shows a one-time chat warning when none is active.