### PR TITLE
Update live-on-clan icon

### DIFF
--- a/plugins/live-on-clan
+++ b/plugins/live-on-clan
@@ -1,3 +1,3 @@
 repository=https://github.com/MilicoOSRS/live-on-clan.git
-commit=ce282d7f8ba1aa826a71b9d82b39eb588ae277cc
+commit=dd1078ea6d147002c4c988ad93b6341c26a7d7b8
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates the Live On Clan plugin commit to include its Plugin Hub icon.