### PR TITLE
Add Jam's Solo Tempoross

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,0 +1,2 @@
+repository=https://github.com/JamsRepos/jams-solo-tempoross.git
+commit=957cd6ab24aa83a2f55ea5d5a50aae590d90e526

--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=957cd6ab24aa83a2f55ea5d5a50aae590d90e526
+commit=cea14ef8d91f247db1d681cbd03c0d59b183b7ef


### PR DESCRIPTION
## Summary

- Adds **Jam's Solo Tempoross**, a click-here helper for the 16/19/19 solo Tempoross rotation (west boat, north island)
- Highlights the next click, draws a path (avoiding fires), shows a compact status panel, deposit countdown with optional chimes, and recovery when you fall off rotation
- Manual-click guidance only — no automation or input injection

## Test plan

- [x] Unit tests pass (57 tests)
- [x] shadowJar builds cleanly
- [x] Verified in-game: full 16/19/19 rotation, deposit countdown, douse, spirit pool, recovery, and leave/solo-start loop