### PR TITLE
update farming-patch-advisor

### DIFF
--- a/plugins/farming-patch-advisor
+++ b/plugins/farming-patch-advisor
@@ -1,2 +1,2 @@
 repository=https://github.com/Seadeadmeat/farming-patch-advisor.git
-commit=97cebc0f82178e0c6bec7ba51fc308d43122d61a
+commit=6d39b0850bd546b1ad6dc17837a816e423014641


### PR DESCRIPTION
Updates Farming Patch Advisor timer displays and picked-patch tracking.

Changes include:
- consistent timer colors: white while growing, green when ready, red when dead, and orange when diseased
- planted crop names and countdowns over occupied patches instead of seed quantities
- matching narrow gray scrollbars for the Farm Run panel and dropdown
- removal of the contract seed requirement row after the matching Farming Guild crop is tracked
- persistent white PICKED state for Pick, Pick-fruit, Pick-from, and similar actions, preventing depleted plants from being misclassified as dead
- side-panel planted entries without redundant seed quantities

Validation: `./gradlew test --no-daemon` passes.

No third-party dependencies were added.