### PR TITLE
Add Expose Interface State

### DIFF
--- a/plugins/expose-interface-state
+++ b/plugins/expose-interface-state
@@ -1,0 +1,2 @@
+repository=https://github.com/osrshool222/expose-interface-state.git
+commit=bd76f933a01623ea389efd97dfc9f8747b474579


### PR DESCRIPTION
## Plugin submission

This PR adds the `expose-interface-state` plugin.

The plugin exposes a read-only JSON snapshot of selected local RuneLite interface state on `127.0.0.1`:
- Bank open state
- Grand Exchange slot, buy, sell, quantity-input, and price-input windows
- Active interface tab
- Configurable custom prefix and last-update timestamp

The plugin does not automate gameplay and does not expose player names, coordinates, credentials, or other player data. The plugin repository includes a BSD-2-Clause license, Java 11 configuration, tests, and no runtime dependencies beyond RuneLite.

Validation completed locally with `gradlew clean build`.