### PR TITLE
update better-drift-net to 1.2

### DIFF
--- a/plugins/better-drift-net
+++ b/plugins/better-drift-net
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/better-drift-net.git
-commit=bbbe37074c096ad9a333a6650e9c2e0898c0542a
+commit=43de76fc307718c564db32c10d30db46c3e164f8


### PR DESCRIPTION
1.2
Still movable items default: "Clue box" -> "Clue bottle".
