### PR TITLE
Add OSRS Toolkit Sync

### DIFF
--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=35607926226ad825e3f779de7848abe54260300f
+commit=7eb9f2c8608cd4535aeccf285c8c9dcabc4d95f2

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=7eb9f2c8608cd4535aeccf285c8c9dcabc4d95f2
+commit=85106b412f52fdf6510db150938c118efda07388

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=85106b412f52fdf6510db150938c118efda07388
+commit=104c9ffe34b0faae7613ac918626d503da6862f3

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=334ebc0c951149a689ccc5ffbce691a076569228
+commit=2a16b8561a95d62fad5311574640b79a89750dd6

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=a652df87f7edbafc4853cc8d79cdb18ad32eaa05
+commit=613cf3094bedf301b8cc026e84dba96d0f61e239

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=104c9ffe34b0faae7613ac918626d503da6862f3
+commit=334ebc0c951149a689ccc5ffbce691a076569228

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=2a16b8561a95d62fad5311574640b79a89750dd6
+commit=a652df87f7edbafc4853cc8d79cdb18ad32eaa05

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,3 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
 commit=613cf3094bedf301b8cc026e84dba96d0f61e239
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=649280b7d087d067f4c0f192d193d4fae15248ce
+commit=676cc2b4400347fe0ea246f22481649d4e8edffb

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=b266d6300b0ddc7fd069f3707277c3dff1c91b6c
+commit=649280b7d087d067f4c0f192d193d4fae15248ce

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=676cc2b4400347fe0ea246f22481649d4e8edffb
+commit=8bda4bd3f1db363f6b678f0a614a7209baa6c5be

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,0 +1,2 @@
+repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
+commit=b266d6300b0ddc7fd069f3707277c3dff1c91b6c

--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=8bda4bd3f1db363f6b678f0a614a7209baa6c5be
+commit=35607926226ad825e3f779de7848abe54260300f


### PR DESCRIPTION
Resubmission of #14949, which was closed for depending on a native companion application running on the user's system.

The plugin no longer talks to anything local. It now POSTs the same event data over HTTPS to a self-hosted sync service ([osrs-toolkit-sync-server](https://github.com/Wolklaw/osrs-toolkit-sync-server), open source) instead of writing to `.runelite/`, so the data it sends is inspectable the way a local binary isn't. Cleared with @Pine on the RuneLite Discord: "info that is sent to a website can be verified a random native app can't so yeah."

What it records, all opt-in except Grand Exchange fills:
- Grand Exchange fills, offer opens/cancels, and where you're standing in the GE
- Player-to-player trades (off by default)
- PvM gear/bank/skill snapshots on bank open, for readiness checklists (off by default)
- NPC loot received (off by default)
- What was equipped/carried at the moment of death (off by default)

Repo: https://github.com/Wolklaw/osrs-toolkit-runelite