### PR TITLE
add playtime-logger

### DIFF
--- a/plugins/playtime-logger
+++ b/plugins/playtime-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/mreedon/playtime-logger.git
-commit=c9016af4ff0ff9740ac70928e5238de519da7e10
+commit=d6a569bc2735f7fb265b3b3f4b4dedd5308ec797

--- a/plugins/playtime-logger
+++ b/plugins/playtime-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/mreedon/playtime-logger.git
-commit=73aa056944b0fe0f233afb9202b56bbdd4278cb6
+commit=402e6c8b2b0685367ee3b6ba2721ba9a741d2682

--- a/plugins/playtime-logger
+++ b/plugins/playtime-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/mreedon/playtime-logger.git
-commit=402e6c8b2b0685367ee3b6ba2721ba9a741d2682
+commit=c9016af4ff0ff9740ac70928e5238de519da7e10

--- a/plugins/playtime-logger
+++ b/plugins/playtime-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/mreedon/playtime-logger.git
+commit=73aa056944b0fe0f233afb9202b56bbdd4278cb6


### PR DESCRIPTION
Logs real login/logout session times to a local CSV (`~/.runelite/playtime-logger/sessions.csv`) — start/end timestamps, duration, world hop count, which worlds were visited, and which account. Session boundaries are tracked off the client's `GameState` transitions directly rather than the built-in played-minutes counter, so a world hop doesn't split one play session into two. No network requests, no dependencies beyond `runelite-client`.