### PR TITLE
clan-management: update (live raid times, combat achievements, events, ranks)

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=1c435062b82a4e479800d9212cc325327454ab94
+commit=fb9be4fc048e9cb290e30792665efaf1d5c66745
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=73467a0569ebf5ad3ed07407436aee370f630175
+commit=1c435062b82a4e479800d9212cc325327454ab94
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update to the Solus clan plugin. Adds live raid speed-time detection (CoX/ToB/ToA), combat achievement tracking, an Events tab (schedule, sign-ups, clog-race board, draft), a Ranks tab, and opt-in Discord sharing of your own drops/PBs/deaths, plus fixes and a paginated speed-time board.

All data-sharing is off by default and goes only to the clan's own fixed endpoint (api.solusosrs.com); no bank or inventory data ever leaves the client. Full breakdown in the README.

One thing worth flagging: the Ranks checker pulls its requirements (including which items count) from the clan API rather than hardcoding them, so admins can tweak requirements without a plugin update. It is plain data, not executable; the checks run locally on the client, and only the pass/fail result is sent when a member requests a rank, never the bank or item list.
