### PR TITLE
coffer: bump to a5b6a76 (0.1.1-beta)

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=ae8642dcc8b04bf424daec0d4d98d725e7752ba5
+commit=a5b6a767f9e0c70e8ee348c7f323cf3147acaee2
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Update the `coffer` plugin to commit `a5b6a76` (0.1.1-beta).

Changes since the last release (`ae8642d`):

- **Self-serve sign-up** — the login panel now has a "Create account" button so users can register a free account in-client (previously accounts were provisioned manually). Talks to the existing Coffer server's new public register endpoint.
- **Position coaching** — each open offer now shows a HOLD / REPRICE / CUT verdict badge with a target, computed server-side from live fill-able prices.
- **Average-down suggestion** — for an underwater hold, an advisory line suggests a capped re-buy that lowers your break-even (display-only; never places an order).

No new API usage, no new dependencies, no new config surface. `okhttp3`/`gson` remain injected (not constructed). File access stays within `RUNELITE_DIR/coffer/`. Data sent is unchanged (login/register → session token; GE offers and completed trades), still covered by the existing warning line.