### PR TITLE
Update scavenger

### DIFF
--- a/plugins/scavenger
+++ b/plugins/scavenger
@@ -1,2 +1,2 @@
 repository=https://github.com/Guobmin/runelite-scavenger.git
-commit=6af4fe89c9ebbbc7ae892de7a71d14338e16d3b9
+commit=1d932c38eca4628333e92345c9f037ed3ed177a0


### PR DESCRIPTION
Minor world map fixes/polish for Scavenger:

- World map marker now routes to the cave/dungeon entrance (matching the
  minimap and world-tile overlays), instead of pointing at the raw
  underground spawn tile through solid rock.
- Restored the dot's blink and original size (14px) so it stays easy to
  spot; the off-screen arrow stays larger (34px) and solid instead of
  blinking, since it's already a directional indicator.

Version bumped to 1.2.