### PR TITLE
runealytics v2.0.6

### DIFF
--- a/plugins/runealytics
+++ b/plugins/runealytics
@@ -1,4 +1,4 @@
 repository=https://github.com/Runescape-Tracking/RuneAlytics-Plugin.git
-commit=f06528b9e6d38f3786a22ce0b8de26b7724ae210
+commit=70143c2445f6b818ce0cc7aab5b54543beb26dc5
 warning=This plugin submits your IP address, in-game name, friends list, members of your clan chat, other player metrics, and optional bank contents, to Runealytics.com which is not maintained or reviewed by RuneLite.
 authors=mrtms,cshunton

--- a/plugins/runealytics
+++ b/plugins/runealytics
@@ -1,4 +1,4 @@
 repository=https://github.com/Runescape-Tracking/RuneAlytics-Plugin.git
-commit=70143c2445f6b818ce0cc7aab5b54543beb26dc5
+commit=72a01b0b1c23411f950bd1c480b557cb94ec5fbd
 warning=This plugin submits your IP address, in-game name, friends list, members of your clan chat, other player metrics, and optional bank contents, to Runealytics.com which is not maintained or reviewed by RuneLite.
 authors=mrtms,cshunton

--- a/plugins/runealytics
+++ b/plugins/runealytics
@@ -1,4 +1,4 @@
 repository=https://github.com/Runescape-Tracking/RuneAlytics-Plugin.git
-commit=72a01b0b1c23411f950bd1c480b557cb94ec5fbd
+commit=aa342191c2a09e49c5463f3de0eeb25332b00d31
 warning=This plugin submits your IP address, in-game name, friends list, members of your clan chat, other player metrics, and optional bank contents, to Runealytics.com which is not maintained or reviewed by RuneLite.
 authors=mrtms,cshunton


### PR DESCRIPTION
# RuneAlytics v2.0.6

## New: Doom of Mokhaiotl loot tracking

Full claim-vs-descend tracking for Doom of Mokhaiotl, including the reward widget (group 919), death-loss reporting, and suppression of empty floor-progression “kills.”

## New: Hide, unhide, and delete loot

Right-click control over what the Loot Tracker shows and keeps.

- **Hide / unhide items** — per-boss ignore list from the item context menu (the old header button is gone). Hidden drops stay in storage and still sync; they are just hidden on the panel. Reveal them again from the item menu or the boss header.
- **Hide / unhide a whole boss** — collapse a boss card without dropping its history.
- **Delete an item** — permanently remove it from that boss’s history. Deletions are remembered so a later website / RuneLite sync cannot bring the item back.

## New: Smoother loot panel updates

The loot panel no longer rebuilds the whole list on every drop, so burst loot and delayed drops no longer hitch the sidebar.

- **Incremental card updates** — existing cards refresh in place (fast path), reorder without `removeAll()` (mid path), and only do a full rebuild when the boss set actually changed.
- **Order-stable mid path** — if the cards are already in the right order, the panel skips `removeAll()` / re-add entirely.
- **Client-thread pricing** — ItemManager / GE lookups for deferred NPC loot stay on the client thread; the sidebar work stays off the EDT so busy kills do not hitch.
- **Append-path batching** — Ring of Wealth coins and late drops price on the client thread, update in-memory stats in the background, and notify the panel through a 50ms debounce.
- **Empty placeholder bosses** (no loot, no value) are filtered out of the panel.

## Fixes

- **Loot Tracker:** deleted items no longer reappear after sync or a refresh.
- **Loot Tracker:** hidden items stay filtered from the displayed totals.
- **Loot Tracker:** hide/delete apply to the panel immediately instead of waiting on a debounce.
- **Loot Tracker:** no longer rebuilds the boss list when only totals changed or the card order is already correct.
- **Loot Tracker:** delayed `NpcLootReceived` price lookups no longer run off the client thread (fixes ItemManager assertion errors).
- **Loot Tracker:** `addKill` holds its lock only for the persist, not for pre-computing drop aggregates.
- **Loot Tracker:** late / Ring of Wealth appends no longer do storage I/O on the loot event thread.
- **Loot Tracker:** `"Clue scroll (hard)"`-style names map to the correct clue tier again.
- **Farming / skilling:** loot is captured from a pre-XP snapshot and always bypasses the minimum-value filter (crops, coin pouches, seeds). The farming baseline is refreshed every tick, not only during an already-open skilling session.
- **Sync:** three-source merge is max-wins across local, RuneLite, and website totals, which stops duplicate kills.
- **Gauntlet:** Corrupted Gauntlet encounter adds no longer create empty loot rows.
- **Loot value:** larger, centered gp readout on each card.
- **Matchmaking:** hint arrow no longer sticks to a stale opponent during an in-flight poll; it falls back to the rally tile when they leave render distance.

## Internal (not shipped to the Plugin Hub)

- Sync hardening: dedicated sync executor, file/GE/merge caches, watchdog, memory-pressure and queue-depth monitors.
- Panel mid-path compares the existing component order before rebuilding.
- `appendDropsToLastKill` split into client-thread pricing, background stats/persistence, and debounced listener notifications.
- Plugin Hub guards in CI and `make-submission.sh`: no `java/lang/Runtime` in source or bytecode, and no stray `.class` files.
- Checkstyle gates plus a 435-test suite covering hide/delete, Doom run state, merge filters, deferred NPC loot, zero-loot upgrades, concurrent `addKill`, matchmaking hint-arrow fallback, and the cache/coordinator units.