### PR TITLE
Add rapid-warning

### DIFF
--- a/plugins/rapid-warning
+++ b/plugins/rapid-warning
@@ -1,0 +1,3 @@
+repository=https://github.com/shepherdosrs/rapid-warning-plugin.git
+commit=59668e46ff5c7f0759c3fc4b51936e9f58a809ad
+authors=shepherdosrs


### PR DESCRIPTION
Warns when a Twisted bow or Zaryte crossbow is equipped on any attack style other than Rapid: a color-customizeable panel that is displayed as long as the weapons are not on rapid.