### PR TITLE
update irons-pub-bingo

### DIFF
--- a/plugins/irons-pub-bingo
+++ b/plugins/irons-pub-bingo
@@ -1,4 +1,4 @@
 repository=https://github.com/KaosRichie/irons-pub-bingo.git
-commit=64f2ae1e56b58f2ae37e735f9b98d05e31f73aab
+commit=b437a118ec815abbfb85f0bb433f21fe8e29819f
 authors=KaosRichie
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Loot now comes from ServerNpcLoot, so inventory-delivered drops and pickpockets count. Drop and loot value goals can restrict loot kinds (kill/pickpocket/other). Credit requests can attach a proof screenshot via the player's own Discord webhook (existing opt-in). Editing what a tile tracks resets only that tile's progress. Various panel and message fixes.