### PR TITLE
Add varlamore-distraction-tracker

### DIFF
--- a/plugins/varlamore-distraction-tracker
+++ b/plugins/varlamore-distraction-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/jdkrupajk/varlamore-distraction-tracker.git
+commit=dc621701f8a2f14e3a4941860a32f544a01e0bc4


### PR DESCRIPTION
Adds **Varlamore Distraction Tracker**. This supersedes #15076, which was closed by the stale bot while I sorted out the feedback on it.

### What changed since #15076

**`client.hopToWorld` is gone**, along with `changeWorld`, `openWorldHopper`, the `WorldService` injection and the panel's click handler. On the previous PR @Alexsuperfly wrote:

> Use of the client.hopToWorld api means this requires full manual review, which at the rate we are receiving PRs now a days we can not even keep up with automated review assistance. I suggest you remove this feature.

Removed rather than reworked. The plugin's value is knowing *which* world to hop to; the hop itself is a keystroke the player already has in the world switcher, so the feature was not worth a reviewer's time.

**All third-party server contact is gone.** The previous version had an opt-in, off-by-default feature that pooled distraction timings through a Cloudflare Worker. Nobody asked me to remove it, but it is the other thing that pulls a submission out of automated review, and at zero installs it did nothing useful. The service has been shut down and its repository archived.

### What the plugin does now

Tracks how long ago the urchin distraction fired on each world you visit, so you can time a hop to arrive shortly *before* the next one. Joining a distraction already in progress earns nothing - the game penalises it deliberately - so knowing a world's phase is the whole point.

Purely observational: it reads chat messages and NPC interaction state, and draws a sidebar and an optional overlay.

### Notes for review

- **No network access of any kind.** No okhttp, no Gson, no URLs.
- **No world-hopping or other client-action APIs.**
- **No new dependencies.** `runelite-client` plus Lombok and JUnit; `build=standard`.
- **No scene scanning** - wealthy citizens are tracked from `NpcSpawned`/`NpcDespawned` into a small set rather than iterating cached NPCs each tick.
- Notifications and the overlay are both off by default.
- 33 unit tests. The timing and merge rules live in a class with no RuneLite imports that takes the clock as a parameter, so they run under plain JUnit with no mocked client.
