### PR TITLE
the-birdhouse: 1.3.0

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=4d1f69aba81064099aabcee1cb2374b04736bd51
+commit=897305cd103e7f1623a5c7ef6e40bf186af6d352
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=ffd03ec841e26c9156b30d5a0b49af71902274a6
+commit=f3064e44b6e7730ee03b07185d9d29e548e598a3
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=42eaaa0f93c7525e9c80b5bd1e8e09d33ea7aa48
-warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.
+commit=4d1f69aba81064099aabcee1cb2374b04736bd51
+warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=f3064e44b6e7730ee03b07185d9d29e548e598a3
+commit=42eaaa0f93c7525e9c80b5bd1e8e09d33ea7aa48
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds team status alongside the team chat panel from 1.2.0, and carries the two chat fixes below.

### Team status (new)

Shows which of your event teammates are logged in and what world they are on, in a tab next to team chat in both the sidebar and the pop-out board window. Off by default.

- **No new reporting loop.** The plugin already sent a session heartbeat every five minutes; that write now also carries the world and the sharing flag. A world hop sends one immediately, since that is the only moment a world changes and a stale world is worse than none.
- **Reciprocal, enforced server-side.** Your team's status is returned only while you are sharing yours. Teammates who leave the toggle off are listed but show no status, and neither do you to them. A non-sharer's world is never returned.
- **Own team only**, never the rest of the room, and the team is read from the room roster rather than the request.
- Distinguishes logged into the game from having the client open, and treats two missed heartbeats as offline so a crashed client does not sit there looking online.
- One poller feeds both views, so opening the pop-out window does not double the request rate.

The plugin warning has been updated to disclose online status and current world.

### Fixes carried from 1.2.1

- **A proxy 404 no longer silently disables team chat.** A 404 whose body is not one of our own JSON errors is now treated as retryable, so the fallback to the primary backend still happens. Chat shipped effectively dead in 1.2.0 for this reason: a reverse proxy answered `/chat` with a plain-text 404 that looked authoritative, and the panel sat on "Loading" forever. A persistent failure now says so instead of spinning.
- **Team chat redraws when you are moved between teams.** The panel compared message ids to avoid discarding scroll position on every poll, and two empty threads compare equal ΓÇö so being moved into a team that had not chatted yet left the previous team's messages on screen. No message ever reached the wrong team, but it looked like it had. The same comparison also skipped the first render of an empty thread, showing a blank box instead of "No messages yet".
### Efficiency

- **Chat and status no longer poll while logged out.** The chat poll only checked that the feature was enabled and a token and room existed, so a client left open at the login screen kept requesting messages every ten seconds indefinitely. Both polls now back off to their idle interval out of game and are nudged on login, so nothing waits on that interval in practice. Roughly a 30x reduction in requests from an idle client.