### PR TITLE
Update OSRS Flipper Sync to v5.2.15

### DIFF
--- a/plugins/osrs-flipper-sync
+++ b/plugins/osrs-flipper-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Ishmarr/osrs-flipper-runelite-sync.git
-commit=9809ae4663559fefacd8b74c18a5f4ac394c5366
+commit=0afbf05e679ec3ad424f3e9484b814ec1bf525bc
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-flipper-sync
+++ b/plugins/osrs-flipper-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Ishmarr/osrs-flipper-runelite-sync.git
-commit=0afbf05e679ec3ad424f3e9484b814ec1bf525bc
+commit=9809ae4663559fefacd8b74c18a5f4ac394c5366
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-flipper-sync
+++ b/plugins/osrs-flipper-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Ishmarr/osrs-flipper-runelite-sync.git
-commit=01a228af529f9a239b6e6a0a49e9ea49cc3dc570
+commit=9809ae4663559fefacd8b74c18a5f4ac394c5366
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates OSRS Flipper Sync from v5.0.3 to v5.2.15.\n\nHighlights:\n- Improves account-wide Grand Exchange slot synchronization.\n- Adds scanner-derived flip guidance with current Wiki prices.\n- Improves statistics, cashstack synchronization and selected-slot handling.\n- Improves stale price-test cleanup, startup handling and UI readability.\n- Price and quantity helpers only fill an already-open GE numeric prompt after explicit user interaction. They never confirm or submit an offer.\n- The existing third-party server warning remains unchanged.\n\nTested locally:\n- 95 tests passed.\n- Development client tested with live GE buy, sell, cancel and synchronization flows.