### PR TITLE
Wildy Caves Scoutter

### DIFF
--- a/plugins/wildy-caves-scoutter
+++ b/plugins/wildy-caves-scoutter
@@ -1,0 +1,2 @@
+repository=https://github.com/Diogo-G-Dias/wildy-caves-scoutter.git
+commit=73bfca39ec31cb0279bd4cd7cfa013b2ecca4ba3


### PR DESCRIPTION
Adds Wildy Caves Scoutter: shows a floating "?" above the six wilderness boss lair entrances (Callisto, Artio, Vet'ion, Calvar'ion, Venenatis, Spindel). After using the in-game Peek option, the icon becomes a green checkmark if the lair is empty or a red "!" if there is activity inside. Results are tracked per world and fade back to "?" after a configurable time.

Source: https://github.com/Diogo-G-Dias/wildy-caves-scoutter (BSD 2-Clause)