### PR TITLE
Sailing Bad: opt in from the setting instead of a panel button

### DIFF
--- a/plugins/sailing-bad
+++ b/plugins/sailing-bad
@@ -1,3 +1,3 @@
 repository=https://github.com/YonwiPlugins/sailing-bad.git
-commit=6827a9e312a23da08c4a318d55cd47b34dc30567
+commit=cf507f3ce38b15e04211631c20965cd01f4cff4b
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/sailing-bad
+++ b/plugins/sailing-bad
@@ -1,3 +1,3 @@
 repository=https://github.com/YonwiPlugins/sailing-bad.git
-commit=cf507f3ce38b15e04211631c20965cd01f4cff4b
+commit=ff75275667230677a3a2be44ba18ef4129bdcaf9
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Sailing Bad to cf507f3.

The HiScores opt-in now works from the setting alone. Previously the player had to enable the opt-in setting and then click a button in a side panel; the panel has been removed and ticking the setting adds them on their next login instead.

The network behaviour is otherwise unchanged from the reviewed version:

- Off by default, and the `@ConfigItem` keeps its `warning` prompt, so the player still confirms before anything is sent.
- One POST to `https://2277.telfardo.com/api/hiscores` containing the character name, and nothing else. No levels, no XP, and nothing about any other player is read or sent. The site reads the levels it ranks from the official hiscores itself.
- Sent once per name per session, and unticking the setting stops it.

The request JSON is now built with Gson rather than string concatenation, and the existing name normalising and validation moved alongside it so the name is checked before it is sent.
