### PR TITLE
GPS 0.13.1

### DIFF
--- a/plugins/gps
+++ b/plugins/gps
@@ -1,2 +1,2 @@
 repository=https://github.com/PauloAguiar/runelite-gps-plugin.git
-commit=9299792247dfbe01e81e2e72631f8a1dbe18b264
+commit=32121f17c91c617692d91853137f4bf9089b9a39


### PR DESCRIPTION
**GPS 0.13.1**

**Fixes from the issue tracker**
- #22 mystic/elemental staves count as rune sources · #19 mounted items name their furniture · #17 respawn-portal gating (Prifddinas quest gate, Lumbridge selection flags) · #5 catalog refreshes on inventory changes · #20/#21/#7 bank-detour fixes above.