### PR TITLE
Add Trip Tracker plugin

### DIFF
--- a/plugins/trip-tracker
+++ b/plugins/trip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/OhansonB/trip-tracker.git
-commit=86a63148fa9217a084c982ac6f277034c913ee3a
+commit=b338d8583e0cc0e3a2b79b7b112185feb056cbb8

--- a/plugins/trip-tracker
+++ b/plugins/trip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/OhansonB/trip-tracker.git
-commit=4bd5ca791e21eb63818770c7a69662c16f317b70
+commit=c9216d28df987db579e8e899a36477c3ac70df7b

--- a/plugins/trip-tracker
+++ b/plugins/trip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/OhansonB/trip-tracker.git
-commit=b338d8583e0cc0e3a2b79b7b112185feb056cbb8
+commit=4bd5ca791e21eb63818770c7a69662c16f317b70

--- a/plugins/trip-tracker
+++ b/plugins/trip-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/OhansonB/trip-tracker.git
+commit=86a63148fa9217a084c982ac6f277034c913ee3a


### PR DESCRIPTION
Loot tracker with trip scoping, GP/hour statistics, and trip comparison.

Features:
- Three view modes: individual drops (list), aggregated by NPC (grouped), and per-session trips
- Trip management with pause/resume, rename, and configurable inactivity timeout
- Side-by-side trip comparison with CSV, JSON, and pretty-print export
- Tracks NPC kills, PvP kills, pickpocketing, raids, minigames, farming harvests, bird houses, and chest loot
- Item sprite and text display modes
- Per-item and per-NPC exclusion via right-click context menu
- Real-time filtering across all views
- Persistent storage per account with automatic data retention limits