### PR TITLE
rs-flipper: add a risk level setting

### DIFF
--- a/plugins/rs-flipper
+++ b/plugins/rs-flipper
@@ -1,3 +1,3 @@
 repository=https://github.com/Ramon0205/rs-flipper.git
-commit=acc94c88ad810632ff6216869027c926c2927192
+commit=4c8dfa40f7cc447418a340218aa7575772914154
 warning=This plugin submits your IP address, Grand Exchange offers and trade history to a 3rd-party server (api.rs-flipper.com) not controlled or verified by RuneLite developers. An account is required.


### PR DESCRIPTION
- New "Risk level" setting with three options: Careful, Balanced, Aggressive.
  Selectable in the plugin panel and in the RuneLite config.
- Default is Balanced. Until now everyone ran the most aggressive behaviour
  without being able to change it.
- Careful takes smaller positions and cuts losses earlier. Aggressive keeps
  what the plugin did before.

Commit: 4c8dfa40f7cc447418a340218aa7575772914154