### PR TITLE
Add Max Cape Nice plugin

### DIFF
--- a/plugins/max-cape-nice
+++ b/plugins/max-cape-nice
@@ -1,0 +1,2 @@
+repository=https://github.com/Frailrain/max-cape-nice.git
+commit=67a9076daee585252dca072cec0ef4c71c40550d


### PR DESCRIPTION
Adds Max Cape Nice — a plugin that says "Nice." when you equip your max cape.

Repository: https://github.com/Frailrain/max-cape-nice

🤖 Generated with [Claude Code](https://claude.com/claude-code)