### PR TITLE
Add Bank Tab Storage

### DIFF
--- a/plugins/bank-tab-storage
+++ b/plugins/bank-tab-storage
@@ -1,2 +1,2 @@
 repository=https://github.com/TimoklDev/bank-tab-storage.git
-commit=b5e89e7bfba81f43f4a45a8f813075f662feb177
+commit=c0c27185ffe9c4635c1708299ec9b9cf7c5160e6

--- a/plugins/bank-tab-storage
+++ b/plugins/bank-tab-storage
@@ -1,0 +1,2 @@
+repository=https://github.com/TimoklDev/bank-tab-storage.git
+commit=b5e89e7bfba81f43f4a45a8f813075f662feb177


### PR DESCRIPTION
Bank Tab Storage is a plugin that allows the user to easily store, hide, show, import, and export bank tabs that utilize the bank tags plugin.

It stores the data in the active runelite profile, and only accesses the clipboard when following explicit user actions (import/export).
It does not make any network requests.

This plugin was made because the tag tabs were getting overwhelming for me, i had so many of them and after trying to manage a spreadsheet i figured making a plugin for runelite would be the better option.