### PR TITLE
add uim-utilities

### DIFF
--- a/plugins/uim-utilities
+++ b/plugins/uim-utilities
@@ -1,0 +1,2 @@
+repository=https://github.com/jakevollkommer/uim-utilities.git
+commit=9222253e2b1f80cc2bb4d8ffeb2dbcb978ec81e3


### PR DESCRIPTION
Quality of life and safety warnings for ultimate ironman accounts.

- **Chambers of Xeric ground items.** Ultimate ironmen use the raid floor as storage, and the raid destroys whatever is left on it. While anything carried in and dropped is still lying there, the way out is labelled with the count and its left-click option is deprioritized, so leaving takes a deliberate right-click. The entry is never removed. A drop is recognised as an item leaving the inventory and landing on the floor beside the player, so loot lying around the raid is not counted.
- **Looting bag.** The Destroy option is removed from the bag while the setting is on, since destroying it outside the Wilderness loses everything inside. Turning the setting off gives the option back.
- **Shops.** Sell options are removed for items on a name list, which starts as the gear linked from the ultimate ironman equipment guide and takes `*` wildcards.

Everything is behind a toggle, and everything the raid feature does is gated on the in-dungeon varbit so no ids are matched outside the Chambers of Xeric.

Repository: https://github.com/jakevollkommer/uim-utilities