### PR TITLE
Update traducao-osrs-br to v2.0.1

### DIFF
--- a/plugins/traducao-osrs-br
+++ b/plugins/traducao-osrs-br
@@ -1,2 +1,2 @@
 repository=https://github.com/walterrezende12-tech/Traducao-OSRS-BR.git
-commit=6fa00a56352e98d88fd15125945640d256663411
+commit=525a417c004ee654d51cecc425467445ad88e9f5


### PR DESCRIPTION
Updates the Traducao OSRS BR plugin to published commit 525a417c004ee654d51cecc425467445ad88e9f5.

Includes the Menu Entry Swapper compatibility fix, keeping translation after menus and submenus are created so the option box is sized correctly.

Validation: check/jar build completed successfully in the release repository.