### PR TITLE
Update Crafting Guild Bank Helper

### DIFF
--- a/plugins/crafting-guild-bank-helper
+++ b/plugins/crafting-guild-bank-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/jtclowner/crafting-guild-bank-helper.git
-commit=792f468dfeeac58afea60787ee3476575e605795
+commit=42df8eb180374b858ec3e6eef95104f5e5448399


### PR DESCRIPTION
Updates Crafting Guild Bank Helper:

- Support for POH mounted crafting/max capes
- Added credits mode to celebrate arrival at the guild, with a nod to the person who suggested the idea for plugin