### PR TITLE
Update Skiller Guard to 1.1.3

### DIFF
--- a/plugins/skiller-guard
+++ b/plugins/skiller-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/skiller-guard.git
-commit=7b0edd1aca04066ff7a266d399b4b6232439b528
+commit=e6912e23c37e0b8435d53ab3dda5e6fa59dda6d5


### PR DESCRIPTION
## Summary
- Bumps Skiller Guard to **1.1.3** at `e6912e23c37e0b8435d53ab3dda5e6fa59dda6d5`
- Stops the Player Attack options warning on official PvP and Deadman worlds, where Attack is always on other players
- NPC Attack and Auto Retaliate warnings are unchanged

## Test plan
- [ ] Plugin Hub CI build on this PR is green
- [ ] On a PvP world, the Player Attack banner stays off
- [ ] On that same world, Auto Retaliate / NPC Attack still warn if they are on
- [ ] Hop to a normal world with Player Attack not Hidden: the banner returns