### PR TITLE
update sleepwalker-stakeout to 1.2.0

### DIFF
--- a/plugins/sleepwalker-stakeout
+++ b/plugins/sleepwalker-stakeout
@@ -1,3 +1,3 @@
 repository=https://github.com/manc1n1/sleepwalker-stakeout.git
-commit=6e782e86576a21322f06790052058468d7f94f28
+commit=cfaccae31888301169a147f8e798ec13a4809470
 authors=Suspext


### PR DESCRIPTION
## Summary

Adds new configuration options for Sleepwalker Stakeout, giving users more control over when fake XP drops appear and whether plugin update messages are shown.

## Changes

- Added a **Show for all targets** setting
  - Disabled by default
  - Bypasses the Sleepwalker-only target restriction
  - Keeps supported weapon and animation checks in place
- Added a **Show update messages** setting
  - Enabled by default
  - Allows users to disable one-time plugin update messages
- Updated version tracking so update messages are still marked as seen even when disabled
- Updated the plugin description to better reflect its broader supported weapon behavior
- Updated README documentation for the new configuration options and targeting behavior

## Default Behavior

With **Show for all targets** disabled, fake XP drops continue to only appear when using supported attacks against Sleepwalkers.

With it enabled, supported attacks can display fake XP drops regardless of the current target.

## Testing

- Verified Sleepwalker-only targeting remains the default
- Verified enabling **Show for all targets** bypasses the target restriction
- Verified supported animation and weapon checks still apply
- Verified update messages can be disabled
- Verified disabled update messages are still marked as seen for the current plugin version