### PR TITLE
Add Easy Spores

### DIFF
--- a/plugins/easy-spores
+++ b/plugins/easy-spores
@@ -1,0 +1,2 @@
+repository=https://github.com/elitestate/Easy-Spores.git
+commit=18a5dacbd23259349ce18b0b0e79ccc3e17d3748


### PR DESCRIPTION
Easy Spores highlights the fixed 3×3 danger area of active spores exclusively during the Nightmare and Phosani’s Nightmare encounters. It is hard-restricted to the fixed boss and spore object IDs and cannot activate elsewhere. The plugin supports configurable highlight colour and transparency and performs no prediction, input, menu modification, or automation.