### PR TITLE
Add Mouse Tab Switcher

### DIFF
--- a/plugins/mouse-tab-switcher
+++ b/plugins/mouse-tab-switcher
@@ -1,0 +1,2 @@
+repository=https://github.com/JD-Michelena/MouseTabSwitcher.git
+commit=678fe297f8f574c9cf0a77f7519a4c3ea406e55b

--- a/plugins/mouse-tab-switcher
+++ b/plugins/mouse-tab-switcher
@@ -1,2 +1,2 @@
 repository=https://github.com/JD-Michelena/MouseTabSwitcher.git
-commit=678fe297f8f574c9cf0a77f7519a4c3ea406e55b
+commit=dcc9431828a06ba001b32cccb76256af3e1d1e36


### PR DESCRIPTION
Adds Mouse Tab Switcher, a RuneLite plugin that allows users to assign Mouse 4 and Mouse 5 to supported OSRS interface tabs.

Features:
- Configurable Mouse 4 and Mouse 5 tab assignments.
- Option to disable either mouse button.
- Supports multiple OSRS interface tabs.
- Includes Logout.