### PR TITLE
Update Sixth Degree to 0.1.1

### DIFF
--- a/plugins/sixth-degree
+++ b/plugins/sixth-degree
@@ -1,4 +1,4 @@
 repository=https://github.com/ZoltanPepper/sixth-degree-runelite-plugin.git
-commit=0bb201f4c8aaa6784c456946bef1bf2a6a2ae1d6
+commit=968dd69c90e1ea5b27239464fbddae71a71525f6
 authors=ZoltanPepper
 warning=This plugin submits your IP address, RuneScape display name, linked Discord user ID, clan-related gameplay data, loot/XP/event/LFG data, and screenshots when enabled by Sixth Degree clan settings to a third-party Sixth Degree server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Changes:

Adds automatic BOTW KC tracking.
Adds automatic SOTW XP tracking.
Adds live BOTW/SOTW leaderboard refresh.
Removes the 15-player competition leaderboard cap.
Adds Upcoming / Live / Paused / Closing competition states.
Adds the Sixth Degree Plugin Hub icon.

Boss Lady remains authoritative for competition scoring, closeout and attendance. No Bingo functionality is changed.