### PR TITLE
Update Zeah RC Helper to 1.0.2

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=3060fe0ce7ca688a80a6d0bf81afc6479760baf9
+commit=6bed8ac1a7468aca2495879ac428c5dc38ff410d

--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=5a4b321c366d9f2a3b2a50ff228026808ae87453
+commit=3060fe0ce7ca688a80a6d0bf81afc6479760baf9


### PR DESCRIPTION
## Summary
- Updates Zeah RC Helper to `3060fe0ce7ca688a80a6d0bf81afc6479760baf9` (v1.0.2)
- Routes from one walkable path using Arceuus shortcut stand/land tiles, and can draw that path on the minimap
- Folds gear reminders into a labeled status panel (Bloods red / Souls teal) and announces update notes in chat

## Test plan
- [ ] Plugin Hub CI build passes
- [ ] Install updated plugin and verify shortcut pathing, minimap path, status panel labels, and changelog chat on login
