### PR TITLE
update boss-kd-tracker

### DIFF
--- a/plugins/boss-kd-tracker
+++ b/plugins/boss-kd-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/FlawedLegacie/Boss-KD-Tracker.git
-commit=dc54f47a0750ccd56ea9afca1b19732fd6cf8a47
+commit=9fd02ac449cb90b777d5f35fcf24bf0719859ffd

--- a/plugins/boss-kd-tracker
+++ b/plugins/boss-kd-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/FlawedLegacie/Boss-KD-Tracker.git
-commit=9fd02ac449cb90b777d5f35fcf24bf0719859ffd
+commit=2600dc8ed7d9a2c2be4ebab69fda1195404225ae


### PR DESCRIPTION
Updates Boss KD Tracker to 0.8.2.

The !KD command now prepares a shareable `Boss - Kills: X | Deaths: Y` line in the RuneLite chatbox instead of invoking CHAT_SEND directly.

The player presses Enter a second time to send it normally, preserving the selected public, friends, clan, or guest-clan channel while keeping the actual send user-initiated.

Tested successfully in-game with clan chat before submission.