### PR TITLE
Update Wilderness Agility Course Tracker

### DIFF
--- a/plugins/wilderness-agility-course-tracker
+++ b/plugins/wilderness-agility-course-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/wilderness-agility-course-tracker.git
-commit=d8a54f1ad26126e7e1b26c7cb15920260266d712
+commit=467fce1a4348a38bd57312bcd2b4ea85959fe7a3


### PR DESCRIPTION
Fixes the next-obstacle guide advancing on any small Agility XP gain regardless of which obstacle produced it (so repeating one obstacle would march the highlight all the way to Rocks). It now also requires a recent click on the specific obstacle currently expected.

Repository: https://github.com/andrew-friedman-phd/wilderness-agility-course-tracker