### PR TITLE
Update Wilderness Agility Course Tracker

### DIFF
--- a/plugins/wilderness-agility-course-tracker
+++ b/plugins/wilderness-agility-course-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/wilderness-agility-course-tracker.git
-commit=467fce1a4348a38bd57312bcd2b4ea85959fe7a3
+commit=386a666ee9143948b70001516c961ebce77862cb


### PR DESCRIPTION
Fixes the plugin icon, which was still the leftover ring icon copied from an earlier plugin template instead of the Agility dispenser. Also switches the default valuation mode from an unreliable ironman auto-detection to a straightforward Grand Exchange/Alchemy choice (defaulting to Alchemy), and fixes a stale description string.

Repository: https://github.com/andrew-friedman-phd/wilderness-agility-course-tracker