### PR TITLE
Add Combat Entity Hider

### DIFF
--- a/plugins/combat-entity-hider
+++ b/plugins/combat-entity-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/younghans/combat-entity-hider.git
+commit=5c739b3dfee09b5a305e021e1fffe86d5a22bd79


### PR DESCRIPTION
Combat Entity Hider is a combat-aware replacement for Entity Hider.

Hide attackers overrides Hide others: when Hide attackers is disabled, active and recently detected player attackers remain visible even when Hide others is enabled.

Recent attackers remain visible for a configurable 0–60 second grace period, defaulting to 15 seconds. The plugin also declares conflicts with Entity Hider, Auto Entity Hider, and Dynamic Entity Hider so multiple hiders do not compete over rendering.

Tested successfully in-game and with the project test suite and RuneLite Plugin Hub standard packaging build.

This is inspired by Dead Man Mode breaches. So when you're hiding players, it still see the player that's attacking you.
