### PR TITLE
update clan qol 1.1.5

### DIFF
--- a/plugins/better-clan-broadcasts
+++ b/plugins/better-clan-broadcasts
@@ -1,2 +1,2 @@
 repository=https://github.com/abristow3/Better-Clan-Broadcasts.git
-commit=6dbb7674ab04a93d0e7ffb171cdb4f16baa7c950
+commit=fbdce377a961c7f7dd435b7c446d5380a339d849


### PR DESCRIPTION
- Fixes ClanNoteIcons from disappearing when a user right clicked, and re-appearing once the menu was closed.
- Fixes the CA Broadcasts not having the right click 'view task' and 'open task' options
- Refactored how CA Broadcasts are processed. instead check clan rank icon has been prepended each frame for visual performance (on tick shows visual delay)