### PR TITLE
Update: Ground Item Icons

### DIFF
--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=1169fd47b672c2c2f7f5fb1dadd1a3f630de8827
+commit=e2de38960e3b05b2d7cc2218bbfbfc1722039dc3

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=67c8ba97d9808922f3d5900c9b80b05450eb5c07
+commit=7e4629a3816e7f2855d745cc2993a3a718733a25

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=df87085790ae13958a469754c7254225ead8f903
+commit=1169fd47b672c2c2f7f5fb1dadd1a3f630de8827

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=7e4629a3816e7f2855d745cc2993a3a718733a25
+commit=a4c0f7929aa306192b506eeebd81019dcdd3e292

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=a4c0f7929aa306192b506eeebd81019dcdd3e292
+commit=f8a7f1263003db3265afc9e1fb1678a8d8757cde

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=e2de38960e3b05b2d7cc2218bbfbfc1722039dc3
+commit=67c8ba97d9808922f3d5900c9b80b05450eb5c07

--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=f8a7f1263003db3265afc9e1fb1678a8d8757cde
+commit=f8b8ae112447f6d4ccb8b978dae3afc87c76cb9c


### PR DESCRIPTION
Adds Ground Item Icons, a standalone plugin that displays item icons alongside Ground Items text.

The icons follow the existing Ground Items visibility state, including the hide/show hotkey, and respect Ground Items filtering and visibility behaviour.

Fixed issue with visibilty when toggling Ground Items.