### PR TITLE
Add hit-stats

### DIFF
--- a/plugins/hit-stats
+++ b/plugins/hit-stats
@@ -1,3 +1,3 @@
 repository=https://github.com/ilee2914/runelite_hit_stats.git
-commit=08e1f412f12bda1c9eb2d692341c82b30593c5d2
+commit=7bcdafb4b7f496c8e6e4008510d02c49a6719481
 authors=ilee2914

--- a/plugins/hit-stats
+++ b/plugins/hit-stats
@@ -1,3 +1,3 @@
 repository=https://github.com/ilee2914/runelite_hit_stats.git
-commit=acf492e3bb58ac6e43a0f75c52ce8abd3fdcaba0
+commit=cabf69d510725149e32c02fdf7d25dc265f25aca
 authors=ilee2914

--- a/plugins/hit-stats
+++ b/plugins/hit-stats
@@ -1,3 +1,3 @@
 repository=https://github.com/ilee2914/runelite_hit_stats.git
-commit=cabf69d510725149e32c02fdf7d25dc265f25aca
+commit=08e1f412f12bda1c9eb2d692341c82b30593c5d2
 authors=ilee2914

--- a/plugins/hit-stats
+++ b/plugins/hit-stats
@@ -1,0 +1,3 @@
+repository=https://github.com/ilee2914/runelite_hit_stats.git
+commit=acf492e3bb58ac6e43a0f75c52ce8abd3fdcaba0
+authors=ilee2914


### PR DESCRIPTION
Hit Stats records every hit you deal and groups it by the full context it was dealt under: worn gear, the levels that affect damage, the prayers that affect damage, attack style, spell, special attack, the target monster and the overhead prayer that monster was using. The side panel shows the damage distribution, accuracy, splash rate, DPS and wasted ticks, filterable by monster, attack, target prayer and any worn equipment slot.

It only observes: hitsplats, animations, graphics, varbits and containers. It never sends input, queues a menu action, or changes game state.

**On the optional network feature.** The plugin can share your hit statistics with a community server so the panel can draw everyone else's distribution beside your own. Both halves are separate switches and **both are off by default**; with them off the plugin makes no request of any kind. Sharing sends, per combination of gear, levels, damage prayers, style, spell, special attack, monster and the monster's overhead prayer: the count of hits at each damage value and the totals behind the panel's statistics, plus the item and monster names for the ids involved, identified by a random id generated locally. Your character name, account, world, location, chat and anything about other players are never sent. Requests use the injected OkHttpClient and happen on the plugin's executor at most once every 15 minutes and on logout, never per attack. The settings descriptions and the README state all of this.

Server source (Cloudflare Worker) is available on request; the endpoint is https://osrs-hit-stats-worker.mayorhem.workers.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)