### PR TITLE
update aura-tracker

### DIFF
--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Matelaa/aura-tracker.git
-commit=825eed370239dfb9fb36f885cd3fc699b3718a90
+commit=3483eacac3740ecad61a2bba325da9e61c08cbfb
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds the leaderboard site URL to the README and runelite-plugin.properties description (both previously only said "a community leaderboard" with no URL to actually visit - RuneProfile's own description follows the same pattern: "Share your achievements on RuneProfile.com"). Also updates the one-time in-game sync disclosure chat message to point at the leaderboard site instead of naming the raw API host, which isn't something a player can browse to.