### PR TITLE
update dvd-bounce to 1.6.1

### DIFF
--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=7dd8f46bdef406ee9e6f2c7f261082d81a05827f
+commit=f6363b53885cc6be7002cd56b344ac83498e0eea

--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=f6363b53885cc6be7002cd56b344ac83498e0eea
+commit=0dfdfc5c7734c42cd2914ed9986fe8060d170ccd

--- a/plugins/dvd-bounce
+++ b/plugins/dvd-bounce
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/dvd-bounce.git
-commit=0dfdfc5c7734c42cd2914ed9986fe8060d170ccd
+commit=a26b81184b54e9d4787b7637dc4fc0a82509f241


### PR DESCRIPTION
1.6.1

Description shortened so the plugin list stops cutting it off.
Builds against RuneLite 1.12.36.
No functional change.