### PR TITLE
Add Ground Item Icons

### DIFF
--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=ee329c1d127245ecf4516b5c14f44f93b0189c26
+commit=1e02cc6e1ab91256398f249fe46fcdb91a3b755e

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=022df1f
+commit=022df1f1cbdade1be19004f318fdfc1d5939edbc

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=022df1f1cbdade1be19004f318fdfc1d5939edbc
+commit=dcff186092a862c956a4470ba48f98cc54a5388c

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=dcff186092a862c956a4470ba48f98cc54a5388c
+commit=ee329c1d127245ecf4516b5c14f44f93b0189c26

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=82561f8cc9855d70570545023296c6b2cbfdf925
+commit=022df1f

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,0 +1,2 @@
+repository=https://github.com/Meowdyosrs/GroundItemIcons.git
+commit=82561f8cc9855d70570545023296c6b2cbfdf925


### PR DESCRIPTION
Adds Ground Item Icons, a standalone plugin that displays item icons alongside Ground Items text.

The plugin works alongside the existing Ground Items plugin without modifying it.

Features:
- Displays item icons next to Ground Items
- Respects Ground Items visibility and filtering
- Toggleable icon display
- Configurable icon size

<img width="567" height="435" alt="Untitled" src="https://github.com/user-attachments/assets/bc25d986-ff3e-406d-b4b1-709020c1a413" />

