### PR TITLE
update sleepwalker-stakeout to 1.1.0

### DIFF
--- a/plugins/sleepwalker-stakeout
+++ b/plugins/sleepwalker-stakeout
@@ -1,3 +1,3 @@
 repository=https://github.com/manc1n1/sleepwalker-stakeout.git
-commit=35751ec69881f83ae4d2cc32a0c9f22a9f8c576d
+commit=6e782e86576a21322f06790052058468d7f94f28
 authors=Suspext


### PR DESCRIPTION
## Summary

Expands Sleepwalker Stakeout beyond the Blisterwood stake by adding support for additional commonly used Sleepwalker weapons and improving the plugin's update messaging and documentation.

## Changes

- Added support for additional weapon attack animations:
  - Eye of Ayak
  - Toxic and Blazing blowpipes
  - Bows, including Craw's bow and Webweaver bow
  - Darts
- Fake XP drops now display the sprite of the currently equipped weapon
- Restricted fake XP drops to attacks targeting Sleepwalkers
- Added lazy sprite caching for supported weapons
- Added a one-time plugin update message per version
- Added internal plugin version tracking
- Updated `bump-version.sh` to keep the Java plugin version synchronized with:
  - `gradle.properties`
  - `runelite-plugin.properties`
  - `SleepwalkerStakeoutPlugin.java`
- Updated the README to document:
  - Expanded weapon support
  - Sleepwalker-only targeting
  - Dynamic weapon sprites
  - Overlay positioning and snapping
  - One-time update messages

## Testing

- Verified supported attack animations trigger against Sleepwalkers
- Verified supported animations do not trigger against unrelated NPCs
- Verified the currently equipped weapon's sprite is displayed
- Verified different dart and bow variants use their corresponding item sprite
- Verified manually positioned and snapped overlays continue to work
- Verified resetting the overlay restores player-following behavior
- Verified update messages are only shown once per plugin version
- Verified the version bump script updates all version locations consistently