### PR TITLE
infobox-inventory-count

### DIFF
--- a/plugins/infobox-inventory-count
+++ b/plugins/infobox-inventory-count
@@ -1,0 +1,2 @@
+repository=https://github.com/ellatonin/runelite-infobox-inventory-count.git
+commit=c80524bbccc8752ee02c76e47fc6dff42a328f73


### PR DESCRIPTION
Plugin that counts how much of a specific item is in the inventory.
Intended to use while enchanting jewellery, collecting clue scrolls while thieving, etc. Any activity where you swap between inventory/other to keep track of number of items

<img width="753" height="505" alt="image" src="https://github.com/user-attachments/assets/18225796-f23a-494c-8ebe-2de5a55394c9" />
