### PR TITLE
Add raids-last

### DIFF
--- a/plugins/raids-last
+++ b/plugins/raids-last
@@ -1,0 +1,2 @@
+repository=https://github.com/richardverheyen/raids-last.git
+commit=ee5dcf45625a767efcd47c11e457667a1b2ca0bf


### PR DESCRIPTION
## Raids Last

Chat commands and a sidebar panel that show off the last item you received from each raid.

- `!coxlast`, `!toblast`, `!toalast`, and `!raidslast` rewrite your chat message with the last item received from Chambers of Xeric, Theatre of Blood, and Tombs of Amascut, the same way commands like `!lvl` work — so it's visible to everyone around you.
- A "Raids Last" sidebar panel lists every unique item actually received per raid (not the full theoretical table), most recent first.
- Loot is tracked from the live `LootReceived` event, and backfilled from the in-game Collection Log (both the overview's "Latest items" strip and a raid's own page) so history isn't limited to drops witnessed after installing the plugin.

Repository: https://github.com/richardverheyen/raids-last