### PR TITLE
Update inventory-banked-counter

### DIFF
--- a/plugins/inventory-banked-counter
+++ b/plugins/inventory-banked-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/theovit/inventory-banked-counter.git
-commit=f815a238e0a9060d0e4fed74b00fa23ae6057bfc
+commit=9a06284f0eee21b30f5b559132e4b7415a366d59


### PR DESCRIPTION
Updates Inventory Banked Counter to commit 84c03a7eb5ff4c657d0811ddec064ea2756fcda3.

Changes since the last published version:
- BSD 2-Clause LICENSE added
- Configurable overlay text color, font size, and corner position (useful when another plugin already draws an overlay in the default corner)
- Shift+right-click an inventory item to toggle it in/out of the exclusion list, instead of only adding
- Optional "Remember banked counts after logout" setting (off by default, with an in-app warning) that keeps banked counts visible immediately after relogin, keyed per account so it never shows another account's cached data

Repository: https://github.com/theovit/inventory-banked-counter