### PR TITLE
Update Kill Clog to 2.2.0

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=27989a9fa3e29d014dda5f26f18430e706a6a99f
+commit=1a60d2b4c18aa5c596c4e61f0544be8a63dcdcd5
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill Clog 2.2.0

* keeps the full Total Skill Summary while optionally adding skill cells to the main grid or activity tray
* gives skill cells a configurable level color with an optional completion color at 99+
* reorganizes settings into focused collapsible sections
* shows Colosseum Glory on Sol Heredit tooltips instead of repeating its visible KC
* shows duplicate item counts in `!kclog` results
* answers RuneProfile-style `!log` commands when RuneProfile is not active
* uses verified killclog.com sync data for group ironman account badges
* prevents quest companions from being published as profile followers
