### PR TITLE
clan-tenure-ranks: point at the renamed repository

### DIFF
--- a/plugins/clan-tenure-ranks
+++ b/plugins/clan-tenure-ranks
@@ -1,2 +1,2 @@
-repository=https://github.com/Newrockku/Clan-Tenure-Ranks.git
-commit=40659b129f34ab76bc6dee7fb2cdc7f58f3f51e2
+repository=https://github.com/Newrockku/Clan-Tenure-Notifier.git
+commit=a0536a26c6478c331121417f69a08dcf016b2b3c


### PR DESCRIPTION
The listing page renders the README from the pinned commit, so the developer build-and-publish instructions were still showing there. Those are gone, and the misconfiguration warnings section is kept -- it describes what the panel does for the user.

Also switches the repository URL to the canonical name after the rename from Clan-Tenure-Ranks to Clan-Tenure-Notifier; the old one worked only through GitHub's redirect.

No source changes in this range, so the built plugin is unchanged.