### PR TITLE
Add Shades of Mort'ton plugin

### DIFF
--- a/plugins/shades-of-morton
+++ b/plugins/shades-of-morton
@@ -1,0 +1,2 @@
+repository=https://github.com/nicole-mcg/shades-of-morton-runelite.git
+commit=5917b8737d10f238c7c4d3569c50e485a0d397e2

--- a/plugins/shades-of-morton
+++ b/plugins/shades-of-morton
@@ -1,2 +1,2 @@
 repository=https://github.com/nicole-mcg/shades-of-morton-runelite.git
-commit=21485467686e8b38290cd2c0e8cdbaa7013f3fd6
+commit=f3ae35e37353b51b85e338a0d16e659ff5c4685f

--- a/plugins/shades-of-morton
+++ b/plugins/shades-of-morton
@@ -1,2 +1,2 @@
 repository=https://github.com/nicole-mcg/shades-of-morton-runelite.git
-commit=fe46c89840f12f976d25baf7fe1e230f7e4b29b1
+commit=00674428b93dc2a093fb1f8b2a4749265a04189a

--- a/plugins/shades-of-morton
+++ b/plugins/shades-of-morton
@@ -1,2 +1,2 @@
 repository=https://github.com/nicole-mcg/shades-of-morton-runelite.git
-commit=5917b8737d10f238c7c4d3569c50e485a0d397e2
+commit=21485467686e8b38290cd2c0e8cdbaa7013f3fd6

--- a/plugins/shades-of-morton
+++ b/plugins/shades-of-morton
@@ -1,2 +1,2 @@
 repository=https://github.com/nicole-mcg/shades-of-morton-runelite.git
-commit=f3ae35e37353b51b85e338a0d16e659ff5c4685f
+commit=fe46c89840f12f976d25baf7fe1e230f7e4b29b1


### PR DESCRIPTION
Adds a plugin for Shades of Mort'ton minigame with the following features:
- Highlights chests corresponding to the keys you have in your inventory
- Adds paths to the room with the chests for the keys you have in your inventory
- Prevents duplicate clicks to the pyre objects. In-game repeatedly clicking will keep interrupting the action, resulting in nothing happening.
- Notify on full sanctity when repairing
- Notify when repairing stops
- Notify when sanctifying oil stops