### PR TITLE
Add Instance Party Pings

### DIFF
--- a/plugins/instance-party-pings
+++ b/plugins/instance-party-pings
@@ -1,0 +1,2 @@
+repository=https://github.com/willzero123/instance-party-pings.git
+commit=2d28d4ca978f6e24c6ae85890e61f0f09815926a


### PR DESCRIPTION
Lets you ping tiles in different instances of the same map, like the Colosseum or the Inferno.