### PR TITLE
re-enable object-name-markers

### DIFF
--- a/plugins/object-name-markers
+++ b/plugins/object-name-markers
@@ -1,3 +1,2 @@
 repository=https://github.com/jtclowner/object-name-markers.git
-commit=e5be0018cdbbd5a6a0002636c70aaacdfe66bed7
-disabled=true
+commit=7d98d24a0d3c10c86494e6839f65d6f885715e21


### PR DESCRIPTION
Re-enables Object Name Markers after **removing configurable tile-radius expansion** beyond the tiles occupied by matched objects. This removes the ability to configure the plugin to show an object's surrounding tiles to "automatically indicate where to stand or not stand", bringing the plugin in line with Plugin Hub guidelines.

The updated plugin:

- Limits tile highlights to tiles occupied by the matched object.
- Accepts legacy `name:<number>` configurations for compatibility with existing user settings, but ignores the numeric suffix and applies no expansion.