### PR TITLE
Update gok-irl-xp

### DIFF
--- a/plugins/gok-irl-xp
+++ b/plugins/gok-irl-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/mataeo-eh/GOK-IRL-XP.git
-commit=acb4dbe209f18d61450f32f6438a96b0c5a14e75
+commit=94aa87b5e080f49a0eae7e43a1ffce89bb37606c


### PR DESCRIPTION
Updates gok-irl-xp to commit 94aa87b5e080f49a0eae7e43a1ffce89bb37606c.

Changes in this update:

- **Remove banked XP.** The sidebar now has an Add/Remove switch so users can undo XP banked to the wrong skill. Removal only lists skills that hold XP and is capped at the banked amount, so a balance can never go negative.
- **Overlay resizing fixed.** The overlay's `render()` was calling `panelComponent.render()` directly, skipping the step in `OverlayPanel.render()` that applies the user's dragged size — so it stayed pinned at its default width in every game screen mode. It now returns `super.render(graphics)` and enables dynamic font.
- **Clearer "log completed work" form.** Relabelled the two multiplied inputs, added a worked example, and rewrote the preview as labelled lines; users could not work out what the fields meant.
- **Depletion warning.** Optionally flashes the screen red when a skill is within N more in-game actions of running out (default 5, `0` disables). The per-action cost is learned from that skill's own recent XP drops, so it needs no per-skill logic. Delivered through the standard `Notification` config type, so colour, duration, sound, and tray behaviour are all user-configurable.

No new dependencies; still `build=standard` and Java 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)