### PR TITLE
update clockwork

### DIFF
--- a/plugins/clockwork
+++ b/plugins/clockwork
@@ -1,2 +1,2 @@
 repository=https://github.com/techgaud/ClockWork.git
-commit=1e3ba342c32c4845d7958977e0ada3dbbf163651
+commit=3c3a9d9a95ef65aadab2c19b2c358e2c57158077


### PR DESCRIPTION
Timer boxes get a visibility setting: always, only while running, or never,
with a per-clock override. The old on or off setting is carried over, so
nobody's boxes change behaviour on update.