### PR TITLE
update jumpscare to 1.6.2

### DIFF
--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=8e7afebfa10e009268b6e81385f2798bf88f11d2
+commit=8c4248c4ae0abbcd9ff30c39915f37ff737c1e0a
 authors=vividflash


### PR DESCRIPTION
1.6.2

Description shortened so the plugin list stops cutting it off.
Builds against RuneLite 1.12.36.
No functional change.