### PR TITLE
coffer: bump to ae8642d

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=639069cdb81614cea998849469f11f86fa04eee5
+commit=ae8642dcc8b04bf424daec0d4d98d725e7752ba5
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Update the `coffer` plugin to commit `ae8642d`.

Changes since the last release (`639069c`):

- **GE History import** — reads the in-game Grand Exchange History (widget group 383) to recover fills that completed while the client was closed, reconciles them against already-recorded trades, and offers a panel prompt to import the missed ones so P&L stays accurate. The plugin never reads or opens the History panel on its own; the user opens it and a panel prompt does the rest.
- **Login reminder** to check History after a break (in-client nudge only).
- **Anti-herd / crowding signal** on suggestions.
- **Server-side offer open-time** so open-position timers survive client restarts.
- **GE buy-limit accounting** now counts partially-filled open buys.

No new API usage, no new dependencies, no config surface beyond the existing in-panel login and flip preferences. Data sent is unchanged (login → session token; GE offers and completed trades), still covered by the existing warning line.