### PR TITLE
Add 6 Hour Logout Timer plugin

### DIFF
--- a/plugins/6hour-logout-timer
+++ b/plugins/6hour-logout-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/LeoPalmowski/6Hour-Logout-Timer.git
+commit=c883af08d2c45d1d5a04c447f72a108cb07c7cc8


### PR DESCRIPTION
Warns you before RuneScape's automatic 6-hour session logout, with a
configurable warning time, repeatable reminders, and an on-screen countdown.