### PR TITLE
Add ZigZag plugin

### DIFF
--- a/plugins/zom-zigzag
+++ b/plugins/zom-zigzag
@@ -1,0 +1,2 @@
+repository=https://github.com/JZomDev/zom-external-plugins.git
+commit=0de9ef678e6323ff04eb2dc477b48591e22c875b


### PR DESCRIPTION
Adds ZigZag option to core BankTag layouts.

It matches what the ZigZag from Inventory set ups does to place the items. 