### PR TITLE
Add abyss-rift-rune-highlighter

### DIFF
--- a/plugins/abyss-rift-rune-highlighter
+++ b/plugins/abyss-rift-rune-highlighter
@@ -1,0 +1,2 @@
+repository=https://github.com/xboxnuker-rgb/abyss-highlighter.git
+commit=8818efa1750ac7b1e47f194b8d03547505c52b73


### PR DESCRIPTION
Adds Abyss Rift Rune Highlighter, a passive scene overlay that shows the matching rune icon and optional name above all 13 Abyss rifts.

Validation:
- manually verified every rift mapping and final placement/sizing controls
- builds against Plugin Hub RuneLite 1.12.36
- Java 11, standard build, no third-party dependencies
- TOS/forbidden API/package audit clean