### PR TITLE
Add perilous-moons-splits

### DIFF
--- a/plugins/perilous-moons-splits
+++ b/plugins/perilous-moons-splits
@@ -1,2 +1,1 @@
-repository=https://github.com/HungryPotato67/perilous-moons-splits.git
-commit=18ab257254cc12bf8fb50b022edf7d870912420d
+repository=https://github.com/HungryPotato67/perilous-moons-splits.gitcommit=ccf6e14b9957a2cd84164e2332ce9804932e5941

--- a/plugins/perilous-moons-splits
+++ b/plugins/perilous-moons-splits
@@ -1,1 +1,2 @@
-repository=https://github.com/HungryPotato67/perilous-moons-splits.gitcommit=ccf6e14b9957a2cd84164e2332ce9804932e5941
+repository=https://github.com/HungryPotato67/perilous-moons-splits.git
+commit=ccf6e14b9957a2cd84164e2332ce9804932e5941

--- a/plugins/perilous-moons-splits
+++ b/plugins/perilous-moons-splits
@@ -1,0 +1,2 @@
+repository=https://github.com/HungryPotato67/perilous-moons-splits.git
+commit=18ab257254cc12bf8fb50b022edf7d870912420d


### PR DESCRIPTION
Adds Perilous Moons Splits, a plugin that tracks split times, order-aware personal bests, and per-split food/potion usage for Moons of Peril trips.