### PR TITLE
update trouble-brewing-highlighter to 1.4.2

### DIFF
--- a/plugins/trouble-brewing-highlighter
+++ b/plugins/trouble-brewing-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/trouble-brewing-highlighter.git
-commit=6ac8ab14b9e4aaa2ced7aebc7031ad79ed8ce7ea
+commit=4b0218b479f2736c5bb6876cb8bea3d8ee81d605


### PR DESCRIPTION
Updates Trouble Brewing Highlighter from 1.4.1 to 1.4.2.

- Adds the native in-match personal-contribution counter, coloured red below 100 and green at 100.
- Keeps the movable Brew Status and Pieces of Eight panels beneath game interfaces while preserving Alt-drag positioning.
- Updates the plugin version and README.

The contribution display and both panel-layering behaviours were verified in the development client.