### PR TITLE
Add aerial-cue plugin repository information

### DIFF
--- a/plugins/aerial-cue
+++ b/plugins/aerial-cue
@@ -1,0 +1,2 @@
+repository=https://github.com/skipple/aerial-cue.git
+commit=42b848eec0d0c4db5e53f4defd78b66380e1ee3b

--- a/plugins/aerial-cue
+++ b/plugins/aerial-cue
@@ -1,2 +1,2 @@
 repository=https://github.com/skipple/aerial-cue.git
-commit=42b848eec0d0c4db5e53f4defd78b66380e1ee3b
+commit=6a5a04f2f4822c2af5a3c4978441adc494712cd1


### PR DESCRIPTION
Aerial Cue plays a short countdown of rising notes while your cormorant is out aerial fishing, with the final note landing on the game tick the next fishing spot becomes clickable. The wait is derived from the bird's flight distance (and the fixed timing of frenzied spots), so a close spot gets a two-note run and a far one the full five — each length of wait has its own recognizable shape, so you learn to click on the phrase rather than react to a single beep.

Ten sound profiles are bundled (tone, marimba, kalimba, plucked string, guitar chords, deep percussion and others); the countdown length is configurable from 1 to 5 notes, plus a volume slider. Cues only play while aerial fishing gloves are equipped.

The plugin is audio-only — it adds no overlay, no menu entries, and takes no input. All sounds are bundled resources, and it makes no network requests.