### PR TITLE
update aura-tracker

### DIFF
--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Matelaa/aura-tracker.git
-commit=3225c9c6894e0f75f3fb163e32c696462356b8aa
+commit=14b596f046111d1cddc0aa390fb28254e9d410f8
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Two fixes to first-sync rejections that were silently permanent for legitimate players:

- A brand-new device claiming a name already owned by another device now checks the incoming request's account hash (RuneLite's `Client#getAccountHash()`, hashed before ever being stored — the raw value is never sent to nor kept by the backend) against the one on file for that name. A match means a real reinstall, not a stranger, and the name migrates to the new device instead of staying locked to an abandoned one forever.

- The OSRS Hiscores API returns "not found" both for names that were never real accounts and for genuinely new, not-yet-ranked ones. A device still failing the same check a full day later now falls through to account creation instead of being rejected forever on that ambiguity.

Version bumped to 1.2.