### PR TITLE
Update osrs-game-session-tracker: 1.3.0

### DIFF
--- a/plugins/osrs-game-session-tracker
+++ b/plugins/osrs-game-session-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Golddcaleb/osrs-game-session-tracker.git
-commit=e6049c343c208da727e79673e3341ba645ddbfa5
+commit=b1e97fd91ac5f3f5528ad98db17fefdddb2770d7
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
# Update osrs-game-session-tracker to 1.3.0

Bumps the pinned commit for **OSRS Game Session Tracker** to
`b1e97fd91ac5f3f5528ad98db17fefdddb2770d7`.

- Repository: https://github.com/Golddcaleb/osrs-game-session-tracker
- Previous commit: `e6049c343c208da727e79673e3341ba645ddbfa5`

## What changed

Two additive, opt-in-or-invisible changes. A user who upgrades and touches no settings
writes to the same path with the same fields as 1.2.0.

**1. `itemId` on loot events.** Each entry in a loot event's `items[]` now carries the
OSRS item ID alongside the existing `name`, `qty` and `gp`. `LootReceived`'s `ItemStack`
already exposed it; the plugin simply was not forwarding it. It lets the companion web tool
resolve item icons exactly and key per-item settings on something that survives a rename,
instead of matching on the display name.

- Appended **after** the three existing keys, so the `{name, qty, gp}` prefix is
  byte-identical to what 1.2.0 wrote.
- Omitted when no positive ID is available, rather than written as a placeholder `0`.

**2. An optional room code.** A new config string under *Firebase connection*, **blank by
default**.

- Blank — writes to `gamenight/plugin/…`, exactly as 1.2.0 did. This is what every existing
  user gets until they type something.
- Set — writes to `rooms/<code>/…` instead. Nothing is dual-written.
- The input is sanitized before it can reach a path: trim, lowercase (`Locale.ROOT`), strip
  everything outside `[a-z0-9-_]` (which removes all six characters Firebase forbids in a
  key, plus interior spaces), truncate to 24 characters. A code that sanitizes to nothing is
  treated as no code and falls back to the default path, so an empty or malformed path
  segment cannot be produced. Because that normalization is lossy, the effective code is
  printed to the game chat whenever the field changes.

No new event subscriptions, no new dependencies, still `build=standard`. The boss list and
the kill-count chat parsing are untouched.

## Scope of the data change

The destination and the categories of data are unchanged — the same user-supplied endpoint,
the same kinds of data — but two things are now sent that were not before, so flagging them
explicitly:

- **`itemId`** — the OSRS item ID of loot the local player received. This is a game constant,
  not user data; it accompanies an item name that was already being sent.
- **The room code**, if the user sets one. It is not sent as a field; it becomes part of the
  destination path within the user's own database.

Restating the full disclosure:

- **What is sent:** the local player's OSRS display name, boss kill counts, and loot (item
  name, **item ID**, quantity and GE value) with its source name and type, plus a periodic
  presence timestamp, plus the **optional room code** as part of the path.
- **Where:** a Firebase Realtime Database URL **the user supplies in config**. No hardcoded
  endpoint; nothing is sent until the user enters their own URL, and nothing is sent while
  *Enable tracking* is off. Credentials live only in RuneLite's `ConfigManager`.
- **How:** Firebase REST over OkHttp, all asynchronous (`enqueue`); failures are logged,
  never thrown.
- The disclosure is in the plugin description, at the top of the config panel, and behind a
  consent `warning` on the tracking toggle. **All three were updated in this release** to
  name the item ID and the room code.

## Compliance

- No automation of game actions and no modification of game state.
- Reads only the local player's own loot, via RuneLite's existing `LootReceived` event.
- No new dependencies; still `build=standard`.
- `./gradlew build` (compile + tests) passes; 32 unit tests, including new coverage for the
  `itemId` key order/omission and for room-code sanitization and path selection.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
