### PR TITLE
update combatglance

### DIFF
--- a/plugins/combatglance
+++ b/plugins/combatglance
@@ -1,2 +1,2 @@
 repository=https://github.com/George-API/combatglance.git
-commit=40e951cd6a3001c92cabaa9f2ff539596b957409
+commit=b22fd24092ac60ef68843c57d44677a75c33938d


### PR DESCRIPTION
## Summary
- Add a Tick HUD only setting that hides the Combat Glance card (cells, labels, headers, attack timer) while keeping the tick-progress bar visible
- Tick sound remains its own config-panel setting and is unchanged

Plugin repo commit: George-API/combatglance@b22fd24092ac60ef68843c57d44677a75c33938d

## Test plan
- [x] `./gradlew test` passes in George-API/combatglance
- [ ] Enable **Tick HUD only** in Combat Glance config: only the tick-progress bar remains on screen
- [ ] Confirm tick sound still plays when **Tick sound** is enabled
- [ ] Disable **Tick HUD only**: full card returns