### PR TITLE
add inoculation-bracelet-notifier

### DIFF
--- a/plugins/inoculation-bracelet-notifier
+++ b/plugins/inoculation-bracelet-notifier
@@ -1,0 +1,2 @@
+repository=https://github.com/jakevollkommer/inoculation-bracelet-notifier.git
+commit=33684dba316f263739334476b94ef499a67a4bc1


### PR DESCRIPTION
Shows the bracelet of inoculation item icon whenever one is not worn, and hides it as soon as one is equipped. A bracelet in the inventory does not count, since only the worn one gives the disease immunity.

The icon is the item sprite from ItemManager rather than a bundled image, and the only setting is its size in pixels. Equipment is read from the worn container on ItemContainerChanged, so there is no per-tick polling, and the scaled icon is cached until the size setting changes so the overlay allocates nothing per frame.

Same idea as the existing [Ring of Recoil Notifier](https://github.com/delps1001/recoil-plugin) by delps1001, applied to the bracelet of inoculation and written fresh against the current API.