### PR TITLE
Add perilous-moons-splits plugin

### DIFF
--- a/plugins/perilous-moons-splits
+++ b/plugins/perilous-moons-splits
@@ -1,2 +1,2 @@
 repository=https://github.com/TNT43/perilous-moons-splits.git
-commit --trailer "Co-authored-by: Cursor <cursoragent@cursor.com>"=836ff49cf3b22087dba382a08bd94ac90da83d4a
+commit=836ff49cf3b22087dba382a08bd94ac90da83d4a

--- a/plugins/perilous-moons-splits
+++ b/plugins/perilous-moons-splits
@@ -1,0 +1,2 @@
+repository=https://github.com/TNT43/perilous-moons-splits.git
+commit --trailer "Co-authored-by: Cursor <cursoragent@cursor.com>"=836ff49cf3b22087dba382a08bd94ac90da83d4a


### PR DESCRIPTION
## Summary
- Adds [Perilous Moons Splits](https://github.com/TNT43/perilous-moons-splits): tracks prep/boss split times, order-aware personal bests, and supply usage for Moons of Peril trips in Neypotzli.

## Test plan
- [ ] CI build for the plugin succeeds
- [ ] Install from Plugin Hub / verify overlays and timers in Neypotzli