### PR TITLE
Update groupscape to 5e0530e

### DIFF
--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=ab805fae00ab63295c8a625c2572509cfeaffc60
+commit=03760b2e53969e57786dbcab2ef4e3366f1d21b5
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=03760b2e53969e57786dbcab2ef4e3366f1d21b5
+commit=1edc4dfb4c3a41c8c553a5f76779d683edb08665
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=1edc4dfb4c3a41c8c553a5f76779d683edb08665
+commit=5e0530ef1cffbb1a8ad8dc3e40d5d5f47df6afbb
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=ed4cea37da79f95fbaa49629a770301b5b6fa552
+commit=16119ab901ae1f6c616eb2554c9598fdc82f1bb8
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=16119ab901ae1f6c616eb2554c9598fdc82f1bb8
+commit=154bb8413fd8c4eb2f377c8613c24bb6917e8fb7
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=154bb8413fd8c4eb2f377c8613c24bb6917e8fb7
+commit=ab805fae00ab63295c8a625c2572509cfeaffc60
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=ab2916547818567d0b7b68d6f16b4847ec9b8fca
+commit=ed4cea37da79f95fbaa49629a770301b5b6fa552
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Brings the deployed groupscape plugin up to v1.8.7.

- Fixed a false "died" report showing up on the group's activity feed when you hadn't actually died.
- Finishing a raid (Chambers of Xeric, Theatre of Blood, or Tombs of Amascut) now reports it to your group's Activity Feed, along with difficulty and reward chest value.
- Discord boss kill notifications now show your account's real kill count instead of a count GroupScape happened to see logged on its own server.
- Fixed loot going missing from the Activity Feed/Discord for bosses that split their drop across more than one loot roll per kill (e.g. Vet'ion).
- Fixed kills, loot, and deaths sometimes appearing twice in the Activity Feed and Discord around a GroupScape server restart.
- Your current slayer task, master, points, and streak are now reported to your group, so the website can show them in each member's side panel.
- Fixed the Corrupted/Crystalline Hunllef never showing up as a kill, and the Gauntlet reward chest loot never showing in the Loot Log.
- Fixed your own row in the party overlay always showing a gold accent bar instead of your assigned helmet colour.
- Fixed Tombs of Amascut (and occasionally Chambers of Xeric) completions sometimes not appearing in the Activity Feed at all.
- Fixed collection log unlocks not syncing to your group until you next opened your collection log.
- Fixed deaths (and any kill/loot alongside them) sometimes not appearing in the Activity Feed, toasts, or Discord at all.
- Combat achievement progress now syncs to the site immediately instead of waiting up to a minute (or a relog).
- Fixed a slayer task's assigning master getting stuck showing as unknown after a client restart mid-task.
- Boss slayer tasks (Leviathan, Whisperer, Vardorvis, Duke Sucellus) now show the actual boss name to your group instead of just "Boss".
- Fixed collection log items with an apostrophe in their name (e.g. Beekeeper's gloves) sometimes not syncing until you next opened your collection log.
