### PR TITLE
Update Jam's Blast Mine to 1.1.1

### DIFF
--- a/plugins/blast-mine-improved
+++ b/plugins/blast-mine-improved
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/blast-mine-improved.git
-commit=133dd6ed2b452b3c5a5002c04531d15c6fe09df0
+commit=95abf5c686c51ecf7a05c9996ef0a99df31990b1


### PR DESCRIPTION
## Summary

- Renamed from Blast Mine Improved to Jam's Blast Mine

## Test plan

- [x] Unit tests pass
- [x] Only manifest commit hash changed