### PR TITLE
update botw

### DIFF
--- a/plugins/botw
+++ b/plugins/botw
@@ -1,3 +1,3 @@
 repository=https://github.com/marcushill13/botw.git
-commit=2b79b8b8268c15959d6852081a02083bd087a0e7
+commit=cb6a7e64a0618fc0b1dc8d230fcab253c4d95415
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Lets a player remove a challenge that the person running it has deleted.

Until now that challenge stayed on their list for good: opening it said "No challenge with that code" and nothing removed it, while its queued kills were retried every minute for as long as the plugin was installed. Opening one now offers to take it off the list and drops those events.

This relies on separating "the service says there is no such challenge" from "the service could not be reached", which the plugin previously treated as one kind of failure. Only a 404 counts as gone; a timeout or a refused connection leaves everything exactly as it was, so a moment without a connection cannot delete a live competition.
