### PR TITLE
Daily CA Picker: update

### DIFF
--- a/plugins/daily-ca-picker
+++ b/plugins/daily-ca-picker
@@ -1,2 +1,2 @@
 repository=https://github.com/NickTechRepo/daily-ca-picker.git
-commit=87b4739a52db5beccf2632ae4b4f0f120d712dfc
+commit=da161354f78d888f52e07f8b63bfbdec19aef60e


### PR DESCRIPTION
Updates Daily CA Picker to commit `da161354f78d888f52e07f8b63bfbdec19aef60e`.

Changes:
- adds an OSRS parchment-themed daily CA reveal panel
- adds an animated Roll Today’s CA interaction
- delays chat announcement until reveal
- cleans up Swing timers and rejects stale account-session callbacks
- adds regression coverage for reveal, timer, date, and account-session behavior

Verification:
- clean `./gradlew test build`
- 46 tests passing
- Java 11 target retained