### PR TITLE
Update DropTracker (v6.0.1)

### DIFF
--- a/plugins/droptracker
+++ b/plugins/droptracker
@@ -1,3 +1,3 @@
 repository=https://github.com/joelhalen/droptracker-plugin.git
-commit=87d66f3fc93bcc451cf5a6f6cdf59bdb5f74e77e
+commit=41782e3352f0c24261c910e70ba71128078672e0
 authors=joelhalen,OSRSKoeppy


### PR DESCRIPTION
Fixes a few minor bugs that were present in the newly published (v6.0) code.

I was hoping to get to this update before our PR got merged, but I was beat by a tiny bit. :(

Namely, fixes the manifest for cas/clogs/combat achievements, and adds some 2-way chat polishes.