### PR TITLE
update stop-misclicking-orbs

### DIFF
--- a/plugins/stop-misclicking-orbs
+++ b/plugins/stop-misclicking-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/jtclowner/orb-clickthrough.git
-commit=5f290af7c7d0eda55a11d14481cf854676cd0c1c
+commit=7de36b7ce2a0a86292da9aa1a57d055e9deaaf9c


### PR DESCRIPTION
- detect and patch only the active minimap layout
- apply clickthrough across orb widget trees
- resync state when widgets are recreated
- add layout-selection tests