### PR TITLE
update smoke-scape-hub

### DIFF
--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=34e8eb8b910b8c15166448dc4441ace4ad60cfae
+commit=96748812ed75684e32a2b611a3c5861a62b63e7e

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=5817abb1b1b0261c884aa5c8123c95e2cb8aa5de
+commit=34e8eb8b910b8c15166448dc4441ace4ad60cfae

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=6ebbfa942d2d6885fc31a8a0dd671292dcbb223c
+commit=dd5862e7634b7ace3e18f148f2511df0a2719936

--- a/plugins/smoke-scape-hub
+++ b/plugins/smoke-scape-hub
@@ -1,2 +1,2 @@
 repository=https://github.com/kwushy/smoke-scape-hub.git
-commit=dd5862e7634b7ace3e18f148f2511df0a2719936
+commit=5817abb1b1b0261c884aa5c8123c95e2cb8aa5de


### PR DESCRIPTION
Update to the latest commit.

- Tab renames: Ranks -> Leaderboards, Discord -> Info, Milestones -> Recent
- Recent tab now merges group achievements (99s, boss KC) with notable recent collection log unlocks (pets, rare clue items) into one newest-first feed
- Larger, more readable fonts across most tabs
- Custom scrollbar UI matching RuneLite's actual theme (previous approach wasn't rendering with the right colors/width)
- Info tab now includes a short clan blurb above the Discord invite section
- Comps tab's Show more/less toggle now has a visible border

Source: https://github.com/kwushy/smoke-scape-hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)