### PR TITLE
update flati-boss-tracker

### DIFF
--- a/plugins/flati-boss-tracker
+++ b/plugins/flati-boss-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Flati/Flati-Boss-Tracker.git
-commit=e59d0ece53c862d795fec550730cb2cfcd453ccf
+commit=65870aa937d019c3fd1016aaf977119468b56159
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updated to latest version of flati-boss-tracker plugin.
2 bugfixes are part of this release
 - Spamming collection log would send corrupted KC information to backend. This has been fixed by waiting for the window to draw.
 - Replay queue would send multiple identical requests once connection is re-established. This has been fixed by replaying messages one at a time and adding unique constraint on backend.