### PR TITLE
bank-architect: 0.4.0

### DIFF
--- a/plugins/bank-architect
+++ b/plugins/bank-architect
@@ -1,2 +1,2 @@
 repository=https://github.com/PKoka5/bank-architect.git
-commit=4635b3d2e470f1c5b3c81ee54c49439045df9f38
+commit=54a5ddcfe5ec2b7a332290a52a35d47cb887e25f

--- a/plugins/bank-architect
+++ b/plugins/bank-architect
@@ -1,2 +1,2 @@
 repository=https://github.com/PKoka5/bank-architect.git
-commit=54a5ddcfe5ec2b7a332290a52a35d47cb887e25f
+commit=8ecb21ed4a76483a899a31066d9855c56f351750


### PR DESCRIPTION
Commit bump only, as the second half of #15864 — that PR moved the repository URL after the rename and kept the commit, this one moves the commit and leaves the URL alone. Thanks for the steer.

0.3.1 -> 0.4.0. What is in it:

- Sorting guidance now handles banks holding several physical entries of one item ID (charged and degraded copies), which previously blocked guidance outright.
- Classification fixes: Shayzien armour tiers no longer read as potion doses, unfinished crossbows and ballista parts group with their inputs, cooked pies and cakes classify as food, catalogued cosmetic sets stay on one tab with a lint that keeps them there, and santa hats file with the other holiday cosmetics.
- Combat gear layout is now a choice of three — the best-in-slot matrix (unchanged default), set columns, or a list — with a Grid/List choice per remaining tab and optional curated rune, teleport and potion-dose orders. Every default is unchanged.
- Each tab's layout choice is also offered in the plugin's own sidebar, beside the tab it shapes; the sidebar rows now stretch to the panel's real width, and the row controls draw in a font that actually has their glyphs (they were tofu boxes on macOS).

Full test suite green on the pinned commit, and the fixed-seed simulation reports are byte-identical to 0.3.1 apart from the classification changes listed above.