### PR TITLE
Update Iron Compass to 1.1.5

### DIFF
--- a/plugins/ironpath
+++ b/plugins/ironpath
@@ -1,3 +1,3 @@
 repository=https://github.com/gabworknestio-beep/iron-compass.git
-commit=bf9701438c776029218b4321d1f5f98fc35d00f0
+commit=4f55942723b2f1fd609213ea1b2b528e7641a670
 authors=Gab


### PR DESCRIPTION
## Summary

- expands the account-aware Skill Planner from five pilot guides to researched 1–99 coverage for all 24 skills, including Sailing
- adds conservative Bank-to-Goal projections for nine bankable skills using exact locally observed bank quantities and current skill XP
- exposes recognized XP, target coverage, estimated reachable level, remaining XP, and contributing conversions
- updates Plugin Hub discovery metadata for bank, banked progress, and XP searches

## Safety and behavior

- an unopened bank remains explicitly UNKNOWN
- non-bankable skills receive no invented banked-XP total
- projections are clearly labelled as estimates and respect current-level recipe unlocks and observed secondary ingredients
- all evaluation stays local; no network service or new runtime dependency was added

## Testing

- Java 11
- `.\gradlew.bat clean test build --no-daemon`
- 183 tests passed

Release notes: https://github.com/gabworknestio-beep/iron-compass/blob/4f55942723b2f1fd609213ea1b2b528e7641a670/CHANGELOG.md
