### PR TITLE
Update Everykill

### DIFF
--- a/plugins/everykill
+++ b/plugins/everykill
@@ -1,4 +1,4 @@
 repository=https://github.com/everykill/everykill-plugin.git
-commit=c48143ca6fce5a9ff198161e66abe9889818c1f9
+commit=e386e489d21003e65b20506f864acbb36a610a19
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.
 authors=Delkyy


### PR DESCRIPTION
- **Monster rows split by combat level.** Ordinary guards exist at combat 19, 20, 21 and 22, so a player who killed a few saw three separate "Guard" rows. Rows now group by name and the label carries the levels — `Guard (19, 21, 22)` — which keeps genuine distinctions visible (`Xarpus (331, 960, 1160)` is entry/normal/hard mode ToB) without inventing a rule about which levels count as the same monster. The Records tab had the same bug on a second code path and reported the wrong "most killed".
- **The overlay drew over cutscenes.** Now checks `VarbitID.CUTSCENE_STATUS`, same as core's `TileIndicatorsOverlay`.
- **A monster count in the README was wrong** — it said 1,757, the real figure is about 1,300.

New:

- **Awakened DT2 bosses report a variant.** They reuse their npc id across quest, post-quest and Awakened, so combat level is the only signal that separates them and only the client can see it.
- **Helmet and title picker** on the panel, for the cosmetics the site awards. Sprites come from `ItemManager`'s existing cache — no new network calls for images.
- The upload toggle now states that kills counted while it was off are never sent retroactively.

209 tests. No new dependencies.
