### PR TITLE
rs-bingo: update to f324d23

### DIFF
--- a/plugins/rs-bingo
+++ b/plugins/rs-bingo
@@ -1,4 +1,4 @@
 repository=https://github.com/Newrockku/RS-Bingo.git
-commit=52edd494a14e0225a623301384e5d50dd86868d7
+commit=f324d234ecb69b96d3706198f12d5dfb2fe94306
 authors=Newrockku
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Refuses to fetch URLs that arrive in an API response (follow-up hardening on top of the reviewed change).
- Names the actual transport failure instead of one generic "could not reach the site" for DNS, TLS, timeout and refused alike.
- Rounded buttons matching the panel surfaces, with pressed and disabled states they previously lacked.
- author now reads "Newrockku" rather than the site's domain.