### PR TITLE
slayer alternatives: combat-style icons + abyssal demon catacombs fix

### DIFF
--- a/plugins/slayer-alternatives
+++ b/plugins/slayer-alternatives
@@ -1,2 +1,2 @@
-repository=https://github.com/Delkyy/slayer-alternatives.git
-commit=7eabbc957817acc5e2206087a670b74b4d621a65
+repository=Delkyy/slayer-alternatives
+commit=79aef3bd6037afa768824c38a5b8076f09f1b4a8


### PR DESCRIPTION
Real skill icons (Attack/Ranged/Magic) + bring-item notes from the wiki task page, plus a data-scraper fix: the wiki lists Abyssal demon twice with the same name/level/xp but different locations — the dedup logic was dropping the second row instead of merging its location, so Catacombs of Kourend never appeared for the standard (non-greater, non-boss) variant.