### PR TITLE
Add Discord Loot Boxer

### DIFF
--- a/plugins/discord-loot-boxer
+++ b/plugins/discord-loot-boxer
@@ -1,0 +1,2 @@
+repository=https://github.com/Diogo-G-Dias/discord-loot-boxer.git
+commit=2d1e07146c42b9e23c06cb8ef6fa3343f94d9b08

--- a/plugins/discord-loot-boxer
+++ b/plugins/discord-loot-boxer
@@ -1,2 +1,3 @@
 repository=https://github.com/Diogo-G-Dias/discord-loot-boxer.git
 commit=2d1e07146c42b9e23c06cb8ef6fa3343f94d9b08
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Sends clean, screenshot-first Discord webhook messages: one bold line with a crisp account-badge or item-sprite thumbnail and the full resolution screenshot, no clutter.

- PK kills: victim, combat level, loot value from the clan broadcast, victim account type (hiscore probing with exp comparison, persistent chat-icon sightings, TempleOSRS), random flavor lines (toggleable)
- Big loot: single item over a configurable threshold, or total Loot Chest value
- Webhook URL only reaches Discord when the user configures it; per-type override webhooks supported

Repository: https://github.com/Diogo-G-Dias/discord-loot-boxer