### PR TITLE
instant-replay: bump commit — never capture the bank PIN keypad

### DIFF
--- a/plugins/instant-replay
+++ b/plugins/instant-replay
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/instant-replay.git
-commit=de23e2279242a44d3781b542dd16ac51fb256934
+commit=cfef246f028b6c2f55456bfd8531dccbda2404c3

--- a/plugins/instant-replay
+++ b/plugins/instant-replay
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/instant-replay.git
-commit=cfef246f028b6c2f55456bfd8531dccbda2404c3
+commit=a99641038b8df6241847514275337c93fddefdff

--- a/plugins/instant-replay
+++ b/plugins/instant-replay
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/instant-replay.git
-commit=e9aa1954fc796d6898cb755e5ddbe3cae9d89ac1
+commit=de23e2279242a44d3781b542dd16ac51fb256934

--- a/plugins/instant-replay
+++ b/plugins/instant-replay
@@ -1,2 +1,2 @@
 repository=https://github.com/georgeparamore/instant-replay.git
-commit=e1a317f7c3ac135c213e3afd0d853f0120162df2
+commit=e9aa1954fc796d6898cb755e5ddbe3cae9d89ac1


### PR DESCRIPTION
Bumps the pinned commit for `instant-replay` to `e9aa1954fc796d6898cb755e5ddbe3cae9d89ac1`.

This commit adds a check for the bank PIN keypad widget (`WidgetID.BANK_PIN_GROUP_ID`) in the frame-capture listener and skips the frame entirely — before it's encoded or added to the rolling buffer — whenever that widget is visible, so PIN entry can never end up in a saved clip.

Repo: https://github.com/georgeparamore/instant-replay
Commit: https://github.com/georgeparamore/instant-replay/commit/e9aa1954fc796d6898cb755e5ddbe3cae9d89ac1