### PR TITLE
Add Agamemnon Companion

### DIFF
--- a/plugins/agamemnon-companion
+++ b/plugins/agamemnon-companion
@@ -1,3 +1,3 @@
 repository=https://github.com/HDFreitas/agamemnon-companion-plugin.git
-commit=CHANGEME_PLACEHOLDER
+commit=c63e490ad1421f37e6f4e90c2bebf302c5afe663
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/agamemnon-companion
+++ b/plugins/agamemnon-companion
@@ -1,3 +1,3 @@
 repository=https://github.com/HDFreitas/agamemnon-companion-plugin.git
-commit=8c52107fe0ee6dbd2a75e8fcc1958d9911c01ff6
+commit=CHANGEME_PLACEHOLDER
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/agamemnon-companion
+++ b/plugins/agamemnon-companion
@@ -1,3 +1,3 @@
 repository=https://github.com/HDFreitas/agamemnon-companion-plugin.git
-commit=67111e2e9a40bf58f03e02ddc86e4d5e9923a15e
+commit=8c52107fe0ee6dbd2a75e8fcc1958d9911c01ff6
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/agamemnon-companion
+++ b/plugins/agamemnon-companion
@@ -1,0 +1,3 @@
+repository=https://github.com/HDFreitas/agamemnon-companion-plugin.git
+commit=67111e2e9a40bf58f03e02ddc86e4d5e9923a15e
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/agamemnon-companion
+++ b/plugins/agamemnon-companion
@@ -1,3 +1,3 @@
 repository=https://github.com/HDFreitas/agamemnon-companion-plugin.git
-commit=c63e490ad1421f37e6f4e90c2bebf302c5afe663
+commit=669edf52797d0106bcf2aae6918814a928e8d619
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/agamemnon-companion
+++ b/plugins/agamemnon-companion
@@ -1,3 +1,3 @@
 repository=https://github.com/HDFreitas/agamemnon-companion-plugin.git
-commit=669edf52797d0106bcf2aae6918814a928e8d619
+commit=6a6c2b705ef51aa4c4d03f55316049cc45c14968
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary

Syncs the local account's XP, slayer task, farming patches, quests and achievements to a self-hosted Agamemnon Companion dashboard at companion.tpbrothers.com.br.

- All features off by default, each with the required IP warning
- Only the logged-in account's data; no other players are read
- Hardcoded server URL (no free-text URL field)
- Users can erase their data via the documented DELETE endpoint

Plugin repository: https://github.com/HDFreitas/agamemnon-companion-plugin

## Test plan

- [x] `./gradlew test` passes in the plugin repository
- [ ] CI green on this PR