### PR TITLE
Update Blert to 0.9.18

### DIFF
--- a/plugins/blert
+++ b/plugins/blert
@@ -1,4 +1,4 @@
 repository=https://github.com/blert-io/plugin.git
-commit=6974b31cdffff2ff5106408798bb3e476fbfd162
+commit=b04f51ac602d865c00e63167c2b4047dca189677
 authors=frolv
 warning=This plugin submits your IP address, RSN, and data about your raids to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Sends player update events on a player's death tick
- Removes unused coords from bloat up events