### PR TITLE
update osrs-fliphub

### DIFF
--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,3 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=b4fac2e59b6cabb78cc1d441e1dd202da3731148
+commit=5410284083725900857541388c6fa0fab799dca7
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps `commit=` for `osrs-fliphub` to pick up an updated README.

No plugin code changed between the old and new commit — the diff is the README plus nine images added under `docs/`, so the built jar is identical. The README now documents the Grand Exchange offer-prompt suggestions accurately (previously it described them as firing during item search and showing both buy and sell prices at once, which was wrong) and shows the plugin panel in-client.

Images are committed to the plugin repo and referenced by relative path, so they resolve against the pinned commit.