### PR TITLE
Update Spell Reminder to v1.10.1

### DIFF
--- a/plugins/thrall-helper
+++ b/plugins/thrall-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/PortAGuy/thrall-helper.git
-commit=b4a7dd54f59626d670bc9cdf825a5844d0965730
+commit=811a57f5ebd9865af9ba695925a5aba1b7ea13d8

--- a/plugins/thrall-helper
+++ b/plugins/thrall-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/PortAGuy/thrall-helper.git
-commit=811a57f5ebd9865af9ba695925a5aba1b7ea13d8
+commit=758de245793d09ea3c765b70a3c3e0dfbe9852e3


### PR DESCRIPTION
- Fixes for Mark of Darkness and Ward of Arceuus reminders due to Jagex introducing chat macros for colours
- Fixes for Magic Imbue reminding when entering the Death Altar