### PR TITLE
Create FlippingRS.com plugin

### DIFF
--- a/plugins/flipping-rs
+++ b/plugins/flipping-rs
@@ -1,2 +1,2 @@
 repository=https://github.com/jmwri/flipping-rs-runelite.git
-commit=1af952f98550ff8266bba088658376be890e5d8d
+commit=d3473400e293e308385461eb289b7a87f40387ac

--- a/plugins/flipping-rs
+++ b/plugins/flipping-rs
@@ -1,2 +1,3 @@
 repository=https://github.com/jmwri/flipping-rs-runelite.git
 commit=d3473400e293e308385461eb289b7a87f40387ac
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/flipping-rs
+++ b/plugins/flipping-rs
@@ -1,0 +1,2 @@
+repository=https://github.com/jmwri/flipping-rs-runelite.git
+commit=546c45ad6a2977ff00d77bbe1f199928fbcbc567

--- a/plugins/flipping-rs
+++ b/plugins/flipping-rs
@@ -1,2 +1,2 @@
 repository=https://github.com/jmwri/flipping-rs-runelite.git
-commit=c901a02b1c580dd59c84fb4f9cb825501a5cd148
+commit=1af952f98550ff8266bba088658376be890e5d8d

--- a/plugins/flipping-rs
+++ b/plugins/flipping-rs
@@ -1,2 +1,2 @@
 repository=https://github.com/jmwri/flipping-rs-runelite.git
-commit=546c45ad6a2977ff00d77bbe1f199928fbcbc567
+commit=c901a02b1c580dd59c84fb4f9cb825501a5cd148


### PR DESCRIPTION
Adds FlippingRS, which records the player's Grand Exchange trades to their journal on flippingrs.com (a third-party site I run) and shows their journal, watchlists and item prices in a side panel.

**Please attach a warning.** The plugin sends data to a third-party service that is not run or verified by RuneLite. Suggested text:

> This plugin sends your Grand Exchange trades, open offers, Grand Exchange history and a FlippingRS API key to flippingrs.com, a third-party service not controlled or verified by the RuneLite developers. Your character name is not sent.

## What it sends, and where

Everything goes to one fixed host, `https://flippingrs.com`, over TLS, under `/api/plugin/`. The host is a constant in `FlippingRsApi`, not a setting. There is a "Server URL" setting, but it is only read when the client was started with `--developer-mode` and is ignored otherwise (`FlippingRsPlugin.baseUrl`), so an ordinary install cannot be redirected.

Sent, with the user's API key as a header:
- each Grand Exchange fill: item, quantity, price, gp moved, buy or sell, slot, world, time
- the state of the eight offer slots (on login, on opening the exchange, after sends)
- the rows of the Grand Exchange history screen, read off its widgets when opened
- watchlist additions and removals, and closing or deleting a position from the panel

Read back for the panel: the user's journals, plan, recent trades, open positions, watchlists and item quotes.

Not sent: display name, account hash, anything about other players, inventory, bank, location or chat. The plugin reads `GrandExchangeOfferChanged` events, the GE offer and history widgets, `VarPlayerID.TRADINGPOST_SEARCH` for the item on the offer setup screen, item names and prices from `ItemManager`, and `WorldType`.

Nothing is sent until an API key is entered, and nothing at all while the "Record trades" setting is off.

## Guideline points worth checking

- Menu entries: two are added on GE items ("View item", "Add to watchlist"). Both are `MenuAction.RUNELITE` (`GeMenu`); neither sends anything to the game server. Hooked on `MenuOpened`.
- Overlay: one small `OverlayPanel` on the offer setup screen showing the site's buy and sell price for the item, only when that item is on the user's watchlist (`GeQuoteOverlay`). Informational; it does not fill in or change anything.
- No widget modification, no click-through, no menu swapping, no automation. Config writes are to the plugin's own group only.
- Trades on Deadman, seasonal, beta, tournament, speedrunning, PvP Arena and Fresh Start worlds are not recorded.
- Network runs on the plugin's own two single-thread executors, never the client thread. A 30-second call timeout is set on a `newBuilder()` of the injected `OkHttpClient`.
- Disk: pending fills are written to `~/.runelite/flippingrs/queue-<accounthash>.json` so a crash or a bad connection does not lose a trade; refused fills go to `dropped-<accounthash>.json` beside it. Nothing else is written outside RuneLite config.

## Build

`build=standard`. Every dependency is a transitive of `runelite-client`; Lombok is used for `@Slf4j` only. `./gradlew test` runs 162 tests covering the tracker, the disk queue, the HTTP client against a mock server, the GE menu and history reader, the panel, and the plugin's orchestration.

Source: https://github.com/jmwri/flipping-rs-runelite