### PR TITLE
update monsterstats

### DIFF
--- a/plugins/monsterstats
+++ b/plugins/monsterstats
@@ -1,2 +1,2 @@
 repository=https://github.com/Koitere/monster-stats.git
-commit=6a2a441ba122f9173827049d833316475344a1bd
+commit=b864d83740d950eb6b16b69dbcb4d493d215daae


### PR DESCRIPTION
Small fix to enable key presses to not be consumed while listening for the selected key to display tooltips. Allows for non-modifier key keys to be used as a keybind and still have them be typed in chat. Intended to fix https://github.com/Koitere/monster-stats/issues/15

Thanks,
Koi