### PR TITLE
update better-slayer to 1.2.1

### DIFF
--- a/plugins/better-slayer
+++ b/plugins/better-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/better-slayer.git
-commit=18f4c61dc2baf1b9ae51564c025a5f24e9f61051
+commit=e8b5172323483d9e0c0a02401985af6804714cad


### PR DESCRIPTION
1.2.1

Description shortened so the plugin list stops cutting it off.
No functional change.