### PR TITLE
Add True Tile Player Indicators

### DIFF
--- a/plugins/true-tile-player-indicators
+++ b/plugins/true-tile-player-indicators
@@ -1,0 +1,2 @@
+repository=https://github.com/willzero123/true-tile-player-indicators.git
+commit=8ca66e55721b0f158f5805a855e017c34bab3d8c

--- a/plugins/true-tile-player-indicators
+++ b/plugins/true-tile-player-indicators
@@ -1,2 +1,2 @@
 repository=https://github.com/willzero123/true-tile-player-indicators.git
-commit=8ca66e55721b0f158f5805a855e017c34bab3d8c
+commit=d9ab60665e6ccf1dc8a7808d72564695debf317a


### PR DESCRIPTION
True Tile Player Indicators

Adds true tile highlights to the Player Indicators plugin, inheriting the same highlight options and colors from Player Indicators. Disabled in PvP.