### PR TITLE
update waypoint-sync

### DIFF
--- a/plugins/waypoint-sync
+++ b/plugins/waypoint-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Xiodrade/waypoint-sync.git
-commit=1c351d0e73c18f21a35fb9ad40bcfa6e8e3b76af
+commit=a7740d8e977a06075c1c5aa7d2cac2918d48b5ab
 warning=This plugin submits your IP address, display name, quests, diaries, and combat achievements to a third party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Combat achievements — completion is now read from the game's own per-task varplayers (CA_TASK_COMPLETED_0..20) at login and decoded server-side, rather than scraping task names out of the Combat Achievements interface. This removes the need for the user to open and scroll that interface, and fixes accounts where tasks that had merely been displayed were recorded as complete.

Collection log — when the collection log is opened, the plugin invokes the log's own "Search" option so the server transmits every entry, reads those entries from script 4100, then re-runs the setup script to restore the view. Previously only the pages a user manually clicked through were captured. Capture is skipped entirely while the log is open via another player's POH adventure log, so another player's items are never recorded against the local account.