### PR TITLE
Add TCG Session Overlay

### DIFF
--- a/plugins/tcg-session-overlay
+++ b/plugins/tcg-session-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/Samantha-Butler/TCGSessionOverlay.git
-commit=ec1445d5983f126465f278325fed485b7c7f4d49
+commit=8ccc1cbc09efdb129e247484c698be65ebadfcbb

--- a/plugins/tcg-session-overlay
+++ b/plugins/tcg-session-overlay
@@ -1,0 +1,2 @@
+repository=https://github.com/Samantha-Butler/TCGSessionOverlay.git
+commit=ec1445d5983f126465f278325fed485b7c7f4d49


### PR DESCRIPTION
Adds TCG Session Overlay. It is a read-only companion to the existing osrs-tcg plugin. This plugin shows credits earned, progress until the next credit award, and credits per hour, as an in-game overlay.

It reads the osrs-tcg save file from the local RuneLite directory and never writes to it. No network calls, no threads, and no dependencies beyond runelite-client.