### PR TITLE
Update collection log plugin to 1.45

### DIFF
--- a/plugins/collection-log-popup-enhanced
+++ b/plugins/collection-log-popup-enhanced
@@ -1,2 +1,2 @@
 repository=https://github.com/TimHeessels/collection-log-popup-enhanced.git
-commit=2d835eaf8e3f91cf54b7b5c2ff677362cacc019a
+commit=06534662e033a4824014da563da770cb32d61939


### PR DESCRIPTION
Hide that native popup completely instead of simply 'hiding' behind the enhanced panel. 
(Only hides native collection log popups, combat tasks still show up in the native popup)