### PR TITLE
Add Farming Discord Status

### DIFF
--- a/plugins/farming-discord-status
+++ b/plugins/farming-discord-status
@@ -1,2 +1,2 @@
 repository=https://github.com/zDezo/farming-discord-status-plugin.git
-commit=c9ea18fcea88391a28b6d5986bcba765c633a09a
+commit=276a9e04cc3ad30195fee5e734f66acc4e42abb0

--- a/plugins/farming-discord-status
+++ b/plugins/farming-discord-status
@@ -1,0 +1,2 @@
+repository=https://github.com/zDezo/farming-discord-status-plugin.git
+commit=c9ea18fcea88391a28b6d5986bcba765c633a09a


### PR DESCRIPTION
Adds an opt-in farming timer companion that sends RuneLite Time Tracking summaries and ready times to the user's private Discord DMs.

The plugin communicates with `https://farming-status-bot.onrender.com` and discloses the transmitted data in its enabling configuration option and README. It sends the RuneLite character name, farming category states, estimated ready times, and a private authentication token. It does not automate gameplay or send clicks.

Privacy policy: https://farming-status-bot.onrender.com/privacy