### PR TITLE
create death-message

### DIFF
--- a/plugins/death-message
+++ b/plugins/death-message
@@ -1,0 +1,2 @@
+repository=https://github.com/Romansolja/death-message.git
+commit=3b4925b6b32aca98ea7eb79f29ce7352bb622dbd


### PR DESCRIPTION
Adds Death Message, a cosmetic client-side plugin that shows a configurable message when your own player dies, as overhead text, a chatbox game message, or both.

It reacts only to the local player's death, and renders with `Actor#setOverheadText` / `setOverheadCycle` and `Client#addChatMessage(GAMEMESSAGE, ...)`. Nothing is sent to the server: no injected input, no packets, no menu entries, nothing written to the chatbox input. Configured text is escaped with `Text#escapeJagex` so it renders literally. No added dependencies, Java 11.

Existing death plugins cover sounds, effects and counting; none display custom text.

Repo: https://github.com/Romansolja/death-message (BSD 2-Clause)
