### PR TITLE
Update live-on-clan to 1.2

### DIFF
--- a/plugins/live-on-clan
+++ b/plugins/live-on-clan
@@ -1,3 +1,3 @@
 repository=https://github.com/MilicoOSRS/live-on-clan.git
-commit=f06f7b34bd2b6ac80a5bcb95a3c18f1a20c708b8
+commit=c5c3ab722264245e556af53f66d48ecbb51d4ee8
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Live On Clan to 1.2.

- Improves automatic rank availability notifications and rank UI.
- Adds an allowlisted loot fallback for Discord and MVP submissions.
- Updates the Plugin Hub description and documentation.
- Adds regression tests for rank notifications and Discord loot filters.

Build verified with clean check jar.