### PR TITLE
update iron compass

### DIFF
--- a/plugins/ironpath
+++ b/plugins/ironpath
@@ -1,3 +1,3 @@
-repository=https://github.com/gabworknestio-beep/ironpath.git
-commit=0444acdea8986cfdd1d9827a0ff63c3b78d80d41
+repository=https://github.com/gabworknestio-beep/iron-compass.git
+commit=ca7202eb44918969d329f58086febc0f657d5d41
 authors=Gab


### PR DESCRIPTION
Renames the published plugin to Iron Compass to resolve the display-name and configuration-group collision.

Changes:
- Display name: Iron Compass
- ConfigGroup: ironcompass
- Repository: gabworknestio-beep/iron-compass
- Java package: com.ironcompass
- Targeted migration of known existing settings
- No gameplay automation or functional scope changes

Java 11 clean build and all 95 tests pass.