### PR TITLE
update ring-menu

### DIFF
--- a/plugins/ring-menu
+++ b/plugins/ring-menu
@@ -1,2 +1,2 @@
 repository=https://github.com/mepatrick73/ring-menu-plugin.git
-commit=f7f480f04ba57612e0742631f025acfe2bab5390
+commit=8db01ac00968af915f8a8e98e446813a51e5d541


### PR DESCRIPTION
Updates Ring Menu to 1.1.0.

- Inventory Setups integration now uses that plugin's PluginMessage API (added in inventory-setups v1.25.0) instead of reading its config, so Ring Menu no longer depends on the setupsV3_ key schema or its bank tag layout hashing.
- The saved ring list is versioned, and rings written by earlier releases are migrated on load. A stored value that cannot be read is left untouched rather than overwritten.
- Ring entries whose inventory setup has been deleted are drawn in red in the side panel and in the ring.