### PR TITLE
pocketge-flip-tracker: 0.3.0 -> 0.5.0

### DIFF
--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,2 +1,2 @@
-repository=https://github.com/lazyblob/pocketge-flip-tracker.git
-commit=8ce0f8a9eff13cc0548f7b78acb3edcf04131eb9
+repository=https://github.com/grant9008/pocketge-flip-tracker.git
+commit=77749d8819257c77430f1f771d303808e066e976


### PR DESCRIPTION
Also corrects the repository URL. The account was renamed lazyblob -> grant9008; GitHub still redirects the old one, so the build kept working, but the manifest should name where the repo actually lives.

Changes since 0.3.0, briefly: flip recommendations sized to liquid cash and free GE slots, a single recommendation card the GE offer screen and the watchlist take over rather than stacking cards under, the recommended price written onto the offer screen itself, a 4x2 GE slot grid matching the clerk's own layout, an item finder with 5-day extremes, named watchlists, and profit tags on stacks you already hold.


Claude-Session: https://claude.ai/code/session_01CrbbnpxzzXajkmFNwfAgTw