### PR TITLE
Add FlipX plugin

### DIFF
--- a/plugins/flipx
+++ b/plugins/flipx
@@ -1,0 +1,3 @@
+repository=https://github.com/JoshiOS-VRY/osrs-flip-plugin.git
+commit=d1af4b375c750098e3fceb44de35a14d06a3ae29
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/flipx
+++ b/plugins/flipx
@@ -1,3 +1,3 @@
 repository=https://github.com/JoshiOS-VRY/osrs-flip-plugin.git
 commit=e293698898dc78d54cb47888fd5b263419a8f713
-warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by RuneLite developers.
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/flipx
+++ b/plugins/flipx
@@ -1,3 +1,3 @@
 repository=https://github.com/JoshiOS-VRY/osrs-flip-plugin.git
-commit=d1af4b375c750098e3fceb44de35a14d06a3ae29
-warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.
+commit=e293698898dc78d54cb47888fd5b263419a8f713
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary

Resubmission of #14474 after the stale close. Addresses @riktenx's review (no reconstructed GE clientscripts) and @ldavid432's review (no `client.menuAction`).

- **Repository:** https://github.com/JoshiOS-VRY/osrs-flip-plugin
- **Pinned commit:** `e293698898dc78d54cb47888fd5b263419a8f713`
- **Privacy policy:** https://www.flipx.gg/privacy
- **Web app:** https://www.flipx.gg

## Review response

GE assist no longer captures or invokes `ge_offers_setup_changequantity` / `changeprice` (scripts 777/778), does not `runScript` to submit the chatbox, and does not call `client.menuAction`. Optional setup icons prefill the native Enter quantity / Enter price chatbox if it is already open, or remember the value until you open it (same prefill pattern as Flipping Copilot). You still press Enter and Confirm every offer.

## Features

- **Opt-in GE upload** (disabled by default) — syncs offers you place manually for portfolio analytics on flipx.gg
- **Market panel** — tier-scoped opportunity browsing, filters, slot optimizer, watchlist sync
- **Display-only overlays** — GE copilot score/profit overlay, slot highlights, stagnation timers (read-only)
- **GE assist buttons** — optional qty/price helpers that prefill native Enter quantity/price after you open that chatbox; user must press Enter and Confirm every offer

## Compliance

- **No automation** — does not place offers, auto-confirm, reconstruct GE clientscripts, or invoke `menuAction`
- **All network features opt-in** with RuneLite config warnings on upload, market, overlays, and GE assist
- **Open source** — BSD-2, `build=standard`, no extra runtime dependencies
- **Third-party server disclosed** — fixed production host `https://www.flipx.gg`
- Warning text matches the previous maintainer suggestion

## Test plan

- [x] `./gradlew test shadowJar` passes on pinned commit
- [x] Production API live at https://www.flipx.gg
- [x] Privacy policy returns 200 at https://www.flipx.gg/privacy