### PR TITLE
Add Gielinor Deeds

### DIFF
--- a/plugins/gielinor-deeds
+++ b/plugins/gielinor-deeds
@@ -1,0 +1,2 @@
+repository=https://github.com/Sevin47/gielinor-deeds.git
+commit=233df27ab1263b9cc2cd1fda7709aff0d47cb971


### PR DESCRIPTION
Adds **Gielinor Deeds**: https://github.com/Sevin47/gielinor-deeds

A single-player land game over the OSRS map. Gielinor is divided into 115,200 parcels of 8x8 tiles, 29,766 of them ownable. Standing on a deed lets you survey it; surveying reveals its district and price; rent from what you own buys more. There is an optional **Deed Locked** challenge run, off by default, which hides everything you have not surveyed and only lets you survey deeds touching land you own.

Everything is local. No account, no server, no network traffic, no third-party runtime dependencies — the plugin uses only what already ships inside runelite-client.

### Two things worth flagging up front

**`src/main/resources/com/gielinordeeds/parcels.bin` is a 345 KB binary.** It is the survey: one record per parcel holding a district id and a price. It is generated offline from the game cache, and `export_parcels.py` in the repository root is the script that produces it, so the blob is reproducible rather than opaque.

**"Lock me to my land" refuses clicks aimed off your estate.** It is off by default. I tried to build it to match the precedent set by [Hold Your Ground](https://runelite.net/plugin-hub/show/hold-your-ground), which is on the hub doing the same job:

- menu entries are **never** removed or reordered — the menu is left exactly as the game wrote it, and the click is consumed instead
- **other players are never resolved or affected**; only ground, objects and NPCs, in line with the guideline against reordering or removing player-based options
- every refusal prints a chat line, so a swallowed click is never silent

Happy to change or drop that feature if you would rather it were not there.