### PR TITLE
update osrs-fliphub

### DIFF
--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,3 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=b7512b5900b1ff3888943fae95b7571ee630177b
+commit=a3366837b7a2c77d13ac1b81f9b12d0a6b2b5000
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps `commit=` for `osrs-fliphub`.

This update does change plugin code. Two user-facing additions and a set of fixes.

**Grand Exchange search.** The panel's search box only narrowed the list of items the account had already traded, so there was no way to look an item up before flipping it once. It now searches the whole Grand Exchange, using `ItemManager.search`. Results are capped at 100 and ranked exact-name then starts-with before that cap, so a broad query cannot bury the item actually named. Catalogue items show live Wiki prices, margin, ROI and buy limit; last buy/sell stay empty until the account trades one.

**Activity sort.** The activity list gains the sort control the profile tab already had — completion (default), profit, or ROI — applied before pagination so it orders the whole list rather than the page on screen. The choice persists across restarts in a hidden config item.

Also included:

- Bookmarks did not work at all. The plugin held its own `bookmarkedItems` set shadowing the one in `PluginState`; the star buttons wrote to one and the item filter read the other, so enabling the filter always emptied the list. Both now use a single set. Hidden items had the same defect and so did not survive a restart.
- The bookmark filter button is a `JButton` rather than a `JToggleButton`, because the look-and-feel paints a selected toggle's text in its own colour and discarded the button's.
- The price age tooltip blinked on every data refresh: the panel disposed and rebuilt the popup window, and re-acquired the hover before the replacement rows had been laid out. The window is now reused and the re-acquire is deferred behind the layout pass.
- An empty result under the search or bookmark filter no longer falls back to showing the unrelated offer currently on screen.
- Panel sizing: thinner search and sort rows sharing one trailing-control width, a rounded-square sort direction button on both tabs, and a shorter pager.

No new dependencies, no new network calls — the catalogue search reads the item data RuneLite already has. `build` is still `standard`, and `build.gradle`, `settings.gradle` and `runelite-plugin.properties` are unchanged from the currently published commit.
