### PR TITLE
Add RuneAudit

### DIFF
--- a/plugins/runeaudit
+++ b/plugins/runeaudit
@@ -1,2 +1,2 @@
 repository=https://github.com/aTrapDeer/RuneAudit.git
-commit=eebc3b426a885cb730f18d6ed4a4f049f67f2b76
+commit=1772039c4459821d8610fe8bdf8e6d76822d279f

--- a/plugins/runeaudit
+++ b/plugins/runeaudit
@@ -1,0 +1,2 @@
+repository=https://github.com/aTrapDeer/RuneAudit.git
+commit=b50c6ae5634ca182823a736aa9038afb5e292fee

--- a/plugins/runeaudit
+++ b/plugins/runeaudit
@@ -1,2 +1,2 @@
 repository=https://github.com/aTrapDeer/RuneAudit.git
-commit=1772039c4459821d8610fe8bdf8e6d76822d279f
+commit=f192c0998088b13ead1f9f1afbfe6c74c59ec33a

--- a/plugins/runeaudit
+++ b/plugins/runeaudit
@@ -1,2 +1,2 @@
 repository=https://github.com/aTrapDeer/RuneAudit.git
-commit=b50c6ae5634ca182823a736aa9038afb5e292fee
+commit=eebc3b426a885cb730f18d6ed4a4f049f67f2b76


### PR DESCRIPTION
RuneAudit syncs a player's own progress (quest states, quest points, levels, worn gear, diary tiers, personal bests) to their private profile on the RuneAudit's website, which uses it to suggest what's worth doing next. Read-and-report only: no automation, no gameplay interaction, nothing about other players.

Consent and data:
- Nothing is sent until the player links: they generate a code on the site while signed in and paste it into the plugin while logged into the character. Tokens are revocable from the site; unlinking deletes synced data.
- Never touches Jagex/RuneLite credentials. The character is identified by a salted SHA-256 of the account hash; the raw hash never leaves the client.
- Bank sync is a separate opt-in, OFF by default, and summary-only: the plugin prices the bank locally and sends total GE value, stack count, and which items from a public list (https://osrs-accountaudit.vercel.app/api/items-of-interest) are present. The inventory itself is never transmitted. Stored encrypted, never shown publicly.
- The API URL is a visible, editable config field.
- The plugin and every account feature are free; nothing in the plugin depends on the site's optional paid AI chat.

Full data manifest: https://github.com/aTrapDeer/RuneAudit/blob/main/SCOPE.md
Privacy: https://osrs-accountaudit.vercel.app/privacy

Same category as Wise Old Man, TempleOSRS, and WikiSync.