### PR TITLE
Update bankstand

### DIFF
--- a/plugins/bankstand
+++ b/plugins/bankstand
@@ -1,3 +1,3 @@
 repository=https://github.com/CVE-078/bankstand-runelite.git
-commit=9e24961e7046635f2d9902e443f7c982af478d9f
+commit=28698197fc0ea64aff4eabb1a8e86936ac411167
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps the pinned commit to `v0.2.0` (CVE-078/bankstand-runelite@2869819). No manifest changes beyond the commit bump; the install warning stays as the maintainer set it in #15447.

What changed since the currently-pinned commit (`9e24961`):

- Added a sidebar status panel: when each capability last synced, your recent activity, and a manual sync button.
- Added `::bstand export` (share your current capture settings) and `::bstand help` (list every command).
- Combat achievements now also capture completed task counts per boss or activity, not just per tier.
- Combat achievements now also capture the moment a whole tier finishes, not just individual tasks.
- Fixed a bug where a captured combat achievement task name could carry a stray leading icon character.

Full changelog: https://github.com/CVE-078/bankstand-runelite/blob/main/CHANGELOG.md
