### PR TITLE
Update mystix

### DIFF
--- a/plugins/mystix
+++ b/plugins/mystix
@@ -1,4 +1,4 @@
 repository=https://github.com/Dmurph24/mystix-plugin.git
-commit=d8646e89019009e35c1e08f994a0180e20c949e9
+commit=9a2004dd9e4c41ec4962c20939a0bd3e7310ceb0
 authors=Dmurph24
 warning=This plugin submits your RSN, skills, bank, equipment, loadouts, farming timers, and loot data to a 3rd-party server (Mystix) not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Mystix to the latest release.

Single fix: the plugin's combat achievement sync reads completion bits from an ordered list of VarPlayers, and task ids 640 and above live in a 21st varp (5673) that was missing from that list, so completions of the newest tasks (the Maggot King and Mad Angel sets) were never picked up. This adds the varp to the list, matching WikiSync's ordering. No new data source is introduced.