### PR TITLE
update impling-finder

### DIFF
--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=8a3a5a8d28eb9c94422a1e8abb07de0896866617
+commit=6be3df0a7a270c842226c0a70700bd1d9355e355
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-c425f3780aa991319833a4803e3cdbcbbdd2142c
+commit=c425f3780aa991319833a4803e3cdbcbbdd2142c
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=c425f3780aa991319833a4803e3cdbcbbdd2142c
+commit=bf60bdd8b7bef3c6a60588eeed050770dee9e21d
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=6be3df0a7a270c842226c0a70700bd1d9355e355
+c425f3780aa991319833a4803e3cdbcbbdd2142c
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Adds a location filter system,193 per-location config toggles under a new collapsible "Filter Locations" section, letting users hide implings from specific named areas permanently across restarts. Also recovers the Drops reference panel 