### PR TITLE
Update Ground Item Icons plugin icon

### DIFF
--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=1e02cc6e1ab91256398f249fe46fcdb91a3b755e
+commit=df87085790ae13958a469754c7254225ead8f903


### PR DESCRIPTION
Updates the Ground Item Icons plugin entry to reference the latest plugin commit containing the new plugin icon.