### PR TITLE
Update recipe-checklist

### DIFF
--- a/plugins/recipe-checklist
+++ b/plugins/recipe-checklist
@@ -1,2 +1,2 @@
 repository=https://github.com/KludensVogter/Recipes_Checklist.git
-commit=b070d7d0f03e91f849abcb4011cdd70c8f84f038
+commit=b221cad7355068cec90b7e4518b77a431f14ed36


### PR DESCRIPTION
Add materials summary, sub-recipe tree and persistent bank memory
Sub-recipes added from a material now belong to the goal that needs them:
they nest under it, scale with its amount, and are removed or folded along
with it. Two goals needing the same material each keep their own entry, so
neither disturbs the other's totals.

A foldable summary at the top combines everything the checklist still needs
into one list, summed per item. It shows only what has to be gathered - a
material you have decided to make yourself drops out in favour of whatever
its recipe needs.

Bank contents are now snapshotted and saved per account rather than read
from the bank container on demand. The client drops that container when the
bank closes, so any inventory change - picking up loot, most obviously -
recomputed bank totals as zero. Counts now survive both looting and logout.

In-game clicks require shift by default, so ordinary building no longer
fills the checklist up. Shift keeps this working without touching any menu,
which the plugin rules forbid for Construction.

Also: shared MaterialRow between the summary and per-recipe rows, and the
bank tooltip on materials is gone now that the colours convey it.