### PR TITLE
Add Everykill

### DIFF
--- a/plugins/everykill
+++ b/plugins/everykill
@@ -1,3 +1,4 @@
 repository=https://github.com/everykill/everykill-plugin.git
 commit=c48143ca6fce5a9ff198161e66abe9889818c1f9
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.
 authors=Delkyy

--- a/plugins/everykill
+++ b/plugins/everykill
@@ -1,0 +1,2 @@
+repository=https://github.com/everykill/everykill-plugin.git
+commit=c48143ca6fce5a9ff198161e66abe9889818c1f9

--- a/plugins/everykill
+++ b/plugins/everykill
@@ -1,2 +1,3 @@
 repository=https://github.com/everykill/everykill-plugin.git
 commit=c48143ca6fce5a9ff198161e66abe9889818c1f9
+authors=Delkyy


### PR DESCRIPTION
Kill counts for every monster in the game, not just the ~90 on the hiscores.

There are over 1,000 monsters in OSRS. The official hiscores rank about 90 of them, so nobody knows who's killed the most Rockslug, nothing counts them. This plugin counts them, locally, and grades every kill by how well it can be evidenced.

**Why it isn't a duplicate:** Collection Log Luck does log slots, Dry Rate Tracker does raid dryness, Bossing Info covers the bosses that already have hiscores. Those answer *"how am I doing"* from your own data. This answers *"how am I doing compared to everyone else"*, which needs a shared denominator. Loot Lookup owns drop tables and Dink owns Discord webhooks — neither is rebuilt here, and milestones are handed to Dink via `PluginMessage` rather than a second webhook implementation.

**Upload is opt-in and off by default.** With it off the plugin is fully useful and makes no network calls. With it on, it sends kill records to everykill.com. Your RuneScape name is never sent unless you separately turn on name publishing, which is its own toggle and also defaults off. There's an in-plugin export and delete for anything already uploaded.

Notes for review:

- Zero dependencies. `build=standard`, Java 11, `@Inject` OkHttp and Gson, all calls on `enqueue()`
- No reflection, no classloading, no serialization, no `Thread.sleep`
- Nothing subscribes to NPC animations, projectiles or incoming hitsplats — counters only move after something has already died, and there's no per-boss logic
- The overlay is off by default and shows kill counts only
- Kills from Deadman, Leagues, beta and tournament worlds are excluded for now

BSD 2-Clause. 186 tests.