### PR TITLE
Add runescapeador

### DIFF
--- a/plugins/runescapeador
+++ b/plugins/runescapeador
@@ -1,3 +1,3 @@
 repository=https://github.com/fcaStockhausen/runescapeador.git
-commit=e8968e0b4ab511587270e4150f5d87f58036237b
+commit=2c666989017a8ae731482eaf5b369788f3c466f9
 authors=fcaraneda

--- a/plugins/runescapeador
+++ b/plugins/runescapeador
@@ -1,0 +1,3 @@
+repository=https://github.com/fcaStockhausen/runescapeador.git
+commit=e8968e0b4ab511587270e4150f5d87f58036237b
+authors=fcaraneda


### PR DESCRIPTION
Adds **runescapeador**, a mouse-free accessibility plugin: a virtual
cursor controlled entirely from the keyboard, for players who cannot
use a mouse (RSI/tendonitis).

### How it works
The cursor is always relative to the player (like a joystick): the
targeted tile is `player position + aim direction x distance`.

- `I J K L` aim the cursor (diagonals by combining keys)
- `W` / `S` (hold) extend / retract the cursor distance
- `A` / `D` (hold) rotate the camera
- `Space` executes the action for the targeted tile (first option of an
  NPC / object / ground item found there, or "Walk here"), via
  `Client#menuAction`
- `Q` executes the second option, `E` cycles candidates on the tile,
  `R` recenters the cursor
- An overlay highlights the targeted tile and labels the action Space
  will perform

### Design notes
- Strictly 1:1: one keypress performs exactly one menu action that a
  human could do with a single click. No queuing, no automation, no
  delays, nothing happens without user input, keys only act on press
  (OS auto-repeat is filtered out).
- Keys are only captured when the game canvas is focused and the
  chatbox is not accepting input.
- No networking, no reflection, no external dependencies.