### PR TITLE
add duelscape-tcg

### DIFF
--- a/plugins/duelscape-tcg
+++ b/plugins/duelscape-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/osrs-tcg-battles.git
-commit=a1e50584ba04652c755bd1b4f7569f1df527db2d
+commit=358b938650fc0c2a655ef0dcc105998a81f397da

--- a/plugins/duelscape-tcg
+++ b/plugins/duelscape-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/osrs-tcg-battles.git
-commit=358b938650fc0c2a655ef0dcc105998a81f397da
+commit=1ed76a76976202f66cc37221effea8bf9b2f6e40

--- a/plugins/duelscape-tcg
+++ b/plugins/duelscape-tcg
@@ -1,3 +1,3 @@
 repository=https://github.com/randytkrx/osrs-tcg-battles.git
-commit=67e14db14d8d92222fa0a7d28fd00093affa8b3e
+commit=6365432412c000e690eb16673064b92625333872
 warning=This plugin downloads card artwork from oldschool.runescape.wiki and osrs-tcg.net, which exposes your IP address and requested image URLs to third-party servers not controlled or verified by the RuneLite developers.

--- a/plugins/duelscape-tcg
+++ b/plugins/duelscape-tcg
@@ -1,3 +1,3 @@
 repository=https://github.com/randytkrx/osrs-tcg-battles.git
 commit=6365432412c000e690eb16673064b92625333872
-warning=This plugin downloads card artwork from oldschool.runescape.wiki and osrs-tcg.net, which exposes your IP address and requested image URLs to third-party servers not controlled or verified by the RuneLite developers.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/duelscape-tcg
+++ b/plugins/duelscape-tcg
@@ -1,0 +1,2 @@
+repository=https://github.com/randytkrx/osrs-tcg-battles.git
+commit=a1e50584ba04652c755bd1b4f7569f1df527db2d

--- a/plugins/duelscape-tcg
+++ b/plugins/duelscape-tcg
@@ -1,2 +1,3 @@
 repository=https://github.com/randytkrx/osrs-tcg-battles.git
-commit=737bb0a582365197e563af7d8bbaca729dbed8ba
+commit=67e14db14d8d92222fa0a7d28fd00093affa8b3e
+warning=This plugin downloads card artwork from oldschool.runescape.wiki and osrs-tcg.net, which exposes your IP address and requested image URLs to third-party servers not controlled or verified by the RuneLite developers.

--- a/plugins/duelscape-tcg
+++ b/plugins/duelscape-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/osrs-tcg-battles.git
-commit=1ed76a76976202f66cc37221effea8bf9b2f6e40
+commit=737bb0a582365197e563af7d8bbaca729dbed8ba


### PR DESCRIPTION
Adds Duelscape TCG, a RuneLite card-battle plugin built around the OSRS TCG collection. It provides deck building, local hot-seat battles, and encrypted friend duels over RuneLite Party.

Repository: https://github.com/randytkrx/osrs-tcg-battles

The plugin uses the standard Plugin Hub build, stores decks in profile-aware RuneLite configuration, requests ownership through local plugin messages, and downloads catalog artwork to the documented shared OSRS-TCG cache.