### PR TITLE
Add Lively Cities

### DIFF
--- a/plugins/lively-cities
+++ b/plugins/lively-cities
@@ -1,0 +1,3 @@
+repository=https://github.com/MatthewMariner/lively-cities.git
+commit=76f14938836e9e9cdfcefa81884a4d3d625c6f0f
+authors=MatthewMariner


### PR DESCRIPTION
Lively Cities adds cosmetic townsfolk to Gielinor's cities — figures who stand, sit, work and walk short routes so places like Varrock and Lumbridge feel inhabited. A successor to the abandoned [Citizens](https://github.com/gc/citizens) plugin, shipping its BSD-2 licensed placement dataset with the upstream notice retained.

## What it does

- Places 184 hand-placed figures across 9 cities, drawn from a dataset shipped in the jar.
- Adds Examine, Hide and Mute to each of them, and an optional line of overhead chatter.
- Offers a crowd-density dial, a render-distance dial, per-city toggles, and a hard off switch for the chatter.

## Cosmetic and local

**It uses RuneLiteObjects only, adds RUNELITE-type menu entries only, and sends nothing to the server.** No packets, no input generation, no interaction with real NPCs, objects or scene tiles, and no network calls of any kind. Unlike its predecessor it never removes anything from the loaded scene — the `removedObject` field the vendored dataset carries is parsed and deliberately discarded. Nothing here reveals game state; every figure is static authored content.

The jar writes no files. The two developer diagnostics that produce reports live in the test source set and are not on a hub user's classpath.

## Telling fake from real

This was treated as the licence to exist rather than polish, since the predecessor was disabled after a player mistook a broken-looking figure for a real one:

- Menu entries are always deprioritised, so real options sort above them.
- No clickbox is generated at all while an item or spell is on the cursor.
- The menu target uses a colour the game never uses for a real one, and Examine says what the figure is.

One opt-in feature worth naming: six named, human-looking "friend cameo" figures at the Grand Exchange. They are **off by default**, because a cluster of named humans at the busiest bank is the one thing here that could be mistaken for real players. Examine says outright that each is a likeness, and each can be hidden or muted individually.

## Durability and cost

The failure that got Citizens disabled was an OSRS update renumbering model cache ids. Two things are different here: partial model builds never render, so a half-loaded figure cannot appear; and `./gradlew auditCacheIds` walks every cache id the dataset depends on and reports what no longer resolves.

Frame cost is measured rather than asserted, against thresholds registered before any number existed. Over 19,000 frames of ordinary play: **the per-frame pass is 8µs at p99**, about half a percent of a 60fps frame. The clickbox hull is computed in `MenuOpened`, never per frame. Full figures are in the README.

Repository: https://github.com/MatthewMariner/lively-cities (BSD 2-Clause).
