### PR TITLE
Update Kill Clog to 2.1.1

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=27989a9fa3e29d014dda5f26f18430e706a6a99f
+commit=3ac83d808e97c8871484d075b56e10bef25fc260
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill Clog 2.1.1

* shows duplicate item counts in `!kclog` results
* answers RuneProfile-style `!log` commands when RuneProfile is not active
* uses verified killclog.com sync data for group ironman account badges
* restores Colosseum Glory to solo and comparison PvM summaries