### PR TITLE
Update stockpile to 1.6

### DIFF
--- a/plugins/stockpile
+++ b/plugins/stockpile
@@ -1,2 +1,2 @@
 repository=https://github.com/Oveduumnakal/Stockpile-Plugin.git
-commit=4712998283177bddbcc478cf9ca5308e571c24fc
+commit=2bb1cf44794923ed803e42f42a4a01fb3b7a74cf


### PR DESCRIPTION
Updates Stockpile to release 1.6 (tag `R-1.6`, commit `2bb1cf4`).

Highlights: a new Compare window that puts up to six items side by side with prices, market info, alchemy, holdings, and per-item trend and volume charts; "Compare all variants" to fill it with a potion's dose line or a food's raw and cooked forms in one click; saving, reloading, and sharing named comparisons via a short code; a Quick Actions setting choosing whether tracked-row actions arrive as hover buttons, a right-click menu, or both; and a Change category submenu on that menu. Full notes: https://github.com/Oveduumnakal/Stockpile-Plugin/releases/tag/R-1.6
