### PR TITLE
create sleepwalker-stakeout

### DIFF
--- a/plugins/sleepwalker-stakeout
+++ b/plugins/sleepwalker-stakeout
@@ -1,0 +1,3 @@
+repository=https://github.com/manc1n1/sleepwalker-stakeout.git
+commit=89ae60792909f9d5ae41fa6ac1ab33cf231ec677
+authors=Suspext


### PR DESCRIPTION
A RuneLite plugin that displays a movable (<kbd>Alt</kbd> + Drag) [Blisterwood stake sprite](https://oldschool.runescape.wiki/w/Blisterwood_stake#/media/File:Blisterwood_stake.png) as a fake XP drop whenever your character throws a [Blisterwood stake](https://oldschool.runescape.wiki/w/Blisterwood_stake).

The primary use case is during Phosani's Nightmare, where Blisterwood stakes are used against Sleepwalkers.

This plugin was created because the XP drops displayed when attacking Sleepwalkers with a Blisterwood stake can be unreliable. Sometimes, a successful attack may not produce a visible XP drop, even though the attack still registers. The plugin provides an additional visual indicator to confirm that you attacked the Sleepwalker.

The additional visual indicator provides a more consistent way to track stake throws without relying exclusively on XP drops, character animations, or game-world visuals.