### PR TITLE
Update Leadman Mode to 1.0.0-beta.2

### DIFF
--- a/plugins/leadman
+++ b/plugins/leadman
@@ -1,2 +1,2 @@
 repository=https://github.com/felippeomgt/leadman-mode.git
-commit=542514b5ba58ddcadd1592e692cf547e1d83237f
+commit=9bd9a69ca677a413a441648f272f11cbea3c323b


### PR DESCRIPTION
## Summary
- Bumps Leadman Mode to **1.0.0-beta.2** (`9bd9a69`)
- Crafting ranged equipment modes (Restrict / Balanced / Mixed)
- Additional shop-only rules and rune pack `packOf` mappings
- GE obtain fix and expanded shop review rules from beta.1 line

## Repository
https://github.com/felippeomgt/leadman-mode

## Test plan
- [ ] Plugin Hub CI builds successfully
- [ ] Plugin loads from hub listing
- [ ] GE trade requires obtain + skill for fabricable items
- [ ] Crafting ranged equipment Mixed mode: balanced wield, fabrication trade