### PR TITLE
Small bugfix for faux-bingo plugin

### DIFF
--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,3 +1,3 @@
 repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
-commit=027faa042942720d676c31421f90a3599642bfc9
+commit=5b567fcf4461076adca94f630276eb43409486a5
 authors=ThatOhio


### PR DESCRIPTION
On startup we were checking client data improperly on the wrong thread. 