### PR TITLE
Add HapticScape

### DIFF
--- a/plugins/hapticscape
+++ b/plugins/hapticscape
@@ -1,0 +1,3 @@
+repository=https://github.com/ashy0019/HapticScape.git
+commit=799e035efe2a43472096076c3465e9296dec14f4
+authors=ashy0019


### PR DESCRIPTION
## HapticScape

Adds configurable haptic feedback for Old School RuneScape events through a
user-operated Intiface server.

### Current functionality

- Connects to and disconnects from Intiface
- Displays supported connected devices
- Triggers configurable feedback from qualifying XP gains
- Provides intensity, duration, and XP-threshold controls
- Includes test-pulse and emergency-stop controls
- Handles connection loss and reconnection without blocking RuneLite

The default Intiface address is localhost. No RuneScape account, chat, or
other-player information is transmitted. The plugin uses RuneLite's existing
HTTP and JSON libraries and adds no runtime dependencies.

Tested with a Nintendo Switch Pro Controller through Intiface.