### PR TITLE
create teleport-blocker

### DIFF
--- a/plugins/teleport-blocker
+++ b/plugins/teleport-blocker
@@ -1,0 +1,2 @@
+repository=https://github.com/vividflash/teleport-blocker.git
+commit=1212154191b47f51a95438aaf6e90c447dd05210


### PR DESCRIPTION
Teleport Blocker: per-spell removal of the click options on standard spellbook teleports, for chunk-locked accounts.