### PR TITLE
update friend-aliases

### DIFF
--- a/plugins/friend-aliases
+++ b/plugins/friend-aliases
@@ -1,2 +1,2 @@
 repository=https://github.com/jakevollkommer/friend-aliases.git
-commit=f3825b3d5d9c0894c49bb8578f66578035307e97
+commit=daabf1fe28b9bcfe6706d0e8bb80b137ffa1bd6e


### PR DESCRIPTION
Fixes the chatbox Lookup option searching the hiscores for a friend's alias instead of their username. The Lookup entry now shows alias (username) and looks up the real player.