### PR TITLE
bank-architect: 0.3.0

### DIFF
--- a/plugins/bank-architect
+++ b/plugins/bank-architect
@@ -1,2 +1,2 @@
 repository=https://github.com/PKoka5/ironman-bank-architect.git
-commit=d5631c52bedfee228d95627d7f7e10b51a8648af
+commit=0e16d24293ad1ac0ff0d804bae17b8c5869de378

--- a/plugins/bank-architect
+++ b/plugins/bank-architect
@@ -1,2 +1,2 @@
 repository=https://github.com/PKoka5/ironman-bank-architect.git
-commit=0e16d24293ad1ac0ff0d804bae17b8c5869de378
+commit=82768c927d75a7bf384f1c8415709ef6ddb28198


### PR DESCRIPTION
Follow-up to #15681, which merged while this was still being worked on.

The row-filling option covered two different decisions under one switch: whether the four combat-style gear columns may be held straight with filler items, and whether a part-finished Herblore recipe row may be padded out. A player who wanted the first had no way to decline the second.

They are the same mechanism but not the same trade, so this splits them into two options, both defaulting to on. Nothing else changes.

- 932 tests, 0 failures
- Bank simulation 150/150 scenarios completed
- `gradlew build` green