### PR TITLE
Add Brutus Helper

### DIFF
--- a/plugins/brutus-helper
+++ b/plugins/brutus-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/Joerikros/brutus-helper.git
+commit=44d197d1c9f3af3e62fd33cffe418cb8dc17aedd


### PR DESCRIPTION
Adds Brutus Helper, a plugin for the Brutus / Demonic Brutus cow boss in the Lumbridge cow field.

It highlights the danger tiles of his two telegraphed special attacks:

- **Slam** (*snorts*): the exact hit pattern - an L of 5 tiles around the footprint corner nearest the player, or a 3-tile strip along an edge when standing centered on it - locked at telegraph time, with a tick countdown. Patterns and 4-tick timing were verified against the impact graphics (id 3588) spawned on the actual hit tiles.
- **Charge** (*growls*): the 3-tile-wide corridor of his run, including the overshoot past the player's position; the path stays highlighted while his run animation is active.

It also draws a permanent outline of his 3x3 footprint for positioning. Triggers are the overhead texts with the corresponding animations (13785/13778) as fallback. No automation, no external requests; overlay rendering only via the public API.

Repository: https://github.com/Joerikros/brutus-helper

Replaces #15399, which was auto-closed after a history rewrite in the plugin repository.