### PR TITLE
Update fire-max-cape-removal

### DIFF
--- a/plugins/fire-max-cape-removal
+++ b/plugins/fire-max-cape-removal
@@ -1,2 +1,2 @@
 repository=https://github.com/petty-mods/fire-max-cape-removal.git
-commit=f796707201f8ffd95d250df5ea444daa6ef5a1f4
+commit=5a2f6945dc05fa97f220310e598dc67810dbff13


### PR DESCRIPTION
Fixed bug that prevented fire max cape (l) from being replaced.