### PR TITLE
Add smoke-scape-hub

### DIFF
--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=224290e248923775b8911dd8236b27f29ac26a69
+commit=466ab0e5116370300441f6d8d7bd7449748ee345

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=466ab0e5116370300441f6d8d7bd7449748ee345
+commit=e653bd02ebb6f605f762ca908444f1afff851633

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=84c488552d9f170e985b59f32800985a1fee60d8
+commit=fb2846820023b01427b6deeb6b560ed4fe53ac34

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=fb2846820023b01427b6deeb6b560ed4fe53ac34
+commit=4d5f5a8c8db688e3fcb92d7d4a8ee0ea46d947b7

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,0 +1,2 @@
+repository=https://github.com/kwushy/smoke-scape-hub.git
+commit=6c30072a0e76e2ef3ea674e4a19d7ad3c15e920d

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=5d47963b30a8a6b31b79cd05a7a732ac490ec09e
+commit=84c488552d9f170e985b59f32800985a1fee60d8

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=6c30072a0e76e2ef3ea674e4a19d7ad3c15e920d
+commit=5d47963b30a8a6b31b79cd05a7a732ac490ec09e

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=e653bd02ebb6f605f762ca908444f1afff851633
+commit=e1948a7e102a80bb8d1bb082f337157d7d71faca

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=4d5f5a8c8db688e3fcb92d7d4a8ee0ea46d947b7
+commit=224290e248923775b8911dd8236b27f29ac26a69


### PR DESCRIPTION
Smoke Scape Hub is a clan sidebar plugin for the Smoke Scape clan, built around TempleOSRS group tracking.

Tabs:
- Milestones — recent clan-wide 99s and boss KC milestones (group achievements)
- Comps — active/upcoming group competitions with live top-5 standings (skill of the week, yearly XP comp, etc.)
- Ranks — pet count, collection log, EHP and EHB leaderboards
- Discord — invite link

No config panel — it's wired to one clan, so the TempleOSRS group ID and Discord invite are hardcoded constants rather than user settings. Data refreshes every 6 hours.

Source: https://github.com/kwushy/smoke-scape-hub