### PR TITLE
Add Wilderness Agility Course Tracker

### DIFF
--- a/plugins/wilderness-agility-course-tracker
+++ b/plugins/wilderness-agility-course-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/andrew-friedman-phd/wilderness-agility-course-tracker.git
+commit=c2181f8433de8738a2bb7f30e4ef377b4f0e6ac2

--- a/plugins/wilderness-agility-course-tracker
+++ b/plugins/wilderness-agility-course-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/wilderness-agility-course-tracker.git
-commit=c2181f8433de8738a2bb7f30e4ef377b4f0e6ac2
+commit=d8a54f1ad26126e7e1b26c7cb15920260266d712


### PR DESCRIPTION
## Plugin: Wilderness Agility Course Tracker

Repository: https://github.com/andrew-friedman-phd/wilderness-agility-course-tracker

Tracks streak, loot value, and XP/hr for the Wilderness Agility Course, and highlights whichever obstacle comes next in the lap (advancing only once success is actually confirmed, not just on a click). Also handles the streak resetting/penalizing on leaving, dying, or logging out mid-course, and suppresses the built-in Agility plugin's own clickbox highlighting while in this course specifically so the two don't visually clash.