### PR TITLE
Update Lively Cities: hold on to objects teardown could not deactivate

### DIFF
--- a/plugins/lively-cities
+++ b/plugins/lively-cities
@@ -1,3 +1,3 @@
 repository=https://github.com/MatthewMariner/lively-cities.git
-commit=1d2a2a0ccbd9efc7554d235b30634132850e39e5
+commit=2b1904936004f114388f1a99f977c541debb69e2
 authors=MatthewMariner


### PR DESCRIPTION
One-line manifest bump, `1d2a2a0` → `2b19049`.

### Fix

**A `RuneLiteObject` could survive teardown with nothing left holding it.** `EntityScene.shutdown()` deactivated every entity, counted the ones still registered, logged an error if any remained — and then cleared the map that held them anyway. Deactivation catches its own `RuntimeException` and reports failure, so the state was reachable. The result was an object still in the client's registered list with no reference to it: it kept rendering, disabling and re-enabling the plugin could not reach it, and only a client restart cleared it.

Entities the client still reports as registered are now retained and retried instead of dropped, and a failed registration check is treated as "still held" rather than assumed released.

The same path also called an unguarded `isActive()` while counting, so a client that threw on that check threw out of teardown itself, before the overlays were deregistered. The count now comes from the guarded sweep.

### Also

- Corrected three code comments that cited a disassembly and described client behaviour that does not occur. The null checks they annotate are correct and unchanged; only the stated reason was wrong.
- Hardened two `ClientThread.invoke` call sites. Both passed a lambda over an `int`-returning method, which is void-compatible only because the return type is `int`; a change to `boolean` would bind them to the `BooleanSupplier` overload, which is re-queued every tick until it returns true. Both are explicit block lambdas now, and a test fails if the shape returns.
- Documented three config settings that were reachable in the panel but absent from the README, with a test that fails when a new setting is added without documenting it.
- Added a build workflow.

### Notes for review

No new dependencies, no new client APIs, no file I/O, no configuration migration. Rendered content is unchanged — no model, animation or placement data was touched. 511 tests, green.