### PR TITLE
update follower-buddy

### DIFF
--- a/plugins/follower-buddy
+++ b/plugins/follower-buddy
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeSpatol/follower-buddy.git
-commit=b8389e02e62cf558118576d1b46b31b08bfd2591
+commit=d548038246ea133b93ad318b47d8fa15ec7fe85f

--- a/plugins/follower-buddy
+++ b/plugins/follower-buddy
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeSpatol/follower-buddy.git
-commit=5d5a0e472030b921a15642de72dedece58d6bae7
+commit=b8389e02e62cf558118576d1b46b31b08bfd2591

--- a/plugins/follower-buddy
+++ b/plugins/follower-buddy
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeSpatol/follower-buddy.git
-commit=18ace2057f3c5b8b899809555cbfb4875cd5fd4c
+commit=5d5a0e472030b921a15642de72dedece58d6bae7

--- a/plugins/follower-buddy
+++ b/plugins/follower-buddy
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeSpatol/follower-buddy.git
-commit=88f409843022c80b6eb95ac5eb93b2bd46c330be
+commit=71f88357562d4642396786f28289c6700c3393e2

--- a/plugins/follower-buddy
+++ b/plugins/follower-buddy
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeSpatol/follower-buddy.git
-commit=d548038246ea133b93ad318b47d8fa15ec7fe85f
+commit=88f409843022c80b6eb95ac5eb93b2bd46c330be


### PR DESCRIPTION
Follower Buddy 1.3.0 — pin `18ace20` → `5d5a0e4`.

Two new features, one design fix and a batch of bugs found in play.

**Give any line a voice.** A sound file can be attached to any line — one the player wrote or one that ships — and it plays when the follower says it, with the text still appearing as before. The plugin ships no audio and fetches none: files are the player's own, read from `~/.runelite/follower/sounds`, and listed from that folder rather than browsed to. `javax.sound.sampled` only, WAV/AIFF/AU, clips opened lazily, one sounding at a time, all closed on shutdown.

**Share what you have written.** The Messages window exports the player's own lines and their sounds as a `.zip`, and imports somebody else's. A pack is a diff against the shipped defaults, so it never carries the ~2,200 bundled lines, and importing merges rather than replaces.

### The two things a reviewer will want to look at

This version adds the plugin's **first file access outside the profile folder**: sharing writes a `.zip` where the player points a `JFileChooser` and reads one they pick. Both are behind a button and neither happens without the player choosing the file. `README.md` and `docs/DEVELOPMENT.md` have been corrected — they previously said nothing outside `~/.runelite/follower` was touched, which was true until this version.

An imported pack **comes from another user and is treated as hostile**:

- entry names matched against a fixed set of four rather than resolved as paths, so there is no location for a crafted name to escape into;
- entry and total sizes capped before anything is read;
- JSON nesting depth counted before the parser sees it, so a nested pack cannot throw `StackOverflowError` past the handler;
- every incoming line refused if it carries chat markup or control characters — spoken lines mirror into the chatbox, which reads Jagex markup, so an unchecked `<col=...>` from a stranger would render on the recipient's screen;
- text a pack supplies for display sanitised before it reaches a Swing dialog.

`PackRoundTripTest` and `HostilePackTest` cover this; the latter is nine tests, each written as an attack against the zip.

### Fixes

- Bosses that fight below their combat level were treated as ordinary monsters by the spectating shield and the kill celebration — "boss" was combat level 100 in two places rather than one definition.
- Examining anything in the inventory, bank or equipment produced nothing: those arrive as `CC_OP_LOW_PRIORITY`, not `EXAMINE_ITEM`.
- Phantom gear after a world hop; a block animation used as an attack in thrall mode; the guessing game never revealing its answer; the follower snapping onto unwalkable tiles.

### Hub rules

No `Thread.sleep` and no thread interrupt anywhere in `src/main/java` (re-verified for this PR). Still no network access, no reflection, no process spawning. `shadowJar` is untouched.

741 tests pass.