### PR TITLE
Bank Tab Shortcuts

### DIFF
--- a/plugins/bank-tab-shortcuts
+++ b/plugins/bank-tab-shortcuts
@@ -1,0 +1,3 @@
+repository=https://github.com/iamthecodeDECODEDORG/runelite-bank-tab-shortcuts.git
+commit=3edcf1e3145684f5103dbfebaa8e6198d6fce64f
+authors=iamthecodeDECODED


### PR DESCRIPTION
Adds **Bank Tab Shortcuts**, a narrow keyboard-navigation plugin for native bank tabs.

- `Ctrl+1` through `Ctrl+9` open the corresponding existing bank tab.
- `Ctrl+Tab` cycles forward and wraps.
- `Ctrl+Shift+Tab` cycles backward and wraps.
- Shortcuts are inactive outside the visible bank and skip missing tabs.
- No runtime dependencies, networking, filesystem access, synthetic input, menu actions, or gameplay automation.

The standalone verifier passes 13 navigation/integration tests, source and JAR capability scans with mutation controls, strict dependency verification, and reproducible-JAR checks against RuneLite 1.12.37.