### PR TITLE
Add Oracle

### DIFF
--- a/plugins/oracle
+++ b/plugins/oracle
@@ -1,3 +1,3 @@
 repository=https://github.com/StamppG/osrs-oracle.git
-commit=22ad105ee4d2fb236cc3a355a1bd989e4c575523
+commit=339abe21121cfd37cdba859902a4f7fb27fb5ff0
 warning=This plugin exposes your IP address, and submits various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/oracle
+++ b/plugins/oracle
@@ -1,2 +1,2 @@
 repository=https://github.com/StamppG/osrs-oracle.git
-commit=4702aac7f86eb9ab36887dc224014863b9973f60
+commit=22ad105ee4d2fb236cc3a355a1bd989e4c575523

--- a/plugins/oracle
+++ b/plugins/oracle
@@ -1,0 +1,2 @@
+repository=https://github.com/StamppG/osrs-oracle.git
+commit=4702aac7f86eb9ab36887dc224014863b9973f60

--- a/plugins/oracle
+++ b/plugins/oracle
@@ -1,2 +1,3 @@
 repository=https://github.com/StamppG/osrs-oracle.git
 commit=22ad105ee4d2fb236cc3a355a1bd989e4c575523
+warning=This plugin exposes your IP address, and submits various account information, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds Oracle, a RuneLite plugin for synchronizing OSRS account state with a user-configured external backend for use by AI assistants and other tools.