### PR TITLE
anvil: one Anvil instead of one site per clan

### DIFF
--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=67d9a5ac2440db8642d345f6ba35511decbac759
+commit=f4f686528faa9eeca1207475f7142b2524108f31

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=914994a0e2f83b3fe88605c8383b2316bfb20ffa
+commit=0879570665308a95bf9ca78dbec17b56202cdcf2

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=f4f686528faa9eeca1207475f7142b2524108f31
+commit=29c1ea5fb56c628106838f5afe92737c5bb6e15b

--- a/plugins/anvil
+++ b/plugins/anvil
@@ -1,2 +1,2 @@
 repository=https://github.com/AhmedFathy2001/anvil-plugin.git
-commit=29c1ea5fb56c628106838f5afe92737c5bb6e15b
+commit=914994a0e2f83b3fe88605c8383b2316bfb20ffa


### PR DESCRIPTION
Updates `anvil` from 67d9a5a to e8b0bd3 (plugin 1.5.0 → 1.6.0).

The site this plugin talks to used to be one deployment per clan, so the
plugin held one URL and belonged to one clan. It is now a single site with
clans as rows, and this release follows it:

- The clan comes from the account token rather than the URL. Someone in
  several clans picks between them in the sidebar instead of retyping a
  site address.
- Federation is removed — the whole mechanism existed to let separate
  per-clan deployments talk to each other, and there are no longer any.
- An Anvil button in the collection log and clan windows, placed in the
  same title bar as WikiSync and RuneProfile and anchored so it does not
  overlap them.
- Fixes: raid kill counts report the mode actually killed (an Expert ToA
  drop was reporting the normal mode's count), a 99 survives a plugin
  reload instead of being swallowed by the stat baseline, clumped NPC
  kills are counted off ServerNpcLoot rather than one per event, and drop
  attribution stops crediting a guaranteed drop as a lucky one.
