### PR TITLE
Update CA Roulette Export

### DIFF
--- a/plugins/ca-roulette-export
+++ b/plugins/ca-roulette-export
@@ -1,2 +1,2 @@
 repository=https://github.com/renattamaria/ca-roulette-export.git
-commit=cdbe3ef4bec80bcde25ee910305a508676df1984
+commit=24eeeefee4a0272e04d3fcca60c8a7b3c952a7b5

--- a/plugins/ca-roulette-export
+++ b/plugins/ca-roulette-export
@@ -1,0 +1,2 @@
+repository=https://github.com/renattamaria/ca-roulette-export.git
+commit=c901649cda45eaa1836aa520b596815ae33af72c

--- a/plugins/ca-roulette-export
+++ b/plugins/ca-roulette-export
@@ -1,2 +1,2 @@
 repository=https://github.com/renattamaria/ca-roulette-export.git
-commit=c901649cda45eaa1836aa520b596815ae33af72c
+commit=cdbe3ef4bec80bcde25ee910305a508676df1984


### PR DESCRIPTION
Bump to latest commit: adds a guard against overlapping exports, diagnostic logging if CA tier data can't be read, and a link to the live site in the README.