### PR TITLE
Update Jam's Arceuus Runecrafting to 1.0.4

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=52e2463221df66ea0a8c96c5e2aee1151cbf6ab2
+commit=cf019f8d898bd681d3007bf3191b638099a3b7e9


### PR DESCRIPTION
## Summary

- Path display dropdown (floor & minimap / floor only / minimap only / off), migrating the old checkboxes
- Path source dropdown: plugin lines or Shortest Path (step-coloured, depleting route; falls back if SP is off)

## Test plan

- [x] Unit tests pass on https://github.com/JamsRepos/zeah-rc-helper
- [x] Only `plugins/zeah-rc-helper` commit hash changed