### PR TITLE
Update gauntlet-chest-popup

### DIFF
--- a/plugins/gauntlet-chest-popup
+++ b/plugins/gauntlet-chest-popup
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/gauntlet-loot-popup.git
-commit=fe75950f405730d2489dba67199f34b50c4f238c
+commit=0e20c56415da6e82088ac5fa83c8b973564bfccc


### PR DESCRIPTION
- Fix custom background boolean not being tracked when flipped while popup is closed
- Get KC from chat commands plugin