### PR TITLE
Update Group TCG to 0.1.4

### DIFF
--- a/plugins/group-tcg
+++ b/plugins/group-tcg
@@ -1,3 +1,3 @@
 repository=https://github.com/Sqwiglyy/groupman-tcg.git
-commit=b7e6049e020ca315e2bf1378cc9dea26ccaa54c4
+commit=71fec5e77949a75579f0c6f26c58b95c3bef7f74
 warning=IMPORTANT MULTIPLAYER PRIVACY WARNING: Group TCG deliberately has no official public server; multiplayer uses only a private server chosen by your group. Only connect to servers run by friends you trust. The host controls the endpoint and may see or record your IP address and synced Group TCG data. Private servers are independently operated; the Group TCG creator does not operate, verify, endorse, or accept responsibility for servers hosted by others. Use a VPN if you need to hide your IP address. Solo play does not connect to a group server. Optional card artwork also sends your IP address and requested image URLs to the OSRS Wiki.

--- a/plugins/group-tcg
+++ b/plugins/group-tcg
@@ -1,3 +1,3 @@
 repository=https://github.com/Sqwiglyy/groupman-tcg.git
-commit=71fec5e77949a75579f0c6f26c58b95c3bef7f74
+commit=4e897fb9c3a60bb5e977b6e1e5312f9050496878
 warning=IMPORTANT MULTIPLAYER PRIVACY WARNING: Group TCG deliberately has no official public server; multiplayer uses only a private server chosen by your group. Only connect to servers run by friends you trust. The host controls the endpoint and may see or record your IP address and synced Group TCG data. Private servers are independently operated; the Group TCG creator does not operate, verify, endorse, or accept responsibility for servers hosted by others. Use a VPN if you need to hide your IP address. Solo play does not connect to a group server. Optional card artwork also sends your IP address and requested image URLs to the OSRS Wiki.


### PR DESCRIPTION
Updates Group TCG to 0.1.4.\n\nOSRS TCG 0.18 persists an incremented pack count before writing the five pulled card rows. Group TCG 0.1.3 could observe that intermediate master save and advance its detection baseline before the completed pack arrived, so collection synchronization worked but no live pack event was uploaded. This update retains the prior baseline until the matching card rows appear, with a bounded fallback for malformed saves.\n\nIt also adds a Pack popup size setting from 40% to 125%, defaulting to a compact 70%. The cards, header, badges, border and timer scale together.\n\nRegression coverage includes the counter-first/card-rows-second sequence and scale clamping. gradlew clean test passes all 53 tests.