### PR TITLE
Update Reval clan

### DIFF
--- a/plugins/reval-clan
+++ b/plugins/reval-clan
@@ -1,4 +1,4 @@
 repository=https://github.com/revalOSRS/reval-cc-plugin.git
-commit=35963a7e3f5aec2d96219b99f783a0374536d24d
+commit=d579b577b11b346966e53e7b74f071b8dbedd708
 authors=stenjansarv
 warning=This plugin submits your IP address and comprehensive records of your account activity and progress to a 3rd-party server not controlled or verified by the Runelite developers.


### PR DESCRIPTION
- Handle the Runelite bug where items can be made show up as actual "loot" by dropping items or switching gear as interacting on the same tick