### PR TITLE
Update Skiller Guard

### DIFF
--- a/plugins/skiller-guard
+++ b/plugins/skiller-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/skiller-guard.git
-commit=acbc8c4dd1cbc91583a1d45937696ec06a0a0466
+commit=867dd3905e5ba352f1ae457f1d7fa13c82e153cb


### PR DESCRIPTION
## Summary
- Updates Skiller Guard to `867dd3905e5ba352f1ae457f1d7fa13c82e153cb`
- Status panel now defaults off
- In-progress quest warnings (Recipe for Disaster and similar) are opt-in
- Warning sounds no longer fire just because you logged in

## Test plan
- [ ] Plugin Hub CI build on this PR is green
- [ ] Logging in with Recipe for Disaster already started does not spam chat or sound
- [ ] Auto Retaliate / attack-option banners can still appear, without an immediate login ding