### PR TITLE
update bolt-enchant-tracker

### DIFF
--- a/plugins/bolt-enchant-tracker
+++ b/plugins/bolt-enchant-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/EaezySait/bolt-enchant-tracker.git
-commit=21a2ec54e84a54bd6a29a6a1ff865aeaadc7aa01
+commit=cb12f3098c8d13f6b5b359b14b0e1af641405be0

--- a/plugins/bolt-enchant-tracker
+++ b/plugins/bolt-enchant-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/EaezySait/bolt-enchant-tracker.git
-commit=cb12f3098c8d13f6b5b359b14b0e1af641405be0
+commit=6d0c951c61c50f0537aea1a76b94126a0925648d

--- a/plugins/bolt-enchant-tracker
+++ b/plugins/bolt-enchant-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/EaezySait/bolt-enchant-tracker.git
-commit=0cdeba2ff1d41ecc0bcdfc0d121aebf93aea31cf
+commit=21a2ec54e84a54bd6a29a6a1ff865aeaadc7aa01


### PR DESCRIPTION
Updates Bolt Enchant Tracker to use the author's GitHub handle and replaces development/testing notes with a concise player-facing support guide.

No plugin behavior or game interaction has changed.