### PR TITLE
Update groupscape to b304a0f

### DIFF
--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=26915a64be5decd9c9cd52645f4215c7003f6bd1
+commit=accd1eeb140dac0332189d72bd7c000e86269163
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=37ecd454a41005d982640bc006c3b907d3f076d4
+commit=fef78120a970400375a6b6a32515e074f305333d
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=accd1eeb140dac0332189d72bd7c000e86269163
+commit=37ecd454a41005d982640bc006c3b907d3f076d4
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=3437a255b97756571c36d75f7d8a3251b9ec4013
+commit=8b49f65aaf7d395d2b2b57c1ddd050dde13c2d38
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=8b49f65aaf7d395d2b2b57c1ddd050dde13c2d38
+commit=26915a64be5decd9c9cd52645f4215c7003f6bd1
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=8e9d0bbfb3ce9bb85752b5e85fe619962b95b18f
+commit=b304a0f5538e94fe534de9ec870193bf9ede6b8d
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=df03a9c5813d3624fb6bbe156d312612598e1eac
+commit=83cb4265fc328a029b22b25e93c777608c35ccee
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=fef78120a970400375a6b6a32515e074f305333d
+commit=df03a9c5813d3624fb6bbe156d312612598e1eac
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=83cb4265fc328a029b22b25e93c777608c35ccee
+commit=8e9d0bbfb3ce9bb85752b5e85fe619962b95b18f
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Brings the deployed plugin to v1.8.19.

- Slayer tasks now build a history on the site (each task's master, points earned/spent, kills, and how it ended) plus an all-time stats summary, viewable from new tabs on the Slayer panel.
- Fixed active prayer icons showing both Eagle Eye and Deadeye (or both Mystic Might and Mystic Vigour) at once - only the upgraded prayer you actually have unlocked shows now.