### PR TITLE
Update Kill Clog to 2.0.2

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=afc574ac78838fc28456dd99fe1c892c5649d66b
+commit=eec57e4f9da19d01bac7472e55612b84a50da901
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill Clog 2.0.2

* the plugin follows account name changes: your local log and sync move to the new name automatically
* accounts sharing a pc never mix logs