### PR TITLE
add clockwork plugin

### DIFF
--- a/plugins/clockwork
+++ b/plugins/clockwork
@@ -1,0 +1,2 @@
+repository=https://github.com/techgaud/ClockWork.git
+commit=1e3ba342c32c4845d7958977e0ada3dbbf163651


### PR DESCRIPTION
Clockwork 00.01.000

Times things you repeat in game and keeps a history, so you can track your
progress.

A clock is started, lapped and stopped from the side panel, or on its own by
either built in triggers or by custom triggers you define and name yourself.
Each clock keeps its last 50 runs with a personal best and a live delta
against it, and adds an optional timer box in game while it runs.

I checked for an existing plugin to contribute to first. The nearest are Boss
PB Timer, which is boss fights, Grimy Herb Stopwatch, which times herb
cleaning rather than a herb run, and Generic Autosplitter, which bridges to
LiveSplit.

Clockwork is a general timer for any repeated routine, with
triggers you define.