### PR TITLE
create extinction-man

### DIFF
--- a/plugins/extinction-man
+++ b/plugins/extinction-man
@@ -1,2 +1,2 @@
 repository=https://github.com/avankoai/extinction-man.git
-commit=7abda83d1332abec592ef86caa50822270a25577
+commit=377315551b8f4f8faa228bdb850902cf28fc8b18

--- a/plugins/extinction-man
+++ b/plugins/extinction-man
@@ -1,0 +1,2 @@
+repository=https://github.com/avankoai/extinction-man.git
+commit=1eff18e5f7f224d6e79c89152fb790dc48daa621

--- a/plugins/extinction-man
+++ b/plugins/extinction-man
@@ -1,2 +1,2 @@
 repository=https://github.com/avankoai/extinction-man.git
-commit=1eff18e5f7f224d6e79c89152fb790dc48daa621
+commit=7abda83d1332abec592ef86caa50822270a25577


### PR DESCRIPTION
Adds Extinction Man, a self-imposed OSRS challenge plugin that tracks valid NPC kills as Souls and marks exact monster names extinct at 100.

Features include a searchable Bestiary, Soul Points and Soul Items, activity-specific exceptions, profile-scoped storage, backups, milestone popups, and visual forbidden-loot guidance.

The public version does not automate input or remove Attack/Take menu options.

Tested locally with 49 passing automated tests and an in-game manual test pass.

Plugin repository: https://github.com/avankoai/extinction-man