### PR TITLE
update sleepwalker-stakeout

### DIFF
--- a/plugins/sleepwalker-stakeout
+++ b/plugins/sleepwalker-stakeout
@@ -1,3 +1,3 @@
 repository=https://github.com/manc1n1/sleepwalker-stakeout.git
-commit=c212e640babaff96333ad594186d4230db06a9c4
+commit=e8b02b4fd24fbbe7595d5f107d4eb7897cb2df79
 authors=Suspext


### PR DESCRIPTION
## Summary

Updates the Sleepwalker Stakeout overlay positioning behavior and improves the project README.

## Changes

- Position the Blisterwood stake overlay directly above the local player by default
- Automatically follow the player's canvas position until the overlay is manually moved
- Allow the overlay to be repositioned with <kbd>Alt</kbd> + Drag
- Enable RuneLite's built-in overlay anchor snapping
- Preserve manually selected or snapped overlay positions
- Restore player-following behavior when the overlay position is reset
- Update README documentation to explain the new positioning behavior
- Improve README presentation and plugin preview layout

## Testing

- Verified the overlay follows the local player by default
- Verified the fake XP drop renders above the player
- Verified <kbd>Alt</kbd> + Drag disables automatic positioning
- Verified the overlay can snap to RuneLite anchor points
- Verified manually positioned overlays remain in place
- Verified resetting the overlay restores automatic player-following behavior
