### PR TITLE
update visual-ticks

### DIFF
--- a/plugins/visual-ticks
+++ b/plugins/visual-ticks
@@ -1,2 +1,2 @@
 repository=https://github.com/mcscoobe/visual-ticks.git
-commit=3083e66211fa4b9ad9bd4105d06af724a10a6b11
+commit=45847a6b4be9366049bd9eba14e068a09b0e37a9

--- a/plugins/visual-ticks
+++ b/plugins/visual-ticks
@@ -1,2 +1,2 @@
 repository=https://github.com/mcscoobe/visual-ticks.git
-commit=45847a6b4be9366049bd9eba14e068a09b0e37a9
+commit=42f274cf807333b457b7c54542ef6ae78931d3bd


### PR DESCRIPTION
Bumps the pinned commit from `3083e66` to `45847a6`.

Since the last hub update:

- new: increase/decrease hotkeys for tick counts, global or per tick set
- fix: ticks laid out on one uniform cell pitch
- fix: negative tick spacing clamped at total overlap
- fix: tick counts and rows clamped when read from stored config
- unit test suite (72 tests)
