### PR TITLE
coffer: bump to c5639bf (0.1.2-beta)

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=a5b6a767f9e0c70e8ee348c7f323cf3147acaee2
+commit=c5639bf650a87265cac28475f792a332be41ae01
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Update the `coffer` plugin to commit `c5639bf` (0.1.2-beta).

Change since the last release (`a5b6a76`):

- **Flip filters + Risk tolerance in Settings.** The panel's Settings cog gains a **Risk tolerance** selector (conservative / balanced / aggressive) that fills four flip filters — minimum hourly volume, minimum margin, minimum ROI, and fill target — plus a collapsed **Advanced** section to hand-tune them. These preferences are now sent with each suggestion request so results respect the user's chosen liquidity/quality floor (previously only bankroll/slots/pace/access were sent).

No new API usage, no new dependencies, no new config surface beyond the in-panel settings. `okhttp3`/`gson` remain injected; file access stays within `RUNELITE_DIR/coffer/`. Data sent is unchanged in kind (login/register → session token; GE offers and completed trades), still covered by the existing warning line.