### PR TITLE
Add Chat-Over-Keybinds

### DIFF
--- a/plugins/chat-over-keybinds
+++ b/plugins/chat-over-keybinds
@@ -1,0 +1,2 @@
+repository=https://github.com/Endrit-alt/Chat-Over-Keybinds.git
+commit=e63400c4a8dbf6259d8ae4af718db602f3afcd46

--- a/plugins/chat-over-keybinds
+++ b/plugins/chat-over-keybinds
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/Chat-Over-Keybinds.git
-commit=e63400c4a8dbf6259d8ae4af718db602f3afcd46
+commit=0721ab4f015931e361a0bc616e594ae33a6542d1


### PR DESCRIPTION
Allows bound keys to still be used in chat. This is a temporary fix until "Press Key to Chat" Feature gets added as a core runelite feature.

Currently you can not keybind a letter, and still use it in chat.

https://github.com/runelite/runelite/pull/20321