### PR TITLE
Add Tithe Farm Tooltip

### DIFF
--- a/plugins/tithe-farm-tooltip
+++ b/plugins/tithe-farm-tooltip
@@ -1,0 +1,2 @@
+repository=https://github.com/CampbellTrevor/Tithe-Farm-Tooltip.git
+commit=14ecf4db8e9d4c7b6c61d0d3f037ad5f4a811c29


### PR DESCRIPTION
Adds Tithe Farm Tooltip, a small plugin that shows what a stack of Tithe Farm fruit is worth when you hover over it in your inventory.

The tooltip shows:

- XP gained from turning in the stack
- Current and resulting Farming levels
- Number of levels gained
- XP remaining to the next level
- The full farmer’s outfit bonus, when equipped

It supports Golovanova, Bologano, and Logavano fruit, including the 75-fruit bonus and repeated batches for stacks over 100.

### Existing Tithe Farm plugins

I did check the existing built-in Tithe Farm plugin and Tithe Farm Improved before submitting this.

This plugin is intentionally narrower: it only adds a tooltip for fruit turn-in calculations. It doesn’t track plants, add tile or inventory overlays, replace the points display, or add any configuration. The idea is to keep it useful for someone who only wants the turn-in information without enabling a broader Tithe Farm helper.