### PR TITLE
Update SlayerPlus

### DIFF
--- a/plugins/slayerplus
+++ b/plugins/slayerplus
@@ -1,2 +1,2 @@
 repository=https://github.com/rickernet/SlayerPlus.git
-commit=d087ac7ad4a103ea14c3bac6c48efa02fbb2c96a
+commit=68262573f0551358d27d9896f6f3c7cccb773189

--- a/plugins/slayerplus
+++ b/plugins/slayerplus
@@ -1,2 +1,2 @@
 repository=https://github.com/rickernet/SlayerPlus.git
-commit=b763829bb156a4d0056924276ba2aa13520bd1a4
+commit=dca21871e699929072021dd8dfd5ee8d51b46f93

--- a/plugins/slayerplus
+++ b/plugins/slayerplus
@@ -1,2 +1,2 @@
 repository=https://github.com/rickernet/SlayerPlus.git
-commit=4e729e32552789b1aaa15c4df1071e3ac0c52ce7
+commit=b763829bb156a4d0056924276ba2aa13520bd1a4

--- a/plugins/slayerplus
+++ b/plugins/slayerplus
@@ -1,2 +1,2 @@
 repository=https://github.com/rickernet/SlayerPlus.git
-commit=70a7de28be95cdd5fa168fd07f8b71802c158bba
+commit=4e729e32552789b1aaa15c4df1071e3ac0c52ce7

--- a/plugins/slayerplus
+++ b/plugins/slayerplus
@@ -1,2 +1,2 @@
 repository=https://github.com/rickernet/SlayerPlus.git
-commit=dca21871e699929072021dd8dfd5ee8d51b46f93
+commit=d087ac7ad4a103ea14c3bac6c48efa02fbb2c96a


### PR DESCRIPTION
Updates SlayerPlus to 68262573f0551358d27d9896f6f3c7cccb773189.

- Fixed SlayerPlus interfering with other players’ custom bank-tag layouts and preview/auto-layout controls.
- Fixed green teleport-option highlighting for Max capes and Slayer rings.
- Corrected Cave Crawler routing to Fremennik Slayer Dungeon.
- Improved synchronization between the selected teleport item, its highlight, and routing.
- Corrected Slayer-ring arrival handling.
- Paused route updates while the bank is open.
- Expanded Cave Crawler poison-protection options.
- Fixed Rockslug salt recommendations across task-name spellings.
- Added Zygomite fungicide refills alongside the spray.
- Corrected Turoth/Kurask broad-ammunition selection.
- Kept required tools from being displaced by food.
- Restricted ice coolers to applicable lizards.
- Expanded warped-creature name matching for crystal chimes.
- Reduced full loadout recalculation on kill-count and rune-pouch quantity changes.
- Stopped rebuilding unchanged helmet and task-variant dropdowns.
- Preserved finisher-quantity updates without recalculating the whole loadout.
- Added right-click Pin/Unpin inside the SlayerPlus bank tag, with Shift-right-click access elsewhere in the bank.
- Added a compact rune-pouch and spellbook setup reminder below the minimap.
- Improved rune quantity checks, carried-pouch capacity handling, and overflow rune requirements.
- Prefer ordinary runes when they use the same number of slots; retain combination runes when they save a slot or provide an owned fallback.
- Made offensive spellbook requirements and inventory runes follow the selected powered magic weapon across setups, while retaining utility and encounter spells.
- Updated Barrows Brothers inventories: omit ranged switches for Shadow/Air-spell setups, supply compatible switch ammunition where needed, and recommend powered-staff boosts.
- Prefer owned Spider cave teleports for Araxyte/Araxxor loadouts over Max cape alternatives.
- Add a SlayerPlus Spider cave teleport instruction while native Shortest Path lacks that transport.
- Omit Araxxor ranging potions when the selected safe araxyte switch is melee.
- Fix bank-close tracking so restock routing does not override the task teleport after banking.
- Remember previously used non-instanced banks per account, including while the SlayerPlus session is stopped; expand unrestricted fallback bank locations without continuous scene scans.
- List the actual selected spells in the setup-required reminder, including individual Arceuus utility spells.
- Add regression coverage for teleport priority/rebanking, bank memory, destination selection, inventory bounds, and spell reminders. Full regression suite passes; reported live-client food overflow is not claimed resolved by these checks.
- Stop automatic full loadout rebuild requests from inventory/equipment changes outside the bank, including eating, drinking, looting, and gear switches.
- Skip inventory snapshot comparisons and quantity-sensitive item-set allocation outside the bank.
- Keep automatic bank-triggered setup refreshes, lightweight task/finisher/bracelet updates, and travel progress. New tasks and manual setup changes still refresh the setup; bank closing alone does not request another full rebuild.