### PR TITLE
Add Item Option Hider

### DIFF
--- a/plugins/item-option-hider
+++ b/plugins/item-option-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/YOUR_USERNAME/item-option-hider.git
+commit=5375d699a8661c157c7e26b699a9c46401237c7e

--- a/plugins/item-option-hider
+++ b/plugins/item-option-hider
@@ -1,2 +1,2 @@
-repository=https://github.com/YOUR_USERNAME/item-option-hider.git
+repository=https://github.com/kekingbd/item-option-hider.git
 commit=5375d699a8661c157c7e26b699a9c46401237c7e


### PR DESCRIPTION
Hide specific menu options on specific items. Only menu entries belonging to items are ever affected. Entries on players,
  NPCs, spells, and objects are never touched.