### PR TITLE
Update hiscore-notifications

### DIFF
--- a/plugins/hiscore-notifications
+++ b/plugins/hiscore-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/malafel-dev/hiscore-notifications.git
-commit=51dcfbfdcdf36ec6b20414c6285846f8aba8c789
+commit=32c108211de926d0db033f166756d5f67d7a62d4

--- a/plugins/hiscore-notifications
+++ b/plugins/hiscore-notifications
@@ -1,2 +1,2 @@
 repository=https://github.com/malafel-dev/hiscore-notifications.git
-commit=32c108211de926d0db033f166756d5f67d7a62d4
+commit=02c277125158d4c86c67a09459c0c6ff17efd139


### PR DESCRIPTION
Fixes:
- Players near the top of a boss leaderboard get the same notification after every kc .
- Boss leaderboard messages by default show the kc of the person who was passed on the leaderboards, which is unclear.

Adds:
- Notifications via in game chat message.
- Ability to get an up to date list of bosses without updating the plugin.
- Change from scraping the hiscore webpage to using the hiscore API provided by Jagex.