### PR TITLE
Update Divine: Skies

### DIFF
--- a/plugins/divine-skies
+++ b/plugins/divine-skies
@@ -1,2 +1,2 @@
 repository=https://github.com/GarnetDivine/divine-skies.git
-commit=b800876ef555f9ab1a2ac88e6970b03ec1031cc0
+commit=7a4d421d7b851d32bedd969a665783bab7aa203c

--- a/plugins/divine-skies
+++ b/plugins/divine-skies
@@ -1,2 +1,2 @@
 repository=https://github.com/GarnetDivine/divine-skies.git
-commit=5800593f16de0901ee3c1050aecd551b19d76198
+commit=b800876ef555f9ab1a2ac88e6970b03ec1031cc0


### PR DESCRIPTION
Updates Divine: Skies to v1.1.0.

**Detection**
- Area classification is now instance-aware (resolves template coordinates via `WorldPoint.fromLocalInstance`, guarded against mid-load AIOOBE)
- Added server-authoritative varbit gates for CoX / ToB / ToA / POH build mode
- POH detection now uses the eight template region IDs instead of a chunk-coordinate range
- Corrected the underground Y threshold from 8000 to 6400
- Added an optional per-region manual override hotkey, persisted via ConfigManager, so users can correct misclassified areas without waiting on a release

**Fixes**
- Scene tint no longer bleeds a night tint into the day phase when only one phase tint is enabled
- Scene tint opacity now interpolates through sunrise/sunset instead of popping
- Scene tint no longer defaults to a permanent transition-color tint when no phase tints are enabled

**New**
- Optional night shadow control for 117 HD (off / reduced / unchanged), with the user's original shadow mode captured and restored on shutdown

No new dependencies. Builds against JDK 11.