### PR TITLE
Add Gielinor Compass

### DIFF
--- a/plugins/gielinor-compass
+++ b/plugins/gielinor-compass
@@ -1,2 +1,2 @@
 repository=https://github.com/GiggyCash/osrs-strategist.git
-commit=3a7c6ff9d5b2be2e17f2c8b166d297be657cf1bc
+commit=7f286f637583014a0a753a835e88a7b64ed8de6d

--- a/plugins/gielinor-compass
+++ b/plugins/gielinor-compass
@@ -1,2 +1,2 @@
 repository=https://github.com/GiggyCash/osrs-strategist.git
-commit=6903ccfa0fb722bb6256c192d54ebdaf2a81a15d
+commit=3a7c6ff9d5b2be2e17f2c8b166d297be657cf1bc

--- a/plugins/gielinor-compass
+++ b/plugins/gielinor-compass
@@ -1,2 +1,2 @@
 repository=https://github.com/GiggyCash/osrs-strategist.git
-commit=7f286f637583014a0a753a835e88a7b64ed8de6d
+commit=58c10e26dadaf54259a140557c024e23a6ecda1e

--- a/plugins/gielinor-compass
+++ b/plugins/gielinor-compass
@@ -1,0 +1,2 @@
+repository=https://github.com/GiggyCash/osrs-strategist.git
+commit=6903ccfa0fb722bb6256c192d54ebdaf2a81a15d


### PR DESCRIPTION
Adds Gielinor Compass, a local OSRS progression and strategy planner.

Gielinor Compass uses observable RuneLite account state, goals, resources,
and account restrictions to recommend a useful next action.

The plugin supports Main, Ironman, Group Ironman, Ultimate Ironman,
Hardcore Ironman, Hardcore Group Ironman, and Unranked Group Ironman
where their mechanics differ.

Planning is local. The plugin does not automate gameplay or make runtime
Wiki/network requests.

Build type: standard
Version: 0.2.0