### PR TITLE
update better-drift-net to 1.1

### DIFF
--- a/plugins/better-drift-net
+++ b/plugins/better-drift-net
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/better-drift-net.git
-commit=a5d672a99f2077dd7ef62dd19c3197c7a9ba74d3
+commit=bbbe37074c096ad9a333a6650e9c2e0898c0542a


### PR DESCRIPTION
update better-drift-net to 1.1
fix claim, untagged priority ordering, highlight entrance tunnel text