### PR TITLE
create better-item-examine

### DIFF
--- a/plugins/better-item-examine
+++ b/plugins/better-item-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/jamescer/better-item-examine.git
-commit=621774837744697eb6321bfe81ae525f5c3fa9a4
+commit=2492cccc290fc6f2ef340909e4d5ad022777a65f

--- a/plugins/better-item-examine
+++ b/plugins/better-item-examine
@@ -1,0 +1,2 @@
+repository=https://github.com/jamescer/better-item-examine.git
+commit=b4bec5b029c199c834fcf5bddba0bcc2d2ae14af

--- a/plugins/better-item-examine
+++ b/plugins/better-item-examine
@@ -1,2 +1,2 @@
 repository=https://github.com/jamescer/better-item-examine.git
-commit=b4bec5b029c199c834fcf5bddba0bcc2d2ae14af
+commit=621774837744697eb6321bfe81ae525f5c3fa9a4


### PR DESCRIPTION
Adds the new plugin Better Item Examine;

The goal of this plugin is to help bring more information easily accessible ingame, without having to wiki every single little thing.

This can be used to show passives for complex items, such as Twisted Bow, or Fang etc etc.