### PR TITLE
create flip-goblin

### DIFF
--- a/plugins/flip-goblin
+++ b/plugins/flip-goblin
@@ -1,2 +1,2 @@
 repository=https://github.com/BigDru/FlipgoblinPlugin.git
-commit=af11a974f48287c49934527b85ac9ff6f798a4f8
+commit=3ca140d848c2da0a473e5998f312c255f9b3b225

--- a/plugins/flip-goblin
+++ b/plugins/flip-goblin
@@ -1,2 +1,4 @@
 repository=https://github.com/BigDru/FlipgoblinPlugin.git
-commit=3ca140d848c2da0a473e5998f312c255f9b3b225
+commit=2f8c71cb61e9b4a743465db304ddcd0a45be68ce
+authors=BigDru
+warning=This plugin submits your IP address, character name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.

--- a/plugins/flip-goblin
+++ b/plugins/flip-goblin
@@ -1,0 +1,2 @@
+repository=https://github.com/BigDru/FlipgoblinPlugin.git
+commit=af11a974f48287c49934527b85ac9ff6f798a4f8


### PR DESCRIPTION
Flip Goblin is a Grand Exchange flip tracker/helper. The goal is to stop alt-tabbing to price-check when setting up buy/sell offers at the GE. 

It captures your fills as they happen and shows session profit/loss after tax, buy-limit usage, live market data, and tracks your total account wealth so you can see number go up. This plugin is informational only. It never places, changes, or collects offers.

Note for review: a fresh install makes NO network calls. Pasting an account token (generated at flipgoblin.com) is the only opt-in. Once set the plugin fetches market data from our backend (flipgoblin.com) and syncs the user's own fills and assets to their own dashboard. The token setting and COMPLIANCE.md carry the full disclosure.

Thank you for your consideration

<img width="747" height="682" alt="offer-charts" src="https://github.com/user-attachments/assets/de5983c4-f9fa-4924-bb82-347b1d9bb659" />
