### PR TITLE
loadout-lab 0.4.0

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=45cf99118e56351549982499413731e620ba40fd
+commit=e8406c25e77e2c3a6238ccfa9f20b5c3961b173b
 authors=ajkatz


### PR DESCRIPTION
Bumps Loadout Lab from 0.3.5 (`45cf991`) to 0.4.0 (`e8406c2`).

The diff is large but nearly net-neutral in size (110 files, +13.6k/-13.2k). Most
of it is a **merge-back**: after [#15129](https://github.com/runelite/plugin-hub/pull/15129)
I withdrew the proposed core/companion split and brought the renderer back into
this single plugin, per the reviewer's ruling that one plugin should stay one
plugin. Source is **186,332 tokens**, under the 200k review cap (gated in CI by
`./gradlew checkTokens`).

## Network features (new since the 0.3.5 pin — please review these specifically)

Both files below are **net-new in this release** (`WikiCalcLink.java` +335,
`ui/MonsterIcons.java` +279). 0.3.5 made no network requests at all, so this is
the change most worth a close look. Both talk to the OSRS wiki and nowhere else,
and both use the injected `OkHttpClient`.

**1. "Open in wiki calculator" button — strictly click-initiated**

- `POST https://tools.runescape.wiki/osrs-dps/shortlink`, then opens
  `https://tools.runescape.wiki/osrs-dps/?id=<returned id>` in the browser.
- This is the same endpoint the official calculator's own Share button uses; it
  is the only way a full setup can ride a URL.
- Fires **only** from the button on a result card (`WikiCalcLink#open`, reached
  through the `wiki-calc` command). There is no timer, no startup call, and no
  path that reaches it without a click.
- Payload is the setup already displayed on that card: equipment item ids, the
  monster's calculator id/version, the prayers and boosts the card assumed,
  slayer-task and wilderness flags, and the player's **combat levels**. The
  loadout is labelled with the literal string `"Loadout Lab"` — no account name,
  no account hash, no username is included or available to it.

**2. Monster thumbnails — config-gated**

- `GET https://oldschool.runescape.wiki/w/Special:FilePath/<file>`, cached to
  `.runelite/loadout-lab/npc-icons/`.
- The file name is never guessed: every row of the bundled monster corpus carries
  the wiki's own `image` value, so a thumbnail costs exactly one request, a miss
  costs one and is remembered in a `failed` set, and a cached icon costs none.
- Off switch: *Connections → Monster pictures (wiki)* (`fetchMonsterIcons`). The
  toggle is checked at the call site before any request is constructed
  (`ResultCards.java:303`), so **off means no wiki request is ever made**.
- Runs on a single daemon thread at `MIN_PRIORITY + 1` so it can never compete
  with the client thread; every failure fails quiet (the row just stays text-only).

Nothing is sent while the plugin sits idle. No analytics, no telemetry. The
README's Privacy section states the above verbatim for users.

## Also in 0.4.0

- Engine reconciliation against the official wiki calculator across a 68-scenario
  vector battery — 60 of 68 now inside 0.5%. Fixes include the flat-armour
  per-roll clamp, the twisted bow scaling clamp, twinflame/smoke staff handling,
  Inquisitor's, the dizana's quiver bonus, sanguinesti healing, and Confliction
  gauntlets' second accuracy roll. Known remaining deltas are tracked in
  `docs/ENGINE-GAPS.md`.
- Sea combat / sailing storage support bumped.
- Maggot King: the Far phase is correctly melee-immune, and the three versions
  group like the Royal Titans.
- Spellbook swap + Vengeance rune planning; combination-rune preference.
- Wilderness risk cap fixes (the displayed cap is now the single source of truth).
- Config shrunk from 47 options to 11 — the rest were inert and are deleted.
- ASCII compute animation replaces the previous animated mascots (frames live in
  a resource file, not in source).

## Verification

`./gradlew preSubmit` is green: 560 tests / 0 failures, three golden-file
comparisons, plus the token, glyph, and docs gates.
