### PR TITLE
Update live-on-clan

### DIFF
--- a/plugins/live-on-clan
+++ b/plugins/live-on-clan
@@ -1,3 +1,3 @@
 repository=https://github.com/MilicoOSRS/live-on-clan.git
-commit=8f69ae9b1906f75fe2896d780fb6858d4a969139
+commit=3ea822805a874a0a1e374e317e7229046bb845b4
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Live On Clan Update

- Shows each member’s position in the Drops, EHB, and EHP rankings.
- Improves drop tracking for valuable untradeable items and retries failed submissions without duplicates.
- Includes minor layout and text corrections throughout the plugin.

`./gradlew test` passes.