### PR TITLE
update ba-gamble-tracker to 1.1

### DIFF
--- a/plugins/ba-gamble-tracker
+++ b/plugins/ba-gamble-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/ba-gamble-tracker.git
-commit=71af587a4de9c6f268848c808a54855efd1487f3
+commit=d558fa3b049e881cf4bd37794c86406d6b0c3321

--- a/plugins/ba-gamble-tracker
+++ b/plugins/ba-gamble-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/ba-gamble-tracker.git
-commit=d558fa3b049e881cf4bd37794c86406d6b0c3321
+commit=7a4bda569d5390dc261f75dd0148d2ea26fefd60


### PR DESCRIPTION
1.1

Each tier can block or highlight its shop row.
Settings in Diagnostics.
Fixed medium gambles.