### PR TITLE
Update Faux Bingo Plugin to not cache team icons

### DIFF
--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,3 +1,3 @@
 repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
-commit=51f26a185805cfe9fd9ac3e725d9c075b8c76f86
+commit=dd4b7cbeea9859970902c0392f4b8ef1b05b41a9
 authors=ThatOhio


### PR DESCRIPTION
We only pull these icons once at the start of any one plugin session, so caching them is not strictly necessary, and being able to quickly update the icons is worth it to us in this case. 

Also a small targeted fix to better sanitize player names to better support spaces in names.