### PR TITLE
Update ClanHQ plugin

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=ca5dca52620e08df4597a4d4d3c4025d270fe58d
+commit=c8a42b232ed5096c57875f945ba3db3c46fd7601

--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=c8a42b232ed5096c57875f945ba3db3c46fd7601
+commit=f27be32

--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=f27be32
+commit=f27be32c686d918ddddd8d7a5e185ae8aa6fe3aa


### PR DESCRIPTION
Updates the ClanHQ plugin manifest to the current gear-free standalone RuneLite build. The plugin includes finalized Tasks, Drip Rush/Drop Rush, Overview, current-character detection, balance, and all-time DD Rank updates. Gear Advisor is excluded.