### PR TITLE
Update live-on-clan to 1.1

### DIFF
--- a/plugins/live-on-clan
+++ b/plugins/live-on-clan
@@ -1,3 +1,3 @@
 repository=https://github.com/MilicoOSRS/live-on-clan.git
-commit=dd1078ea6d147002c4c988ad93b6341c26a7d7b8
+commit=ffc83905334a82923ae59cd9793036d67b1a6fb7
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Changes

- Redesign the ranks and staff panels with clearer progression and request states
- Refresh the monthly MVP Drops, EHB, and EHP leaderboards
- Add text-only MVP and LIVE labels while preserving native clan ranks
- Improve rank request handling and Discord drop notifications
- Simplify plugin settings and update the displayed authors and version

## Testing

- Tested rank requests, staff actions, broadcasts, live status, and MVP rankings with multiple clan accounts
- Verified the plugin builds and packages successfully on Java 11