### PR TITLE
Update configurable-slayer-task-overlay

### DIFF
--- a/plugins/configurable-slayer-task-overlay
+++ b/plugins/configurable-slayer-task-overlay
@@ -1,2 +1,2 @@
 repository=https://github.com/NathanVegetable/configurable-slayer-task-overlay.git
-commit=9f09e813a19c236f0eef37b840154feca113efa5
+commit=225ca0350e9350562f0a646ebc7c98aa8f7667a2


### PR DESCRIPTION
Bumps the plugin to the latest release.

Fixes [NathanVegetable/configurable-slayer-task-overlay#5](https://github.com/NathanVegetable/configurable-slayer-task-overlay/issues/5): the world map location entry now only shows while the overlay is up, sits at the bottom of the menu, and saves the point you right-clicked.

Fixes [NathanVegetable/configurable-slayer-task-overlay#6](https://github.com/NathanVegetable/configurable-slayer-task-overlay/issues/6): adds a `::slayertask` command to show or hide the overlay.
