### PR TITLE
Updated flati boss tracker to track hunter rumours and reduce chat spam.

### DIFF
--- a/plugins/flati-boss-tracker
+++ b/plugins/flati-boss-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Flati/Flati-Boss-Tracker.git
-commit=5e230ba56d71053ca706feeff5cd328ff3209e37
+commit=8a6164fbe76d3b2edbcf827da45b3c98844bdbef
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Hunter rumours were synced from the collection log but now they are also tracked in realtime when finishing rumours.
Also removed the reminder on logon that wasn't working properly.