### PR TITLE
Add TOA Keris Reminder

### DIFF
--- a/plugins/toa-keris-reminder
+++ b/plugins/toa-keris-reminder
@@ -1,0 +1,2 @@
+repository=https://github.com/stadtehrsoftware/toa-keris-reminder.git
+commit=f302c6935d0cc46fa3ced8ec6e9581d11547b0aa


### PR DESCRIPTION
## Summary
Adds TOA Keris Reminder, an inventory-only reminder that pulses the Keris Partisan of the Sun green at 50+ current Prayer and red below 50.

## Behavior
- Only affects the normal inventory interface
- Highlights only the Keris item sprite
- Does not automate input, recommend prayers, or predict mechanics
- Uses a fixed 50 Prayer threshold

## Testing
Tested in the RuneLite development client at Prayer levels below and at/above 50.