### PR TITLE
update minimalist

### DIFF
--- a/plugins/minimalist
+++ b/plugins/minimalist
@@ -1,2 +1,2 @@
 repository=https://github.com/jakevollkommer/osrs-minimalist.git
-commit=148161eb36ace8c5b3140e44acdf56e5c961f42b
+commit=8d3b3910b13978d4bb7da69f1b2ca9edf186e7e3


### PR DESCRIPTION
Bug fix: the GOTR hide toggles matched object and NPC IDs globally instead of only at GOTR, which unrendered unrelated NPCs and scenery elsewhere across Gielinor, such as the manticore in the Fortis Colosseum. All hiding is now scoped to scenes containing the supported content, and each activity owns its regions, IDs, and rules so this class of leak cannot recur.

New content: the Blast Furnace is now a supported activity. Default hiding covers the operator dwarves, machinery, smoke, and room decoration. Optional toggles cover the merchants, delivery miners, the foreman, manual operation equipment, the coffer, sink, smithing area, bank deposit box, conveyor ramp, staircase, item spawns, and other players with a Show friends exemption.

Quality of life: each activity section gains an Enable master switch, and a ::minimalist chat command writes a local scene report players can attach to bug reports.