### PR TITLE
instant-replay: bump commit — fix OOM/black-screen on stock client

### DIFF
--- a/plugins/instant-replay
+++ b/plugins/instant-replay
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/instant-replay.git
-commit=eb116dc228a51bdf3ff0e7ee60d42b25c9f4cb4a
+commit=e1a317f7c3ac135c213e3afd0d853f0120162df2


### PR DESCRIPTION
Bumps the pinned commit for the already-merged `instant-replay` plugin to pick up a bugfix.

**Bug:** the rolling capture buffer used a fixed 256 MB ceiling with no way to reduce it. On the stock RuneLite client (-Xmx768m) with several other plugins loaded, this could exhaust the heap, causing an OutOfMemoryError and a black screen / crash, alongside FPS drops as the buffer grew.

**Fix (georgeparamore/instant-replay@e1a317f, "Fix OOM on stock client: small default buffer, configurable cap"):** default buffer cap lowered to 64 MB, exposed as a user-configurable "Max memory (MB)" setting (16–512), with an absolute 512 MB ceiling regardless of configuration.

No other behavior changes; no new dependencies.