### PR TITLE
bank-architect: point at the renamed repository

### DIFF
--- a/plugins/bank-architect
+++ b/plugins/bank-architect
@@ -1,2 +1,2 @@
-repository=https://github.com/PKoka5/ironman-bank-architect.git
-commit=4635b3d2e470f1c5b3c81ee54c49439045df9f38
+repository=https://github.com/PKoka5/bank-architect.git
+commit=54a5ddcfe5ec2b7a332290a52a35d47cb887e25f

--- a/plugins/bank-architect
+++ b/plugins/bank-architect
@@ -1,2 +1,2 @@
 repository=https://github.com/PKoka5/bank-architect.git
-commit=54a5ddcfe5ec2b7a332290a52a35d47cb887e25f
+commit=4635b3d2e470f1c5b3c81ee54c49439045df9f38


### PR DESCRIPTION
Repository URL only; the pinned commit is unchanged at `4635b3d`, so this is the same plugin build that is live today.

The repo was renamed from `ironman-bank-architect` to `bank-architect`, matching the plugin id and the display name. GitHub redirects the old URL, so nothing is broken either way — this just makes the marker point at the real address.

The 0.4.0 version bump follows as its own PR once this lands, as requested.