### PR TITLE
Add Combat Vitals

### DIFF
--- a/plugins/combat-vitals
+++ b/plugins/combat-vitals
@@ -1,0 +1,2 @@
+repository=https://github.com/VinnyVanGogh/combat-vitals-plugin.git
+commit=4673b530bdeb71e1aed9eac720a24d72f28fcce1

--- a/plugins/combat-vitals
+++ b/plugins/combat-vitals
@@ -1,2 +1,2 @@
 repository=https://github.com/VinnyVanGogh/combat-vitals-plugin.git
-commit=4673b530bdeb71e1aed9eac720a24d72f28fcce1
+commit=7e9eac9c07548875c4ae09b17f0813f072661cd8


### PR DESCRIPTION
## Combat Vitals

Health for your target and for you, drawn over the target in the game world or
in a corner panel. It also documents how accurate that number actually is,
which as far as I can tell nobody has measured before.

Repo: https://github.com/VinnyVanGogh/combat-vitals-plugin
README: https://github.com/VinnyVanGogh/combat-vitals-plugin#readme

### Why this isn't a PR to an existing plugin

I went looking for what this overlaps with before submitting, so here's what I
found and where I think the line is.

**Opponent Information** is the closest thing, but it's in the base client, not
the Hub. There's nothing here to contribute to, and what this does differently
are things the base client deliberately doesn't do. The scope is also wider than
that name: this covers both sides of a fight, yours and theirs, in one visual
style. You can get your own health from another plugin, but it renders
differently right next to your opponent's readout, which looks broken.

**`monster-hp-percentage`** is the popular plugin in this space and it's
NPC-only, so it doesn't touch player targets at all.

**`custom-hp-bar`** is the closest Hub plugin, and it's genuinely good: overhead
bars with numbers for NPCs, players and yourself, plus damage trails and native
sprite matching that I haven't attempted. I want to be straight that it exists
rather than pretend otherwise. What it can't do is show a real hitpoints number
for a player, because it has no hiscores integration, so a player target
resolves to a percentage. Its own source says so.

That's the actual gap. Showing `44 / 73` over a player needs their Hitpoints
level, and the only way to get it is the hiscores lookup that the base client's
Opponent Information already does. No Hub plugin I could find does that lookup.
Adding it to `custom-hp-bar` would mean bolting a network path, a compliance
argument and a corner panel onto a plugin built around none of those.

### What it does

- Draws at the target. Three styles, with Top/Middle/Bottom placement and a
  pixel offset, because large NPC name plates and the top-screen boss bar both
  crowd the space above a target's head.
- Real hitpoints numbers for player targets, via one cached hiscores lookup.
- Optionally shows your own health in the same style, taken from the orb.
- Corner panel at parity with the stock plugin, stat comparison included.
- Configurable colour ramp, display format and opponent timeout.
- Gets out of the way: stands down when the game's boss HP bar already covers
  the target, and hides its panel while Opponent Information is enabled so the
  two never stack in one corner.

### The accuracy work

Opponent health never reaches the client. The server sends a health bar, and
every plugin showing a number is inverting that ratio to guess. I wanted to know
what the guess was worth, so I measured it.

`healthScale` is 30 for every actor I sampled. NPCs at or below 30 max hitpoints
resolve exactly; players never do. For a player the midpoint is exactly right
about a third of the time and is never off by more than one or two.

The bigger problem isn't quantisation. It's that the bar you can see lags behind
when your opponent eats. I measured that with a probe on two accounts fighting
each other, each logging its own true hitpoints from the orb alongside the ratio
it observed for the other, joined on wall clock. 386 scored readings. Every
wrong one was wrong in the same direction, catch-up was usually two game ticks
and up to four, and the worst single reading was 19 hitpoints stale.

Nothing in the API says an opponent ate, so it can't be detected or corrected.
The base client has the same error and doesn't mention it. Mine says so in the
README, with the method and the analysis script.

### Compliance

- One hiscores lookup per opponent, gated on
  `event.getSource() == client.getLocalPlayer()`. It only fires in direct
  response to the user engaging that specific target. Never speculative, never
  for bystanders, never more than one player at a time. Goes through
  `HiscoreManager`, so it shares the client's existing cache.
- That lookup has an off switch. The base client's equivalent doesn't.
- No scene scanning. Exactly one tracked actor, handed over by
  `InteractingChanged`.
- Things I checked the rules on and then didn't build: time-to-kill or
  kill-threshold estimates, DPS and damage history, and any opponent history or
  fight log. That last one is PvP target scouting wherever it's stored.
- `gameval` constants throughout. No reflection, no JNI, no subprocesses.

### Technical

- No dependencies beyond runelite-client, so there's nothing to verify.
- Java 11, `build=standard`, BSD 2-Clause.
- The readout is rebuilt once per game tick and published as an immutable
  snapshot. The overlays render that and compute nothing themselves, since they
  run every frame while the bar only changes on a tick.
- 20 unit tests over the recovery and formatting, including exhaustive checks
  that the recovered range always contains the true health and that the midpoint
  is never off by more than half the range width, for every
  `(maxHealth, health)` pair up to 120.
- `shutDown()` removes both overlays and unregisters the renderable draw
  listener.
