### PR TITLE
Update Gielinor Cartography

### DIFF
--- a/plugins/gielinor-cartography
+++ b/plugins/gielinor-cartography
@@ -1,3 +1,3 @@
 repository=https://github.com/jacke9708/Gielinor-Cartography.git
-commit=30a3b974a1ff14e52834f2d52de8ccb55955355c
+commit=4d2ed3dfdd5ad756cb8329963026cf0e33c5dcde
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Fixes a bug that broke the plugin for every installer: tasks.json was bundled from the project root via a custom build.gradle step, which worked in my own local builds but wasn't picked up by the Hub's own packaging tool, so the published jar was missing the file entirely and crashed on startup (IOException: tasks.json resource not found in plugin jar).

Moved tasks.json into src/main/resources/ (the standard Gradle resource location, verified against an existing working Hub plugin's layout) so it's bundled correctly regardless of which build tool packages it. Verified locally via `./gradlew shadowJar` that the file is now actually present in the built jar, and confirmed the live backend still works correctly after redeploying.

Also hardened shutDown() to not throw a second exception if startUp() fails partway through, since RuneLite still calls it during cleanup either way.