### PR TITLE
Update Morty's Ledger to 1814306

### DIFF
--- a/plugins/mortys-ledger
+++ b/plugins/mortys-ledger
@@ -1,2 +1,2 @@
 repository=https://github.com/ruffensteint/Mortys-Ledger.git
-commit=4627b074975a10ff1e36d3fe1a3ee9bb3df14a6d
+commit=18143064373b1208ca46389b7bf902ea679cc976


### PR DESCRIPTION
Updates Morty's Ledger to ignore repeated Mortimer completion-count messages received around login. A task is now completed and announced only when the saved completed-task count increases, preventing false zero-XP completion posts and duplicate task starts. Also includes the previously committed removal of player names from webhook posts.\n\nValidation: Gradle test suite passes on Java 11, including a regression test for a repeated login completion count.