### PR TITLE
update follower-buddy

### DIFF
--- a/plugins/follower-buddy
+++ b/plugins/follower-buddy
@@ -1,2 +1,2 @@
 repository=https://github.com/MikeSpatol/follower-buddy.git
-commit=71f88357562d4642396786f28289c6700c3393e2
+commit=c82e360204e6cc022d96557ad2b33d425c3a00cc


### PR DESCRIPTION
Follower Buddy 1.4.0, pin 71f8835 to c82e360.

A small release, mostly in response to feedback that it talks too much.

Quieter by default. Chattiness gains a Minimal level, 45 seconds between lines, below Quiet at 12. New installs now start on Occasional rather than Normal, and chatbox mirroring is off unless switched on. Anyone who has set either keeps their setting.

Fixes. Killing a boss produced the generic "well fought" line and then the boss celebration eight seconds later; the generic line now stands aside for bosses and the celebration arrives in about four. The follower also announced taking a Stay post when returning from spectating a fight, because the release window after a fight was indistinguishable from a commanded Stay.

Nothing new touches the network, files outside the profile folder, or the restricted APIs raised last time. No Thread.sleep, no thread interrupt, no javax.sound, no Desktop or LinkBrowser. 770 tests pass.