### PR TITLE
Update gok-irl-xp

### DIFF
--- a/plugins/gok-irl-xp
+++ b/plugins/gok-irl-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/mataeo-eh/GOK-IRL-XP.git
-commit=b77fe83d6f3d5b4455979c52d7f9763ecfad273f
+commit=abd1b3964527a9e7f90437d22052134b384ad9e4


### PR DESCRIPTION
Fixes banked XP being lost after a client restart.

The plugin stored banked XP only in the profile config. When a synced profile's upload fails mid-session, RuneLite re-downloads the server copy on the next launch and the local balances roll back. Banked XP is now also saved to a plugin-owned file under `~/.runelite/gok-irl-xp/`, and on load the newer of the two copies wins. Also stops the plugin reloading on the echo of its own config writes, which was re-arming its warn-once notifications on every XP drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)