### PR TITLE
update bank-templates to v2.3.2

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=59fb42c1cbcf30306d6289924bd43a1d0f54583c
+commit=90157b485e40866ac398540e2456e35e56c673d3


### PR DESCRIPTION
v2.3.2 changes when the plugin talks to its backend. Nothing else moves.

The sync loop polled every 90 seconds for the life of the client, whatever was
happening. Most installs have no linked account, so the server answered those with an
empty set every time. Three cases now settle differently:

- No linked account: back off to 15 minutes. It backs off rather than stopping,
  because the account can appear without the panel being touched.
- Linked, side panel closed: stop. Opening the panel, editing a template, and logging
  in each restart the loop.
- Linked, panel open, nothing changing: step 20s to 40s to 80s, reset by any change.

Pending local changes still retry at 4 seconds.

One user-visible effect: with the panel closed, a template imported on the website
arrives when you open the panel instead of in the background. Opening it syncs first
thing, so the list is never shown stale.

Compare: https://github.com/TheSpryt/bank-templates/compare/59fb42c...90157b4