### PR TITLE
update impling-finder

### DIFF
--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=bf60bdd8b7bef3c6a60588eeed050770dee9e21d
+commit=123b52e98c18712891cb0635b88deb8f4b0ec7ac
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Makes Supabase the primary read/write source for everyone, replacing Oracle as the default. Oracle is now used automatically as a fallback only. If a Supabase write or read fails, that specific request falls back to Oracle (write fallback limited to the 5 types Oracle's schema supports). The dual-write/dual-read testing toggles have been removed since this is no longer opt-in.