### PR TITLE
update whospoonedit

### DIFF
--- a/plugins/whospoonedit
+++ b/plugins/whospoonedit
@@ -1,3 +1,3 @@
 repository=https://github.com/marcushill13/whospoonedit.git
-commit=0a89a2fbdc81303f90959dc3e1dd72a373d2e21d
+commit=63237845753bef8372d1784039812690a0126fb2
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Fixes a layout bug: the luck figure at the end of each drop row was
being pushed under the scrollbar and off the side of the panel. Rows
are now held to the sidebar's actual width.