### PR TITLE
exchange-logger

### DIFF
--- a/plugins/exchange-logger
+++ b/plugins/exchange-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/istid/exchange-logger.git
-commit=d289dbc9b16882dd5160e5abc0bfb319ead2188d
+commit=a089e754a280bdf83bfd1d36a5a532d6630d208a

--- a/plugins/exchange-logger
+++ b/plugins/exchange-logger
@@ -1,2 +1,3 @@
 repository=https://github.com/istid/exchange-logger.git
-commit=a089e754a280bdf83bfd1d36a5a532d6630d208a
+commit=c88dd3b9f3d76c6a0ae1631f9e5deeb1031b0ec8
+authors=clamzhi-dev


### PR DESCRIPTION
Updates the exchange-logger manifest to https://github.com/istid/exchange-logger/pull/15 - fixes GE sale tax not accounting for the 2% tax, log files always being .log regardless of the selected format, added option to split logs into separate files for each account and adds item names alongside item IDs.