### PR TITLE
Update Reval clan

### DIFF
--- a/plugins/reval-clan
+++ b/plugins/reval-clan
@@ -1,4 +1,4 @@
 repository=https://github.com/revalOSRS/reval-cc-plugin.git
-commit=f7571609779dbce5c623970793d889c63b63996c
+commit=6ade16941cbb93b37cbdcb51d5b01180d3c1dfe2
 authors=stenjansarv
 warning=This plugin submits your IP address and comprehensive records of your account activity and progress to a 3rd-party server not controlled or verified by the Runelite developers.


### PR DESCRIPTION
- Change clan rank display page & its logic
- Rank icons are resolved at runtime from the game cache's CLAN_RANK_NAME/CLAN_RANK_GRAPHIC enums
- Adds a points-log "album" window opened from the side panel
- Adds a user-triggered overlay that glows the path to the plugin's existing "Sync Reval" collection log menu entry
- Unicode glyphs the RuneScape font lacks (→ • ▲ ✓) are replaced with code-drawn Icon implementations or ASCII