### PR TITLE
Update Group TCG to 0.1.3

### DIFF
--- a/plugins/group-tcg
+++ b/plugins/group-tcg
@@ -1,3 +1,3 @@
 repository=https://github.com/Sqwiglyy/groupman-tcg.git
-commit=d87a88719ce62d9f5e8d12ecbef9c6032644d92d
+commit=b7e6049e020ca315e2bf1378cc9dea26ccaa54c4
 warning=IMPORTANT MULTIPLAYER PRIVACY WARNING: Group TCG deliberately has no official public server; multiplayer uses only a private server chosen by your group. Only connect to servers run by friends you trust. The host controls the endpoint and may see or record your IP address and synced Group TCG data. Private servers are independently operated; the Group TCG creator does not operate, verify, endorse, or accept responsibility for servers hosted by others. Use a VPN if you need to hide your IP address. Solo play does not connect to a group server. Optional card artwork also sends your IP address and requested image URLs to the OSRS Wiki.


### PR DESCRIPTION
Updates Group TCG to 0.1.3.\n\nThis release reads OSRS TCG 0.18's current per-profile master save instead of relying solely on its older RuneLite profile checkpoint, restoring current-session collection syncing, recent-card metadata, and remote pack event detection. The RuneLite profile checkpoint remains as a fallback.\n\nLocal verification: gradlew clean test passes.