### PR TITLE
update injury-animations

### DIFF
--- a/plugins/injury-animations
+++ b/plugins/injury-animations
@@ -1,2 +1,2 @@
 repository=https://github.com/xyg123/injury-animations.git
-commit=be16da31ba84f2b45adacde97f5152c4f9fa02f3
+commit=b106ceb42eaf740691b14b3a71d8bffaee30fd35


### PR DESCRIPTION
Changes the default injured HP threshold from 25% to 40%.

Existing saved configurations remain unchanged. The new default applies to new installations and configurations that are reset.