### PR TITLE
Update ClanHQ activity verification and task UI

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=d2ec011fb9e080a4919c93b645daf6efaa2e739f
+commit=8ebd37b41dc5850c26f6a60bdec8822e921ab354


### PR DESCRIPTION
## Changes
- Update the ClanHQ task UI and overlay from Minigame to Activities.
- Add live RuneLite verification for Pest Control, Hunter Rumours, Fishing Trawler, Barbarian Assault waves, Giants' Foundry, Mahogany Homes, Agility laps, and Tithe Farm deposits.
- Use Jagex completion counters, varbits, and RuneLite course endpoints where available; the server remains authoritative for task matching and rewards.
- Include the recent Overview all-time DripDrops and leaderboard-rank display fixes.

## Privacy and behavior
- Activity telemetry is sent only from a paired installation for the currently logged-in RSN.
- Telemetry contains the recognized activity, positive quantity, timestamp, and limited signal metadata; it does not expose bank or inventory contents.
- Existing complete-character submission remains explicitly player initiated and confirmation gated.
- The plugin does not perform game actions, award currency, or modify clan ranks.

## Testing
- Full RuneLite plugin test suite passed against the exact submitted source.
- Added coverage for every direct activity detector, completion-counter deltas, Tithe resets, both Colossal Wyrm courses, and all supported standard Agility endpoints.