### PR TITLE
Add Chat World Hop

### DIFF
--- a/plugins/chat-world-hop
+++ b/plugins/chat-world-hop
@@ -1,0 +1,2 @@
+repository=https://github.com/sulfight/chat-world-hop.git
+commit=71fe61dcf5e326aa8bc625728b4077e46f0ccbc1

--- a/plugins/chat-world-hop
+++ b/plugins/chat-world-hop
@@ -1,2 +1,2 @@
 repository=https://github.com/sulfight/chat-world-hop.git
-commit=71fe61dcf5e326aa8bc625728b4077e46f0ccbc1
+commit=e2a850750eef8377727d7bea78fce72304ccae03


### PR DESCRIPTION
Adds a menu entry to hop worlds directly from chat.

When a player's message in public, clan, friends, group ironman or
private chat mentions a world (w302, w 302, world 302), right-clicking
the message adds a "Hop to world 302" entry. A message mentioning
several worlds gets one entry per world.

This is handy for e.g. hopping to shooting star worlds that are scouted
in a friends chat, or for multi pking to call out a world.

Only worlds present in the live world list are offered, and the world
you are already on is skipped. The hop itself uses the same
openWorldHopper/hopToWorld path as the built-in World Hopper, so the
game's own warnings for PvP, high-risk and members worlds still apply.

Repository: https://github.com/sulfight/chat-world-hop
