### PR TITLE
Update collection-log-progress

### DIFF
--- a/plugins/collection-log-progress
+++ b/plugins/collection-log-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/Collection-log-completion-viewer.git
-commit=ab86076a831541b2c4cd36b2e60bd139a87ddf3a
+commit=2e6ec82ff9f5b47c602bf1d3cfe1d427c94b8fe3

--- a/plugins/collection-log-progress
+++ b/plugins/collection-log-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/Collection-log-completion-viewer.git
-commit=f0724409caf7b98d1d5fb2c1390fefb511a7f7ee
+commit=ab86076a831541b2c4cd36b2e60bd139a87ddf3a


### PR DESCRIPTION
Updates `collection-log-progress` to [`2e6ec82`](https://github.com/xboxnuker-rgb/Collection-log-completion-viewer/commit/2e6ec82ff9f5b47c602bf1d3cfe1d427c94b8fe3).

## Changes
- add disabled-by-default completion sorting for Collection Log rows
- default to 100%–0%, with an optional reverse order for 0%–100%
- keep equal percentages alphabetical and compose sorting with existing Hide filters
- count RuneLite-declared item variants, including Amy's off-hand saw, against their Collection Log slot

## Testing
- `.\gradlew.bat clean build` — 18 tests passed, 0 failures
- manually validated completion sorting, existing row filters, and Mahogany Homes at 100% in RuneLite