### PR TITLE
osrscn: bump to 0.2.2

### DIFF
--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=568da8ccc8bd857583e718ae56ef1dfa3da21e70
+commit=6cddd50988bdf337050ad0538a604f70a859835e
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update commit to 6cddd50988bdf337050ad0538a604f70a859835e. Widens the translation table download timeout for slow networks, makes the missing-translation uploader start its watermark at the current file size (never replays old backlog), and adds four composition rules for quest-complete and XP reward lines.