### PR TITLE
coffer: bump to c73f592 (0.1.7-beta)

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=e8d71382bbd7db344e425f33172f839dbdd330c2
+commit=dcc683f52608f95b470abb7514076663dddbb248
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=dcc683f52608f95b470abb7514076663dddbb248
+commit=c73f59265d3edb4fe939634105d05b6d9f370496
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Bumps Coffer to 0.1.7-beta (commit c73f59265d3edb4fe939634105d05b6d9f370496). Rolls the earlier 0.1.6-beta content into this same PR plus the changes below.

Changes since 0.1.5-beta:
- No-account preview: on a fresh install the panel shows a read-only list of live F2P flip opportunities (item, margin, risk) with a "Create free account" prompt, instead of a bare login form. Prices, buy plan, and fill data stay gated behind sign-up. Backed by a public GET /api/preview endpoint.
- P&L time-window tracker: a small Session / 24h / 7d / All selector by the REALIZED P&L header; the headline profit + flip count recompute for the chosen window (realized bucketed by sell time).
- Per-account P&L: each fill is now attributed to the RS display name that made it, and an ACCOUNT selector (shown once 2+ accounts have traded) scopes the P&L to one account or all.

No new permissions or dependencies. External-server behavior remains disclosed via the `warning=` line and the plugin description/README.