### PR TITLE
the-birdhouse: 1.1.0

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=09799dfe7315f12da2453e7fc915231687546659
+commit=bf3f37a2f16ededaf5209f2c0fc39235e7052453
 warning=This plugin submits your IP address, RSN, in-game screenshots, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps `the-birdhouse` to 1.1.0.

### What changed

The plugin previously only showed a board in the sidebar, where `PluginPanel.PANEL_WIDTH` caps everything at 225px — enough for a coloured strip, not enough to read a 7x7 board. This release adds an optional pop-out `JFrame` that draws the same board data at a size the user sizes themselves, and lets a user click a tile to capture a screenshot and submit it as proof.

Notable for review:

- **New window.** A `JFrame` opened on demand from a sidebar button, or on startup if the user enables that config option (default off). It saves its bounds via `ConfigManager` and falls back to defaults if the saved position is off-screen. Disposed when the plugin stops.
- **`LinkBrowser.browse`.** One button opens the event's public standings page on the plugin's own site. No other URLs are opened.
- **Screenshot capture** goes through `DrawManager` as before, on user click rather than automatically, with a preview shown before anything is sent and a timeout so the button is released if the client isn't rendering.
- **Client API access** stays on the client thread (`ClientThread.invoke` for `getLocalPlayer` and `addChatMessage`); all UI work stays on the EDT.
- **No new polling.** The window renders board data the existing panel already fetched; the request cadence is unchanged.

### Data sent

Unchanged from the existing warning, which still applies: RSN, screenshots and optional loot data to the plugin's own server. Manual submissions send the same fields the automatic path already sent, and the server routes them to human review rather than approving them automatically.
