### PR TITLE
zom zigzag add runepouchplacement options

### DIFF
--- a/plugins/zom-zigzag
+++ b/plugins/zom-zigzag
@@ -1,2 +1,2 @@
 repository=https://github.com/JZomDev/zom-external-plugins.git
-commit=0de9ef678e6323ff04eb2dc477b48591e22c875b
+commit=17e73676c5917bdb63fa349d0e170b9500d22146

--- a/plugins/zom-zigzag
+++ b/plugins/zom-zigzag
@@ -1,0 +1,2 @@
+repository=https://github.com/JZomDev/zom-external-plugins.git
+commit=0de9ef678e6323ff04eb2dc477b48591e22c875b


### PR DESCRIPTION
Add RunePouchPlacement options.

Default behaves like normal, matching what ZigZag does for Inventory Set ups.
Bottom puts the runes in the first available row that is blank. 
Top puts the runes in the top right of the bank instead of below the gear + inventory

Match core's default way of clearing and moving items. It seems to do do entire row checks deleting the data from 0 to 39, so I am also doing 0-16 gear and 0-32 inventory even though neither go up to 16 or 32.