### PR TITLE
Update Clan Piano MIDI (fix: no audio)

### DIFF
--- a/plugins/clan-piano-midi
+++ b/plugins/clan-piano-midi
@@ -1,2 +1,2 @@
 repository=https://github.com/TheOffSeason/clan-piano-midi.git
-commit=d05245f03e77f0381eb9866af663e5330a6b8cf1
+commit=7071b44a44ded0b8805481042f96e8fbfff33947


### PR DESCRIPTION
Fixes a regression in the currently published build of `clan-piano-midi`.

The `Instrument` enum returned by the config interface was package-private. The config interface is implemented by a runtime proxy, which cannot access a non-public return type, so `config.instrument()` threw `IllegalAccessError` on every note and no audio was ever produced:

```
java.lang.IllegalAccessError: failed to access class com.clanpiano.Instrument
  from class com.sun.proxy.$Proxy229
    at com.clanpiano.ClanPianoPlugin.onNote(ClanPianoPlugin.java:269)
```

The enum is now public. No other change.