### PR TITLE
Fix four Thrall Check bugs

### DIFF
--- a/plugins/thrall-check
+++ b/plugins/thrall-check
@@ -1,2 +1,2 @@
 repository=https://github.com/Delkyy/thrall_check.git
-commit=40b8ca0a7cda01774917239d707f807bb70b733e
+commit=4cf7f0ce1bf4f42d8a275e7222041a267697ab0f


### PR DESCRIPTION
Fixes four bug reports from users:

- Overlay never hid once every requirement was met - the hide-when-ready check only fired in a specific mode/state combo that excluded the exact moment you finish fixing the last thing wrong.
- AUTO mode showed only the spellbook warning while a rune shortfall was also present, hiding the second problem behind the first. Now shows every unmet requirement at once whenever anything is wrong.
- The Impish whistle cosmetic override (reskins a thrall as an imp - same spell, same tier) was not recognised as a thrall, so the summon reminder fired even with one active. Added all nine THRALL_IMP_* npc ids alongside the nine ARCEUUS_THRALL_* ones.
- The summon reminder could not be dragged. It was drawn on the same OverlayPosition.DYNAMIC overlay as the full-screen flash, and DYNAMIC overlays are excluded from RuneLite's drag-to-move handling. Moved it to its own OverlayPanel at TOP_CENTER, which gets the normal move/reset/hide menu.

27 unit tests (up from 20), including new coverage that pins the two overlay-logic bugs directly by extracting the show/hide decision into static methods.