### PR TITLE
Update fate-locked-ironman

### DIFF
--- a/plugins/fate-locked-ironman
+++ b/plugins/fate-locked-ironman
@@ -1,2 +1,2 @@
 repository=https://github.com/Nubles/RS3-Fate-Locked-Runelite.git
-commit=1e118ec73f5a0fad17fc7b0704461a602d169041
+commit=64157ebd7146ece0754e03cf21a819bfd73aee7f


### PR DESCRIPTION
Updates Fate Locked Ironman to Nubles/OSRS-Fate-Locked-Runelite@52f45f5b709e60be80d69e33ad3f98e83b6442a3.

This release reduces relay traffic by limiting healthy profile checks to once per minute, exponentially backing off failures and HTTP 429 responses, honoring integer Retry-After values, and retaining responsive first-time pairing.

It also restores the explicit third-party network warning requested in review. Online sync is default-off behind a new consent setting, including for existing pairings. Connect tracker and the sidebar toggle require acceptance of the warning that the server receives the user's IP address and is not controlled or verified by RuneLite developers; the native RuneLite setting carries the same warning. Declining leaves sync disabled. Disabling sync blocks subsequent polls and invalidates pending imports. Clipboard and file imports remain available offline.

The consent fix is merged in Nubles/OSRS-Fate-Locked-Runelite#14. The plugin repository's Gradle clean check, all 268 tests, and Plugin Hub jar verification pass locally, and the source PR's GitHub build passed.
