### PR TITLE
the-birdhouse: update commit

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=e92e2d64a39dd008d6d75ea88349466d086ee460
+commit=09799dfe7315f12da2453e7fc915231687546659
 warning=This plugin submits your IP address, RSN, in-game screenshots, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Non-commit plugin change.

Changes:
- Fix raid loot (TOA/COX/TOB) not being reported to clan leaderboard
- Add 100k GP minimum threshold to match previous Dink config
- Allow clan leaderboard reporting without auth token via WOM membership validation
- Include playerName in all clan-loot request bodies