### PR TITLE
Update jams-solo-tempoross to 1.0.7

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=738e3379f74dfbf8208895880c9bc762286dc059
+commit=3c006beb61eb2a626e1608fdb9e33824effdcc7a


### PR DESCRIPTION
## Summary
- Bump Jam's Solo Tempoross to `f2dab18491b0841a3cf437219cea6a095a984024` (1.0.7)
- Removes hammer requirement for this rotation
- Fixes plugin chime volume slider
- Adds double-fish chime and Advanced sound picker dropdowns

## Test plan
- [ ] Plugin Hub CI builds cleanly
- [ ] In-game: no hammer gate; volume slider works; Advanced sound picks apply
