### PR TITLE
Update ClanHQ plugin

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=35afc17
+commit=35afc172aff24a11009bc96e168dcd480267f3d1

--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=ca5dca52620e08df4597a4d4d3c4025d270fe58d
+commit=35afc17

--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=35afc172aff24a11009bc96e168dcd480267f3d1
+commit=f27be32c686d918ddddd8d7a5e185ae8aa6fe3aa


### PR DESCRIPTION
## ClanHQ plugin update

This updates the existing ClanHQ Plugin Hub entry to the latest public release commit.

- Repository: https://github.com/jewatson1994/clanhq-runelite
- Updated commit: 35afc17
- Includes daily task progress overlay, refreshed event/Bingo/daily panels, and character sync UX improvements.
- Gear Advisor work is intentionally excluded from this release.
- The plugin repository contains no ClanHQ credentials, API tokens, databases, or bundled production endpoint.

The plugin’s existing metadata and privacy boundaries are unchanged.