### PR TITLE
Add Leadman Mode plugin

### DIFF
--- a/plugins/leadman
+++ b/plugins/leadman
@@ -1,2 +1,2 @@
 repository=https://github.com/felippeomgt/leadman-mode.git
-commit=b1632008246a05b606e3385f145558e9168a70f9
+commit=8dd1f54ac6e22b2970db35672fc84bb5ffe0ec5b

--- a/plugins/leadman
+++ b/plugins/leadman
@@ -1,2 +1,2 @@
 repository=https://github.com/felippeomgt/leadman-mode.git
-commit=89cfa17a02e824e684a72fe401ebffd362ebe03d
+commit=b1632008246a05b606e3385f145558e9168a70f9

--- a/plugins/leadman
+++ b/plugins/leadman
@@ -1,2 +1,2 @@
 repository=https://github.com/felippeomgt/leadman-mode.git
-commit=495521ddc4ce9f293d78940aae543beecf6db049
+commit=89cfa17a02e824e684a72fe401ebffd362ebe03d

--- a/plugins/leadman
+++ b/plugins/leadman
@@ -1,0 +1,2 @@
+repository=https://github.com/felippeomgt/leadman-mode.git
+commit=495521ddc4ce9f293d78940aae543beecf6db049

--- a/plugins/leadman
+++ b/plugins/leadman
@@ -1,2 +1,2 @@
 repository=https://github.com/felippeomgt/leadman-mode.git
-commit=8dd1f54ac6e22b2970db35672fc84bb5ffe0ec5b
+commit=542514b5ba58ddcadd1592e692cf547e1d83237f


### PR DESCRIPTION
## Summary
- Adds **Leadman Mode**, a self-imposed challenge plugin for normal accounts
- Grand Exchange and NPC shop access unlock item-by-item based on fabrication skill levels
- Optional use gates (food, potions, jewellery, charges, etc.) with Strict and Bronzeman+ presets
- Client-side menu blocking and GE search filtering only — no gameplay automation

## Repository
https://github.com/felippeomgt/leadman-mode

## Test plan
- [ ] Plugin Hub CI builds successfully
- [ ] Plugin loads from the hub listing
- [ ] GE search hides locked fabrication items
- [ ] Shop buy blocked below required skill level
- [ ] Unlock popup fires on level-up crossing a fabrication threshold