### PR TITLE
Fix ClanHQ Barbarian Assault wave tracking

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=8ebd37b41dc5850c26f6a60bdec8822e921ab354
+commit=d1a7f0f80bbe59880b8cc7e93bbd23c1b54b29f1


### PR DESCRIPTION
Updates ClanHQ to detect Barbarian Assault wave completions from the wave-complete interface and RuneLite's actual numbered duration message. The two signals are deduplicated, so each completed wave contributes exactly one progress increment. The standalone plugin test suite passes (56 tests).