### PR TITLE
Update compact-orbs to v1.9.5

### DIFF
--- a/plugins/compact-orbs
+++ b/plugins/compact-orbs
@@ -1,2 +1,2 @@
 repository=https://github.com/its-cue/compact-orbs.git
-commit=8a6f6f77087628a8596ca830c83f4dfb75ee270c
+commit=09c22b979f1c15bee064055a6f4fab7886705035


### PR DESCRIPTION
- remove orb hiding by scriptId

bugfixes:
- apply the default opacity to the spec orb indicator when closing edit-mode
- count the wiki slot as hidden only if the wiki button and toggle button are hidden
- fix the detached minimap not following its snapcorner when repositioned