### PR TITLE
Update blast-mine-improved to 1.1.0

### DIFF
--- a/plugins/blast-mine-improved
+++ b/plugins/blast-mine-improved
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/blast-mine-improved.git
-commit=59d93e294a7cc3e72d75622081019f88a8637acc
+commit=133dd6ed2b452b3c5a5002c04531d15c6fe09df0


### PR DESCRIPTION
## Summary
- Updates **blast-mine-improved** to `1.1.0` (`133dd6ed2b452b3c5a5002c04531d15c6fe09df0`)
- Adds a rotation-method dropdown: keep loot-as-you-go (default) or blast every dynamite then loot
- Guide ore pickups can be turned off; dynamite-per-trip is configurable and placeholder filler is calculated automatically
- Fixes lighting the leftover pot when dynamite runs out (including an odd 21st)

## Test plan
- [ ] Plugin Hub CI build passes
- [ ] Default loot-as-you-go still guides 20-dynamite trips, off-path hide, and paired Light
- [ ] Blast then loot with 21 dynamite: ore stacks on the ground; leftover pot still shows Light
- [ ] Guide ore pickups off: no collect prompts; trip does not wait on ground piles
- [ ] Out of dynamite: Excavate deprioritized, Light remains on a loaded pot
