### PR TITLE
Add green-combat-achievements plugin

### DIFF
--- a/plugins/green-combat-achievements
+++ b/plugins/green-combat-achievements
@@ -1,0 +1,2 @@
+repository=https://github.com/camjewell11/GreenCombatAchievementsMenu.git
+commit=09713aae12314c8803f6f9b6a54837b4dccf9e18

--- a/plugins/green-combat-achievements
+++ b/plugins/green-combat-achievements
@@ -1,2 +1,2 @@
 repository=https://github.com/camjewell11/GreenCombatAchievementsMenu.git
-commit=09713aae12314c8803f6f9b6a54837b4dccf9e18
+commit=4b4bcd5f54f1dfad9182fc3f4f26da3426845f08

--- a/plugins/green-combat-achievements
+++ b/plugins/green-combat-achievements
@@ -1,2 +1,2 @@
 repository=https://github.com/camjewell11/GreenCombatAchievementsMenu.git
-commit=4b4bcd5f54f1dfad9182fc3f4f26da3426845f08
+commit=bcc29e2c778f0fc1abc3a273a6ea42fa7b895f95


### PR DESCRIPTION
Green Combat Achievements Menu highlights bosses and difficulty tiers green in the Combat Achievements task list's filter dropdowns once every task for that boss/tier is completed.

- Reads completion state from the existing Bosses grid (per-boss) and the Combat Achievements overview screen (per-tier), which already render this info, and reuses it to color the otherwise-static Monster and Tier filter dropdowns.
- Completion is cached to disk per account so highlighting is available immediately on login; opening the Bosses grid or CA overview rescans and refreshes it.

Repo: https://github.com/camjewell11/GreenCombatAchievementsMenu
