### PR TITLE
Update Reval clan

### DIFF
--- a/plugins/reval-clan
+++ b/plugins/reval-clan
@@ -1,4 +1,4 @@
 repository=https://github.com/revalOSRS/reval-cc-plugin.git
-commit=6ade16941cbb93b37cbdcb51d5b01180d3c1dfe2
+commit=daf2d837ceb70334f58921d1b2e63542a8d955b5
 authors=stenjansarv
 warning=This plugin submits your IP address and comprehensive records of your account activity and progress to a 3rd-party server not controlled or verified by the Runelite developers.


### PR DESCRIPTION
- Team name colors: during active events, clan members' names are colored by their team in the clan list and clan chat (toggleable, on by default)
- Player profile cards: right-click a clan member -> "View Reval Profile" opens an in-game card with rank, points, GP from drops, pets, clog count, diary tasks, event win stars, and member-since (toggleable)
- Staff checkmarks: Deputy Owner+ see a checkmark in the clan list next to members signed up for an upcoming event, with the event name on hover
- New Events config section for the team color toggle