### PR TITLE
rs-flipper: fix stuck login state and a key handler crash

### DIFF
--- a/plugins/rs-flipper
+++ b/plugins/rs-flipper
@@ -1,3 +1,3 @@
 repository=https://github.com/Ramon0205/rs-flipper.git
-commit=e75d99d8ae9ce39d93768d5033c947587304becf
+commit=acc94c88ad810632ff6216869027c926c2927192
 warning=This plugin submits your IP address, Grand Exchange offers and trade history to a 3rd-party server (api.rs-flipper.com) not controlled or verified by RuneLite developers. An account is required.


### PR DESCRIPTION
- Login panel stayed on "Log out" with the login fields hidden after the
  session token expired, and the button did nothing. Only a client restart
  got you out of it. The panel now redraws when the session is dropped.
- keyPressed read client varc values without checking the game was loaded,
  throwing a NullPointerException on any keypress at the login screen.
- Panel sat on "Renewing session ..." for up to 30s after a token refresh
  instead of syncing right away.

Commit: acc94c88ad810632ff6216869027c926c2927192