### PR TITLE
Takeover Discord Notifications Plugin

### DIFF
--- a/plugins/discord-notifications
+++ b/plugins/discord-notifications
@@ -1,2 +1,2 @@
-repository=https://github.com/pairofcrocs/RuneLite-Discord-Notifications.git
+repository=https://github.com/ThatOhio/RuneLite-Discord-Notifications.git
 commit=686a54422360438bf055f0eb122cd030a091436d

--- a/plugins/discord-notifications
+++ b/plugins/discord-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/ThatOhio/RuneLite-Discord-Notifications.git
-commit=686a54422360438bf055f0eb122cd030a091436d
+commit=2d6ebe2231fabb02c47f0bc043ff21010a465089


### PR DESCRIPTION
I requested contributor access over 3 weeks ago, see this issue here: https://github.com/pairofcrocs/RuneLite-Discord-Notifications/issues/1

Plugin seems abandoned, likely due to Dinks superiority. Some of the work I plan to do to the plugin is listed in that contributor request. 

I've tried to reach out to current repository owner, and most recent person to commit to the project, and have been unable (nor can I locate them in the discord with the /whois command). 