### PR TITLE
update aura-tracker

### DIFF
--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Matelaa/aura-tracker.git
-commit=d8ebbabbb51a643f6e7402c1deed824415fbe39a
+commit=825eed370239dfb9fb36f885cd3fc699b3718a90
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Matelaa/aura-tracker.git
-commit=ca36c36b015e5479ec9ed38af66c23edd7560994
+commit=d8ebbabbb51a643f6e7402c1deed824415fbe39a
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Trims the README to player-facing content (no code structure/build setup docs), and updates runelite-plugin.properties: fixes an em dash in the description that broke under the packager's ISO-8859-1 Properties.load, sets an explicit version, and adds a friendlier description/tag.

Also scopes local Aura tracking per RuneScape account instead of per machine (accountHash-based, one file per account, matching the pattern RuneLite's own ConfigManager uses). The previous single shared file meant switching to a different account on the same machine silently inherited whatever the last account had accumulated.