### PR TITLE
Add Bankstand

### DIFF
--- a/plugins/bankstand
+++ b/plugins/bankstand
@@ -1,0 +1,3 @@
+repository=https://github.com/CVE-078/bankstand-runelite.git
+commit=8a89076c08bd74a5510d33d1ee17a696e9cfe520
+warning=This plugin sends your account hash, display name and skill XP to Bankstand while you're paired. Turn on more of its toggles and it also sends quest progress, achievement diary tiers, collection log slots and new unlocks, combat achievement tier counts and completed tasks, your account type, notable drops and pet drops. Everything's private to your account by default; you can share it with your Bankstand groups or publicly from your privacy settings there. Data goes to whatever Server URL you set, the official Bankstand server by default over https. Change that URL and your data goes there instead.

--- a/plugins/bankstand
+++ b/plugins/bankstand
@@ -1,3 +1,3 @@
 repository=https://github.com/CVE-078/bankstand-runelite.git
-commit=8a89076c08bd74a5510d33d1ee17a696e9cfe520
+commit=32df118f50a857e10ba9bd33f1bacdb98963d650
 warning=This plugin sends your account hash, display name and skill XP to Bankstand while you're paired. Turn on more of its toggles and it also sends quest progress, achievement diary tiers, collection log slots and new unlocks, combat achievement tier counts and completed tasks, your account type, notable drops and pet drops. Everything's private to your account by default; you can share it with your Bankstand groups or publicly from your privacy settings there. Data goes to whatever Server URL you set, the official Bankstand server by default over https. Change that URL and your data goes there instead.


### PR DESCRIPTION
## Description

Bankstand ([bankstand.gg](https://bankstand.gg/)) tracks OSRS account progress. This plugin keeps your skills, quests,
achievement diaries, combat achievements and collection log synced to your Bankstand account
automatically, so you don't have to go to the site and look anything up by hand.

## Data sent, and to whom

Only to your own Bankstand account, at whatever Server URL you set (bankstand.gg by default).
Each capability is its own toggle in the config, and only skill XP is on by default. The
manifest's warning= line and the plugin's README both spell out exactly what each toggle sends.

Everything's private to your account by default. Sharing it with a group or making it public is
a separate decision you make later, on the site, not something pairing turns on for you.

## Review notes

- build=standard, no runtime dependency beyond net.runelite:client
- No reflection, no native code, no process execution
- No client.menuAction/client.runScript/client.invokeMenuAction anywhere, enforced by a test
  (NoAutomationApiTest) that scans the source for it
- The pairing token never goes through ConfigManager (another test, NoCredentialsInConfigTest,
  checks this) and is never logged
- docs/for-reviewers.md in the repo names the exact files that touch the network and gives you
  the grep commands to check nothing else does

Repository: https://github.com/CVE-078/bankstand-runelite