### PR TITLE
update teleport-blocker to 1.1

### DIFF
--- a/plugins/teleport-blocker
+++ b/plugins/teleport-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/teleport-blocker.git
-commit=2acc08ba5b38dcaef2085e6a2ba62c3164521cf8
+commit=016b7ae394de515446313c1f94d121d94e712a36

--- a/plugins/teleport-blocker
+++ b/plugins/teleport-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/teleport-blocker.git
-commit=1212154191b47f51a95438aaf6e90c447dd05210
+commit=2acc08ba5b38dcaef2085e6a2ba62c3164521cf8

--- a/plugins/teleport-blocker
+++ b/plugins/teleport-blocker
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/teleport-blocker.git
-commit=016b7ae394de515446313c1f94d121d94e712a36
+commit=0913ed52997a2dab8e2c9307b7d36838c1c7660a


### PR DESCRIPTION
1.1 added lots of functionality to teleports/ transports: 
Plugin icon added.
Minigame Teleport: the 21 destinations in the Minigames window and the four rat pit options are blockable individually.
Ancient and lunar spellbook teleports, 9 each, off by default.
Canoe destinations on both rivers, 11 in total, off by default.
Teleport jewellery: 10 items, 43 destinations, blocked on the worn menu, the submenu and the rub dialogue.
Dialogue options are blocked by number key as well as by mouse.
