### PR TITLE
Update Wilderness Agility Course Tracker

### DIFF
--- a/plugins/wilderness-agility-course-tracker
+++ b/plugins/wilderness-agility-course-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/andrew-friedman-phd/wilderness-agility-course-tracker.git
-commit=386a666ee9143948b70001516c961ebce77862cb
+commit=1f23a85f7de91758d9dd17d8ed887fbba67c6810


### PR DESCRIPTION
Fixes the next-obstacle guide getting stuck on Log Balance and never advancing to Rocks - the click-to-XP confirmation window was too short for a real walk-across (confirmed live at 14+ seconds), so it was silently rejecting real completions. Also switches the highlight's fill from a ground-tile shade to the object's actual convex hull, since the tile only ever lit up whichever tile sat under the object's anchor point rather than the object itself.

Repository: https://github.com/andrew-friedman-phd/wilderness-agility-course-tracker