### PR TITLE
chat-fade: update to 1.3

### DIFF
--- a/plugins/chat-fade
+++ b/plugins/chat-fade
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/chat-fade.git
-commit=af26591a95d8f767b2d2ac89748be2bcddecbdf2
+commit=5441c1a17e9c8b66491272c0fb55cc556f38a0b1


### PR DESCRIPTION
Updates the chat-fade manifest to the latest commit (5441c1a).

Changes since 1.2:
- Fix Jagex's `@name@` colour tokens (e.g. `@mes_hl_pur@`) rendering as literal text in the overlay, and restore "Preserve In-Game Colors" for messages that use them. These got a lot more common after the Mad Angel CA update.
- Fix the "Respect Chat Filter Plugin" option, which never actually suppressed anything — `chatFilterCheck` fires after the ChatMessage event, so blocked messages are now removed retroactively by message id.
- Add per-message ignore lists: "Ignored Messages" (comma-separated fragments) and "Ignored Regex". Contributed by @jarredgoddard.
- Separate Guest clan and Group Ironman chat from regular clan chat, each with its own colour and visibility toggle. Contributed by @TyboJones24.
- Prefix private messages with From/To so incoming and outgoing are distinguishable, matching the in-game chatbox.

All the above were tested, and the repo now carries 69 unit tests over the message pipeline, colour parsing, filtering and config integrity. If any problems turn up, please open an issue on the plugin repo and I'll get it patched.

Plugin version bumped 1.2 -> 1.3.
