### PR TITLE
update farming-patch-advisor

### DIFF
--- a/plugins/farming-patch-advisor
+++ b/plugins/farming-patch-advisor
@@ -1,2 +1,2 @@
 repository=https://github.com/Seadeadmeat/farming-patch-advisor.git
-commit=6d39b0850bd546b1ad6dc17837a816e423014641
+commit=9bdbdaf678f8046cc53a9b1ef705a6aaf5c20d82


### PR DESCRIPTION
Updates Farming Patch Advisor picked-patch handling and public description.

Changes include:
- treats Bush and Cactus Harvest actions as PICKED instead of dead
- keeps picked patch status white and preserves normal harvest behavior for other patch types
- refreshes the RuneLite and README descriptions to emphasize patches, contracts, timers, customizable runs, crop recommendations, and bank support

Validation: `./gradlew test --no-daemon` passes.

No third-party dependencies were added.