### PR TITLE
Update groupscape to ab29165

### DIFF
--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=d3f7dcf5b11bc718454f675bae71a11cdf8ed387
+commit=ab2916547818567d0b7b68d6f16b4847ec9b8fca
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates GroupScape to the latest commit (v1.8.4), tagged in the source repo.

Since the last update (v1.7.5), this adds:
- Raid markers: right-click/shift-right-click Danger, Defend, Loot, Focus, plus numbered (1-4) and lettered (A-D) callouts, with per-type hide toggles
- Group pings on NPCs/tiles, shown on minimap, world map, and the group's website map
- Group member position markers on the world map and minimap
- More reliable boss kill/loot detection (now tracks all monsters, not just a curated list)
- "[gs]" prefixed, colored chat messages for group notifications/pings/kill-loot lines
- Various reliability fixes for pings, raid markers, and connection heartbeats