### PR TITLE
Add Item ID Overlay

### DIFF
--- a/plugins/item-id-overlay
+++ b/plugins/item-id-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/Giorgosfl/item-id-overlay.git
+commit=4a5ee7f87c0c4c91a5828077770598ab790d9a6a


### PR DESCRIPTION
Shows item IDs on inventory and bank items — drawn on the lower side of the item icon, in the hover tooltip, or both.

Config: inventory/bank checkboxes, icon/tooltip display toggles, text color (default white).

Unlike the existing `item-id` plugin (which adds IDs to hover menu text and a search panel), this renders the ID directly on the item grid, covering the bank via `showOnBank()`.

Repository: https://github.com/Giorgosfl/item-id-overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)