### PR TITLE
update aura-tracker

### DIFF
--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Matelaa/aura-tracker.git
-commit=3483eacac3740ecad61a2bba325da9e61c08cbfb
+commit=3225c9c6894e0f75f3fb163e32c696462356b8aa
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Fixes GE area detection missing real, standable tiles near the west and east walls.

The courtyard is an octagon (a square with its four corners cut on the diagonal), not a rectangle. The previous bounding box was narrow enough to exclude the corners but that also excluded valid tiles along the flat west/east edges. Rebuilt as the intersection of two axis-aligned ranges and two diagonal ranges (x+y, x-y), with all eight bounds walked and read in-game via the RuneLite Developer Tools' Location overlay.

Version bumped to 1.1.