### PR TITLE
coffer: bump to 633f053 (0.1.3-beta)

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=c5639bf650a87265cac28475f792a332be41ae01
+commit=633f0534eee8eede27f5c259a089a27a7cb0a355
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=633f0534eee8eede27f5c259a089a27a7cb0a355
+commit=786dd72832512e3e1f410977f16f004086056b58
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Update the `coffer` plugin to commit `633f053` (0.1.3-beta).

Changes since the last release (`c5639bf`):

- **Quiet hours** — a Settings option to suppress off-client Discord alerts during a nightly window (timezone-aware; the plugin uses the machine's own timezone).
- **Send test alert** — a button to fire a test message to the configured Discord webhook so users can confirm it works.
- **First-run guide** — a one-time dismissible welcome banner for new users (set bankroll → place a flip → open the Finder).
- **Fix:** the average-down suggestion line in a position card no longer truncates in the narrow panel.

No new API usage, no new dependencies, no new config surface beyond the in-panel settings. `okhttp3`/`gson` remain injected; file access stays within `RUNELITE_DIR/coffer/`. Data sent is unchanged in kind, still covered by the existing warning line.