### PR TITLE
Update world-splitter group range display

### DIFF
--- a/plugins/world-splitter
+++ b/plugins/world-splitter
@@ -1,2 +1,2 @@
 repository=https://github.com/LLLosrs/world-splitter.git
-commit=fd324f9d1fdf6bc0b2bdaf448b72d24c42290bd4
+commit=5280809f09be18a44c0fdc60d612df41a64a6959


### PR DESCRIPTION
Updates World Splitter group mode to display every group member's assigned world range and keep assignments synchronized when members join or leave.