### PR TITLE
Add Bolt Enchant Tracker

### DIFF
--- a/plugins/bolt-enchant-tracker
+++ b/plugins/bolt-enchant-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/EaezySait/bolt-enchant-tracker.git
+commit=0cdeba2ff1d41ecc0bcdfc0d121aebf93aea31cf


### PR DESCRIPTION
Adds Bolt Enchant Tracker, an observational plugin for tracking bolt-enchanting sessions.

Features:
- Tracks bolts enchanted, spell casts, Magic XP, bolts/hour, and XP/hour
- Calculates rune costs and GE-tax-aware profit or loss
- Supports actual buy and sell price overrides
- Projects bolts, XP, time, and profit remaining to a target Magic level
- Supports standard and dragon variants of all enchantable gem bolts
- Preserves sessions safely across world hops
- Provides a manual session reset and free elemental-rune settings

The plugin does not automate clicks, typing, casting, banking, or any other game action.

Testing completed:
- `gradlew test build` passes
- Verified live tracking in the RuneLite development client
- Verified banking does not create false enchantment counts
- Verified configuration changes and world-hop persistence