### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=1b6dd8a52ef8e4d5c54991f559bedc851e162325
+commit=e7f743abb98af8260a4d59b3b28834d0c9e6dc91
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
- Reconciled the Flip Finder panel and RuneScape login state when the plugin is enabled mid-session, so the panel no longer gets stuck out of sync
- Closed out the round-trip flip cycle correctly when a sell fills while offline
- Fixed a bug where collected buy quantity attribution could corrupt flips of the same item
- Reduced complexity in the smart sell pricing calculation for maintainability
- Fixed a GP formatter overflow on the recommendation card by widening totals to a 64-bit integer
