### PR TITLE
Mathscape Calculator: Fix toggle button bug

### DIFF
--- a/plugins/mathscape-calculator
+++ b/plugins/mathscape-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/ArashCod3r/mathscape-calculator.git
-commit=359674f5459e51d9c360dce00f0f4b64f78c9e10
+commit=54cd2e1cd4735fc3a8759c652f2cc2bf0b1fbe4a

--- a/plugins/mathscape-calculator
+++ b/plugins/mathscape-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/ArashCod3r/mathscape-calculator.git
-commit=7cb8a224c375ccd5ffad54192adc8a720966d0b4
+commit=acd45b4275e4b00dd952614269356672ea9cbd59

--- a/plugins/mathscape-calculator
+++ b/plugins/mathscape-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/ArashCod3r/mathscape-calculator.git
-commit=54cd2e1cd4735fc3a8759c652f2cc2bf0b1fbe4a
+commit=7cb8a224c375ccd5ffad54192adc8a720966d0b4

--- a/plugins/mathscape-calculator
+++ b/plugins/mathscape-calculator
@@ -1,0 +1,2 @@
+repository=https://github.com/ArashCod3r/mathscape-calculator.git
+commit=359674f5459e51d9c360dce00f0f4b64f78c9e10


### PR DESCRIPTION
Quick fix for the toggle button not working on fresh installs.

The icon.png file wasn't being packaged in the JAR properly, causing startUp() to fail and the toggle to bounce back off. I've added a copy of the icon to src/main/resources