### PR TITLE
the-birdhouse: add clan loot reporting

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=4c50adfb00c6b0da5ed4b7e269ddfc4100a378e8
+commit=e92e2d64a39dd008d6d75ea88349466d086ee460
 warning=This plugin submits your IP address, RSN, in-game screenshots, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=0b6002a791b1a9e768c3c2a277eeb1942af1d03e
-warning=This plugin submits your IP address, RSN, and in-game screenshots to a 3rd-party server not controlled or verified by Runelite developers.
+commit=4c50adfb00c6b0da5ed4b7e269ddfc4100a378e8
+warning=This plugin submits your IP address, RSN, in-game screenshots, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates The Birdhouse plugin to add optional clan loot reporting. Players can enable this in plugin settings to report loot and collection log entries to their clan leaderboard via the Birdhouse backend, replacing the Dink dynamic-config pipeline. Warning text updated to reflect the additional data sent.

Made with [Cursor](https://cursor.com)