### PR TITLE
Update Mortimer Calculator to 1.5

### DIFF
--- a/plugins/mortimer-calculator
+++ b/plugins/mortimer-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/ZacharyHJacobson/mortimer-plugin.git
-commit=d8c9fad03122cdd4d02c1b30db9923e0b45d85a2
+commit=0613b57c175aca23165bb66dec7572f0818af508


### PR DESCRIPTION
Blocks and skips updated.  When skips are enabled, the user has enough points to afford a skip, and the best available task is sufficiently slow enough, the task is outlined in yellow instead of green.  When blocks are enabled, the best available task is below average, and one of the worst tasks is available, the worse task is suggested with a red outline indicating to block it.

Rockslug and Bloodveld locations updated.