### PR TITLE
Add Coffer

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=6ef656da6060f5833261b76210a10470a38365e7
+commit=a4e0c9f6c6976926a1d3ba10903233b61333193d
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=89aa92f0c10778877a66fa7f9514f36a312fdc32
+commit=4e590cb8c65ba63d4eaafa5d3069e4b1c78a653b
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=69485178f3e69650b0874293937363f6301595ef
+commit=89aa92f0c10778877a66fa7f9514f36a312fdc32
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=286cfd402bd928ece8d565a075f64f251d9a1d0c
+commit=b20126e875be1b7cb4092cb03e06125db1d1d8bf
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=b20126e875be1b7cb4092cb03e06125db1d1d8bf
+commit=0bfc08b47fe0d83d98824bc0861e236f92859c51
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=4e590cb8c65ba63d4eaafa5d3069e4b1c78a653b
+commit=286cfd402bd928ece8d565a075f64f251d9a1d0c
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=ab06eb8672cbffc55ba841da0ce2d3d10e0c2333
+commit=69485178f3e69650b0874293937363f6301595ef
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=a4e0c9f6c6976926a1d3ba10903233b61333193d
+commit=5e2579081997aa6ed8ca7168620d40d4e250e4d5
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=e7c242dcce5b647070300de355bda46f7261282e
+commit=10208b188c0e0c83e2466acc16680caa2beff586
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=5e2579081997aa6ed8ca7168620d40d4e250e4d5
+commit=e7c242dcce5b647070300de355bda46f7261282e
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=0bfc08b47fe0d83d98824bc0861e236f92859c51
+commit=6ef656da6060f5833261b76210a10470a38365e7
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,0 +1,3 @@
+repository=https://github.com/Paul2357/coffer.git
+commit=ab06eb8672cbffc55ba841da0ce2d3d10e0c2333
+warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=10208b188c0e0c83e2466acc16680caa2beff586
+commit=639069cdb81614cea998849469f11f86fa04eee5
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Coffer is a Grand Exchange flipping assistant: ranked flip suggestions, a per-slot plan, open-position coaching, a watchlist, high-alch and crash finders, and automatic P&L tracking.

It requires a free Coffer account and submits the player's Grand Exchange offers to the Coffer server for flip suggestions and cross-account fill data. This is disclosed in the plugin description, the README, and a `warning=` line in the manifest.

Source: https://github.com/Paul2357/coffer