### PR TITLE
Add Stations Party Pings

### DIFF
--- a/plugins/stations-party-pings
+++ b/plugins/stations-party-pings
@@ -1,0 +1,2 @@
+repository=https://github.com/StationEarthxo/stations-party-pings.git
+commit=ce10ee1b40893127dfa413002c41f10ae43d6303


### PR DESCRIPTION
## Summary
- Adds a League-inspired eight-direction radial ping wheel for RuneLite parties
- Shares user-selected tiles and ping types through RuneLite's built-in PartyService
- Includes configurable wheel size, duration, sounds, labels, icon size, halo, tile marking, and standard tile-ping fallback
- Uses bundled resources only and has no third-party runtime dependencies or servers

## Testing
- `./gradlew test`
- Verified two development clients in the same RuneLite Party can exchange custom pings in both directions
- Verified the sender renders locally without relying on websocket echo
- Targets Java 11 and uses the standard Plugin Hub build