### PR TITLE
Update Party defence tracker to 1.2.2

### DIFF
--- a/plugins/party-defence-tracker
+++ b/plugins/party-defence-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Hyftar/party-defence-tracker.git
-commit=924583caf440e19d23819971f4d2a687267f2715
+commit=2bf4b058391d9b7a8234aee01ae47cb4e8a02958

--- a/plugins/party-defence-tracker
+++ b/plugins/party-defence-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Hyftar/party-defence-tracker.git
-commit=2bf4b058391d9b7a8234aee01ae47cb4e8a02958
+commit=53c47c25655b72fab9115f2698a59e6deb015b2d

--- a/plugins/party-defence-tracker
+++ b/plugins/party-defence-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Hyftar/party-defence-tracker.git
-commit=53c47c25655b72fab9115f2698a59e6deb015b2d
+commit=c6c4fdcbc128e3580488fb242c60bd84c2eb1ca2


### PR DESCRIPTION
Previous PR closed because the build was still set to `gradle` and there wasn't a version key.