### PR TITLE
Fix world-splitter world switcher overlay

### DIFF
--- a/plugins/world-splitter
+++ b/plugins/world-splitter
@@ -1,2 +1,2 @@
 repository=https://github.com/LLLosrs/world-splitter.git
-commit=5280809f09be18a44c0fdc60d612df41a64a6959
+commit=214f24f664fc7d62fea9198ba65507298bb3d206


### PR DESCRIPTION
Updates World Splitter to prevent assigned-world highlighting from covering the entire World Switcher. Highlights are now clipped to individual world entries with a light fill and border.