### PR TITLE
Add Mathscape Calculator plugin

### DIFF
--- a/plugins/mathscape-calculator
+++ b/plugins/mathscape-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/ArashCod3r/mathscape-calculator.git
-commit=359674f5459e51d9c360dce00f0f4b64f78c9e10
+commit=54cd2e1cd4735fc3a8759c652f2cc2bf0b1fbe4a

--- a/plugins/mathscape-calculator
+++ b/plugins/mathscape-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/ArashCod3r/mathscape-calculator.git
-commit=54cd2e1cd4735fc3a8759c652f2cc2bf0b1fbe4a
+commit=7cb8a224c375ccd5ffad54192adc8a720966d0b4

--- a/plugins/mathscape-calculator
+++ b/plugins/mathscape-calculator
@@ -1,0 +1,2 @@
+repository=https://github.com/ArashCod3r/mathscape-calculator.git
+commit=359674f5459e51d9c360dce00f0f4b64f78c9e10


### PR DESCRIPTION
Adds a simple calculator overlay to RuneLite. You can use your keyboard to type math expressions or click the buttons. Supports basic operations like +, -, *, and /. Also has a togglable history that saves your previous calculations so you can reuse them.

Works well for quick in game math without alt/tabbing out

Tested locally with gradlew run and everything seems fine.