### PR TITLE
Added Dry Streak Tracker plugin

### DIFF
--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
-commit=f9d0be4039b4618acd15ea7ca4076db5b6f8a080
+commit=8873772e0de24311c566b59f59177d87af34d07a

--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
-commit=f458a5473c846f134ee8e2b41c30df8198331a9c
+commit=f9d0be4039b4618acd15ea7ca4076db5b6f8a080

--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,2 +1,3 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
 commit=8873772e0de24311c566b59f59177d87af34d07a
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
-commit=e61d3547e1681ffab5412806fa84e88a05a6be1d
+commit=f458a5473c846f134ee8e2b41c30df8198331a9c

--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
+commit=638eab70ea025703ee49f9aeb7974f209bdfcb07

--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
-commit=e1cc1216c50ce341f4a23e09846d2569ddc6042a
+commit=e61d3547e1681ffab5412806fa84e88a05a6be1d

--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
-commit=638eab70ea025703ee49f9aeb7974f209bdfcb07
+commit=e1cc1216c50ce341f4a23e09846d2569ddc6042a


### PR DESCRIPTION
Dry Streak Tracker tracks the current and the longest dry streaks between unique drops at supported bosses, raids, and other encounters. It also tracks unique drops, pets, and the last drop killcount through a side panel. There's also a recent drops panel showing your recent uniques pulled and some helpful data with it. It also has discord webhook integration for auto-submission uploads with a screenshot, as well as supporting manual uploads without a screenshot.