### PR TITLE
Update jams-solo-tempoross to 1.0.8

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=3c006beb61eb2a626e1608fdb9e33824effdcc7a
+commit=2e13fbbe96b377c91f1a8477fadb0869d51de470


### PR DESCRIPTION
﻿## Summary
- Bumps Jam's Solo Tempoross to 1.0.8 (`2e13fbb`)
- Far-side double fishing spots are detected more reliably
- No longer redirects to a double while cooking, or after Tempoross retreats

## Test plan
- [ ] Plugin Hub CI builds the plugin
- [ ] Far-east fishing when far-west becomes double shows the path
- [ ] Cooking stays on cook when a double appears mid-animation
- [ ] After retreat/ferry, helper goes refill/leave instead of fishing
