### PR TITLE
Update live-on-clan

### DIFF
--- a/plugins/live-on-clan
+++ b/plugins/live-on-clan
@@ -1,3 +1,3 @@
 repository=https://github.com/MilicoOSRS/live-on-clan.git
-commit=c5c3ab722264245e556af53f66d48ecbb51d4ee8
+commit=cde236280f99759ec15ba9972f46c1c3d2774c58
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/live-on-clan
+++ b/plugins/live-on-clan
@@ -1,3 +1,3 @@
 repository=https://github.com/MilicoOSRS/live-on-clan.git
-commit=cde236280f99759ec15ba9972f46c1c3d2774c58
+commit=8f69ae9b1906f75fe2896d780fb6858d4a969139
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Live On Clan 2.0

- Added optional clan-only PB rankings using the local player's Adventure Log, Combat Achievements, and supported scoreboards.
- Added support for raid team sizes, ToB room/overall times, and awakened bosses.
- Added separate opt-in settings for PB submissions and monthly MVP drops.
- Improved the PB, MVP, ranks, staff, and activity feed interfaces.
- Fixed Discord pet attachments and other UI issues.

PB and MVP submissions are disabled by default. Rankings are available only to verified Live On members.

`./gradlew clean check` passes with 34 tests.