### PR TITLE
Shorten Bankstand's install warning and add its icon

### DIFF
--- a/plugins/bankstand
+++ b/plugins/bankstand
@@ -1,3 +1,3 @@
 repository=https://github.com/CVE-078/bankstand-runelite.git
 commit=9e24961e7046635f2d9902e443f7c982af478d9f
-warning=Sends your account hash, name and skill XP to Bankstand while paired.<br>Optional toggles add quest, diary and combat achievement progress,<br>collection log data, account type, and drops.<br>Private by default; sharing is opt-in in your Bankstand settings.<br>Goes to your configured Server URL (Bankstand's by default).
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/bankstand
+++ b/plugins/bankstand
@@ -1,3 +1,3 @@
 repository=https://github.com/CVE-078/bankstand-runelite.git
-commit=32df118f50a857e10ba9bd33f1bacdb98963d650
-warning=This plugin sends your account hash, display name and skill XP to Bankstand while you're paired. Turn on more of its toggles and it also sends quest progress, achievement diary tiers, collection log slots and new unlocks, combat achievement tier counts and completed tasks, your account type, notable drops and pet drops. Everything's private to your account by default; you can share it with your Bankstand groups or publicly from your privacy settings there. Data goes to whatever Server URL you set, the official Bankstand server by default over https. Change that URL and your data goes there instead.
+commit=9e24961e7046635f2d9902e443f7c982af478d9f
+warning=Sends your account hash, name and skill XP to Bankstand while paired.<br>Optional toggles add quest, diary and combat achievement progress,<br>collection log data, account type, and drops.<br>Private by default; sharing is opt-in in your Bankstand settings.<br>Goes to your configured Server URL (Bankstand's by default).


### PR DESCRIPTION
The install warning was a single 587-char unbroken sentence with no `<br>` breaks, so Swing's HTML renderer (which needs an explicit width or line breaks to wrap `<p>` content) rendered it as one line wider than a 1440p display.

- Shortened the warning to ~330 chars split across 5 short `<br>`-separated lines (matching WikiSync's existing entry), keeping every capture toggle named and the configurable-URL risk
- Bumped `commit=` to CVE-078/bankstand-runelite@9e24961, which adds `icon.png` at the repo root so the plugin shows its actual mark in the Hub browser instead of the placeholder