### PR TITLE
update clockwork

### DIFF
--- a/plugins/clockwork
+++ b/plugins/clockwork
@@ -1,2 +1,2 @@
 repository=https://github.com/techgaud/ClockWork.git
-commit=3c3a9d9a95ef65aadab2c19b2c358e2c57158077
+commit=29df330bdd705ebb365f0af36d73cf099d664f56


### PR DESCRIPTION
Alerts when a countdown reaches zero, hotkeys to start, stop and lap a clock,
sharing clocks as text, and live splits shown in the timer box and the side
panel while a run is going. The alert and the chime can each be set per clock
or left to follow the plugin-wide setting.