### PR TITLE
update camera-restore

### DIFF
--- a/plugins/camera-restore
+++ b/plugins/camera-restore
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/camera-restore.git
-commit=084d530f729cfc4489b672fcdd6c7d68407828f1
+commit=82c9a0894b48e0184499478f673d24ed849d8ccf


### PR DESCRIPTION
- bugfix : only occurs if a login has occurred, overwrites with default values otherwise.