### PR TITLE
update whospoonedit

### DIFF
--- a/plugins/whospoonedit
+++ b/plugins/whospoonedit
@@ -1,3 +1,3 @@
 repository=https://github.com/marcushill13/whospoonedit.git
-commit=c3a5dab8325c55da4bc0e9d603c23292e870ab31
+commit=0a89a2fbdc81303f90959dc3e1dd72a373d2e21d
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Who Spooned It to the latest commit.

Changes since the pinned commit:

- Importing a group's history from a Discord channel now reads it in pieces
  rather than in one request, so a channel with years of messages in it can be
  brought in at all. It previously exceeded the client's read timeout and failed.
- Pet notifications are read. They use different wording and put the item in a
  field rather than in the sentence, so they were being skipped entirely.
- A drop's rarity is worked out from the bundled drop data when the notification
  did not state one, instead of being left unscored.
- Drop rates for monsters the bundled data does not cover, read from the wiki at
  build time and credited in NOTICE.md.
- Drops that cannot be scored are collapsed under a toggle at the bottom of a
  player's list rather than mixed in with the ones that can.

No new permissions, dependencies or network endpoints.