### PR TITLE
Update ClanHQ plugin

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=ca5dca52620e08df4597a4d4d3c4025d270fe58d
+commit=c8a42b232ed5096c57875f945ba3db3c46fd7601


### PR DESCRIPTION
Updates the ClanHQ Plugin Hub manifest to the latest release commit. This release includes the tasks/events and shared observation updates; Gear Advisor remains excluded from this release.