### PR TITLE
loadout-lab: update to 0.4.3

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=a94ebdf5445e6b19caa2a4d150bea20c716316b9
+commit=ade3fe332dd36ae0dfc5cc18ecc2f355909f6756
 authors=ajkatz


### PR DESCRIPTION
One field fix, reported by **Not on Hand** (thank you again!): picking "None" for the prayer on a card with no boost assumed erased both assume icons - and the icons are the pickers, so there was no way to pick a prayer back without hitting Back. The empty state now renders sentinel icons (the prayer-book wings and a muted dash) that stay clickable.

fixes https://github.com/AKAddons/runelite-loadout-lab/issues/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)