### PR TITLE
Update groupscape to 3437a25

### DIFF
--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=5e0530ef1cffbb1a8ad8dc3e40d5d5f47df6afbb
+commit=3d0d4ddd14e1de68b199ba2442bd4680ac32c656
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=1096c218a162bc01cbd166f321c2fda4044b0ffc
+commit=2925f775d80f1c4cb5f670ac867a72348eec8607
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=3d0d4ddd14e1de68b199ba2442bd4680ac32c656
+commit=1096c218a162bc01cbd166f321c2fda4044b0ffc
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=2925f775d80f1c4cb5f670ac867a72348eec8607
+commit=3437a255b97756571c36d75f7d8a3251b9ec4013
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Brings the deployed GroupScape plugin to v1.8.11.

- New party overlay Layout options: Orb Grid (circular HP orbs in a grid) and Scoreboard (side-by-side vertical HP meters) - the old "Scale" setting is now called "Layout" to reflect this.
- Orb Grid/Scoreboard visual polish: bolder status pips that no longer spill past the panel edge, bigger bolder Scoreboard labels, and fixed text overlap in Compact/Super Compact layouts.
- Notable drop pings sent to Discord now show the item's icon.
- Drops received as a "noted" stack no longer show up as an unrecognized item - correct name, link, and gp value now shown.
- Deaths to bosses that hit you with a ranged/special attack now correctly attribute the killer instead of showing just "died".
- Fixed slayer task name occasionally showing "null" on the site after a lookup hiccup.
- New collection log items unlocked mid-session now reliably sync to the Activity Feed - including a follow-up fix for boss-unique drops that could still be missed by the first fix.
- Fixed talking to Mortimer, Aya, Achtryn, or Kuradal not updating your tracked slayer master.