### PR TITLE
Add Money Making Guide plugin

### DIFF
--- a/plugins/money-making-guide
+++ b/plugins/money-making-guide
@@ -1,2 +1,2 @@
 repository=https://github.com/simoncraig90/osrs-money-making-guide.git
-commit=06d35d61c2931c689ed55eeff2e79bdfa07ed67c
+commit=86311a7ba1d2760fb9c61704b92b97c394c072be

--- a/plugins/money-making-guide
+++ b/plugins/money-making-guide
@@ -1,2 +1,2 @@
 repository=https://github.com/simoncraig90/osrs-money-making-guide.git
-commit=be713d3c33b0de5baf8a52b120f7dea302a1ddf4
+commit=06d35d61c2931c689ed55eeff2e79bdfa07ed67c

--- a/plugins/money-making-guide
+++ b/plugins/money-making-guide
@@ -1,0 +1,2 @@
+repository=https://github.com/simoncraig90/osrs-money-making-guide.git
+commit=be713d3c33b0de5baf8a52b120f7dea302a1ddf4


### PR DESCRIPTION
Adds **Money Making Guide** — a side panel listing the OSRS Wiki's money making guides, filtered to the ones the logged-in account can actually do and repriced against live Grand Exchange data.

- Guide data comes from the wiki's Bucket API (`action=bucket`), not HTML scraping, and is regenerated weekly in CI rather than baked into the jar.
- Skill requirements are enforced against `getRealSkillLevel`, distinguishing hard gates from *recommended* and *optional* levels — "44 Runecraft (91 recommended)" is shown at 44 with a warning, not hidden.
- Profit is computed from the real-time prices API, paying the instant-buy price for inputs and taking the instant-sell price for outputs, with GE tax applied to outputs (2%, floored, 5m cap, exempt below 100gp and for the exempt category). This mirrors `Module:Mmgtable`; the scaling formula reproduces the wiki's own stored values on 641/641 guides.
- Optional hiscores lookup so the filter works before logging in.

No third-party dependencies beyond what the client already provides. BSD 2-Clause. 25 unit tests.

Repo: https://github.com/simoncraig90/osrs-money-making-guide