### PR TITLE
Update lazy-farming

### DIFF
--- a/plugins/lazy-farming
+++ b/plugins/lazy-farming
@@ -1,3 +1,3 @@
 repository=https://github.com/Speaax/Farming-Helper.git
-commit=4b32572dac7d94241bfefe5f44d841e8c97c5435
+commit=1a61afac5c5a72b79d1931fac2f6af82fc926d85
 authors=Speaax, JThomasDevs


### PR DESCRIPTION
Bump lazy-farming to include the Skip step button (#98) — adds a sidebar button on the custom-run overview panel that force-advances past the current patch when the plugin is stuck. Also resets sticky compost state and chat-message cache so a skipped step can't poison the next step's detection.