### PR TITLE
update deathbank-utility

### DIFF
--- a/plugins/deathbank-utility
+++ b/plugins/deathbank-utility
@@ -1,2 +1,2 @@
 repository=https://github.com/jakevollkommer/deathbank-utility.git
-commit=4a1a0a22232ca72c820c40b1717700ab00281d9b
+commit=3541d3d893f8a72fb8550c7265302cbae9071034


### PR DESCRIPTION
Fixes a false positive where the plugin reported a deathbank that did not exist.

Dying is not proof that anything was banked. Plenty of content is item safe, or holds the items and hands them back afterwards, so inferring a deathbank from the death itself produced phantom banks: an indicator, a highlighted retrieval chest, and an on screen warning for items that were never at risk.

Every real deathbank announces itself with a retrieval message within seconds, and the deaths that bank nothing are silent, so that message is now what creates the bank. A death only arms the item snapshot, and if no message arrives the snapshot is discarded.

A death no longer clears an existing bank either, for the same reason in reverse: a death that banks nothing does not wipe what is already stored, and clearing on a guess risks telling a player they are safe when they are not. Clearing is left to the game's own wipe message, an emptied retrieval interface, and the login check.