### PR TITLE
Create phosani-spore-warning

### DIFF
--- a/plugins/phosani-spore-warning
+++ b/plugins/phosani-spore-warning
@@ -1,2 +1,2 @@
 repository=https://github.com/IGna7iuS/phosani-spore-warning.git
-commit=0f62053037db9dd52ecc0043c95ce6cb9a53ab18
+commit=b7bf3c17b73d6773ea415e76bb2a74ee6ca0a780

--- a/plugins/phosani-spore-warning
+++ b/plugins/phosani-spore-warning
@@ -1,0 +1,2 @@
+   repository=https://github.com/IGna7iuS/phosani-spore-warning.git
+   commit=0f62053037db9dd52ecc0043c95ce6cb9a53ab18

--- a/plugins/phosani-spore-warning
+++ b/plugins/phosani-spore-warning
@@ -1,2 +1,2 @@
-   repository=https://github.com/IGna7iuS/phosani-spore-warning.git
-   commit=0f62053037db9dd52ecc0043c95ce6cb9a53ab18
+repository=https://github.com/IGna7iuS/phosani-spore-warning.git
+commit=0f62053037db9dd52ecc0043c95ce6cb9a53ab18


### PR DESCRIPTION
Adds Phosani's Spore Warning, a small overlay plugin for the Nightmare / Phosani's Nightmare fight.

Nightmare periodically drops "Spore" objects (object id 37739) around the arena; standing within 1 tile of one triggers a drowsy effect (reduced attack speed, disabled run, and at Phosani's, a prayer drain). This plugin highlights the 3x3 area around each live spore so it's easier to see at a glance which tiles are unsafe.

Tracks spores via GameObjectSpawned/GameObjectDespawned, matched on a single hardcoded object id — no user-configurable IDs, so it's scoped to this one mechanic only. Configurable colors (with alpha) for the spore's own tile vs. the surrounding danger tiles, adjustable border width, and an outline-only mode.