### PR TITLE
the-birdhouse: 1.1.1

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=3ac2739c91f08d7ba31a2b29169e59a96f0dbae6
+commit=b04a9a6f92ebddcc80b464b619acaaad0e857e74
 warning=This plugin submits your IP address, RSN, in-game screenshots, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=b04a9a6f92ebddcc80b464b619acaaad0e857e74
+commit=5fe7185c5315c89fd462c6933f41fd32bd222e00
 warning=This plugin submits your IP address, RSN, in-game screenshots, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=bf3f37a2f16ededaf5209f2c0fc39235e7052453
+commit=3ac2739c91f08d7ba31a2b29169e59a96f0dbae6
 warning=This plugin submits your IP address, RSN, in-game screenshots, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
the-birdhouse 1.1.0 -> 1.1.1

Visual pass on the plugin's board window, which previously drew every tile as a small centered text label.

- Tiles now show an item icon. The client's own sprite is used for the item a tile's match rule names, resolved via `ItemManager.search` with an exact name match only; where no item resolves, the plugin falls back to an image URL supplied by the backend, fetched once per URL and cached for the session.
- Multi-drop tiles get a `ThinProgressBar` instead of only a fraction, plus one in the header for overall board completion.
- Tile notes set by the event host are now displayed in the tile list, tooltips, and the submit dialog.
- Cell text moved from the RuneScape font to `FontManager.getDefaultFont()`; the former is a 16px bitmap design and looked poor derived to the 9-13px a board cell needs.

No new permissions, no new dependencies, and no change to what the plugin sends. Both new backend fields are optional, so the plugin degrades to item sprites alone if they are absent.
