### PR TITLE
Update BA Minigame Plugin to 1.74.0

### DIFF
--- a/plugins/ba-minigame
+++ b/plugins/ba-minigame
@@ -1,3 +1,3 @@
 repository=https://github.com/SkylerPIlot/Ba-Minigame.git
-commit=710a79255594e9ddefe22449e23c706eb24a283f
+commit=9204c0831b02c76eb50e3e9676306b3c15f3ccf3
 authors=SkylerPIlot,ransty,equirs


### PR DESCRIPTION
This update was to fix death timer infoboxes. The code was looking for a specific string and assuming the text had been sanitized by Text.removeTags(). Instead we've added our own helper function to remove the new macros from Jagex.