### PR TITLE
Create tab-keybind-display

### DIFF
--- a/plugins/tab-keybind-display
+++ b/plugins/tab-keybind-display
@@ -1,0 +1,2 @@
+repository=https://github.com/Jin-Jiyunsun/jins-plugins.git
+commit=1827f45761ab0ee25631174d7f4f37155e86ce78


### PR DESCRIPTION
Plugin lets you display which key is assigned to which tab for learning which is assigned to which, or simple ease of use