### PR TITLE
Create doom-delve-advisor

### DIFF
--- a/plugins/doom-delve-advisor
+++ b/plugins/doom-delve-advisor
@@ -1,0 +1,2 @@
+repository=https://github.com/James-K-Lawson/doom-delve-advisor.git
+commit=73575ccc585d8ad7873648a328acf265ae696c41


### PR DESCRIPTION
Adds Doom Delve Advisor, a display-only claim-vs-descend advisor for the
Doom of Mokhaiotl delve. It reads the reward screen and chat to estimate
the expected value of pushing versus banking, and shows a recommendation
plus a per-level stats panel. It never interacts with the game.