### PR TITLE
Update bank-coffer-scanner

### DIFF
--- a/plugins/bank-coffer-scanner
+++ b/plugins/bank-coffer-scanner
@@ -1,2 +1,2 @@
 repository=https://github.com/osrsrigid/bank-coffer-scanner.git
-commit=d7d7182a94d0170fb6029864c32e227fc06b6ac3
+commit=e2a663650a8bfd24ba19e2c4b37ee2aebc4480f5


### PR DESCRIPTION
Updates bank-coffer-scanner to a new commit:

- Redesigned the side panel from a wide table to a scrollable card list (avoids horizontal scrolling in the narrow sidebar)
- Added a "Show" mode (Recommended / Any coffer edge / All items) using the existing warn thresholds to filter out marginal coffer-vs-alch edges
- Added optional category filters (ores, cut gems, herblore supplies, teleports) and min quantity / min total value filters
- Added a sort-by option (stack profit / per-item profit / coffer value)
- All filter/sort choices now persist across logins
- Coffer-eligible-only is now the default
- Coins/platinum tokens are now always excluded from scan results