### PR TITLE
Update RuneAudit

### DIFF
--- a/plugins/runeaudit
+++ b/plugins/runeaudit
@@ -1,2 +1,2 @@
 repository=https://github.com/aTrapDeer/RuneAudit.git
-commit=f192c0998088b13ead1f9f1afbfe6c74c59ec33a
+commit=c5e8d78257915f1ec1537b22ab2ddef618c908d6


### PR DESCRIPTION
Updates RuneAudit from f192c09 to c5e8d78. Three changes, all read-only and all disclosed in SCOPE.md:

**PvP record (new, separate toggle, on by default)** The game exposes no lifetime PK counter, so the plugin now counts from RuneLite's own events: player kills via PlayerLootReceived, deaths where a player was involved (ActorDeath in the Wilderness / on PvP worlds, with a recent player-aggro check), Wilderness loot keys appearing in the inventory, and the GE value of PvP loot priced in-client. Counts persist per RS profile and are sent with progress data. Because it only counts while the plugin is running, the website labels it a rough estimate everywhere it appears. Toggle: "Track PvP record".

**Pet drops (new, part of progress data)**
When the pet-drop chat message fires, the plugin records the name of the follower that appears, so the player's pet log on the site fills itself in from install onward. Nothing is read from the collection log interface.

**Icon**
Adds the plugin's icon.png (48×48).

No new dependencies, no new permissions, no gameplay interaction. Bank sync remains a separate off-by-default opt-in and remains summary-only (value, stack count, and which items from a public list are present — never the inventory). Full data manifest: https://github.com/aTrapDeer/RuneAudit/blob/main/SCOPE.md