### PR TITLE
Add ScapePath

### DIFF
--- a/plugins/scapepath
+++ b/plugins/scapepath
@@ -1,0 +1,2 @@
+repository=https://github.com/ClipToTik/ScapePathPlugin.git
+commit=6c3380ad5fe653e3d1c29e0415320610da562c63

--- a/plugins/scapepath
+++ b/plugins/scapepath
@@ -1,2 +1,2 @@
 repository=https://github.com/ClipToTik/ScapePathPlugin.git
-commit=6c3380ad5fe653e3d1c29e0415320610da562c63
+commit=4b230887b56cb4abed57ddf703fedb23a55c2d2d


### PR DESCRIPTION
ScapePath is a read-only OSRS account progression companion for RuneLite.

It reads the local player's own game state through public RuneLite APIs and shows it in a side panel: skills, quests, achievement diaries, inventory, equipment, bank, and wealth, plus a local preview of a normalized snapshot.

- Current functionality is entirely local and read-only.
- No account data is transmitted; the plugin makes no network requests.
- No credentials, passwords, cookies, or session tokens are handled.
- No gameplay automation and no input injection.
- No reflection, JNI, or native code.
- No third-party runtime dependencies (build=standard).
- Only the local player's own account state is read (no other players' data).

Repo: https://github.com/ClipToTik/ScapePathPlugin
