### PR TITLE
poh-portal-labels: fix POH detection for Wilderness theme and instanced region gate

### DIFF
--- a/plugins/poh-portal-labels
+++ b/plugins/poh-portal-labels
@@ -1,2 +1,2 @@
 repository=https://github.com/jcbmcn/poh-portal-labels.git
-commit=2ad6c62eb19212eab41ce7e44996249a6d8de610
+commit=fbe5191f97f73faad5e303d527f32d8c0cde0159


### PR DESCRIPTION
Update the commit hash for jcbmcn/poh-portal-labels to fbe5191f97f73faad5e303d527f32d8c0cde0159.

This release includes:

- [**#49** ](https://github.com/jcbmcn/poh-portal-labels/issues/48)— Labels no longer appear outside POH (e.g. the Gauntlet portal in Prifddinas). Gate on `client.isInInstancedRegion()` in addition to the exit-portal scan.
- [**#48**](https://github.com/jcbmcn/poh-portal-labels/issues/49) — Recognize the Wilderness (Annihilation) theme exit portal (object ID 60789) so labels render in all POH house styles.

Closes https://github.com/jcbmcn/poh-portal-labels/issues/48
Closes https://github.com/jcbmcn/poh-portal-labels/issues/49