### PR TITLE
log-adviser: bump to e2be991 (v1.4.0)

### DIFF
--- a/plugins/log-adviser
+++ b/plugins/log-adviser
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/LogAdviser.git
-commit=f21ce3e78073db67bc4b1b20fd082dba223eb8aa
+commit=e2be991abfc1a0dcba316c8e8a9559a4e72365f3


### PR DESCRIPTION
Bumps the pinned commit for `log-adviser` to v1.4.0.

Adds the five new early-game Slayer uniques from the 2 September 2026 update, so they show up in
the plugin's time-to-next-slot ranking:

- Fire ruby 1/64 from infernal mages
- Necklace of fangs 1/128 from turoth
- Earth emerald 1/64 from molanisks (new activity, Slayer 39 + Death to the Dorgeshuun)
- Water sapphire 1/64 from sea snake hatchlings (new activity, Slayer 40 + Royal Trouble)
- Air diamond 1/64 from killerwatts (new activity, Slayer 37 + Ernest the Chicken)

Data-only change — the bundled JSON plus a unit test covering the new rates. No `src/main/java`
changes, so no new client-API surface.
