### PR TITLE
Add Zeah Blood Rune Tracker

### DIFF
--- a/plugins/zeah-blood-rune-tracker
+++ b/plugins/zeah-blood-rune-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/georgemcclure1295-maker/zeah-blood-rune-tracker.git
+commit=65051a907ed5600b3dc49d47b05619330f4e5bb3


### PR DESCRIPTION
Adds a session tracker for blood runes crafted using dark essence fragments on Zeah.

Features:
- Tracks blood runes crafted and blood runes per hour
- Correctly counts inventory stacks exceeding 100,000
- Displays GE price, money made and money per hour
- Ignores bank withdrawals and ground-item pickups
- Provides configurable display toggles and session timeout
- Refreshes hourly-rate displays every 10 seconds

Tested in-game with normal stacks and stacks exceeding 100,000 blood runes.