### PR TITLE
Update Kill Clog to 2.1.0

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=f6a96f611b29bd9e2d51960404e7434fd2627fc6
+commit=27989a9fa3e29d014dda5f26f18430e706a6a99f
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill Clog 2.1.0

* an optional Character model setting adds a one-click button that publishes your current player and follower to your killclog.com profile
* pinned hover-mode tooltips now suppress new summary popups until the pinned tooltip closes
