### PR TITLE
exchange-logger

### DIFF
--- a/plugins/exchange-logger
+++ b/plugins/exchange-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/istid/exchange-logger.git
-commit=c88dd3b9f3d76c6a0ae1631f9e5deeb1031b0ec8
+commit=1546c58bb3ec14ec03493a9a8392e9d23121e704
 authors=clamzhi-dev


### PR DESCRIPTION
Fixes rare bug where account name is not yet available right after login which causes GE events silently falling back to the shared log file.