### PR TITLE
Add Sixth Degree plugin

### DIFF
--- a/plugins/sixth-degree
+++ b/plugins/sixth-degree
@@ -1,0 +1,4 @@
+repository=https://github.com/ZoltanPepper/sixth-degree-runelite-plugin.git
+commit=a1cc77f1d084b57acd6844e6fe21d2587d75d781
+authors=ZoltanPepper
+warning=This plugin submits your IP address, RuneScape display name, linked Discord user ID, clan-related gameplay data, loot/XP/event/LFG data, and screenshots when configured to a third-party Sixth Degree server not controlled or verified by RuneLite developers.

--- a/plugins/sixth-degree
+++ b/plugins/sixth-degree
@@ -1,4 +1,4 @@
 repository=https://github.com/ZoltanPepper/sixth-degree-runelite-plugin.git
-commit=a1cc77f1d084b57acd6844e6fe21d2587d75d781
+commit=3a066b1540247d1cda1c93b46196be1ae48ecf05
 authors=ZoltanPepper
 warning=This plugin submits your IP address, RuneScape display name, linked Discord user ID, clan-related gameplay data, loot/XP/event/LFG data, and screenshots when configured to a third-party Sixth Degree server not controlled or verified by RuneLite developers.

--- a/plugins/sixth-degree
+++ b/plugins/sixth-degree
@@ -1,4 +1,4 @@
 repository=https://github.com/ZoltanPepper/sixth-degree-runelite-plugin.git
-commit=3a066b1540247d1cda1c93b46196be1ae48ecf05
+commit=0bb201f4c8aaa6784c456946bef1bf2a6a2ae1d6
 authors=ZoltanPepper
-warning=This plugin submits your IP address, RuneScape display name, linked Discord user ID, clan-related gameplay data, loot/XP/event/LFG data, and screenshots when configured to a third-party Sixth Degree server not controlled or verified by RuneLite developers.
+warning=This plugin submits your IP address, RuneScape display name, linked Discord user ID, clan-related gameplay data, loot/XP/event/LFG data, and screenshots when enabled by Sixth Degree clan settings to a third-party Sixth Degree server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Adds the Sixth Degree clan companion plugin.

The plugin provides clan events and competition views, LFG, loot leaderboards, Discord-linked clan access, and centrally managed loot/pet/collection-log/milestone/boss notifications with optional screenshots.

It communicates with the Sixth Degree backend for member verification, clan data, leaderboards, LFG and notification delivery. The Plugin Hub warning lists the data sent to that service.

Bingo is not part of this plugin.