### PR TITLE
Update collection-log-popup-enhanced to 1.55

### DIFF
--- a/plugins/collection-log-popup-enhanced
+++ b/plugins/collection-log-popup-enhanced
@@ -1,2 +1,2 @@
 repository=https://github.com/TimHeessels/collection-log-popup-enhanced.git
-commit=d570ceb4d220827ba6d916aeffcff63dc2c7b689
+commit=b091ab9d386b207e32c4f3f18fd415e6113bd189


### PR DESCRIPTION
Fixed rare bug where icons that could not be loaded caused null ref. 
KC can now be detected for more bosses and minigames. 
A list of content with unique KC messages now show a unique label (Example: 'Chests' for barrows or 'Rifts' for gotr instead of generic KC)