### PR TITLE
Update gok-irl-xp: fix profile isolation and timer accounting

### DIFF
--- a/plugins/gok-irl-xp
+++ b/plugins/gok-irl-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/mataeo-eh/GOK-IRL-XP.git
-commit=abd1b3964527a9e7f90437d22052134b384ad9e4
+commit=ee96b37c80902b0f87a7fe01705f406620a5590f


### PR DESCRIPTION
Updates gok-irl-xp from abd1b3964527a9e7f90437d22052134b384ad9e4 to ee96b37c80902b0f87a7fe01705f406620a5590f.

Fixes five issues found during a code review:

- Reload actions, units, timers, observed levels, multipliers, and balances on configuration-profile changes. Guard timer saves and XP deposits during the profile transition so the previous profile's state is not carried into the new profile.
- Freeze each timer's starting action duration and XP rates, and persist those terms across restarts. Editing an action applies to new timers instead of reinterpreting elapsed time already awarded.
- Settle completed units when stopping a timer, matching pause behavior without rounding up partial units.
- Skip null entries in saved timer lists while retaining valid timers.
- Saturate combined timer awards instead of overflowing negative.

Validation: `./gradlew --gradle-user-home .gradle-user-home check` passes all 110 tests, including 10 new regression tests covering profile switching, timer restart/migration, edits, stop/pause settlement, malformed saves, and overflow. `git diff --check` passes. No new dependencies; Java 11 target and standard Plugin Hub packaging are unchanged.

Source diff: https://github.com/mataeo-eh/GOK-IRL-XP/compare/abd1b3964527a9e7f90437d22052134b384ad9e4...ee96b37c80902b0f87a7fe01705f406620a5590f
