### PR TITLE
Update Loadout Lab to 0.4.1

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=e8406c25e77e2c3a6238ccfa9f20b5c3961b173b
+commit=a94ebdf5445e6b19caa2a4d150bea20c716316b9
 authors=ajkatz


### PR DESCRIPTION
Field-fix release. All three reports came from **Not on Hand** — thank you!

- **Boosts are never assumed unless owned.** The card claimed "Assumes: Ranging potion" on an account with none banked; the selector now reads the collection, with bastion/battlemage outranking the plain family and divine variants named so the assumes icon shows a potion the player actually owns.
- **Sim/exclude/profile lists are per character** (previously per RuneLite profile, so a main and an alt shared one set). Scoped by account hash + world type, with a one-time adopt-and-move migration so an existing install keeps its lists.
- **The F2P filter chip is back** and can be turned off to preview members gear; a manual untick survives region changes.
- Idle-panel fixes: the sim/exclude counters update without a search up; the inventory slider only shows with a result.
- The "Best in game" ceiling now respects the player's own level/quest requirements, so it never names gear they cannot equip.

575 tests, preSubmit green, 187,533 tokens main source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)