### PR TITLE
update ironpath

### DIFF
--- a/plugins/ironpath
+++ b/plugins/ironpath
@@ -1,3 +1,3 @@
 repository=https://github.com/gabworknestio-beep/iron-compass.git
-commit=ca7202eb44918969d329f58086febc0f657d5d41
+commit=01d058390c4a5d0af798b4b2a3f331d87fc406d0
 authors=Gab


### PR DESCRIPTION
Updates the existing Iron Compass Plugin Hub manifest to release 1.3.0.

Highlights:
- Multi-goal planning with Primary and Secondary Goals
- Goal Synergy and Recommendation V2
- Structured local Method and Resource Planner
- Useful Break alternatives and expanded 26-goal catalog

Validation:
- Java 11 `gradlew clean test build` passes
- 113 tests: 0 failures, 0 errors, 0 skipped
- Standard build, no new dependencies, runtime network, or telemetry

Only `plugins/ironpath` is changed; the historical manifest filename is retained for update continuity.