### PR TITLE
create ba-gamble-tracker

### DIFF
--- a/plugins/ba-gamble-tracker
+++ b/plugins/ba-gamble-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/vividflash/ba-gamble-tracker.git
+commit=71af587a4de9c6f268848c808a54855efd1487f3


### PR DESCRIPTION
BA Gamble Tracker: puts the rewards from low and medium Barbarian Assault gambles in the Loot Tracker, which currently records the high gamble only.
also checks the high gambles, but doesnt save their results. 

requires  loot tracker