### PR TITLE
update osrs-tcg

### DIFF
--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=8b4afc5e35faa63f684ef7aa5c6f048332291f0d
+commit=37ce5c5838e876efe83a8129fb5ba2b59ff5a545

--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=fe08c7d6cce721402111be9eb848e397f200d07f
+commit=18a7ff359f384adde81f317b5eb7f55ab97a2093

--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=18a7ff359f384adde81f317b5eb7f55ab97a2093
+commit=4d90a7276559c7e12b105ce1cf1d9b846fdd6ebc

--- a/plugins/osrs-tcg
+++ b/plugins/osrs-tcg
@@ -1,2 +1,2 @@
 repository=https://github.com/Azderi/osrs-tcg.git
-commit=4d90a7276559c7e12b105ce1cf1d9b846fdd6ebc
+commit=8b4afc5e35faa63f684ef7aa5c6f048332291f0d


### PR DESCRIPTION
Updates OSRS TCG to v1.0.
Moving from a local-only beta to a server-authoritative model backed by osrs-tcg.net.