### PR TITLE
update deathbank-utility

### DIFF
--- a/plugins/deathbank-utility
+++ b/plugins/deathbank-utility
@@ -1,2 +1,2 @@
 repository=https://github.com/jakevollkommer/deathbank-utility.git
-commit=bf0971e428ef964bfd3fba33cd2e4a94154a20e5
+commit=8f48e82de171d13fb2f4024e8b585e88549a57de


### PR DESCRIPTION
Detection fixes found by field testing at the Theatre of Blood, the Nightmare, and Phosani's Nightmare.

- Deathbank location is now captured. Child 1 of the retrieval interface is a frame rather than a title, so the location was stored empty. The interface text and the login message are read instead.
- Services are identified by the claim NPC's name, since the interface and messages are named after the NPC rather than the boss ("Shura's Item Retrieval Service").
- Phosani's Nightmare is tracked separately from the Nightmare, which share a region and are only distinguishable from that text.
- Discarding a bank is now detected, read from the interface's stack count. Discarding fires no container update, sends no message, and changes no varp.
- Claim NPC dialog is read generically to confirm or clear a bank, which replaced a Zulrah-specific special case.
- Game text is sanitized of unresolved formatting macros before matching.
- State is flushed immediately so a crash cannot lose the recorded item list, and stale state no longer shows a warning before the login check confirms it.
- Indicator legibility, a hover tooltip, location label, claim point highlighting scoped to the service holding the items, and side panel layout fixes.