### PR TITLE
Create herb-harvest-guard

### DIFF
--- a/plugins/herb-harvest-guard
+++ b/plugins/herb-harvest-guard
@@ -1,0 +1,2 @@
+repository=https://github.com/iwakeman/herb-harvest-guard.git
+commit=1a4956a68818449d150161e3af9093867afbbd5b

--- a/plugins/herb-harvest-guard
+++ b/plugins/herb-harvest-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/iwakeman/herb-harvest-guard.git
-commit=1a4956a68818449d150161e3af9093867afbbd5b
+commit=9ebf3fb48791346ab55203bedcb87498948927bb

--- a/plugins/herb-harvest-guard
+++ b/plugins/herb-harvest-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/iwakeman/herb-harvest-guard.git
-commit=9ebf3fb48791346ab55203bedcb87498948927bb
+commit=4c1bf6216211139bd4f2467c60ad09672b7da2b2

--- a/plugins/herb-harvest-guard
+++ b/plugins/herb-harvest-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/iwakeman/herb-harvest-guard.git
-commit=4c1bf6216211139bd4f2467c60ad09672b7da2b2
+commit=d8b7eb960973707e4ddc7c88fda11a4276e3bcb8

--- a/plugins/herb-harvest-guard
+++ b/plugins/herb-harvest-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/iwakeman/herb-harvest-guard.git
-commit=d8b7eb960973707e4ddc7c88fda11a4276e3bcb8
+commit=a656ac81178f8b9e51645135f399576fe3c5a293


### PR DESCRIPTION
Adds Herb Harvest Guard.

Prevents players from accidentally harvesting herb patches without their configured yield-boosting items.

Supports:
- Magic secateurs equipped or in inventory
- Optional Farming cape requirement
- Replaces the Pick option with "Missing yield boost" when requirements are not met
- Blocks the harvest action and displays a chat warning