### PR TITLE
Add Activity Webhook

### DIFF
--- a/plugins/activity-webhook
+++ b/plugins/activity-webhook
@@ -1,0 +1,2 @@
+repository=https://github.com/Laurfully/runelite-discord-tracker.git
+commit=e48823766cfdc11dbe273fe83fff64fea62ab864


### PR DESCRIPTION
Adds Activity Webhook, a passive RuneLite plugin that sends user-selected in-game activity to Discord webhooks.

Features include configurable events for login/logout, travel, chat, skilling, quests, pets, loot, combat outcomes, inventory/bank activity, shops/Grand Exchange, Slayer, minigames/raids, and firsts/milestones.

All reporting options are opt-in. Webhook URLs are configured locally by the user, and screenshots, locations, and chat forwarding have separate controls.