### PR TITLE
Update clan companion loot

### DIFF
--- a/plugins/clan-companion
+++ b/plugins/clan-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/NickypooRS/clan-companion.git
-commit=af27ad28374028deefb1893d1f51f13d336092e7
+commit=cf1b3d514b3ce43d90ffd5335688678080dcb714


### PR DESCRIPTION
Updates clan-companion to the latest commit, fixing PvP loot and biggest-PK value tracking.
Previous fix was Kills/Death count, this fix is now for actual loot tracking.