### PR TITLE
update clanhq

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=d1a7f0f80bbe59880b8cc7e93bbd23c1b54b29f1
+commit=78ddeb29f1c5450c9a6c469e54230d654472984c


### PR DESCRIPTION
Updates ClanHQ to the latest tested release.

- Uses the confirmed Barbarian Assault `Wave X duration:` completion signal
- Uses the exact Pest Control reward dialogue signal
- Removes the unreliable completion-counter wiring that caused false activity detections
- Updates the daily-activity UI/API support and privacy documentation
- Excludes the development-only testing controls and Gear Advisor from the public release

Local plugin tests pass.