### PR TITLE
Update Iron Compass

### DIFF
--- a/plugins/ironpath
+++ b/plugins/ironpath
@@ -1,3 +1,3 @@
 repository=https://github.com/gabworknestio-beep/iron-compass.git
-commit=4f55942723b2f1fd609213ea1b2b528e7641a670
+commit=96dc43b51c6d2cf96ed179330dd7b5d85edc5af3
 authors=Gab


### PR DESCRIPTION
Update Iron Compass to gabworknestio-beep/iron-compass@96dc43b51c6d2cf96ed179330dd7b5d85edc5af3.

Source PR: https://github.com/gabworknestio-beep/iron-compass/pull/1

Changes for review:
- account-need bonuses in the local recommendation scoring and explanations
- compact Overview summaries for Quick Wins, Unlock Soon, Current Blockers, and Goal Packs
- Goal Pack projections over existing goals and dependencies, without a second roadmap engine
- tighter dependencies for Dragon Scimitar, Barrows Gloves, Rune Crossbow, and Barrows readiness
- updated Plugin Hub metadata and README discoverability for Ironman progression searches

Validation:
- .\gradlew.bat test: 185 tests passed
- .\gradlew.bat build: successful