### PR TITLE
update book-of-the-dead-reminder

### DIFF
--- a/plugins/book-of-the-dead-reminder
+++ b/plugins/book-of-the-dead-reminder
@@ -1,2 +1,2 @@
 repository=https://github.com/jakevollkommer/book-of-the-dead-reminder.git
-commit=04094891e2b739022cbdf94e0d2ccaccd90d17ea
+commit=90eee3bdd863159b9f30473eaca35c68304898ac


### PR DESCRIPTION
Fixes thrall requirement detection for modern rune sources and adds a Feedback config section.