### PR TITLE
Transfer ownership of better-npc-highlight

### DIFF
--- a/plugins/better-npc-highlight
+++ b/plugins/better-npc-highlight
@@ -1,2 +1,2 @@
-repository=https://github.com/riktenx/better-npc-highlight.git
+repository=https://github.com/SamuelDev/runelite-plugins.git
 commit=333d60c826824573b12a07fe317569016e3b4e04


### PR DESCRIPTION
I am requesting to regain control of the better npc highlight plugin after giving it over to the runelite maintainers a few months ago. That happened in https://github.com/runelite/plugin-hub/pull/13365