### PR TITLE
Add Retro NPC Swapper

### DIFF
--- a/plugins/retro-npc-swapper
+++ b/plugins/retro-npc-swapper
@@ -1,0 +1,2 @@
+repository=https://github.com/AJD-/RetroNPCSwapper.git
+commit=99b3f3f8092b2a39a48bfa8b21ad36f1f7d9ced7


### PR DESCRIPTION
Swaps a handful of modern NPC models and animations back to their 2004/2005 look, using the retro assets that still live in the Old School RuneScape cache. Piggybacks off of the `GPU Plugin` to avoid reflection issues - this also keeps the original, "modern" model as the hitbox.

Video of plugin in action:
[retro-plugin-sample.webm](https://github.com/user-attachments/assets/f30f7452-28b3-4497-ba90-6b35a67cebcf)
