### PR TITLE
update party-health-status

### DIFF
--- a/plugins/party-health-status
+++ b/plugins/party-health-status
@@ -1,2 +1,2 @@
 repository=https://github.com/1Defence/party-health-status.git
-commit=7d4f82b8e7e2a3e4eb709e55a1475a52404aad5e
+commit=a8bfc2faa5ceed87e4be735ddea836f0badd2286


### PR DESCRIPTION
- track generic party members as a fallback for users who don't have this plugin, or are dropping these packets.