### PR TITLE
Add runeassist-flipping

### DIFF
--- a/plugins/runeassist-flipping
+++ b/plugins/runeassist-flipping
@@ -1,0 +1,4 @@
+repository=https://github.com/RuneAssist/runeassist.git
+commit=1d2adbdcaf397e32b668fe9b1aa5509976326dfa
+warning=This plugin submits your coin stack size, held Grand Exchange stock with cost basis, grand exchange offers, grand exchange transactions, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.
+authors=RuneAssist

--- a/plugins/runeassist-flipping
+++ b/plugins/runeassist-flipping
@@ -1,4 +1,4 @@
 repository=https://github.com/RuneAssist/runeassist.git
-commit=1d2adbdcaf397e32b668fe9b1aa5509976326dfa
-warning=This plugin submits your coin stack size, held Grand Exchange stock with cost basis, grand exchange offers, grand exchange transactions, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers.
+commit=15ba3c867d4100bfca037d87325dd7c94f4f98bb
+warning=This plugin submits your coin stack size, held Grand Exchange stock with cost basis, Grand Exchange offers and transactions, trading preferences, account/device identifiers, and IP address to a 3rd party server not controlled or verified by the RuneLite Developers. Suggestion actions and offer timing, prices, quantities, partial fills, cancellations and completions are contributed for training by default; this contribution can be disabled in Configuration > Privacy. Optional bug reports submit your report text, RSN, and a screenshot only if selected.
 authors=RuneAssist


### PR DESCRIPTION
RuneAssist Flipping is a Grand Exchange flipping assistant: server-composed
flip suggestions, held-cost/portfolio tracking, and potion-decant support.

- Suggestions are composed server-side via the RuneAssist backend's
  `/v1/suggestion` endpoint, from a wiki-price-based scorer. There is no
  on-device scorer; the plugin sends account state and renders what the
  server returns.
- Flip history is server-owned once a device is linked to an OSRS account.
  Held-cost basis and portfolio valuation are computed server-side too.
- The `warning=` line covers everything sent, none of which is opt-in: coin
  stack size, held Grand Exchange stock with cost basis, GE offers and
  transactions, and IP address.
- Adapted from Flipping Copilot under BSD-2. Attribution is in `LICENSE` and
  `THIRD_PARTY_LICENSES.md` in the plugin repo. It has since diverged
  substantially: its own backend, scorer, decant handling and held-cost ledger.
- `build=standard`; no custom Gradle dependencies.
- Icon is 32x32, under the 48x72 limit.