### PR TITLE
add tithe farm coach

### DIFF
--- a/plugins/tithe-farm-coach
+++ b/plugins/tithe-farm-coach
@@ -1,0 +1,2 @@
+repository=https://github.com/GalesongAS/tithe-farm-coach.git
+commit=550f5268c4c017f055030709315e7074f7d2371c

--- a/plugins/tithe-farm-coach
+++ b/plugins/tithe-farm-coach
@@ -1,2 +1,2 @@
 repository=https://github.com/GalesongAS/tithe-farm-coach.git
-commit=550f5268c4c017f055030709315e7074f7d2371c
+commit=f517e8148a0806cfec02cccad38926e122f41b8e


### PR DESCRIPTION
Adds **Tithe Farm Coach**, a read-only, one-step-at-a-time route guide for Tithe Farm.
Existing Tithe Farm plugins provide useful timers and tracking. This plugin focuses on a Quest Helper-style workflow: it observes plant and inventory state, highlights one suggested action, and advances when the game state changes. Supported actions include planting, watering, harvesting, depositing fruit, and refilling watering cans.
It supports five methods with progressively tighter timing, based on the methods present in the wiki strategy article (I swear the wiki wasnt harmed)

Every gameplay action remains with the player.

Repository: [https://github.com/GalesongAS/tithe-farm-coach](https://github.com/GalesongAS/tithe-farm-coach)\
Commit: `550f5268c4c017f055030709315e7074f7d2371c`