### PR TITLE
Update loot-lookup to v1.2.3 - add hold shift option for right-click menu

### DIFF
--- a/plugins/loot-lookup
+++ b/plugins/loot-lookup
@@ -1,3 +1,3 @@
 repository=https://github.com/donth77/loot-lookup-plugin.git
-commit=283a82dadfa2e8e68034a2fbab0353a9eeb0fcfa
+commit=58812e18d0f955d597c4894ece0ae23aff1a3a74
 authors=donth77,riktenx


### PR DESCRIPTION
- Add hold shift option for the right click menu: Resolves donth77/loot-lookup-plugin#13
  - Replaces the "Disable Right Click Menu option" checkbox with 3 options: Always Show, Hold Shift, Disable