### PR TITLE
ScapePath: update to 0.2.1

### DIFF
--- a/plugins/scapepath
+++ b/plugins/scapepath
@@ -1,2 +1,2 @@
 repository=https://github.com/ClipToTik/ScapePathPlugin.git
-commit=faacb7d10103af1ded27fb91ed32bfb2263e85e9
+commit=a036ad4d846f918c153f6cac9f20f1b7d9f3881f

--- a/plugins/scapepath
+++ b/plugins/scapepath
@@ -1,2 +1,2 @@
 repository=https://github.com/ClipToTik/ScapePathPlugin.git
-commit=4b230887b56cb4abed57ddf703fedb23a55c2d2d
+commit=f6182341010e4159ad1745a59fd02f24f5e584f9

--- a/plugins/scapepath
+++ b/plugins/scapepath
@@ -1,2 +1,2 @@
 repository=https://github.com/ClipToTik/ScapePathPlugin.git
-commit=f6182341010e4159ad1745a59fd02f24f5e584f9
+commit=7fb6046dbcc3145eaa8feb7489535ba2dbae7121

--- a/plugins/scapepath
+++ b/plugins/scapepath
@@ -1,2 +1,2 @@
 repository=https://github.com/ClipToTik/ScapePathPlugin.git
-commit=7fb6046dbcc3145eaa8feb7489535ba2dbae7121
+commit=f643c15a4e18a8c28ac6c054eebd318e6a938f6c

--- a/plugins/scapepath
+++ b/plugins/scapepath
@@ -1,2 +1,2 @@
 repository=https://github.com/ClipToTik/ScapePathPlugin.git
-commit=f643c15a4e18a8c28ac6c054eebd318e6a938f6c
+commit=faacb7d10103af1ded27fb91ed32bfb2263e85e9


### PR DESCRIPTION
Update to the existing **ScapePath** plugin (not a new submission).

Points the `plugins/scapepath` marker at release commit `7fb6046dbcc3145eaa8feb7489535ba2dbae7121` (v0.2.1).

Changes in this release:
- accountHash serialized as a JSON string (fixes a 64-bit precision mismatch); schemaVersion stays 1
- UI hardening: RuneLite-native scrolling, collapsible sections, bounded skills height, wrapped notes
- Connection UX: clear connect/connected states, Sync now, Disconnect, error messages
- Sync lifecycle: 5-min throttle, in-flight guard, 429 Retry-After, 401 token clear, off-thread network
- HTTPS-only to the ScapePath production origin; no reflection, native code, credentials, or telemetry
- 104 tests pass; `./gradlew clean build` succeeds

Author remains Magic Muck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)