### PR TITLE
Update gok-irl-xp

### DIFF
--- a/plugins/gok-irl-xp
+++ b/plugins/gok-irl-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/mataeo-eh/GOK-IRL-XP.git
-commit=94aa87b5e080f49a0eae7e43a1ffce89bb37606c
+commit=b77fe83d6f3d5b4455979c52d7f9763ecfad273f


### PR DESCRIPTION
Adds per-skill level multipliers for banked XP, and regroups the settings panel so each option is findable.

**Level multipliers** — each skill gets its own ladder of user-defined thresholds (level -> multiplier), edited from a new sidebar tab. Thresholds do not stack: the highest one reached applies and replaces the lower one. Skills with no thresholds bank XP unchanged, so the feature is inert unless opted into. Applied at a single choke point so timers, logged work and manual deposits all scale exactly once; removals and in-game XP drain are unaffected.

**Settings** — the config items are now grouped into three named `@ConfigSection`s with plain-language descriptions, and item names read as instructions.

Two new `@Singleton` services (`XpMultiplierManager`, `SkillLevelTracker`), both persisting through `ConfigManager` with the injected `Gson`. No new dependencies, no banned APIs, Java 11, `./gradlew build` passes with 76 tests.