### PR TITLE
Update Ground Item Icons to fix icon ordering.

### DIFF
--- a/plugins/ground-item-icons
+++ b/plugins/ground-item-icons
@@ -1,2 +1,2 @@
 repository=https://github.com/Meowdyosrs/GroundItemIcons.git
-commit=f8b8ae112447f6d4ccb8b978dae3afc87c76cb9c
+commit=59adf926beeba14304bfc39d3dd6a5af2667c9ff


### PR DESCRIPTION
Updated Ground Item Icons to fix icon ordering for stacked ground items.

Icons now follow their corresponding Ground Items entries regardless of drop order.