### PR TITLE
Add Compact Mode

### DIFF
--- a/plugins/compact-mode
+++ b/plugins/compact-mode
@@ -1,0 +1,2 @@
+repository=https://github.com/gabworknestio-beep/Compact-Mode.git
+commit=2f993b755410cb0519913c307d953d2e74c640fc


### PR DESCRIPTION
Adds Compact Mode, a display-only plugin that scales the complete RuneLite game window to a compact size while preserving accurate mouse input.

It supports 35%, 25%, and 20% widths, restores the original window bounds, and can dock the window to the right.

Tested locally with the external plugin launcher on Windows.