### PR TITLE
create irons-pub-bingo

### DIFF
--- a/plugins/irons-pub-bingo
+++ b/plugins/irons-pub-bingo
@@ -1,0 +1,4 @@
+repository=https://github.com/KaosRichie/irons-pub-bingo.git
+commit=14082f8809acd8a4db252563366eec5989aabf1a
+authors=KaosRichie
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/irons-pub-bingo
+++ b/plugins/irons-pub-bingo
@@ -1,4 +1,4 @@
 repository=https://github.com/KaosRichie/irons-pub-bingo.git
-commit=14082f8809acd8a4db252563366eec5989aabf1a
+commit=64f2ae1e56b58f2ae37e735f9b98d05e31f73aab
 authors=KaosRichie
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
A plugin for running clan bingo events (mainly for the Iron's Pub clan). The host shares a board file; the plugin tracks drops, raid uniques, boss kill counts, NPC kills, pets, XP, agility laps, loot value and chat messages against the board's tiles, shown in a sidebar panel.

Team sync is optional and comes in two independent layers: live sync over RuneLite's party service, and a Google Apps Script team store the event host deploys, which carries progress between sessions and drives the admin sheet. Neither layer needs the other. The team store and the Discord webhook for completion posts are off by default, and their config toggles carry the third-party IP warning.