### PR TITLE
Update Poison Dynamite

### DIFF
--- a/plugins/poison-dynamite
+++ b/plugins/poison-dynamite
@@ -1,2 +1,2 @@
 repository=https://github.com/yonnski/poison-dynamite.git
-commit=0cc75addcd0a584fb859e86be4e0070aa46cb276
+commit=9011ae4c3c5579c2406478ed9eac3fa5f369593e

--- a/plugins/poison-dynamite
+++ b/plugins/poison-dynamite
@@ -1,2 +1,2 @@
 repository=https://github.com/yonnski/poison-dynamite.git
-commit=b4f5e5223fa9767cf68acea6fad2a84b759b325c
+commit=0cc75addcd0a584fb859e86be4e0070aa46cb276


### PR DESCRIPTION
Updates the pinned commit for `poison-dynamite`.

## What's new

- **Poison tracking after the proc** — once poison lands, tracks the target's remaining poison hits and damage, time until the next hit, time until the poison wears off, and time until it kills the target. NPCs have no poison varp, so the poison value is inferred from the hitsplats: a splat whose damage differs from the previous one pins the value at `5 * damage`, and equal damage decrements. Hitpoints come from `NPCManager.getHealth()` and the inverted health-bar ratio.
- **Config sections** — the display options are grouped with `@ConfigSection` (Overlays / Info panel / Notifications) instead of one flat list, with a toggle per info panel section.
- **Info panel grouped** into target / poison / supplies sections.
- **Poison-immune targets** resolve immediately instead of running a countdown that cannot proc.
- **Fix**: retrying a cancelled throw no longer inherits the previous throw's detonation timeout, which could evict the attempt just before the splat arrived so no timer appeared.
- Dropped two readouts that carried no live information: poison chance (a fixed fraction of hit chance) and max hit (a Firemaking-level constant).

Demo: https://youtu.be/XALXfeWzRfU

## Testing

`./gradlew build` — 36 unit tests, 0 failures. The poison decay model and the 18.2s hit interval were verified against a live client; the plugin loads and runs with no injection errors.