### PR TITLE
Update Skiller Guard to 1.1.2

### DIFF
--- a/plugins/skiller-guard
+++ b/plugins/skiller-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/skiller-guard.git
-commit=02a6c1a7b808262a620b4200aa859224efb119d9
+commit=7b0edd1aca04066ff7a266d399b4b6232439b528


### PR DESCRIPTION
## Summary
- Bumps Skiller Guard to **1.1.2** at `7b0edd1aca04066ff7a266d399b4b6232439b528`
- Update notes now keep each version's bullets, so a Hub PR that ships more than one bump still shows the skipped versions
- Unseen notes are listed oldest first, then `seenChangelogVersion` is set to the current version

## Test plan
- [ ] Plugin Hub CI build on this PR is green
- [ ] First login with empty `seenChangelogVersion` lists 1.1.0, then 1.1.1, then 1.1.2
- [ ] After that, world hop / re-login stays quiet
- [ ] An account that already saw 1.1.1 only gets the 1.1.2 note