### PR TITLE
Update parentsguild

### DIFF
--- a/plugins/parentsguild
+++ b/plugins/parentsguild
@@ -1,3 +1,3 @@
 repository=https://github.com/kulcris/ParentsGuildPlugin.git
-commit=20c997bb57709bcd82597ac55732fd960b199800
+commit=8163ce09c60761f0a312b6891bc373e63ab4d6a4
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/parentsguild
+++ b/plugins/parentsguild
@@ -1,3 +1,3 @@
 repository=https://github.com/kulcris/ParentsGuildPlugin.git
-commit=8163ce09c60761f0a312b6891bc373e63ab4d6a4
+commit=603a66ab9d4cfa3a92d037566dedad4bc12f9dc4
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/parentsguild
+++ b/plugins/parentsguild
@@ -1,3 +1,3 @@
 repository=https://github.com/kulcris/ParentsGuildPlugin.git
-commit=603a66ab9d4cfa3a92d037566dedad4bc12f9dc4
+commit=85a6231cf8f01647242c2e5b362540d4c2874325
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Removed need for bingo token
Added localization for timestamps
Optional bingo metric tracking for XP, boss KC, and clues.
Pending metric progress uploads before WOM confirms.
Metric progress display like 0(+20)/200 xp.
Reminder to log out/back in when a metric is met locally so WOM can update.
Optional WOM refresh on logout/world-hop, default off.
Multi-item proof item selection before taking a screenshot.
Multi-item tiles now show multiple item icons on the plugin board.
Multi-item tiles now show multiple item icons on the website board.
Better board progress text, including 0/1 for single drop tiles.