### PR TITLE
Update Jam's Skiller Guard to 1.1.4

### DIFF
--- a/plugins/skiller-guard
+++ b/plugins/skiller-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/skiller-guard.git
-commit=e6912e23c37e0b8435d53ab3dda5e6fa59dda6d5
+commit=338de5fa8ee503381ed73b5ddc0bb466c6006ba6


### PR DESCRIPTION
## Summary

- Renamed from Skiller Guard to Jam's Skiller Guard

## Test plan

- [x] Unit tests pass
- [x] Only manifest commit hash changed