### PR TITLE
coffer: bump to 68018f9 (0.1.4-beta)

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=786dd72832512e3e1f410977f16f004086056b58
+commit=68018f9379ba87e94aed7f4e71b6529b2f4572b3
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Bumps Coffer to 0.1.4-beta (commit 68018f9379ba87e94aed7f4e71b6529b2f4572b3).

Changes since 0.1.3-beta:
- Plugin Settings redesigned into collapsible accordion sections (Preferences open by default; Goal, Nudges, Alerts, Web dashboard collapsed) to declutter the ~225px side panel.
- About line cleaned up — shows the client version plus a "Server: connected/unreachable" status instead of a stale, truncated server-version string.

No new permissions or network endpoints. External-server behavior remains disclosed via the `warning=` line in the manifest and the plugin description/README (unchanged).