### PR TITLE
update wecorpcc

### DIFF
--- a/plugins/wecorpcc
+++ b/plugins/wecorpcc
@@ -1,2 +1,2 @@
 repository=https://github.com/shimonos/wecorpcc-.git
-commit=f0b0bd6bdd48d2facab051cd4dbeec483a006069
+commit=680208ff2290c315fa88aa088b4e7d8bbf8aba86


### PR DESCRIPTION
Fix player tracking outside the Corporeal Beast region.

- Prevents players at GE and other locations from being added to Away / AFK
- Uses the local player's Corp region to determine whether the plugin is at Corp