### PR TITLE
create copy-player-name

### DIFF
--- a/plugins/copy-player-name
+++ b/plugins/copy-player-name
@@ -1,0 +1,2 @@
+repository=https://github.com/Pirrkatt/copy-player-name.git
+commit=67baf59dc954ca54f12df7088570f0d1e1e65786

--- a/plugins/copy-player-name
+++ b/plugins/copy-player-name
@@ -1,2 +1,2 @@
 repository=https://github.com/Pirrkatt/copy-player-name.git
-commit=67baf59dc954ca54f12df7088570f0d1e1e65786
+commit=27e0ced15b7f142e56585ed0029e4108875c718c


### PR DESCRIPTION
Add a "Copy Name" option to the right-click menu for chat messages and player models, allowing players to easily copy a player's name to the clipboard.