### PR TITLE
Add Spoon Tracker

### DIFF
--- a/plugins/spoon-tracker
+++ b/plugins/spoon-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/spoon-tracker.git
-commit=f5f058c0ce9a1a285874c99e9b7636d0f43876fe
+commit=174d51899c2fbbaaad2953a1822b4295df35e309

--- a/plugins/spoon-tracker
+++ b/plugins/spoon-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/spoon-tracker.git
-commit=e3501d4392742e364496ae5efae0b5bf421015cf
+commit=f5f058c0ce9a1a285874c99e9b7636d0f43876fe

--- a/plugins/spoon-tracker
+++ b/plugins/spoon-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/spoon-tracker.git
-commit=174d51899c2fbbaaad2953a1822b4295df35e309
+commit=1dcf043dc6dc334f34a5cceb6fe71678fb3a14ff

--- a/plugins/spoon-tracker
+++ b/plugins/spoon-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/nassarao/spoon-tracker.git
+commit=e3501d4392742e364496ae5efae0b5bf421015cf

--- a/plugins/spoon-tracker
+++ b/plugins/spoon-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/nassarao/spoon-tracker.git
-commit=1dcf043dc6dc334f34a5cceb6fe71678fb3a14ff
+commit=ec5db7008b13f198b22530402e3f81e63d512416


### PR DESCRIPTION
## What it does

Spoon Tracker records newly observed Collection Log uniques and grades how lucky each drop was using spoon tiers. It includes Collection Log badges, configurable celebrations and sounds, a sidebar cabinet, and shareable drop cards.

## Implementation

- Tracks earned uniques locally per RuneScape profile.
- Preloads ranked boss KC through RuneLite's hiscore client and merges in-game Collection Log counters.
- Correlates current RuneScape KC/completion chat formats with loot events.
- Uses a bundled, versioned probability catalog and RuneLite's local game cache.
- Performs no uploads of player data.

## Validation

- Clean Gradle build and test run.
- 34 tests passed with zero failures.
- Supersedes closed PR #14227; branch rebased onto current master.

The author's other open Plugin Hub PR updates Recipe Tracker, which is already an existing merged plugin.