### PR TITLE
gearforge: bows with their own ammo, slayer helms, level requirements

### DIFF
--- a/plugins/gearforge
+++ b/plugins/gearforge
@@ -1,2 +1,2 @@
 repository=https://github.com/marcushill13/gearforge.git
-commit=46253562f0f47a93ffa2b4fedcdea07c2c9997ee
+commit=057be8c87d3958c860e1b2abe2c90d32b1000f07


### PR DESCRIPTION
Updates gearforge to 057be8c87d3958c860e1b2abe2c90d32b1000f07.

Fixes, all from user reports:

- Ranged weapons that supply their own ammunition were being scored as though they could not attack, so any setup holding one was discarded. Bow of faerdhinen, every crystal bow, the Gauntlet's corrupted bows, Craw's bow and the webweaver are all recommended again.
- Slayer helmets and black masks were recognised by a single item id. Every colour, every charge, both Soul Wars and Emir's Arena copies and the unimbued versions now apply on task; ranged and magic still require the imbue.
- Equipment level requirements came from a dataset that stopped updating in 2021, so everything released since read as unrestricted. Requirements are now also read from the wiki, which covers modern gear and corrects a few stale entries.
- Special attack weapons are matched across variant families, so a dagger(p++) counts as owning a dragon dagger.
- Panel widths are derived from PluginPanel.PANEL_WIDTH rather than hardcoded, and are asserted in tests. Swing scales CSS pixels in HTML labels, which is why several of them were wider than the panel.
- New Raids tab, deliberately empty and labelled as such.
