### PR TITLE
rs-flipper: lock GE slots, tidy up settings

### DIFF
--- a/plugins/rs-flipper
+++ b/plugins/rs-flipper
@@ -1,3 +1,3 @@
 repository=https://github.com/Ramon0205/rs-flipper.git
-commit=4c8dfa40f7cc447418a340218aa7575772914154
+commit=14b313e88d713b01d3e2ecd7a6c839ee7b19e1f6
 warning=This plugin submits your IP address, Grand Exchange offers and trade history to a 3rd-party server (api.rs-flipper.com) not controlled or verified by RuneLite developers. An account is required.


### PR DESCRIPTION
- Slots can now be locked with a padlock on the empty slot. A locked slot is
  left alone completely and gets a faint red outline. Replaces the "Ignored GE
  slots" text field, which nobody found.
- The GE hover tooltip is hidden while pointing at a slot with a running offer,
  where it clashed with the plugin's own readout. Empty slots keep it so the buy
  and sell buttons still explain themselves.
- "Target time to fill" is now "Preferred fill time" and works as a window
  instead of an upper limit. Setting 8h no longer hands you five-minute flips.
- Removed the old "Offer adjustment" setting. The fill time drives that now.
- Dump alerts show the 24 hour baseline next to the 4 hour one.
- Changing the dump setting applies straight away, and the skip key says when
  there is nothing to skip.

Commit: 14b313e88d713b01d3e2ecd7a6c839ee7b19e1f6