### PR TITLE
Add prayer-alert

### DIFF
--- a/plugins/prayer-alert
+++ b/plugins/prayer-alert
@@ -1,3 +1,3 @@
 repository=https://github.com/ilee2914/runelite_prayer_alert.git
-commit=38970b43712b6819728ba9cb0056ddc33043a3e2
+commit=2815b4e9516d66a2833bbe7f426426f43559b8fd
 authors=ilee2914

--- a/plugins/prayer-alert
+++ b/plugins/prayer-alert
@@ -1,0 +1,3 @@
+repository=https://github.com/ilee2914/runelite_prayer_alert.git
+commit=38970b43712b6819728ba9cb0056ddc33043a3e2
+authors=ilee2914

--- a/plugins/prayer-alert
+++ b/plugins/prayer-alert
@@ -1,3 +1,3 @@
 repository=https://github.com/ilee2914/runelite_prayer_alert.git
-commit=2815b4e9516d66a2833bbe7f426426f43559b8fd
+commit=cb973e35da38ec898c7e06d1fefc194736249e21
 authors=ilee2914


### PR DESCRIPTION
Prayer Alert beeps while you attack an NPC with a combat style its overhead prayer protects against, so you notice you are hitting into protection instead of watching the icon.

It reads the NPC's overhead prayer sprites and your combat style, and plays a sound. No network use, no input, no menu actions, no game state changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)