### PR TITLE
update osrs-fliphub

### DIFF
--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,3 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=a3366837b7a2c77d13ac1b81f9b12d0a6b2b5000
+commit=6d60cc3f12789acb656230ce7424ff7a5d394b91
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps `commit=` for `osrs-fliphub`.

Screenshots only. The two panel captures in the README still showed the plugin as it looked before the previous update: the activity shot predated the search hint, the sort row and the shorter pager, and the profile shot predated that tab's sort row taking the same shape as the activity one. The listing was describing controls that were not visible in its own screenshots.

The only difference between this commit and the currently published one is two PNGs under `docs/`. No code changed, and neither file is bundled into the jar.

No new dependencies. `build` is still `standard`, and `build.gradle`, `settings.gradle` and `runelite-plugin.properties` are unchanged from the currently published commit.
