### PR TITLE
Add low-hp-alarm plugin

### DIFF
--- a/plugins/low-hp-alarm
+++ b/plugins/low-hp-alarm
@@ -1,2 +1,2 @@
 repository=https://github.com/brevinleethomas-commits/runelite-low-hp-alarm.git
-commit=5f1decb38943a266991398266f421d11f2e86a21
+commit=e4962452f02eac8a0625fb7310780a3fbe74d7a4

--- a/plugins/low-hp-alarm
+++ b/plugins/low-hp-alarm
@@ -1,0 +1,2 @@
+repository=https://github.com/brevinleethomas-commits/runelite-low-hp-alarm.git
+commit=e4c00094b1ad0e746f6760dd9418f0e66e61ef84

--- a/plugins/low-hp-alarm
+++ b/plugins/low-hp-alarm
@@ -1,2 +1,2 @@
 repository=https://github.com/brevinleethomas-commits/runelite-low-hp-alarm.git
-commit=e4c00094b1ad0e746f6760dd9418f0e66e61ef84
+commit=5f1decb38943a266991398266f421d11f2e86a21


### PR DESCRIPTION
Adds Low HP Alarm. Loops a sound when hitpoints fall to a configurable percent (default 10%). Reads local HP only. No external servers.