### PR TITLE
update freyjas-flora

### DIFF
--- a/plugins/freyjas-flora
+++ b/plugins/freyjas-flora
@@ -1,2 +1,2 @@
 repository=https://github.com/RaghavMangrola/freyjas-flora.git
-commit=cfda3f1774f50edefd5a2c0d6b2f51b84a925f5c
+commit=b270454ba76032e930a59f61fa02bb0dd9e5a70d


### PR DESCRIPTION
Updates Freyja's Flora to commit b270454, which replaces the non-ASCII curly apostrophe in the display name with a standard ASCII apostrophe. This fixes the mojibake shown in the Plugin Hub.