### PR TITLE
follower-buddy 1.1.0

### DIFF
--- a/plugins/follower-buddy
+++ b/plugins/follower-buddy
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeSpatol/follower-buddy.git
-commit=4efdd3db8bc09429686c6066f5c82eb9deeecc5f
+commit=6a8f57bd8247c0f0fd24e7fd9b7c06f7d2d2ee76

--- a/plugins/follower-buddy
+++ b/plugins/follower-buddy
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeSpatol/follower-buddy.git
-commit=93ea6d3091360c3dff18ad65273b385918c948d7
+commit=4efdd3db8bc09429686c6066f5c82eb9deeecc5f

--- a/plugins/follower-buddy
+++ b/plugins/follower-buddy
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeSpatol/follower-buddy.git
-commit=6a8f57bd8247c0f0fd24e7fd9b7c06f7d2d2ee76
+commit=c19703944feae9ec2f88e374a1d087f79e362170


### PR DESCRIPTION
Updates follower-buddy 93ea6d3 -> 4efdd3d (version 1.1.0).

Since the initial submission:
- Speech corpus grown from 349 to 425 rules (~2,100 lines), with per-line wear so long-term players rotate toward unheard lines.
- New behaviours: an "explore" errand (walks to nearby scenery and notes it down), Stay-mode idle life, a low-mood conversation arc, a one-time naming prompt, and a Memory window in the side panel showing everything the plugin stores locally, with a one-click erase.
- Politeness systems: speech quiets when the player is AFK, unanswered questions back off instead of re-asking, combat lines only fire in two-way combat (not while being chased through aggro).
- Fixes: the stand-clear-of-combat behaviour after a relog, walled-arena positioning, and several speech-timing issues.
- Test suite now 703 tests; still fully client-side, no packets, no automation, nothing leaves the machine.