### PR TITLE
update to 1.0.60

### DIFF
--- a/plugins/osparty
+++ b/plugins/osparty
@@ -1,4 +1,4 @@
 repository=https://github.com/osparty/osparty.git
-commit=2756a5751854bab678de974f3908cde33e9a9cac
+commit=8e853493f4a9d4de6588b5b589dcbd708dbb1a15
 authors=iodrareg
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Type !p followed by a message to chat with your party.
- Type !p alone to toggle party chat mode on/off.
- RuneLite chat commands work inside party chat.
- Choose where party messages appear and customize the prefix.
- Messages from blocked players are hidden.
- Type !osparty to advertise your party in public, friends, or clan chat.
- Other OSParty users can click the chat line to apply for the party.
- Applications use the same checks and role picker as the Search tab.
- Clickable !osparty lines can be disabled.
- Parties created at the CoX board, ToB notice board, or ToA obelisk can be advertised automatically.
- Party details are filled from the game and your previous raid settings.
- ToB and CoX let you choose your role directly from the advertisement.
- Choose between Ask me, Always advertise, or Off.
- CoX and ToA ads can automatically follow in-game scale or invocation changes.
- In-game board syncing can be disabled.
- Use Find me a party to get offers for matching parties.
- Offers can appear as a sidebar banner, in-game card, or both.
- Creating a party now checks for existing parties doing the same activity and offers to join them first.
- Handle party invites, join requests, and party offers directly from chatbox cards.
- Cards show applicant stats, KC, and warnings.
- Accept or decline from either the card or side panel.
- The old pending-applicant corner overlay has been removed.
- Customize the defence tracker with current level, current/starting level, percentage, or combinations.
- Choose how drained defence is displayed.
- Customize magic-defence information.
- Choose levels or percentage drained for thresholds.
- Optionally show the full defence level for monsters with a defence floor.
- Optional sounds are available for ready checks, kicks, map pings, and friends-chat requests.
- All event sounds are off by default.
- Party members with Vengeance active show the spell icon on their model and in the Party tab.
- The Vengeance icon disappears once it is consumed.
- Ad reports now allow up to 500 characters explaining what is wrong.
- All ironman variants, including unranked group ironmen, are now correctly recognized for ironman-only parties.
- Other players' account identifiers no longer leave the server.
- Board cards and rosters now identify players using anonymous OSParty IDs.
- New settings cover raid party advertising, raid party prompts, following the in-game board, checking for similar parties, party-finding notifications, party chat, chat prefixes, event sounds, and defence tracker display options.