### PR TITLE
Add groupscape plugin

### DIFF
--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,2 +1,2 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=c21dee08bdb66d42d7ab00a8e2f2c04cc2db9bc4
+commit=1fe0dfe71cc0f9a5c43405a5173703d3a0a5df89

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,2 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
 commit=1fe0dfe71cc0f9a5c43405a5173703d3a0a5df89
+warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,0 +1,2 @@
+repository=https://github.com/MayzrDev/groupscape-plugin.git
+commit=c21dee08bdb66d42d7ab00a8e2f2c04cc2db9bc4


### PR DESCRIPTION
Tracks a RuneScape group's players (skills, inventory, bank, position, etc.) and streams the data to a group-scoped web dashboard so other group members can view it live. Similar in shape to the existing group-ironmen-tracker plugin already in the hub.