### PR TITLE
update smoke-scape-hub

### DIFF
--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=e1948a7e102a80bb8d1bb082f337157d7d71faca
+commit=6ebbfa942d2d6885fc31a8a0dd671292dcbb223c


### PR DESCRIPTION
Update to the latest commit.

Notable fix: the Ranks tab's Pets leaderboard was pulling from TempleOSRS's dedicated pet-tracking endpoint (pets/pet_count.php), which turned out to have almost no data for this clan. Pet counts are now derived from the same collection log data already used for the Clog leaderboard instead, matched against known pet item IDs.

Also: RuneLite-native fonts throughout, a fixed tab-bar layout bug that made the Discord tab invisible, competition standings collapsed to top 5 with a show more/less toggle, hourly refresh, and a chat-reminders config option for upcoming/active competitions.

Source: https://github.com/kwushy/smoke-scape-hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)