### PR TITLE
Create bank-tag-folders

### DIFF
--- a/plugins/bank-tag-folders
+++ b/plugins/bank-tag-folders
@@ -1,0 +1,2 @@
+repository=https://github.com/kingkj52/bank-tag-folders.git
+commit=4275763f2e6fda8f54575239c68a13e8da380882

--- a/plugins/bank-tag-folders
+++ b/plugins/bank-tag-folders
@@ -1,2 +1,2 @@
 repository=https://github.com/kingkj52/bank-tag-folders.git
-commit=4275763f2e6fda8f54575239c68a13e8da380882
+commit=d4a167b3f4f358bcbaf01fb9d643ede13074c610

--- a/plugins/bank-tag-folders
+++ b/plugins/bank-tag-folders
@@ -1,2 +1,2 @@
 repository=https://github.com/kingkj52/bank-tag-folders.git
-commit=d4a167b3f4f358bcbaf01fb9d643ede13074c610
+commit=cad2380da23e4febc4e8e45485120611cf7ffeca


### PR DESCRIPTION
Bank Tag Folders

This plugin adds collapsible folders to the bank tag tab column. Drag one tag tab onto another to group them, name the folder, and collapse it. Aimed at accounts with more tag tabs than fit down the side of the bank. This is also meant to feel intuitive by mimicking mobile phone behavior. If you drag a tag tab into the top quarter or bottom quarter of another tag tab, it will insert above/below that tag tab, respectively, akin to ordering apps on the home screen of a mobile phone.

Data sent off-client: none. The plugin makes no network calls and touches no files. Folder definitions are stored through RuneLite's own ConfigManager in the banktagfolders group. Tag tab import/export uses the system clipboard, which is local.

Dependencies: none added. It compiles against net.runelite:client plus Lombok and JUnit only. A test asserts this against build.gradle, so a dependency cannot be added without the build failing.

Jagex third-party client guidelines

No menu entries are added. The options on the column are attached to widgets this plugin creates, and are handled entirely client-side.
Nothing is sent to the server. No menu entries are added and no existing actions are invoked programmatically. Where core Bank Tags force-closes the potion store via Client.menuAction before opening a tag, this plugin declines to open the tag instead and tells the user to close the store, since the store is a server-side bank tab and moving off it client-side alone would misroute deposits. A test forbids menuAction outright.
No interface components are unhidden, and no click zones are moved or resized for the 3D scene, inventory, worn equipment, spellbook or prayer book. The bank is the only interface the plugin addresses at all, and a test asserts that no InterfaceID outside Bankmain is referenced.
The plugin draws client-side widgets into the bank's item container, which is what the bundled Bank Tags plugin already does in the same container.

ComplianceTest enforces all of the above from the build, along with no reflection, no runtime code loading or external processes, no filesystem or network access, no Client calls from AWT-facing classes, and @Singleton on injected collaborators.




Why a new plugin rather than extending an existing one?

The hub asks people to extend rather than fragment, so to be explicit about the overlap:

bank-tag-layouts arranges items inside a tab; this arranges the tabs. They compose, and this plugin is written to stay out of its way: it mirrors the tab list into the core TabManager, precisely so Bank Tag Layouts still resolves tabs when the core strip is off.
bank-tab-organizer and bank-tag-generation create and populate tags; this creates none, it only groups tags that already exist.
expanded-bank-tags-viewer changes how tags are viewed; this adds hierarchy to the tab column.

Extending core Bank Tags in place was considered first and is not workable. TabManager.save() writes its in-memory tab list back to banktags.tagtabs on any rename, delete or reorder, so hiding a collapsed folder's tabs by filtering that list would permanently delete them from the user's config. Owning the column is the only way to hide rows safely.

Requires core Bank Tags enabled with its "Tag tabs" option off, since both strips build into the same container. The plugin stays idle and says so in chat (once) and until that is done, will idle and will not set this setting for you.