### PR TITLE
Create bank-coffer-scanner

### DIFF
--- a/plugins/bank-coffer-scanner
+++ b/plugins/bank-coffer-scanner
@@ -1,2 +1,2 @@
 repository=https://github.com/osrsrigid/bank-coffer-scanner.git
-commit=d9ded13239b7357500afa942a1103aef61fb9736
+commit=d7d7182a94d0170fb6029864c32e227fc06b6ac3

--- a/plugins/bank-coffer-scanner
+++ b/plugins/bank-coffer-scanner
@@ -1,2 +1,2 @@
-   repository=https://github.com/osrsrigid/bank-coffer-scanner.git
-   commit=f93b3467c1bd9bb8ce91435c061055f510781667
+repository=https://github.com/osrsrigid/bank-coffer-scanner.git
+commit=f93b3467c1bd9bb8ce91435c061055f510781667

--- a/plugins/bank-coffer-scanner
+++ b/plugins/bank-coffer-scanner
@@ -1,0 +1,2 @@
+   repository=https://github.com/osrsrigid/bank-coffer-scanner.git
+   commit=f93b3467c1bd9bb8ce91435c061055f510781667

--- a/plugins/bank-coffer-scanner
+++ b/plugins/bank-coffer-scanner
@@ -1,2 +1,2 @@
 repository=https://github.com/osrsrigid/bank-coffer-scanner.git
-commit=f93b3467c1bd9bb8ce91435c061055f510781667
+commit=d9ded13239b7357500afa942a1103aef61fb9736


### PR DESCRIPTION
Adds Bank Coffer vs Alch — compares Death's Coffer sacrifice value (105% GE price) against High Alch value for every item in your bank, so you can see which items are worth sacrificing vs alching (particularly useful for Ironmen, who can't sell on the GE).

Items where the gap is large get a highlighted warning in the panel (configurable threshold), and each row has a button to permanently hide items you don't want in the list.

Read-only/informational only — no automation, no menu entry changes, no interface modifications.