### PR TITLE
Update Jam's Solo Tempoross to 1.0.2

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=cea14ef8d91f247db1d681cbd03c0d59b183b7ef
+commit=f9478abd66dca46c7bab68aa806da6c4cc439b99


### PR DESCRIPTION
## Summary

- Updates commit for **Jam's Solo Tempoross** 1.0.2
- Changelog now notes the rename from Easy Tempoross

## Test plan

- [x] Unit tests pass
- [x] Only manifest commit hash changed