### PR TITLE
Fuax Bingo - Raid Loot Bugfix

### DIFF
--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,3 +1,3 @@
 repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
-commit=72c83c4a2896e6b00bb68e947c00e345fad83761
+commit=6655915d3dc55ccdce0a8110c7269250ee5f68b1
 authors=ThatOhio


### PR DESCRIPTION
Proper correlation for loot that can show multiple times in chat (say two rolls of vials of blood) that is then merged in a loot interface.