### PR TITLE
Update tcg-locked

### DIFF
--- a/plugins/tcg-locked
+++ b/plugins/tcg-locked
@@ -1,2 +1,2 @@
 repository=https://github.com/randytkrx/tcg-locked.git
-commit=6a1e9afe3167508fad90ce5b05772a0032164ad0
+commit=693c5ca3e207e57a28e2481c7893a0bafd5f99f0


### PR DESCRIPTION
Updates TCG Locked to source commit `e1b411e98f50bdacab57f71b4c7574db21c49385` (version 1.2.6).

Highlights:
- Supports authoritative OSRS TCG v1 item/NPC IDs and collision identities.
- Adds meta-first public group syncing every five minutes, with offline cached collections.
- Preserves beta name-only payloads, existing RuneLite party approvals, and released v2 pooled snapshots.
- Retains both v1 and beta Shared Cards catalogs/image caches.
- Adds the standard third-party network warning.

Verification:
- Java 21 clean test and build pass.
- Frozen beta resources are byte-identical to 1.2.5.
- Released v2 catalog hash and exhaustive full-bitmap decoding verified.
- Mixed v2/v1 party payload, profile invalidation, HTTP 429/cancellation/size-limit, and image-cache fallback tests pass.
- Restricted API and whitespace scans pass.