### PR TITLE
bank-architect: 0.3.1

### DIFF
--- a/plugins/bank-architect
+++ b/plugins/bank-architect
@@ -1,2 +1,2 @@
 repository=https://github.com/PKoka5/ironman-bank-architect.git
-commit=82768c927d75a7bf384f1c8415709ef6ddb28198
+commit=4635b3d2e470f1c5b3c81ee54c49439045df9f38


### PR DESCRIPTION
Two fixes from player feedback on the 0.3.0 release.

A player reported that armour sets from the same source were being sorted far apart in the gear tab — their Eclipse set near the top, the Blood Moon set near the bottom. The gear-progression data behind the sort had only ever tiered one representative set per combat style, so the sets that were left untiered fell back to name heuristics, scored nothing, and sank below plain metal armour. This tiers the Perilous Moons and Barrows sets as whole families instead.

A second player sat on a "SYNCING BANK" message indefinitely. The cause was bank fillers: a filler holds a bank slot without being a real item, and guidance needs a bank with no gaps. The plugin now counts them and says so, rather than syncing forever with no explanation.

- 945 tests, 0 failures
- Bank simulation 150/150 scenarios completed
- `gradlew build` green