### PR TITLE
Update Group TCG to 0.1.2

### DIFF
--- a/plugins/group-tcg
+++ b/plugins/group-tcg
@@ -1,3 +1,3 @@
 repository=https://github.com/Sqwiglyy/groupman-tcg.git
-commit=4d32609df93cbd6e1959389434d6cb08fdfcda89
+commit=d87a88719ce62d9f5e8d12ecbef9c6032644d92d
 warning=IMPORTANT MULTIPLAYER PRIVACY WARNING: Group TCG deliberately has no official public server; multiplayer uses only a private server chosen by your group. Only connect to servers run by friends you trust. The host controls the endpoint and may see or record your IP address and synced Group TCG data. Private servers are independently operated; the Group TCG creator does not operate, verify, endorse, or accept responsibility for servers hosted by others. Use a VPN if you need to hide your IP address. Solo play does not connect to a group server. Optional card artwork also sends your IP address and requested image URLs to the OSRS Wiki.


### PR DESCRIPTION
## Summary
- update Group TCG to version 0.1.2
- restore collection syncing with OSRS TCG 0.18's grouped `cardEntries`/`variants` save format
- retain compatibility with older `cardInstances` saves
- generate stable per-copy IDs for multiplayer sync and pack reveal detection

## Verification
- full Gradle test/build passes locally
- focused grouped-save, legacy-save, duplicate, foil, and pack-reveal tests pass
- plugin repository GitHub Actions build passes