### PR TITLE
life-tracker: only count items the game treats as consumable

### DIFF
--- a/plugins/life-tracker
+++ b/plugins/life-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/WoodyCode23/runelite-life-tracker.git
-commit=81535a856134e5095467a0de0786917c100e74e2
+commit=b4d4ccae0cd3a244c23932285c718237c5f14396


### PR DESCRIPTION
Bug fix for `life-tracker`.

Consumables were identified by elimination, which was wrong in two places:

**Food was "not a potion, and it left the inventory".** Equipping an item also removes it from the inventory, so weapon and armour switches during combat were recorded as meals. Real captured data logged Tumeken's shadow, Dharok's platebody and an occult necklace as food eaten.

**Potions were "the name ends in a dose suffix".** `Watering can(7)` matches that, and was recorded as seven doses drunk.

Both now ask the client's own consumable table (`ItemStatChanges`) instead of inferring: an item is only counted if the game actually has a consumption effect for it. `ConsumableIdentificationTest` pins the behaviour the fix depends on, asserting that a shark resolves while an occult necklace, Tumeken's shadow and a watering can do not.
