### PR TITLE
unachievements: 1.1.1

### DIFF
--- a/plugins/unachievements
+++ b/plugins/unachievements
@@ -1,2 +1,2 @@
 repository=https://github.com/Tommy-Knight/unachievements.git
-commit=e77923765dbd4937f90cbdd8642bec32d9b4d3c7
+commit=57c03957c8c034bb3cc2168146a331daa176e927


### PR DESCRIPTION
Fixes a conflict with Menu Entry Swapper. The plugin marked unexamined things from MenuEntryAdded, which hid the exact "Examine" option that the swapper anchors on, so shift right clicking an inventory or worn item lost its "Swap left-click" and "Swap shift-click" submenus. The mark now applies from MenuOpened at a lower priority.