### PR TITLE
Update Faux Bingo plugin - Screenshot Upload Hardening 

### DIFF
--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,3 +1,3 @@
 repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
-commit=6655915d3dc55ccdce0a8110c7269250ee5f68b1
+commit=9fe67c24d5eccdf60f531e5c03c8f0ddd47e9b43
 authors=ThatOhio


### PR DESCRIPTION
We noticed some events lacking screenshots, and have decided to make some changes to hopefully harden how we upload screenshots to alleviate.

First, we were not previously retrying the screenshot upload like we were with posting the event. 

Second, we saw a few paths that could fail to actually send a screenshot due to how some drop signals could not carry a screenshot. 

And third, there was no effort done previously to compress or otherwise bound the image before sending it, so players on larger screens / with scaling on in the GPU plugin, etc would send an image the website would immediately need to shrink or compress, let alone the max request size per screenshot. We do some lightweight client side work on the screenshot before sending now to hopefully alleviate that concern. 