### PR TITLE
osrs-fliphub: update to b4fac2e (README, icon, tooltip fix — no API changes)

### DIFF
--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,3 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=f1222128e09149574b10a8453a1496553894c6ee
+commit=afed810f43de6649cd9367f5848760d24c9a6dd6
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,3 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=afed810f43de6649cd9367f5848760d24c9a6dd6
+commit=b4fac2e59b6cabb78cc1d441e1dd202da3731148
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Commit bump for `osrs-fliphub`, approved and merged in #13658. **Manifest diff is one line** — `commit=` only; `repository=` and `warning=` are untouched.

### What changed
No behavioural change to networking or data handling:

- **README rewritten for users.** The plugin hub page was showing build/dev instructions and a reviewer-oriented privacy write-up. It now leads with what the plugin does, a feature list, setup steps and a config reference.
- **Plugin icon** updated to the current osrsfliphub.com logo (the old mark is no longer the site's branding).
- **Price-age tooltip** now stays visible for as long as its row is hovered, and is aligned to the Sell/Buy price rows it describes. Previously it vanished after ~1s and rendered ~2 rows too low.

### Review notes
- No new or restricted APIs. Still `LinkBrowser::browse`, no `Desktop::browse`, no thread interrupts.
- No networking, config, or permission changes. The opt-in sync gate is untouched and every OkHttp call still checks it.
- No change to what is sent to the server — the `user.name` removal already shipped in the pinned f122212.
- Code changes are confined to one panel class; the rest is two PNG assets and the README.

Source diff: https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public/compare/f1222128e09149574b10a8453a1496553894c6ee...b4fac2e59b6cabb78cc1d441e1dd202da3731148
