### PR TITLE
Update Skiller Guard to 1.1.1

### DIFF
--- a/plugins/skiller-guard
+++ b/plugins/skiller-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/skiller-guard.git
-commit=204c499bdda8f8b1c28147ecceb4d7b2a8f675d5
+commit=02a6c1a7b808262a620b4200aa859224efb119d9

--- a/plugins/skiller-guard
+++ b/plugins/skiller-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/skiller-guard.git
-commit=867dd3905e5ba352f1ae457f1d7fa13c82e153cb
+commit=4ced77a5696b12868dbf43c2e08010ba2f048813

--- a/plugins/skiller-guard
+++ b/plugins/skiller-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/skiller-guard.git
-commit=4ced77a5696b12868dbf43c2e08010ba2f048813
+commit=204c499bdda8f8b1c28147ecceb4d7b2a8f675d5


### PR DESCRIPTION
## Summary
- Bumps Skiller Guard to **1.1.1** at `02a6c1a7b808262a620b4200aa859224efb119d9`
- Catalog now identifies clicks by gameval ID instead of option/target globs
- Adds skiller-reachable hides: Forthos burner, Varlamore libation, Camdozaal, Blast Furnace pump, barbarian Use-rod, barehanded Harpoon, house lectern tablets, house ranging games
- Quest denylist uses the `Quest` enum, including Priest in Peril
- Observatory Quest is a disclaimer for now: the 2018 skip may be level-1 skill or a level-3 account
- First login after a version bump posts short player-facing update notes in chat once

## Test plan
- [x] Plugin Hub CI build on this PR is green
- [x] House lectern Study / tablet buttons are hidden; Remove stays
- [x] House dartboard Play is hidden; Remove stays
- [x] Catherby cage/harpoon: Harpoon hidden without a harpoon, present with one; Cage stays
- [x] Bury/Scatter/Take still hidden; Pray-at on house/Chaos altars stays
- [ ] First login after update shows 1.1.1 Observatory disclaimer note once
- [ ] Observatory journal / Quest Helper shows QUEST DISCLAIMER, not DANGEROUS QUEST
- [ ] A real combat-XP quest (e.g. Restless Ghost) still shows DANGEROUS QUEST