### PR TITLE
Add SlayerPlus

### DIFF
--- a/plugins/slayerplus
+++ b/plugins/slayerplus
@@ -1,2 +1,2 @@
 repository=https://github.com/rickernet/SlayerPlus.git
-commit=0031e803f8aea8ea5b9af97f04101248d409c767
+commit=96e5b7519957f3dcdc89aa9fa527e3a62b39b60e

--- a/plugins/slayerplus
+++ b/plugins/slayerplus
@@ -1,2 +1,2 @@
 repository=https://github.com/rickernet/SlayerPlus.git
-commit=96e5b7519957f3dcdc89aa9fa527e3a62b39b60e
+commit=67ba68782e5e706f95bd1007e5c3cedf3f6667ab

--- a/plugins/slayerplus
+++ b/plugins/slayerplus
@@ -1,0 +1,2 @@
+repository=https://github.com/rickernet/SlayerPlus.git
+commit=34c8c53eea8f865bf6a62f8d91146f7d52525b67

--- a/plugins/slayerplus
+++ b/plugins/slayerplus
@@ -1,2 +1,2 @@
 repository=https://github.com/rickernet/SlayerPlus.git
-commit=cd580d969fec671dafbd055718da16176928e1cd
+commit=0031e803f8aea8ea5b9af97f04101248d409c767

--- a/plugins/slayerplus
+++ b/plugins/slayerplus
@@ -1,2 +1,2 @@
 repository=https://github.com/rickernet/SlayerPlus.git
-commit=34c8c53eea8f865bf6a62f8d91146f7d52525b67
+commit=cd580d969fec671dafbd055718da16176928e1cd


### PR DESCRIPTION
Adds SlayerPlus, an all-in-one Slayer planning, loadout, and routing companion.

Repository: https://github.com/rickernet/SlayerPlus
Pinned commit: 34c8c53eea8f865bf6a62f8d91146f7d52525b67

The project targets Java 11, uses a BSD 2-Clause license, includes the required plugin metadata and optimized icon, and passed the local test and release-route validation suites.