### PR TITLE
Add World Grid plugin

### DIFF
--- a/plugins/world-grid
+++ b/plugins/world-grid
@@ -1,0 +1,2 @@
+repository=https://github.com/DanielTate/runelite-world-grid.git
+commit=9dee26779f1dad45bfab8766409cb3b45d6c2717


### PR DESCRIPTION
Draws a labelled grid over the world so two players can name an exact spot to each other — "meet me at W39" instead of describing landmarks.

The grid is anchored to a fixed constant, so the only setting both players need to match is the grid size. Drawn on the world map and in the scene as separate toggles, with a movable readout of your current square. You can search a reference from the world map, save places you care about, and share that list with your clan as a JSON file.

Saved locations store coordinates rather than references, so a shared file points at the right place even if the two players run different grid sizes.

Nothing about other players is read, stored or sent anywhere. Files are written only under `.runelite/world-grid/`, or wherever the user picks in a file chooser. The map search menu entry uses `MenuAction.RUNELITE`, so it is client-side only.

Inside instances it shows `—` and draws nothing, since instanced coordinates would give a confidently wrong answer.