### PR TITLE
update brimhaven-agility to 1.5.0

### DIFF
--- a/plugins/brimhaven-agility
+++ b/plugins/brimhaven-agility
@@ -1,2 +1,2 @@
 repository=https://github.com/kagof/rl-plugin-brimhaven-agility.git
-commit=dc80c9a2d3d16d1147ec51985fac9304e37b4963
+commit=a11b8a9671dfab8000b6819cb6301ebb88f71857


### PR DESCRIPTION
Adds a new (configurable) feature.

A notification (defaulted to off) when the active dispenser is within `x` platforms of the player. This has been a requested enhancement for people who are AFKing in the arena by just camping an obstable, setting it to notify when the active dispenser is nearby will help those users to tag the dispenser without having to watch too closely.