### PR TITLE
Update cox-assistant

### DIFF
--- a/plugins/cox-assistant
+++ b/plugins/cox-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/caasssh/cox-assistant.git
-commit=afae3cc8b9a0eece0ef774260d1481ef6813442a
+commit=3e1667bbd56e9e3dcf3da1ab82d9b13333151870


### PR DESCRIPTION
Updates cox-assistant to 3e1667bbd56e9e3dcf3da1ab82d9b13333151870.

Summary:
- Restores an expanded Total section at the top of Team > Prep.
- Totals prep resources and crafted potions reported by compatible members of the current RuneLite Party.
- Keeps Shared Storage separate to avoid counting deposited supplies twice.
- Uses raid-wide targets for all configured Olm killers while preserving per-killer targets in personal sections.

Party scope:
RuneLite Party messages are scoped to one Party passphrase. Separate RuneLite Parties in the same CoX raid remain isolated and show independent totals. This update adds no new payload fields, external service, dependencies, or gameplay interaction.

Verification:
- Clean focused CoxMegascalePluginTest and CoxMegascalePanelTest run passed.
- Full Gradle check passed.
- 82 focused tests passed with zero failures.
- Release QA and compliance reviews passed with conditions.

Live testing required before merge:
- Two clients in one Party and two independent Parties in one raid.
- Party switching, reconnect/reload, raid exit/re-entry, and incompatible schema.
- Crafting, trades, Shared Storage deposits/withdrawals, staleness, and double-counting checks.
- Normal panel width at 100%, 125%, and 150% UI scale with long names and three-digit totals.

Sources checked 2026-09-03:
- RuneLite Party guide: https://github.com/runelite/runelite/wiki/Party
- RuneLite PartyService: https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/party/PartyService.java
- Plugin Hub update rules: https://github.com/runelite/plugin-hub/blob/master/README.md

