### PR TITLE
Add Slayer Alternatives plugin

### DIFF
--- a/plugins/slayer-alternatives
+++ b/plugins/slayer-alternatives
@@ -1,2 +1,2 @@
 repository=https://github.com/Delkyy/slayer-alternatives.git
-commit=0b02d130f935ab35b1bb60b7039a9147c865e4e0
+commit=7eabbc957817acc5e2206087a670b74b4d621a65

--- a/plugins/slayer-alternatives
+++ b/plugins/slayer-alternatives
@@ -1,0 +1,2 @@
+repository=https://github.com/Delkyy/slayer-alternatives.git
+commit=0b02d130f935ab35b1bb60b7039a9147c865e4e0


### PR DESCRIPTION
What else can I kill for this slayer task, and what is it worth in XP.

Greater demon task shows Tormented Demons at 1,065 xp against a standard greater demon's 87 - a 12x difference nothing else on the Hub surfaces. Reads the current task automatically, recommends the best alternative you can actually reach (gated on finished quests read from the client), links the wiki's money making guides where one exists, and lets you search monsters as well as tasks.

Data is scraped from the OSRS Wiki (task assignment tables + per-task variant tables), cross-checked against the wiki's own Bucket API for 96%+ of rows. The bundled data stays under the wiki's CC BY-NC-SA licence (code is BSD) - see LICENSE-DATA.md, and the panel credits the wiki directly.

51 unit tests, run against the real bundled data file rather than a fixture.