### PR TITLE
Add Who Spooned It

### DIFF
--- a/plugins/whospoonedit
+++ b/plugins/whospoonedit
@@ -1,0 +1,3 @@
+repository=https://github.com/marcushill13/whospoonedit.git
+commit=c3a5dab8325c55da4bc0e9d603c23292e870ab31
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Records how lucky each collection log drop was, and compares it with a group of friends.

When an item is logged the plugin works out what kill count it landed on and how rare it is, then scores it as the share of players who would already have had it by that point. Ten kills for a 1 in 5,000 is a story; six thousand kills for the same thing is not. That puts a pet and a clue reward on one scale, which is what makes a leaderboard across different bosses mean anything.

It works on its own with nothing sent anywhere. A group is optional and adds the comparison: a leaderboard, a search for who in the group has a given item, and a per member view.

**On the third party server.** The plugin talks to a Cloudflare Worker so a group can see the same leaderboard, which a plugin cannot do on its own. Its source is in `backend/` in the same repository. Sent only once someone has joined a group: their RuneScape name, and each collection log item with its kill count and rarity. Nothing before joining, and nothing already held unless the player presses the button offering to share it. I have added the standard warning line to the manifest.

**On the optional Discord import.** If a group already posts Dink notifications to a channel, that channel is a record of who got what and on which kill, and the plugin can read it once to bring that history in. It is entirely opt in. The bot asks for View Channel and Read Message History only, reads nothing until the group's creator presses the button, and shows what it found before anything is kept.

Kill counts are read from what the Chat Commands and Loot Tracker plugins already store rather than counted here. Drop rates are bundled from Dink's dataset under its BSD licence, credited in NOTICE.md, and clue reward rates are read from the wiki at build time. Nothing is fetched while the plugin is running.

Skilling pets are deliberately recorded but not scored, since they are rolled per action at a rate that varies with level and there is no count to be lucky against. The README says so rather than leaving it to be discovered.
