### PR TITLE
update aura-tracker

### DIFF
--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Matelaa/aura-tracker.git
-commit=14b596f046111d1cddc0aa390fb28254e9d410f8
+commit=9ca8fae09ca587be3b1ac64bb56736e21e84184e
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds an "Open Leaderboard" button to the panel, above "Update 3D Model". Many players never see the leaderboard link otherwise — it only ever appears once, in the one-time sync disclosure chat message, which is easy to miss. Opens in the default browser via RuneLite's own `LinkBrowser`, same pattern as the existing model-upload button.

Version bumped to 1.3.