### PR TITLE
Update commit reference in thrall-check plugin

### DIFF
--- a/plugins/thrall-check
+++ b/plugins/thrall-check
@@ -1,2 +1,2 @@
 repository=https://github.com/Delkyy/thrall_check.git
-commit=cef13a94320761de4668422f3060c50e0c5bc91f
+commit=40b8ca0a7cda01774917239d707f807bb70b733e


### PR DESCRIPTION
Update Thrall Check to 0.2.0. Adds a banner alert style as an alternative to the screen flash, an opacity slider on the flash colour, and a reminder to summon a thrall while in combat with none out. Includes a one-shot config migration so existing users who disabled flashing keep it disabled