### PR TITLE
osrscn: bump to 0.2.3

### DIFF
--- a/plugins/osrscn
+++ b/plugins/osrscn
@@ -1,3 +1,3 @@
 repository=https://github.com/Aoldbald/OSRS_CN_Runelite.git
-commit=6cddd50988bdf337050ad0538a604f70a859835e
+commit=222954ad99989770cd41375a29d51a05a55a925e
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update commit to 222954ad99989770cd41375a29d51a05a55a925e. Fixes gaps in the optional missing-text collection: nearby player names are masked to a placeholder before recording, trade screens no longer collect, and colour-tagged or placeholder-keyed lines now resolve from the tables instead of being re-collected.