### PR TITLE
Add Hide Ground Items

### DIFF
--- a/plugins/hide-ground-items
+++ b/plugins/hide-ground-items
@@ -1,0 +1,2 @@
+repository=https://github.com/vahnx/hide-ground-items.git
+commit=990adbe43bc725587eebcdd4cc4678f06fdc0b44


### PR DESCRIPTION
Adds Hide Ground Items to the RuneLite Plugin Hub for review.

Repository: https://github.com/vahnx/hide-ground-items
Commit: 990adbe43bc725587eebcdd4cc4678f06fdc0b44