### PR TITLE
update attacktimer

### DIFF
--- a/plugins/attacktimer
+++ b/plugins/attacktimer
@@ -1,3 +1,3 @@
 repository=https://github.com/ngraves95/attacktimer.git
-commit=9b39763c13d1f4e895fd1d301c87453c061a68f2
+commit=d95a935319214038626c2344cb0280a46a2eeb07
 authors=ngraves95,Lexer747


### PR DESCRIPTION
* Support for Maggot King Larvae (overwrite attack cooldown if attacked with a bow whilst flying)
* Support for Doom of Mokhaiotl
  * Larvae (overwrite attack cooldown if non-demonbane)
  * Volatile Earth (overwrite attack cooldown if non-demonbane)
  * Melee Punish (overwrite attack cooldown)
* Support for Amoxliatl Unstable Ice special being 1 tick attacks

The diff is probably huge and that's mostly caused by a `.gitattributes` skill issue, I had created a bunch of CRLF files which should've been LF, sorry. If requested I can split up the update into pieces such that the `.gitattributes` is it's own update.