### PR TITLE
Update ClanHQ events tab compatibility

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=f27be32c686d918ddddd8d7a5e185ae8aa6fe3aa
+commit=d2ed8149261ba41d11d3495cc3c83d550c7fd901


### PR DESCRIPTION
## Summary\n- update ClanHQ to the latest standalone plugin commit\n- preserve the configured clan name when the events tab encounters a temporary API/parsing error\n- accept legacy event-list payloads so current SOTW/BOTW entries continue to render\n\nThe manifest uses the full 40-character commit SHA required by Plugin Hub packaging. The standalone plugin branch contains the corresponding committed changes.\n\nValidation: git diff --check passes. Gradle validation was attempted, but this environment could not resolve the RuneLite dependency metadata because the wrapper download failed certificate validation.