### PR TITLE
PvM Toolkit 1.4.3

### DIFF
--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=f7dae12c91d2b08d4f2fe6b380fe32c35c376bd4
+commit=d7e11c09d1ff0edd1e043e4f5067753b585ce3b8


### PR DESCRIPTION
## Changes
- Add a configurable `Ignored supplies` list.
- Ignored items still count as used, but add 0 gp to supply costs.
- Apply the setting consistently to chat tabs, statistics, Slayer Log, and Combat Loot Log profit.
- Support potion names with or without dose suffixes.
- Pause the current Slayer task timer after two minutes without task or PvM activity, then resume it on the next activity.
- Include all 1.4.3 changes in the update scroll.

## Verification
- `clean test shadowJar --rerun-tasks` passes: 56 tests, 0 failures.
- Full-profile RuneLite dev client loads and starts `PvmToolsPlugin` successfully.
- Version metadata and `pvm-tools-1.4.3-all.jar` are consistent.