### PR TITLE
osrs-flipper-sync: update to 5.2.22

### DIFF
--- a/plugins/osrs-flipper-sync
+++ b/plugins/osrs-flipper-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Ishmarr/osrs-flipper-runelite-sync.git
-commit=9809ae4663559fefacd8b74c18a5f4ac394c5366
+commit=1f9fbb73dc4c8b5b612d7f879fe80805f4303b59
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates OSRS Flipper Sync from 5.2.15 to 5.2.22.

- Fixes the buy/sell price-direction mapping and profit calculations.
- Keeps the buy price and lowest/break-even price fixed throughout an active flip.
- Allows only a higher Wiki instabuy price to raise an active sell target; the target can never be lowered automatically.
- Clears personal last buy/sell prices after an item has been absent from all GE slots for five uninterrupted minutes.
- Improves Wiki price refreshes and account/server state reconciliation.

No new dependencies or network endpoints are introduced.

Tests: 162 passed.