### PR TITLE
Create weight-overlay

### DIFF
--- a/plugins/weight-overlay
+++ b/plugins/weight-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/lundquistaj-coder/weight-overlay.git
+commit=59d5685356a65c3eb33d04d00ff4b80db14f8ce6

--- a/weight-overlay
+++ b/weight-overlay
@@ -1,0 +1,2 @@
+repository=<https://github.com/lundquistaj-coder/weight-overlay.git>
+commit=59d5685356a65c3eb33d04d00ff4b80db14f8ce6

--- a/weight-overlay
+++ b/weight-overlay
@@ -1,2 +1,0 @@
-repository=<https://github.com/lundquistaj-coder/weight-overlay.git>
-commit=59d5685356a65c3eb33d04d00ff4b80db14f8ce6


### PR DESCRIPTION
A lightweight RuneLite plugin that displays your character's current carried weight directly on screen, so you don't have to dig through the equipment inspection panel to check it.