### PR TITLE
Update Jam's Arceuus Runecrafting to 1.0.3

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=6bed8ac1a7468aca2495879ac428c5dc38ff410d
+commit=52e2463221df66ea0a8c96c5e2aee1151cbf6ab2


### PR DESCRIPTION
## Summary

- Renamed from Zeah RC Helper to Jam's Arceuus Runecrafting

## Test plan

- [x] Unit tests pass
- [x] Only manifest commit hash changed