### PR TITLE
osrs-toolkit-sync: BUGFIX

### DIFF
--- a/plugins/osrs-toolkit-sync
+++ b/plugins/osrs-toolkit-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Wolklaw/osrs-toolkit-runelite.git
-commit=7f93604a3717872dc297a39aad7beb8ca9c06b65
+commit=8b96c6d31e5ca7663ab59ff09972eb8aad091e1f
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bug fix. The plugin only wrote the Grand Exchange slot state when the game fired an offer-changed event, so if it missed the one saying a slot was collected, that offer stuck around forever. It now re-checks the slots on its existing heartbeat and corrects itself.