### PR TITLE
Update Iron Compass to 1.1.0

### DIFF
--- a/plugins/ironpath
+++ b/plugins/ironpath
@@ -1,3 +1,3 @@
 repository=https://github.com/gabworknestio-beep/iron-compass.git
-commit=d0ba475863d8e03e3caf23b2929013d1ef24fab5
+commit=fc4cdbc1315c267dcb9ccb45dc6a7b77647b63c1
 authors=Gab

--- a/plugins/ironpath
+++ b/plugins/ironpath
@@ -1,3 +1,3 @@
 repository=https://github.com/gabworknestio-beep/iron-compass.git
-commit=fc4cdbc1315c267dcb9ccb45dc6a7b77647b63c1
+commit=5e3d2c2ae3969884991af6743e8a37b0f0290962
 authors=Gab

--- a/plugins/ironpath
+++ b/plugins/ironpath
@@ -1,3 +1,3 @@
 repository=https://github.com/gabworknestio-beep/iron-compass.git
-commit=5e3d2c2ae3969884991af6743e8a37b0f0290962
+commit=bf9701438c776029218b4321d1f5f98fc35d00f0
 authors=Gab


### PR DESCRIPTION
Updates Iron Compass to release 1.1.0.

### Highlights
- Adds the account-aware Ironman Skill Planner with complete Hunter, Crafting, Herblore, Construction, and Slayer pilot guides.
- Adds compact premium goal, gear, account-insight, and skill-planner UI improvements.
- Improves Plugin Hub discovery with a clearer description, expanded search tags, and a player-focused README.
- Keeps all method data local and treats unknown bank resources as unknown rather than unavailable.

### Validation
- Java 11
- 176 tests passed
- Gradle build passed
- No runtime web requests

Plugin commit: bf9701438c776029218b4321d1f5f98fc35d00f0