### PR TITLE
grand-flip-out: update to 0a1e078

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,2 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=a07015c04a9125d34ee174fc6459e58c9eae3fe9
+commit=0a1e078002415d46aac7b7be682b43a9e88f59ba


### PR DESCRIPTION
User-facing changes since a07015c:

- The "Create free account" prompt now quotes the top hidden item with its tax-net per-item margin (value line omitted unless the net is genuinely positive).
- Device-link flow opens grandflipout.com/link with the code prefilled (input only — the user still confirms everything).
- The in-panel enable dialog now carries the full data disclosure verbatim from the config warning, including the anonymous usage-counts sentence, with a test pinning the two in lockstep.
- Test-only additions: click-wiring pins, disclosure-lockstep pin.

All network opt-ins remain default-off; no new endpoints; built and tested on JDK 11.
