### PR TITLE
Add oathfall

### DIFF
--- a/plugins/oathfall
+++ b/plugins/oathfall
@@ -1,0 +1,2 @@
+repository=https://github.com/opportunist-ic/oathfall-runelite.git
+commit=231a4b9f709b953f7745c91f53cdefee5e361930


### PR DESCRIPTION
Adds **Oathfall**, a tracker for a hardcore-ironman challenge mode.

The plugin keeps the run's ledger (Doom track, Grace, Scars, Kept Oaths), deals
the challenge's Vow table, watches the sworn restriction for observable breaks,
and advances tier gates from real stat levels.

**No gameplay automation.** Every check is passive — it reads game state and
`MenuOptionClicked` events the player has already generated. Nothing sends input
to the client.

**Networking:** the plugin can optionally serve a small companion tracker page
over HTTP. It is **off by default**, binds to `127.0.0.1` only, requires a token
minted fresh each session, and makes no outbound connections of any kind.

Builds clean against RuneLite 1.12.36 on JDK 11 with no deprecation warnings.