### PR TITLE
update deathbank-utility

### DIFF
--- a/plugins/deathbank-utility
+++ b/plugins/deathbank-utility
@@ -1,2 +1,2 @@
 repository=https://github.com/jakevollkommer/deathbank-utility.git
-commit=8f48e82de171d13fb2f4024e8b585e88549a57de
+commit=4a1a0a22232ca72c820c40b1717700ab00281d9b


### PR DESCRIPTION
Marks which items in the retrieval chest came out of the looting bag, and estimates what was lost before the player reaches the chest.

- The client is told the looting bag's contents whenever an item goes in, so that sighting is kept, persisted per profile, and stamped onto the deathbank at death. Those items are outlined by their own shape with a looting bag badge, and grouped in their own side panel section.
- The estimate of what was lost is now reliable. It snapshots from the tick before the death, since the inventory can already be empty by the time ActorDeath fires, and refreshes until it settles, since the server moves items to the chest several ticks after respawn.
- The looting bag itself is no longer reported as sitting in the deathbank. It is destroyed on death and its contents deposited in its place.
- An inferred deathbank clears itself when those exact items come back into the player's possession, which is what happens after a Theatre of Blood death that returns items at the end of the raid.
- Sidebar icon is the Deadman bank key rather than a hand drawn chest, and side panel text no longer overflows the panel edge.