### PR TITLE
Add Ralos Marker

### DIFF
--- a/plugins/ralos-marker
+++ b/plugins/ralos-marker
@@ -1,2 +1,2 @@
 repository=https://github.com/h181422/RalosMarker.git
-commit=d3411b5fce7aeed83b1829de768f2072e2f36c35
+commit=c0352770bef97d040ed94f9015ee86cdb9b0bf19

--- a/plugins/ralos-marker
+++ b/plugins/ralos-marker
@@ -1,0 +1,2 @@
+repository=https://github.com/h181422/RalosMarker.git
+commit=d3411b5fce7aeed83b1829de768f2072e2f36c35


### PR DESCRIPTION
Adds Ralos Marker, a plugin that marks the exact NPC hit by a charged
Tonalztics of Ralos special attack.

For Chambers of Xeric lizardman shamans, it displays a calculated
Defence value based on the raid scale and observed successful Ralos hits.

The plugin does not automate input, swap or remove menu entries, or
communicate with external services.

Testing performed:
- 14 automated tests pass
- tested with scale 1 and scale 2 Chambers of Xeric
- tested Ralos attacks from another visible account

Repository:
https://github.com/h181422/RalosMarker