### PR TITLE
Update 420 kc to 1.1.2

### DIFF
--- a/plugins/420-kc
+++ b/plugins/420-kc
@@ -1,2 +1,2 @@
 repository=https://github.com/420kc/420kcp.git
-commit=01e6c511a19da76dd2a2bb07e99809560c24ae0f
+commit=eabd1914062957b2e8562f0c9ceec1cac0dbdfcf


### PR DESCRIPTION
420 kc 1.1.2

* treasure trail completion totals now blaze at 420 across every clue tier
* public plugin copy now covers boss, activity, and clue counts