### PR TITLE
Update Faux Bingo - Small Bugfix

### DIFF
--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,3 +1,3 @@
 repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
-commit=327175fa3fa46be2efdf5252d45ff030768eaf65
+commit=72c83c4a2896e6b00bb68e947c00e345fad83761
 authors=ThatOhio


### PR DESCRIPTION
It's possible to check for chat icons before logging in, which that array can be null. Relatively harmless error but simple enough to clean up. 