### PR TITLE
chat resizer 2.3.4 - additions and fixes

### DIFF
--- a/plugins/better-resizable-chat
+++ b/plugins/better-resizable-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/shanktank/better-resizable-chat.git
-commit=8ed2e70c8afa4ee4ac2b30f77ec8eefdca4a1a8f
+commit=7170f8a295c124f9fb0eefadb0f04d88cb5f6873

--- a/plugins/better-resizable-chat
+++ b/plugins/better-resizable-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/shanktank/better-resizable-chat.git
-commit=945704eaf61bc68842ae89337f0475df85c4cb37
+commit=8ed2e70c8afa4ee4ac2b30f77ec8eefdca4a1a8f


### PR DESCRIPTION
add: "compatibility" options

add: seed vault clean refit

remove: old config migration

fix: live update pm split position when drag-resizing chat height

fix: frame-perfect redraws on config value change

fix: avoid single frame of incorrect location for bottom-right snap corner preview when pressing alt

fix: transparent chat: don't lose gradient bands when disabling plugin, prevent artifacts during fixed -> resizable layout switch, fluid background resizing