### PR TITLE
Add Meteor Reporter

### DIFF
--- a/plugins/meteor-reporter
+++ b/plugins/meteor-reporter
@@ -1,3 +1,3 @@
 repository=https://github.com/CoreyUK/MeteorReporter.git
-commit=0cc5d0aa69d7323f696fd80e536f9ead866a9c84
+commit=ce72bbd53641ed4b42c81eec079e28321b93bc9a
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/meteor-reporter
+++ b/plugins/meteor-reporter
@@ -1,0 +1,3 @@
+repository=https://github.com/CoreyUK/MeteorReporter.git
+commit=0fcfb440f9f94d12cdcf982bf869d0eda6bce1ac
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/meteor-reporter
+++ b/plugins/meteor-reporter
@@ -1,3 +1,3 @@
 repository=https://github.com/CoreyUK/MeteorReporter.git
-commit=905fbac06ef6104b3552cf15a2ff273b3c6a3188
+commit=0cc5d0aa69d7323f696fd80e536f9ead866a9c84
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/meteor-reporter
+++ b/plugins/meteor-reporter
@@ -1,3 +1,3 @@
 repository=https://github.com/CoreyUK/MeteorReporter.git
-commit=169c9d8c6fa6be80ab60bd1f4a2c4cee75aa8263
+commit=905fbac06ef6104b3552cf15a2ff273b3c6a3188
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/meteor-reporter
+++ b/plugins/meteor-reporter
@@ -1,3 +1,3 @@
 repository=https://github.com/CoreyUK/MeteorReporter.git
-commit=0fcfb440f9f94d12cdcf982bf869d0eda6bce1ac
+commit=169c9d8c6fa6be80ab60bd1f4a2c4cee75aa8263
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.

--- a/plugins/meteor-reporter
+++ b/plugins/meteor-reporter
@@ -1,3 +1,3 @@
 repository=https://github.com/CoreyUK/MeteorReporter.git
-commit=ce72bbd53641ed4b42c81eec079e28321b93bc9a
+commit=90d66e81685fdc772496f0a0967e03d082244566
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Meteor Reporter shares crashed Shooting Star sightings between plugin users, and shows stars that have not landed yet from player-owned house telescope readings.

**What it does**

- Adds a "Report" option to crashed stars, sharing the world, tier, landing spot and coordinates.
- Keeps a report current as the star degrades, and removes it when a nearby user witnesses the last layer mined out.
- Shows active reports in a **Live** tab and telescope readings (world, region, time window) in a **Scouted** tab, with an optional world hop button.

**Third-party server**

Reports go to `https://meteors.cukservers.net`, which I run. All sharing is opt-in and off by default:

- **Enable shared reports** and **Share telescope readings** each carry the standard IP warning, and the hub manifest carries one too.
- **Show my IGN** is separate, also off by default, and attaches the player's own name and their contribution count.

What is shared is star data: world, tier, landing spot, coordinates and timestamps, plus the reporter's own name if they opt in. Nothing is collected about other players. The server stamps its own timestamps rather than trusting the client, rate limits reads and writes per IP, and expires reports.

Repository: https://github.com/CoreyUK/MeteorReporter (BSD 2-Clause, built from the example-plugin template).