### PR TITLE
Update Discord Notifications Plugin - Extract Discord Webhook Service

### DIFF
--- a/plugins/discord-notifications
+++ b/plugins/discord-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/ThatOhio/RuneLite-Discord-Notifications.git
-commit=2d6ebe2231fabb02c47f0bc043ff21010a465089
+commit=6e9161115d2fbba899a90ee6ac35432cb925604b


### PR DESCRIPTION
Small targeted update to extract a service responsible for sending the discord webhooks. Encase this code triggers a manual review (do to it being a web request) I wanted to get it isolated first so I can do small targeted fixes and improvements that the bot can handle. 