### PR TITLE
update brimhaven-agility to 1.6.0

### DIFF
--- a/plugins/brimhaven-agility
+++ b/plugins/brimhaven-agility
@@ -1,2 +1,2 @@
 repository=https://github.com/kagof/rl-plugin-brimhaven-agility.git
-commit=a11b8a9671dfab8000b6819cb6301ebb88f71857
+commit=4f95e349b93d10f2d3aaff04ace35bb83ab55a23


### PR DESCRIPTION
- distance in panel is coloured green when nearby
- proper version tagging in the plugin properties
- glove warning now shows on the shop over the options to purchase Agility XP

Also fixes a NPE that could occur in one of the overlays.