### PR TITLE
Add gok-irl-xp

### DIFF
--- a/plugins/gok-irl-xp
+++ b/plugins/gok-irl-xp
@@ -1,0 +1,2 @@
+repository=https://github.com/mataeo-eh/GOK-IRL-XP.git
+commit=cf30c25cc64e6d0012ec22946fafc15e994e25c3


### PR DESCRIPTION
Adds **IRL XP**, a plugin that lets you bank RuneScape XP for real-world activities and spend it down as you train.

You define your own actions (e.g. "read a chapter", "walk a mile") with a custom unit and an XP rate per skill, then either bank a chunk manually or run a timer that accrues XP while the activity is in progress. Banked XP is shown in a sidebar panel and an overlay, and is drawn down automatically as you gain real XP in the mapped skill, with an optional chat warning when a skill's balance runs low.

Everything is local: state is persisted through `ConfigManager`, and the plugin makes no network requests and adds no third-party dependencies. It reads `StatChanged` to decrement balances and does not interact with gameplay.