### PR TITLE
Add Timezone HUD plugin

### DIFF
--- a/plugins/timezone-hud
+++ b/plugins/timezone-hud
@@ -1,0 +1,2 @@
+repository=https://github.com/DanielTate/runelite-timezone-hud.git
+commit=80b9501c3274a4281edc8a72378cbbb6c747fd35


### PR DESCRIPTION
World clocks in a movable in-game overlay and a side panel, plus a time converter for arranging things across timezones.

`::tz EST 20:30 > NZST` prints the answer locally. `!TZ` does the same in public chat so everyone running the plugin sees it. Both always show the day on each side, since the whole point is catching the date rollover.

**On `!TZ` and outgoing chat:** the message is sent to the server verbatim and is never touched. The plugin registers only the execute half of `ChatCommandManager.registerCommand`, then rewrites the `MessageNode` of the received message for local display — the same approach as `!kc` and `!pb`. The `ChatInput`/`consume()` path is deliberately not used, and nothing is ever written into the chatbox input. `ChatDisplayRewriter` carries a comment explaining this so it does not get "simplified" later, and there is a test asserting the outgoing message is not mutated.

Ambiguous abbreviations are refused rather than guessed — `IST` is India, Ireland and Israel, and quietly picking one gives a plausible-looking time in the wrong country. `GMT` resolves to UTC rather than `Europe/London`, so a summer conversion does not answer in BST and contradict what was typed.

There is some overlap with the existing `time-zone-clocks` plugin on the side-panel half; the in-game overlay and the converter are the parts it does not have.