### PR TITLE
coffer: bump to e8d7138 (0.1.5-beta)

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=68018f9379ba87e94aed7f4e71b6529b2f4572b3
+commit=e8d71382bbd7db344e425f33172f839dbdd330c2
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Bumps Coffer to 0.1.5-beta (commit e8d71382bbd7db344e425f33172f839dbdd330c2).

Changes since 0.1.4-beta:
- Account bar redesign: the tier now shows as a pill (matching the web dashboard) with icon Settings/Log-out buttons; the username ellipsizes so a long name never overlaps the controls.
- Value-first README with screenshots, and an updated plugin description.

No new permissions or network endpoints. External-server behavior remains disclosed via the `warning=` line in the manifest and the plugin description/README.