### PR TITLE
the-birdhouse: 1.3.1

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=897305cd103e7f1623a5c7ef6e40bf186af6d352
+commit=ac98e121732fa9d5a18169cd4ec44d207b68da04
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=ac98e121732fa9d5a18169cd4ec44d207b68da04
+commit=12b4d68cffb8779f11379957754602f712cceba7
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=12b4d68cffb8779f11379957754602f712cceba7
+commit=bed13fb107b96a114dfc91c524aab0ba3c293d82
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Four bug fixes. No new permissions or data collection — the warning line is unchanged.

**Tile race board read as the wrong path.** The website draws a tile race track as a snake: the first row runs left to right, the next right to left, so the end of a row sits directly above the start of the row below it. The panel drew straight rows at a width it chose itself, so every odd row came out as a mirror image of the website's, and the board was a different shape besides.

Tile positions were correct underneath, so nothing looked obviously broken, but the path read wrongly. Standing at the right-hand end of a row, the next tile appeared to be the one directly below when it was really the one at the far left. The panel now takes the track shape from the board response and lays it out to match, falling back to the previous behaviour if the server does not send one.

Two related fixes in the same place. The track position now comes from the tile's key rather than its index in the response, because boards with hidden tiles leave them out of the list entirely and everything after the first hidden tile was drawn one square early. The grid is also sized from the furthest position received rather than the number of tiles received, so those boards still have somewhere to put the tiles after a gap. Tooltips now include the same tile number the website prints on each tile.

**The login handler threw before it had done anything.** The local player is not populated at the instant `LOGGED_IN` fires, and the handler read a name out of it as its first statement, so it intermittently threw a `NullPointerException` and abandoned the rest of itself. The board did not reload on login, no session was opened, and the panel's chat and team status polls were never nudged out of the idle interval they back off to while logged out — so both sat on a loading message for minutes. The name is now only needed by the session write, which waits on the client thread and retries until the player exists, while the rest of the handler runs straight away. `startUp` had the same unguarded read and got the same guard.

**Automatic submissions did not print their confirmation.** They were already meant to, on the same setting as a manual submission, but the call sat in the submission's completion callback on an HTTP thread, and `addChatMessage` does nothing off the client thread. Manual submissions worked because that path already went through `clientThread`. Both the drop matcher and the achievement tracker now do the same.

**Tile notes in the list were unreadable.** The note under each tile name was a plain label, which does not wrap, so anything longer than the row ran off the edge and the tail was lost — and the notes these boards generate ("Obtain a Ring of the gods from Wilderness Boss Uniques") are all longer than a 225px sidebar row. It was italic at 9pt on top of that, which at that size is mush.

The note now wraps inside the width the row actually has, upright, a point larger and slightly brighter. Rows grow to fit the wrapped text up to a cap, so a host who pastes a paragraph into a tile cannot push the rest of the list off the screen. The full text is in the row's tooltip, which the list did not have at all before; the tooltip is set on the row's labels as well, since a label is not registered with the tooltip manager on its own and sits over the row.
