### PR TITLE
Add Resize Window Smaller

### DIFF
--- a/plugins/resize-window-smaller
+++ b/plugins/resize-window-smaller
@@ -1,0 +1,4 @@
+repository=https://github.com/Jordan-Hn/RuneLite-Resize-Window-Smaller-Plugin.git
+commit=47da2a7cddf2ad8fa28b21f5a86a4f591291b065
+authors=Jordan-Hn
+warning=This plugin lets the client window be made smaller than RuneLite normally allows. Small enough sizes can make the game render incorrectly or become unstable.


### PR DESCRIPTION
Lowers RuneLite's 765x503 minimum window size so the client window can be dragged smaller. ClientPanel hardcodes its minimum to Constants.GAME_FIXED_SIZE, which propagates through ClientUI's layout manager into Window.setMinimumSize() and becomes the window manager's size hint. The plugin replaces it with a configurable value and calls the public ContainableFrame.revalidateMinimumSize().

No reflection, no native code, no third party dependencies. Does not move, focus, or minimize the window. Restores the stock minimum on shutdown.