### PR TITLE
Update Kill Clog to 2.0.3

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=eec57e4f9da19d01bac7472e55612b84a50da901
+commit=f6a96f611b29bd9e2d51960404e7434fd2627fc6
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill Clog 2.0.3

* hover-mode tooltips can be clicked to pin them open for interaction
* skill summaries have their own virtual-level setting, up to 126; virtual totals still follow RuneLite's Virtual Levels setting