### PR TITLE
better-dt2-boss-utilities: add plugin

### DIFF
--- a/plugins/better-dt2-boss-utilities
+++ b/plugins/better-dt2-boss-utilities
@@ -1,0 +1,2 @@
+repository=https://github.com/TheSpryt/better-dt2-boss-utilities.git
+commit=b14a7a9e499a8d3d36899f0ad82bb93847677ae3


### PR DESCRIPTION
Reopening #14120, which was closed on 24 August for falling out of the bot view.

Utilities for the Desert Treasure 2 bosses:

- Vardorvis: hides the axes once they are no longer a threat, so the ones still incoming are easier to read
- Vardorvis: highlights the head that signals the incoming attack style
- Vardorvis: feedback on the spore captcha
- Whisperer: boss utilities
- Projectile swaps for the bosses that use them

Pinned at b14a7a9, two commits later than the pin on the closed PR. Those two add the Whisperer utilities and deduplicate the overlay rendering behind a single highlight-style enum.

One added file, no shared code touched, no third-party dependencies, and build=standard.