### PR TITLE
Create fullscreen-toggle

### DIFF
--- a/plugins/fullscreen-toggle
+++ b/plugins/fullscreen-toggle
@@ -1,0 +1,2 @@
+repository=https://github.com/yourname/fullscreenTogglePlugin.git
+commit=587437e4bebbd5d9ad1cd19f6e17781b4d4c8dba


### PR DESCRIPTION
Adds Fullscreen Toggle, a plugin that toggles borderless fullscreen mode with a configurable hotkey (default F11).