### PR TITLE
Update Jam's Solo Tempoross to 1.0.4

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=60da6409ca5f2a57e51ac233c4552e7d17bebe0d
+commit=ddfa449151e6bce0bacf85a16995a1530d505652

--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=cea14ef8d91f247db1d681cbd03c0d59b183b7ef
+commit=60da6409ca5f2a57e51ac233c4552e7d17bebe0d


### PR DESCRIPTION
## Summary
- Independent plugin chime volume and an All Actions / Deposit Only stop-sound option (1.0.3)
- Path lines no longer snap to a stale waypoint and draw a V; if collision cannot walk a route, the line still draws from your current tile (1.0.4)
- Updated plugin icon (48x72)

## Test plan
- [x] Unit tests pass
- [x] Pathing verified in-game (dock solo-start and former V cases)
- [x] Icon is a real PNG at 48x72