### PR TITLE
update botw

### DIFF
--- a/plugins/botw
+++ b/plugins/botw
@@ -1,3 +1,3 @@
 repository=https://github.com/marcushill13/botw.git
-commit=cb6a7e64a0618fc0b1dc8d230fcab253c4d95415
+commit=e5c68d4d5bb7c41b04fb660a40fb641a1845d858
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Counts pet drops, which were never counted before.

Both loot events are built from items appearing on the ground as something dies, and a pet never appears there — the game hands it to the player directly and announces it in the chat. So a challenge could offer a pet with a points value against it and nothing could ever score it.

The plugin now reads the three pet messages, matching the same strings RuneLite's own screenshot plugin uses, so all three endings count: following the player home, into the inventory, or on to Probita when they had no room for either. The message names neither the pet nor the boss, so which pet is taken from the challenge's own points list, and it only counts within a minute of a kill of that challenge's boss.

No new APIs beyond ChatMessage, and nothing changes on the server side.
