### PR TITLE
Update Group TCG to 1.0.0

### DIFF
--- a/plugins/group-tcg
+++ b/plugins/group-tcg
@@ -1,3 +1,3 @@
 repository=https://github.com/Sqwiglyy/groupman-tcg.git
-commit=4e897fb9c3a60bb5e977b6e1e5312f9050496878
+commit=8cb51b1e9bd938389b0d0b20a2235ddd366c8072
 warning=IMPORTANT MULTIPLAYER PRIVACY WARNING: Group TCG deliberately has no official public server; multiplayer uses only a private server chosen by your group. Only connect to servers run by friends you trust. The host controls the endpoint and may see or record your IP address and synced Group TCG data. Private servers are independently operated; the Group TCG creator does not operate, verify, endorse, or accept responsibility for servers hosted by others. Use a VPN if you need to hide your IP address. Solo play does not connect to a group server. Optional card artwork also sends your IP address and requested image URLs to the OSRS Wiki.


### PR DESCRIPTION
Updates Group TCG to 1.0.0.\n\n- adds OSRS TCG 1.0 collection compatibility through its supported read-only PluginMessage API\n- prevents unavailable startup state from uploading an empty collection\n- infers delayed collection-update notifications from newly visible cards and credits the updating player\n- adds a custom Plugin Hub icon\n- updates displayed version and HTTP user agent\n\nLocal verification: clean build successful; 63 tests passed.