### PR TITLE
Update progressscape

### DIFF
--- a/plugins/progressscape
+++ b/plugins/progressscape
@@ -1,4 +1,4 @@
 repository=https://github.com/whippahh/ProgressScape-plugin.git
-commit=9f6e94693c9a5eb11aa5e130ab6606a327351131
+commit=d698f291399524397d4ddef19574c318a24fecd5
 warning=This plugin submits your IP address, RSN, and numerous account data to a 3rd-party server not controlled or verified by Runelite developers.
  


### PR DESCRIPTION
Fixes collection log sync to capture all categories in one click instead of requiring each to be opened individually; fixes Combat Achievement completion tracking (was reading the wrong varp); adds boss KC syncing from the official Hiscores as a fallback alongside live chat capture.