### PR TITLE
Update Lively Cities: two appearance fixes and per-city liveries

### DIFF
--- a/plugins/lively-cities
+++ b/plugins/lively-cities
@@ -1,3 +1,3 @@
 repository=https://github.com/MatthewMariner/lively-cities.git
-commit=76f14938836e9e9cdfcefa81884a4d3d625c6f0f
+commit=1d2a2a0ccbd9efc7554d235b30634132850e39e5
 authors=MatthewMariner


### PR DESCRIPTION
One-line manifest bump, `76f1493` → `1d2a2a0`.

### Fixes

**Citizens could render a skin tone on their leg slots**, which reads in game as a passer-by wearing no trousers. Two causes:

- At the `Crowded` density the plugin derives extra figures by rotating a citizen's recolour palette. The rotation was slot-blind — the colour authored for one body region landed on another, so a face tone could be applied to a pair of legs. A rotation may now only permute colours within the flesh class and within the non-flesh class.
- Seventeen authored records painted a leg slot a colour inside the flesh gamut. The rule is categorical now rather than exact-match, and calls the plugin's own predicate so the two cannot drift apart.

Also repairs 47 citizens that were genuinely missing a body slot. Twenty of those were one fault: a hood model pasted where legs and boots belong.

### New

127 additional citizens, each wearing the livery of the city it stands in. Purely additive — no pre-existing record is modified, and the distinct model id and animation name counts are unchanged, so no existing figure's appearance can shift.

### Notes for review

- No new dependencies, no new client APIs, no file I/O, no configuration migration.
- All models and animations are ids already present in the game cache; the vendored data and the twelve modifications made to it are disclosed in `NOTICE`.
- 506 tests, green, including placement lint and the render-budget caps.