### PR TITLE
update osrs-fliphub

### DIFF
--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,3 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=b4fac2e59b6cabb78cc1d441e1dd202da3731148
+commit=b7512b5900b1ff3888943fae95b7571ee630177b
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps `commit=` for `osrs-fliphub`.

Unlike the last update this one does change plugin code. The main change is that account linking moved out of the RuneLite settings window and into a new **Link** tab in the plugin's own panel: RuneLite's config panel builds its rows once and subscribes to no config event, so a link status written there could not repaint while the user was looking at it, and the key field only committed on focus-lost. The plugin now shows the third-party consent dialog itself before linking; the config toggle keeps its existing warning as a second gate, and the settings section is reduced to that one opt-in.

Also included:

- The panel restyle, and a third tab in the sidebar.
- Price age tooltip fixes: it disappeared a second into a hover and never returned, and drifted onto the wrong row when the list was scrolled.
- A profile placeholder name (`Profile <key>`) was being persisted over the account's real display name.
- An unlink could be lost, because RuneLite only flushes config on a clean shutdown.
- Bundled images now load through `getResourceAsStream` rather than `getResource`, per the plugin hub README.

No new dependencies. `build` is still `standard`, and `build.gradle`, `settings.gradle` and `runelite-plugin.properties` are unchanged from the currently published commit.
