### PR TITLE
Update thieving-stall-counter plugin

### DIFF
--- a/plugins/thieving-stall-counter
+++ b/plugins/thieving-stall-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/adnapPanda/thieving-stall-counter.git
-commit=ffbff13bf74f9c7f5061d137d112209a6096f27a
+commit=bee0ea6d8005ffa9444a89e33536188370b04ad5

--- a/plugins/thieving-stall-counter
+++ b/plugins/thieving-stall-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/adnapPanda/thieving-stall-counter.git
-commit=7476b9cf104b2051c13b7a932405898c6805d925
+commit=ffbff13bf74f9c7f5061d137d112209a6096f27a


### PR DESCRIPTION
### Fixed
Draynor seed stalls did not work with the plugin