### PR TITLE
Update scavenger

### DIFF
--- a/plugins/scavenger
+++ b/plugins/scavenger
@@ -1,2 +1,2 @@
 repository=https://github.com/Guobmin/runelite-scavenger.git
-commit=e09edc28ddc521f317e562c0a9ab34c43d80e50a
+commit=830af98378aa82db9550834226f165cc8c6f9965


### PR DESCRIPTION
Fixes the sidebar's Target/Requirements display freezing after disabling and re-enabling the plugin once — `ScavengerPanel`'s `refreshTimer` was stopped in `shutDown()` but never restarted in `startUp()`.

Also brings in the entrance-routing feature merged just before this fix: the locator now aims at a cave/dungeon entrance instead of straight through rock when the player is outside it, with curated entrance coordinates for 3 dungeons so far (Taverley Dungeon, Dwarven Mine, Edgeville Dungeon).

Full commit range: https://github.com/Guobmin/runelite-scavenger/compare/e09edc28ddc521f317e562c0a9ab34c43d80e50a...830af98378aa82db9550834226f165cc8c6f9965