### PR TITLE
bank-architect: 0.5.0

### DIFF
--- a/plugins/bank-architect
+++ b/plugins/bank-architect
@@ -1,2 +1,2 @@
 repository=https://github.com/PKoka5/bank-architect.git
-commit=8ecb21ed4a76483a899a31066d9855c56f351750
+commit=2dcdfc36a97ddda622172c7b3913dd52bc185f75

--- a/plugins/bank-architect
+++ b/plugins/bank-architect
@@ -1,2 +1,2 @@
 repository=https://github.com/PKoka5/bank-architect.git
-commit=2dcdfc36a97ddda622172c7b3913dd52bc185f75
+commit=6c65638c71e197981ae2db488c7bd2b59b87e9b2


### PR DESCRIPTION
0.4.0 -> 0.5.0. Commit bump only; the repository line is unchanged.

Three additions, all of which leave the existing behaviour as the default:

- **Frequently used is now a switch.** The quick-access gathering (best axe and pickaxe, hammer, graceful, diary rewards) is on by default as before, but a player who would rather keep tools with tools can turn it off instead of correcting each new tier by hand.
- **A rearranged tab weaves.** A tab holding tags from more than one category used to assemble one category block after another, so an order alternating between them collapsed. Once the player has rearranged that tab's tags, it is now assembled tag by tag in the order they wrote. Tabs in default order, single-category tabs and tabs with a shaped block on them stack exactly as before.
- **Block order within a tag is the player's.** A block is whatever the sorters never split — a catalogued set, a dose or charge family, or a single item. The contents of a block stay curated, so a dose family still reads 4 to 1 and a set still dresses in slot order. Nothing saved means the curated order stands byte for byte, and there is a per-tag reset back to it.

Full suite green on the pinned commit, and all three fixed-seed simulation reports are byte-identical to 0.4.0 — every one of these is a departure the player has to ask for.