### PR TITLE
intelligence-gathering: 1.0.3

### DIFF
--- a/plugins/intelligence-gathering
+++ b/plugins/intelligence-gathering
@@ -1,2 +1,2 @@
 repository=https://github.com/TzJake-Jad/intelligence-gathering.git
-commit=75b8e51315a4c3b42a1e95499723ab84189b3692
+commit=34acf9c2b032530ba579b229441b2135200fa195


### PR DESCRIPTION
Updates `intelligence-gathering` to 1.0.3.

The plugin finds the current Shayzien organised crime meeting from the notice board and points you to it — world map marker, tile highlight, spawn/despawn timers, and a per-world scouting list for hopping.

This release:

- **Share codes.** Copy the current meeting and world scouting to the clipboard as a short code, so one player can scout and the rest import it. No network access — it is a clipboard string the user pastes themselves.
- **Fixes board reads being silently discarded.** Every board message contains the word "gang", which was also treated as a "no meeting" sentinel, so a reading could clear the very meeting it should have set. Board text is now matched before the no-meeting check, and clearing requires the message to actually say there is nothing.
- **Fixes filtered reads looking like failures.** A meeting excluded by the tracking filters was dropped at debug level, leaving an empty panel with no explanation. The panel now says which setting is hiding it.
- **Corrects location data against the wiki.** Two spots were flagged single-way that are multi, and two board messages were missing hyphens, which broke exact matching and fell through to fuzzy matching.

No new dependencies.

