### PR TITLE
the-birdhouse: 1.2.0

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=5fe7185c5315c89fd462c6933f41fd32bd222e00
+commit=a7e213b1e5395dbcf232fbbb8a96bff785d9f332
 warning=This plugin submits your IP address, RSN, in-game screenshots, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=a7e213b1e5395dbcf232fbbb8a96bff785d9f332
-warning=This plugin submits your IP address, RSN, in-game screenshots, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.
+commit=ffd03ec841e26c9156b30d5a0b49af71902274a6
+warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
﻿Scope changed since this was opened: it now also adds an opt-in team chat panel, so the version is 1.2.0 rather than 1.1.2.

**1.1.2 (already in this PR)** — rendering fixes. Battleship cells were drawing full item names into grid squares and overlapping; they now draw a marker and put the name in the tooltip. Bounty cards were stretching and had no icons. Tile names were clipping instead of wrapping, because Swing's HTML renderer ignores a width on a div and only honours it on a table.

**1.2.0 (new)** — read and reply to your event team's chat in the plugin panel and the pop-out board window.

- Off by default, behind the standard third-party warning, which has been updated to mention chat messages.
- Nothing is written to the game chatbox. Messages are only ever drawn in the plugin's own Swing panels, and replies are typed into a Swing text field, never into the game.
- Every message field is HTML-escaped before it reaches a JLabel, since messages are player-authored.
- You only ever receive your own team's thread. The server takes the team from the room roster under your account, so naming another team cannot return its messages.
- One poller feeds both views, so opening the pop-out window does not double the request rate. Reads go to a cache host that serves them from a live database listener, and the poll backs off to five minutes when there is no thread to show.
- Chat images are not downloaded; a message with an image is shown as a placeholder.
