### PR TITLE
Update ring-menu to 1.2.0

### DIFF
--- a/plugins/ring-menu
+++ b/plugins/ring-menu
@@ -1,2 +1,2 @@
 repository=https://github.com/mepatrick73/ring-menu-plugin.git
-commit=8db01ac00968af915f8a8e98e446813a51e5d541
+commit=c5067086bb409235f4409d7031a4e7c28f6afe5c


### PR DESCRIPTION
Per-entry enable/disable toggles, per-ring horizontal/radial label orientation, labels that shrink to fit with a full-name hover tooltip, a ring size setting, and live updates between the editor, the open ring, and the backing plugins.