### PR TITLE
Add Misinformed: PvP and PvM Tracker

### DIFF
--- a/plugins/clan-companion
+++ b/plugins/clan-companion
@@ -1,0 +1,2 @@
+repository=https://github.com/NickypooRS/clan-companion.git
+commit=c5d239f811c79245732b8a7396287ec5e38edffb

--- a/plugins/clan-companion
+++ b/plugins/clan-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/NickypooRS/clan-companion.git
-commit=c5d239f811c79245732b8a7396287ec5e38edffb
+commit=21087ae7eb1092b4a1c834abadaee889ff79c26d


### PR DESCRIPTION
Adds Misinformed: PvP and PvM Tracker by Ybc.

The plugin provides local PvP/PvM session tracking, including kills, deaths, K/D, loot, valuable drops, collection log unlocks, personal session goals, recent activity, and a configurable overlay.

It does not automate gameplay, alter combat interactions, crowdsource player information, or send data to external services.