### PR TITLE
Update buddies

### DIFF
--- a/plugins/buddies
+++ b/plugins/buddies
@@ -1,3 +1,3 @@
 repository=https://github.com/CampbellTrevor/buddies.git
-commit=2923b356c35d8ff91448c07a457471fabfc2cdcb
+commit=0d1cb0f07aff9a5cbb8a8e52592e88980dbafac8
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Summary

- Removes the user-configured shared room key.
- Automatically joins every Buddies client to one stable built-in presence room.
- Keeps received presence restricted in the UI to existing online RuneLite friends.
- Updates the setup, protocol, and privacy documentation for the new trust model.

The room identifier is intentionally public and is not authentication. No dependencies or build configuration changed; Buddies remains a standard build using RuneLite's injected OkHttp client.

## Verification

- Java 11 clean build
- 23 tests passed; the opt-in live-server integration test was skipped because BUDDIES_INTEGRATION_URL was not set