### PR TITLE
PvM Toolkit 1.4.4

### DIFF
--- a/plugins/pvm-tools
+++ b/plugins/pvm-tools
@@ -1,2 +1,2 @@
 repository=https://github.com/arbeerby-pixel/pvm-tools.git
-commit=d7e11c09d1ff0edd1e043e4f5067753b585ce3b8
+commit=6efb27fb9933ce750a073227f06cbb59e298c14c


### PR DESCRIPTION
## Changes
- Pause the current Slayer task timer after two minutes without PvM activity.
- Resume timing automatically when task activity continues.
- Cap the active segment at the inactivity deadline so long breaks are not added later.
- Include the fix in the 1.4.4 update scroll.

## Verification
- `clean test shadowJar --rerun-tasks` passes: 56 tests, 0 failures.
- Full-profile RuneLite dev client loads and starts `PvmToolsPlugin` successfully.
- Update-scroll state was verified against a profile that had seen 1.4.3.
- Version metadata and `pvm-tools-1.4.4-all.jar` are consistent.