### PR TITLE
Update scavenger

### DIFF
--- a/plugins/scavenger
+++ b/plugins/scavenger
@@ -1,2 +1,2 @@
 repository=https://github.com/Guobmin/runelite-scavenger.git
-commit=1d932c38eca4628333e92345c9f037ed3ed177a0
+commit=825cb2b6df0955421a27fab54b407213ffc38860


### PR DESCRIPTION
Updates Scavenger to v1.3 (commit 825cb2b).

- Adds a local troubleshooting log (`.runelite/scavenger/debug.log`, size-capped,
  written off the client thread) for tracking-mismatch bug reports - the
  README's "Help and issues" section now asks reporters to attach it.