### PR TITLE
Add Exodus Bingo

### DIFF
--- a/plugins/exodus-bingo
+++ b/plugins/exodus-bingo
@@ -1,4 +1,4 @@
 repository=https://github.com/drewapalooza/exodus-bingo.git
-commit=f97ca356cf59115b9f8b2878a9b9d2464ec7d104
+commit=f9d428d4608b68700240f8f38d99e9da40e643dd
 authors=drewapalooza
 warning=This plugin submits your IP address, RSN, loot and pet event data, and matching game-view screenshots to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/exodus-bingo
+++ b/plugins/exodus-bingo
@@ -1,4 +1,4 @@
 repository=https://github.com/drewapalooza/exodus-bingo.git
-commit=f9d428d4608b68700240f8f38d99e9da40e643dd
+commit=2db25c52ce851496a278acab561ec36add93abaa
 authors=drewapalooza
-warning=This plugin submits your IP address, RSN, loot and pet event data, and matching game-view screenshots to a 3rd-party server not controlled or verified by RuneLite developers.
+warning=This plugin sends your IP address, RSN, loot and pet event data, and matching game-view screenshots to the Exodus Bingo service. When separately enabled, it also sends filtered drop or pet details and game-view screenshots to a user-configured Discord webhook. Neither third-party destination is controlled or verified by RuneLite developers.

--- a/plugins/exodus-bingo
+++ b/plugins/exodus-bingo
@@ -1,0 +1,4 @@
+repository=https://github.com/drewapalooza/exodus-bingo.git
+commit=f97ca356cf59115b9f8b2878a9b9d2464ec7d104
+authors=drewapalooza
+warning=This plugin submits your IP address, RSN, loot and pet event data, and matching game-view screenshots to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Exodus Bingo adds a compact 5x5 team-event sidebar with tile progress, requirements, per-character contributions, recent achievements, join-by-code, and linked-event switching. Optional bingo event submission is disabled by default and uses metadata preflight before uploading matching game-view screenshots. A separate disabled-by-default Discord webhook can send only locally filtered valuable, listed-unique, or pet drops; webhook tokens are masked and stored locally. Offline bingo evidence is idempotent and bounded. This update removes the runtime thread-interrupt call identified in maintainer feedback. The standalone Java 11 clean build passes 109 tests. Source: https://github.com/drewapalooza/exodus-bingo