### PR TITLE
Add chat-spellcheck

### DIFF
--- a/plugins/chat-spellcheck
+++ b/plugins/chat-spellcheck
@@ -1,0 +1,2 @@
+repository=https://github.com/theovit/chat-spellchecker.git
+commit=c5acaa80f58716e2342ae9b18b8c7e0b66f6d2d0


### PR DESCRIPTION
Chat Spellcheck flags likely misspelled words as you type in the chatbox (public, clan/friends, and private messages), shows a frequency-ranked suggested correction inline next to the word, and blocks sending a message with likely typos until you retype it. Never inserts or modifies chatbox text - the player always retypes the word themselves. Underline/suggestion-box/blocked-notice colors and font size are configurable.

Repo: https://github.com/theovit/chat-spellchecker