### PR TITLE
update clockwork

### DIFF
--- a/plugins/clockwork
+++ b/plugins/clockwork
@@ -1,2 +1,2 @@
 repository=https://github.com/techgaud/ClockWork.git
-commit=29df330bdd705ebb365f0af36d73cf099d664f56
+commit=9020f5a2342f0b0fb2be861bf977848eef10040b


### PR DESCRIPTION
A clock's best run is now kept for good rather than aging out of its history, with an all-time average beside the recent one.
A countdown beeps the last three seconds in, instead of just at the end.
The RuneLite notification and the chime can each be set per clock or left to follow the plugin-wide setting.

Run history also moved to a key per clock, so finishing one run no longer rewrites every clock's history.