### PR TITLE
Update dorgeshkaan agility course

### DIFF
--- a/plugins/dorgeshkaan-agility-course
+++ b/plugins/dorgeshkaan-agility-course
@@ -1,2 +1,2 @@
 repository=https://github.com/Anderzenn/dorgesh-kaan-agility-course.git
-commit=1dd4c2bb2f3261f4d60d7c0ed17b768ee76fb4c6
+commit=47e2f4f3c872330a238aa661385c0d6db8173895

--- a/plugins/dorgeshkaan-agility-course
+++ b/plugins/dorgeshkaan-agility-course
@@ -1,2 +1,2 @@
 repository=https://github.com/Anderzenn/dorgesh-kaan-agility-course.git
-commit=700e5ef86a18cd65ea3805c72eef84de4c7476cb
+commit=1dd4c2bb2f3261f4d60d7c0ed17b768ee76fb4c6


### PR DESCRIPTION
feat: highlight correct route, gate grapple items, modernise API

Implements highlight of the correct route based on if you
picked up a delicate or heavy item, adds grapple-gating for
delicate items, and modernises the plugin off deprecated RuneLite
APIs, alongside a broader cleanup.

New:
- CourseHighlightOverlay: highlights the ground route on the way to
  the generator (both routes, before an item is picked up) and the
  single correct route back once carrying an item. Per the OSRS Wiki,
  delicate items (capacitor/fuse/meter) use the grapple route and
  heavy items (cog/lever/powerbox) use the agility route.
- Grapple gating: delicate items are only highlighted/selectable in
  dialogue, and their route only drawn, when a crossbow and mith
  grapple are equipped; otherwise the info panel shows the item in
  red with "(needs grapple)".
- Info panel now shows item names (not just icons), colours them by
  inventory/grapple status, and adds a "Route:" row naming the active
  route.
- RouteType, DorgeshKaanConstants, RouteColours: centralise the
  item-name/object-ID/colour mappings that were previously duplicated
  or missing entirely.
- Config: new "Course QoL Features" / "Colour Settings" sections,
  highlightCourse and showRoutePanel toggles, heavyRouteColour.

Fixes/modernisation:
- Migrate from deprecated APIs to their gameval equivalents:
  net.runelite.api.widgets.InterfaceID -> gameval InterfaceID,
  InventoryID.INVENTORY -> gameval InventoryID.INV/WORN,
  ItemID.SPANNER -> gameval ItemID.DORGESH_SPANNER,
  client.getNpcs() -> client.getTopLevelWorldView().npcs().
- Strip RuneLite chat formatting tags (Text.removeTags) before regex-
  matching chat messages; a <col=...> tag around the lap-count number
  could otherwise silently break the match and leave the info panel
  showing stale items after turning them in to Turgall.
- Remove SpannerWarningOverlay's dead showWarning field/
  updateWarning(): render() already re-checks plugin state live and
  never read them.
- Normalise "power" -> "powerbox" (previously "power box", which
  didn't match the actual item name or Powerbox.png).
- Normalise the config's empty-string requestedItem1/2 defaults to
  null on startup, avoiding a StringIndexOutOfBoundsException on
  first run.
- Rename hasSpanner() to isMissingSpanner(), matching its actual
  (inverted) return semantics.
- TurgallHighlightOverlay: draw with the same configurable stroke
  width + fill style as the new route highlights, instead of the
  bare OverlayUtil.renderPolygon outline.
- Widen the info panel to 230px so longer labels don't wrap.

No changes to build config, resources, or README.