### PR TITLE
bank-architect: 0.2.0

### DIFF
--- a/plugins/bank-architect
+++ b/plugins/bank-architect
@@ -1,2 +1,2 @@
 repository=https://github.com/PKoka5/ironman-bank-architect.git
-commit=d0665e74f2f57a07548c30a7cef9f7d75680329e
+commit=d5631c52bedfee228d95627d7f7e10b51a8648af


### PR DESCRIPTION
Updates Bank Architect from 0.1.0 to 0.2.0.

Players can now decide which categories go on which bank tab, rather than taking the bundled arrangement as given. The ten categories split into 29 independently placeable tags, so runes need not follow teleports and food need not sit with potions. Layouts can be saved, exported as a readable code and imported.

Also in this release: corrections made from the bank right-click menu now name a tag rather than a category; the destination colours only appear while assign mode is on, so a coloured bank always means a mode is running; two options for whether part-empty rows may be completed with unrelated items and whether outclassed gear is gathered for alching; and a handful of classification fixes reported by players (Void body pieces, the cannon furnace, the Blue moon set, Burning claws, and the dyes).

Still read-only: the plugin plans and guides, and every bank move stays manual.

- 931 tests, 0 failures
- Bank simulation 150/150 scenarios completed
- `gradlew build` green
- README screenshots refreshed for the new panel