### PR TITLE
bank-bridge: update to 1.2.2

### DIFF
--- a/plugins/bank-bridge
+++ b/plugins/bank-bridge
@@ -1,4 +1,4 @@
 repository=https://github.com/theshane0314/bank-bridge-plugin.git
-commit=f3b078b27a40dbb11420a96ebcc0f8c1363f7fa0
-warning=This plugin opens a WebSocket server on 127.0.0.1 so a gear-planning website can read your bank, inventory, worn equipment and levels. Nothing is uploaded and there is no server or account involved, and only allowlisted sites can connect.<br>Be aware that another program already running on your own machine could forge the origin check and read the same data. It cannot see your bank PIN or anything you type.
+commit=c5392d7805483a91cccc8e15ae06478cbd4af06b
+warning=This plugin opens a WebSocket server on 127.0.0.1 so a gear-planning website can read your bank, inventory, worn equipment, levels, and which quests, achievement diaries and combat achievements you have completed. Nothing is uploaded and there is no server or account involved, and only allowlisted sites can connect.<br>Be aware that another program already running on your own machine could forge the origin check and read the same data. It cannot see your bank PIN or anything you type.
 authors=theshane0314


### PR DESCRIPTION
Bumps `bank-bridge` from `f3b078b` to `c5392d7`.

**What changed in the plugin**

`1.2.0` added an unlocks block, behind a new `Share quests and diaries` toggle: which quests and achievement diary tiers are complete, quest points, and combat achievement tiers. Most gear and route requirements are unlocks rather than levels, so without it the site has to guess.

`1.2.1` removed a player-owned-house block that `1.2.0` had briefly served. Three POH varbits read 0 on an account with 99 Construction, so they said nothing about what the player had actually built. The reasoning is recorded in `AccountUnlocks.java`.

`1.2.2` takes the quest ids from RuneProfile's shape and bans the mechanism its other two lookups need. RuneProfile reads per-tier completion counts via `runScript`/`getIntStack`, which is arbitrary code execution in the client and stronger than the passive hooks this plugin already refuses. `runScript`, `getIntStack` and `getObjectStack` are now banned outright and mutation-tested, so the gap stays open rather than the posture being weakened.

The last commit corrects the `shareUnlocks` description, which still named the house settings removed in 1.2.1.

**Warning field**

Updated to name the new data. It previously listed bank, inventory, worn equipment and levels; it now also names quests, achievement diaries and combat achievements. The rest is unchanged, including the note that another program on the same machine could forge the origin check.

**Verified against a live account**

211 quests (209 finished, 1 in progress, 1 not started), 337 quest points, 12 of 12 diary regions, 48 of 48 combat achievement tiers, and the quest join matched 197 with none falling through to the unsourced path.

**One thing worth flagging, unchanged from the original review**

`build=standard` replaces the build file, so my `accountSafetyCheck` task does not run on your side. It fails the build on any reference to widgets, key or mouse listeners, varbits, chat, menu or script hooks, on the grounds that a bank PIN is entered on a widget and this plugin should have no code path that could observe one. It still runs on every local build, and a `standardBuildCheck` task compiles against the standard-build classpath so dependency drift is caught before it reaches you.