### PR TITLE
Update Combat Insight to 0.3.3

### DIFF
--- a/plugins/combat-insight
+++ b/plugins/combat-insight
@@ -1,2 +1,2 @@
 repository=https://github.com/BornDied/combat-insight.git
-commit=2c739351db706155b539400c1c28a618044e948f
+commit=663fcc74be46c6e9e34cdbee30937565345770fc


### PR DESCRIPTION
Updates Combat Insight from 0.3.2 to 0.3.3.

Changes include:

- Exact hit splits for supported multi-hit weapons
- Improved retained-target tracking and compact target-health display
- Reorganized Minimal, Standard, and Advanced HUD configuration sections
- A default-on Show max split setting for Advanced mode
- Updated public support and testing documentation

Testing completed:

- Full Gradle test suite passed
- Manual HUD, configuration, target-health, Scythe, dual macuahuitl, Blood Moon, and max-split toggle tests passed

Source release: https://github.com/BornDied/combat-insight/pull/2