### PR TITLE
Add ge-helper

### DIFF
--- a/plugins/ge-helper
+++ b/plugins/ge-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/ilee2914/runelite_ge_helper.git
-commit=6521ded4d7ada492a0264532b86176b6d68d312d
+commit=f6dae8dc8103920a11f086189d52af044817b4b0
 authors=ilee2914

--- a/plugins/ge-helper
+++ b/plugins/ge-helper
@@ -1,0 +1,3 @@
+repository=https://github.com/ilee2914/runelite_ge_helper.git
+commit=deb787b0805c0e6566947d1195cec120c2c2984e
+authors=ilee2914

--- a/plugins/ge-helper
+++ b/plugins/ge-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/ilee2914/runelite_ge_helper.git
-commit=00c608d136905c6d7ffcfa5dd39dff782ca39ffc
+commit=6521ded4d7ada492a0264532b86176b6d68d312d
 authors=ilee2914

--- a/plugins/ge-helper
+++ b/plugins/ge-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/ilee2914/runelite_ge_helper.git
-commit=deb787b0805c0e6566947d1195cec120c2c2984e
+commit=00c608d136905c6d7ffcfa5dd39dff782ca39ffc
 authors=ilee2914


### PR DESCRIPTION
GE Helper tracks Grand Exchange prices using the OSRS Wiki real-time price API, with price graphs and offer monitoring in a side panel.

Network use is limited to the wiki price API, through the injected OkHttpClient and with a descriptive User-Agent as the wiki asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)