### PR TITLE
CA Roulette Export

### DIFF
--- a/plugins/ca-roulette-export
+++ b/plugins/ca-roulette-export
@@ -1,0 +1,2 @@
+repository=https://github.com/renattamaria/ca-roulette-export.git
+commit=c901649cda45eaa1836aa520b596815ae33af72c


### PR DESCRIPTION
New plugin. Reads Combat Achievement completion, skill levels, quest states and item containers, and writes them to a local JSON file (.runelite/ca-roulette/<name>.json) for an external CA task-randomiser website. No network access.