### PR TITLE
Update clan-qol 1.1.3

### DIFF
--- a/plugins/better-clan-broadcasts
+++ b/plugins/better-clan-broadcasts
@@ -1,2 +1,2 @@
 repository=https://github.com/abristow3/Better-Clan-Broadcasts.git
-commit=55d1c4d9c512facdfe0dd73a8057f9430bf95281
+commit=6dbb7674ab04a93d0e7ffb171cdb4f16baa7c950


### PR DESCRIPTION
bug fix - fixed duplicated clan rank icons for CA Broadcasts that would be twice processed on occasion due to timing. Added checker logic and ignores if already processed