### PR TITLE
Add Thrall Check

### DIFF
--- a/plugins/thrall-check
+++ b/plugins/thrall-check
@@ -1,0 +1,2 @@
+repository=https://github.com/Delkyy/thrall_check.git
+commit=cef13a94320761de4668422f3060c50e0c5bc91f


### PR DESCRIPTION
Thralls have a failure mode that no existing plugin catches: you arrive at the boss, click the resurrection spell, and nothing happens. You were on the standard spellbook, or the Book of the Dead was in the bank, or you were three prayer points short. The spell just doesn't go off, and you usually notice several seconds into the fight.

This plugin checks all three before it costs you anything:

- Book of the Dead in your inventory or equipped, on the wrong spellbook -> the screen flashes until you switch back
- Runes for one resurrection cast, counted across inventory, rune pouch, combination runes, sunfire runes, elemental and combination staves, and a charged tome of fire or earth
- Prayer points, since a Greater cast needs 6 and full runes with an empty prayer bar is still zero casts

Overlay is one line normally and expands to the full rune checklist once you're actually holding the book on Arceuus.

## How this differs from existing thrall plugins

The existing ones all deal with the thrall after it exists, or with reminding you to recast:

- Spell Reminder (formerly Thrall Helper) reminds you to cast, and has an "only on X spellbook" option. It doesn't check whether you're carrying the book or whether you have the runes and prayer to cast at all.
- Thrall Damage Counter / Thrall Damage Tracker count damage after the thrall is up.
- Thrall Highlighter highlights or hides the thrall model.
- Arceuus Timers shows duration and cooldown after casting.

This one is entirely pre-cast: can you cast right now, yes or no. I'd rather fold it into an existing plugin than fragment things, but the readiness check doesn't overlap with what any of them currently do.

## Notes

- build=standard, no third party dependencies. Lombok only, which is already in the verification template's core config.
- BSD 2-Clause.
- Spell costs and prayer costs are from the OSRS Wiki. Varbit and item IDs are read from runelite-api rather than hardcoded literals.
- No network calls, no file IO, no config outside its own group.