### PR TITLE
Add Skiller Guard plugin

### DIFF
--- a/plugins/skiller-guard
+++ b/plugins/skiller-guard
@@ -1,0 +1,2 @@
+repository=https://github.com/JamsRepos/skiller-guard.git
+commit=acbc8c4dd1cbc91583a1d45937696ec06a0a0466


### PR DESCRIPTION
## Summary
- Adds **Skiller Guard**, an always-on safety plugin for level-3 skillers
- Hides accidental combat and Prayer XP clicks, locks those skills on lamps, and warns on dangerous quests, settings, and Quest Helper

## Test plan
- [x] Plugin Hub CI build on this PR is green
- [ ] Plugin installs from the hub listing after merge