### PR TITLE
Update jams-solo-tempoross to v1.0.6

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=ddfa449151e6bce0bacf85a16995a1530d505652
+commit=738e3379f74dfbf8208895880c9bc762286dc059


### PR DESCRIPTION
## Summary

- Path display dropdown (floor and minimap, floor only, minimap only, off) replaces the two path checkboxes; old settings migrate automatically.
- Path source dropdown: plugin lines or optional Shortest Path integration (step-coloured route when that plugin is enabled).
- Click highlight dropdown (this click, this click and next, next only, off) replaces the misleading "highlight next click" checkbox.
- Current-click outlines stay visible while fishing, cooking, depositing, or harpooning the spirit pool.
- While an action is underway, the following destination can be outlined and labelled Next (e.g. shrine after fishing, spirit pool after loading the crate).

## Test plan

- [ ] Path display modes and Shortest Path source (with and without Shortest Path installed)
- [ ] Click highlight modes: this click stays on during AFK actions; Next appears on deposit/fish/cook/spirit
- [ ] Upgrade from 1.0.4: path and highlight preferences carry over from old checkboxes
