### PR TITLE
update boss-helper-bank-sync

### DIFF
--- a/plugins/boss-helper-bank-sync
+++ b/plugins/boss-helper-bank-sync
@@ -1,2 +1,2 @@
 repository=https://github.com/ENiceApps/boss-helper-bank-sync.git
-commit=2a4bfa5c7c8e988b366600f021f5dd9e0b5a6b4e
+commit=e275b7d5a7e42ab8511424c72a74809d17619d23


### PR DESCRIPTION
Updates `boss-helper-bank-sync` to 1.1.

**Fix: the plugin was wiping the bank out of its own output file.**
`collectAndWrite` rebuilt the item list purely from live containers, and
`InventoryID.BANK` is null until the player opens a bank that session. So the
first inventory or equipment change after login rewrote the file with worn +
carried items only, and the bank was gone until the next bank visit.

The plugin now keeps a per-account bank snapshot: seeded on enable by reading
its previous output back, refreshed on every write where the bank container is
live, and carried forward verbatim when it isn't. Snapshots are keyed by RSN, so
logging into an alt neither inherits nor erases the main's remembered bank. The
first write on enable is deferred until the read-back completes so it cannot
clobber the cache it is about to use.

Also in this release:

- Output file v2 — adds per-container `bank` / `equipment` / `inventory`
  sections (needed to tell a remembered bank apart from worn gear), plus
  `bankGp`, `bankUpdatedAt`, `bankCached` and `accounts`. The merged `items`
  pool is still written, so existing readers are unaffected.
- One extra chat line when the bank in the file is remembered rather than
  freshly read, so "updated" doesn't imply a bank nobody has opened this
  session.

No behaviour changes outside the plugin's own file in `.runelite/osrs-boss-helper/`.
Still read-only on game state, still no network calls. File reads and writes
stay off the client thread.
