### PR TITLE
update groupscape

### DIFF
--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=55879f5b3c9da8aa234abfe5f3d45905ab54438e
+commit=acb8ee9e46a07f49741ba6d659300e261c25efa2
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates the groupscape plugin to the latest commit.

## Summary
- Sends a periodic heartbeat POST when idle (previously an idle/AFK player never sent telemetry at all, causing them to read as offline in the web dashboard indefinitely until a client restart).
- Adds logging around telemetry POST failures and the party overlay WebSocket connect/close/failure events for easier diagnosis of connection issues.

Commit: MayzrDev/groupscape-plugin@acb8ee9