### PR TITLE
Update scavenger

### DIFF
--- a/plugins/scavenger
+++ b/plugins/scavenger
@@ -1,2 +1,2 @@
 repository=https://github.com/Guobmin/runelite-scavenger.git
-commit=830af98378aa82db9550834226f165cc8c6f9965
+commit=6af4fe89c9ebbbc7ae892de7a71d14338e16d3b9


### PR DESCRIPTION
Pins the latest Scavenger commit, which includes:

- 13 curated cave/dungeon entrance coordinate/plane corrections found by a
  full audit of every entrance's objectId against its actual position in the
  game cache — several were previously outside the world-overlay's ring-search
  radius (or, in one case, on the wrong plane), silently falling back to
  unrelated scenery instead of highlighting the entrance.
- version bumped to 1.1
- README updated to document the cave/dungeon entrance-routing feature