### PR TITLE
Add inventory-banked-counter

### DIFF
--- a/plugins/inventory-banked-counter
+++ b/plugins/inventory-banked-counter
@@ -1,0 +1,2 @@
+repository=https://github.com/theovit/inventory-banked-counter.git
+commit=f815a238e0a9060d0e4fed74b00fa23ae6057bfc


### PR DESCRIPTION
Adds Inventory Banked Counter, a plugin that shows how many of each inventory item you also have in your bank, drawn directly on the item slot (e.g. carrying 1 coal with 24 banked shows "24" on that slot). Bank contents are read once the bank has been opened during the session.

Features:
- Configurable overlay text color and font size
- Optional shorthand numbers for large counts (1.2K / 1.2M / 1.2B)
- Shift+right-click an inventory item to exclude/include it from the overlay, or manage the exclusion list directly in settings

Repository: https://github.com/theovit/inventory-banked-counter