### PR TITLE
chat-fade: update to 1.3.1

### DIFF
--- a/plugins/chat-fade
+++ b/plugins/chat-fade
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/chat-fade.git
-commit=5441c1a17e9c8b66491272c0fb55cc556f38a0b1
+commit=e213adba70bf9ebc6998469bb11bd5a0ad7ebf6c


### PR DESCRIPTION
Updates the chat-fade manifest to the latest commit (e213adb).

Follow-up to 1.3 addressing review feedback: 1.3 shipped a `ColorTokens` class that hand-rolled `@name@` colour macro handling, which `Client.macroExpand` already does properly. That class is gone and the plugin now calls `macroExpand` once at ingest, so everything downstream only ever sees `<col=...>`.

Three things this fixes:
- Colours are now the game's own values rather than constants I'd approximated, since no palette table is exposed in the API.
- Player-typed text like `@bob_smith@` is no longer eaten — the hand-rolled matcher couldn't tell a real macro from ordinary chat.
- Unrecognised macros expand correctly instead of being silently dropped.

Also fixes a latent bug in the async message-update path, which stripped one string for display but passed the unstripped one to the colour span parser.

Net -217 lines. Thanks for the catch.

Plugin version bumped 1.3 -> 1.3.1.
