### PR TITLE
Update Jam's Solo Tempoross to 1.0.4

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=cea14ef8d91f247db1d681cbd03c0d59b183b7ef
+commit=58d65fb93a5ca4ebeffa826534bf4ced45b184bb

--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=58d65fb93a5ca4ebeffa826534bf4ced45b184bb
+commit=6cbf73e884043f446d444ef3d4d2e9bb4c860187


### PR DESCRIPTION
## Summary

- Updates to 1.0.3
- Renamed from Easy Tempoross to Jam's Solo Tempoross
- Fixed Plugin Hub description encoding (replaced em dash with ASCII hyphen)

## Test plan

- [x] Unit tests pass
- [x] Only manifest commit hash changed