### PR TITLE
update clanhq

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=78ddeb29f1c5450c9a6c469e54230d654472984c
+commit=d14c3d36d95abeef6718c89b9c221176f1fea1cf


### PR DESCRIPTION
Fixes Runecrafting daily tasks being treated as Crafting tasks.

- Runecrafting now uses the correct Runecraft icon
- Crafting XP no longer advances Runecrafting progress
- Runecrafting XP no longer advances Crafting progress
- Adds regression coverage for both directions

Local plugin tests pass.