### PR TITLE
Update Combat Insight to 0.4.0

### DIFF
--- a/plugins/combat-insight
+++ b/plugins/combat-insight
@@ -1,2 +1,2 @@
 repository=https://github.com/BornDied/combat-insight.git
-commit=663fcc74be46c6e9e34cdbee30937565345770fc
+commit=c2f0a1365e578fc8cc41cd125d75c965fcc3e66e


### PR DESCRIPTION
Updates Combat Insight to version 0.4.0.

This release adds:

* Complete basic-attack totals for supported multi-hit weapons
* Supported special-attack max hit, average damage, and on-hit information
* Solo target Defence, Magic, and Magic Defence reduction tracking
* Player-Owned House combat-dummy targeting with variant-aware modifiers

Testing completed:

* 94 automated tests passed
* The cumulative release patch was verified from a fresh committed baseline
* In-game testing passed for combat calculations, available dummy variants, real-NPC replacement, and target clearing

Plugin release PR: https://github.com/BornDied/combat-insight/pull/3