### PR TITLE
Update ClanHQ plugin to current UI build

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=ca5dca52620e08df4597a4d4d3c4025d270fe58d
+commit=c8a42b232ed5096c57875f945ba3db3c46fd7601


### PR DESCRIPTION
The merged ClanHQ manifest currently points to an older plugin commit. Update it to c8a42b232ed5096c57875f945ba3db3c46fd7601, which contains the current Tasks and Overview UI.