### PR TITLE
Add B0aty HCIM Guide v3

### DIFF
--- a/plugins/b0aty-hcim-guide-v3
+++ b/plugins/b0aty-hcim-guide-v3
@@ -1,0 +1,2 @@
+repository=https://github.com/previns/b0aty-hcim-guide-v3.git
+commit=cf1e501fc39c6f06dff3f7c0468281cf4e660651


### PR DESCRIPTION
Follows B0aty's HCIM Guide V3 in game. The guide is a route of roughly 2,900
steps across 236 banks, so the plugin is a checklist first: every bank and step
in the sidebar, with the current step's NPC or object outlined in the world, a
walkable route drawn to it, and markers on the minimap and world map.

Typing a bank number in the bank search shows the items that bank needs, as if
they had been tagged. Steps whose completion the game actually records — a
finished quest, an achievement diary task, a skill target — tick themselves;
the rest are manual.

Guide content is built from the OSRS Wiki by a separate pipeline and ships as a
single data file, so the plugin does no parsing at runtime. The only outbound
request is for the guide's bank setup screenshots: restricted to the single host
that serves them, HTTPS only, and each image verified against a sha256 recorded
at build time. No reflection, no file I/O, no third-party runtime dependencies.

Plugin: https://github.com/previns/b0aty-hcim-guide-v3
Pipeline that builds the data: https://github.com/previns/b0aty-guide-data