### PR TITLE
Fix thrall ownership check and combat-timing accuracy

### DIFF
--- a/plugins/thrall-check
+++ b/plugins/thrall-check
@@ -1,2 +1,2 @@
 repository=https://github.com/Delkyy/thrall_check.git
-commit=4cf7f0ce1bf4f42d8a275e7222041a267697ab0f
+commit=e287f7d6d52034eb4baacdd2b4d2ffe1115381ab


### PR DESCRIPTION
Fixes two reported bugs, both live user reports since the last merge:

- Other players thralls were silencing the summon reminder. The ownership check accepted any thrall interacting with your current target - but a thrall attacking your target is common in a crowded spot (boss room, slayer dungeon, GOTR) regardless of whose thrall it is. Replaced with client.getFollower(), the exact same ownership check core's EntityHiderPlugin uses to tell your pet from everyone elses.

- Overlay timing during combat was not tick-accurate. Combat state was tracked by polling getInteracting() once a tick into a hand-rolled counter with a 3-tick grace window, which is where the drift came from. Rewritten around InteractingChanged (fires the instant the interaction state itself changes) and NpcDespawned (catches a killed target the same tick it dies, since a dead NPC can report stale interacting state for a tick afterward). Combat start/end is now the tick the game itself reports, not something inferred by polling.

29 unit tests, unchanged pass rate - the two fixes touch client-driven state not covered by the existing unit suite, verified against a live client instead.