### PR TITLE
Update modern-chat: Fix chat resize locking up after a world hop

### DIFF
--- a/plugins/modern-chat
+++ b/plugins/modern-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/BenDol/Modern-Chat.git
-commit=7d441b1f27a77d53bfd29692bdb774ea587c56b0
+commit=69d5f0b123732364752f9c6f7ca3c53df0befcd4


### PR DESCRIPTION
Fix an issue where chat resize would lock up after a world hop