### PR TITLE
loadout-lab: update to 0.5.0

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=ade3fe332dd36ae0dfc5cc18ecc2f355909f6756
+commit=305becf982adace12aa1b754b0658f7a9d8f66a8
 authors=ajkatz


### PR DESCRIPTION
Loadout Lab 0.5.0.

Ship combat for the Sailing update: sea monsters are fought from the boat - each cannon's material and operator, the shared cannonball tier, the keel for damage taken, and a card ledger that adds it up (set, spec, gear, cannons, total). Raids: Tombs of Amascut runs Akkha's final stand and one enraged Warden; the Wiki calc link opens at the card's raid level; raid boosts live in the boost picker. Rosters reorder without recomputing. Wilderness trips price the carried kit by fate. The bank filter carries every supply. Plus the mascot flask and sea and raid loading animations, and the fixes since 0.4.3.

Main source: under the hub cap after a slim pass (imports and dead code), tests excluded; the numbers ride resource TSV/JSON.
