### PR TITLE
modern-chat: Fix peek overlay ignoring configured chat colors

### DIFF
--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=57e354f10968fd9453716cf5fde3a5cd818f381a
+commit=7d441b1f27a77d53bfd29692bdb774ea587c56b0


### PR DESCRIPTION
Bug fix for https://github.com/BenDol/Modern-Chat/issues/62