### PR TITLE
the-birdhouse: 1.3.2

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=bed13fb107b96a114dfc91c524aab0ba3c293d82
+commit=f8fc3ebff49112c3740c98a092690ba3def0414d
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
One fix: team status was slow to notice a player logging in or out. No new permissions or data collection — the warning line is unchanged.

Two things were causing it.

**The panel refreshed before the write it was waiting on.** Team status has no idea of its own state; it reads presence back from the server. It was being refreshed on the `LOGGED_IN` event, but the session write that event leads to had not gone out yet — it waits on the client thread until the local player can be named, several ticks later, and then posts asynchronously. So the refresh read the server's idea of us as still logged out, and nothing corrected it until the next poll. The tracker now notifies the panel once the write has actually landed, which is the only moment the answer can have changed.

**The poll was slower than the thing it was watching.** It was 60 seconds, on the reasoning that a client only heartbeats every five minutes so a faster poll would return the same answer. That holds for the steady state and is wrong about the transitions, which are the only part anyone looks at: a login and a logout are both reported the moment they happen, so the poll interval was the entire delay before a teammate appeared or went. Now 20 seconds. It costs no more than chat does at 10 — the cache host answers both from a live listener, so a poll does no database read.

The periodic heartbeat deliberately does not trigger a refresh. It restates what the panel is already showing, so waking the poll for it would buy a request per player every five minutes and never change a pixel.

A client that is killed rather than logged out still has to age out of the staleness window, which is unchanged at two missed heartbeats. Tightening that means heartbeating more often, which is a real cost increase for an edge case, so it stays as it is.
