### PR TITLE
update raids-last

### DIFF
--- a/plugins/raids-last
+++ b/plugins/raids-last
@@ -1,2 +1,2 @@
 repository=https://github.com/richardverheyen/raids-last.git
-commit=82ab1afd4f95e6b1f7e4f286f8b280cc924f630d
+commit=18f2ea6fbe6818ddce945bbdd42f3f95a24eab78

--- a/plugins/raids-last
+++ b/plugins/raids-last
@@ -1,2 +1,3 @@
 repository=https://github.com/richardverheyen/raids-last.git
-commit=18f2ea6fbe6818ddce945bbdd42f3f95a24eab78
+commit=2f4ea810aff1212081c7351104ad1c94d0d085c8
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/raids-last
+++ b/plugins/raids-last
@@ -1,2 +1,2 @@
 repository=https://github.com/richardverheyen/raids-last.git
-commit=47d5c86aabf8f7676e25f50d253ce4bba0ea6e14
+commit=82ab1afd4f95e6b1f7e4f286f8b280cc924f630d


### PR DESCRIPTION
Updates the raids-last plugin to the latest commit.

## What's new
Adds cross-player resolution for all commands (`!coxlast`, `!toblast`,
`!toalast`, `!raidslast`, `!raidslasttob`). Previously each command only
resolved for the player who typed it, since raid loot is only ever tracked
by that player's own client. Now, right as a player's own command is about
to send, their client publishes their current last item per raid to a
short-TTL (20s) Upstash Redis key, holding the message until that publish
completes - guaranteeing the data exists before any other client can
receive it. Anyone else resolving that command reads it back the same way.
Nothing persists past the TTL.

This requires the other player to also be running this version of the
plugin, and resolution now depends on that relay being reachable - both
documented in the README, along with the tradeoff of the relay's access
token necessarily being embedded in the plugin jar.

Repo: https://github.com/richardverheyen/raids-last
Commit: 82ab1afd4f95e6b1f7e4f286f8b280cc924f630d