### PR TITLE
Add magic-imbue-necklace-reminder

### DIFF
--- a/plugins/magic-imbue-necklace-reminder.txt
+++ b/plugins/magic-imbue-necklace-reminder.txt
@@ -1,0 +1,2 @@
+repository=https://github.com/Guge94/magic-imbue-necklace-reminder.git
+commit=c27fe11c0bf6a128f99324493e8c29187bdee525


### PR DESCRIPTION
Warns you if Magic Imbue is active without a binding necklace equipped while you're carrying one, so you stop losing 50% success rate on combination runes.