### PR TITLE
loadout-lab: update to 0.5.1

### DIFF
--- a/plugins/loadout-lab
+++ b/plugins/loadout-lab
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-loadout-lab.git
-commit=305becf982adace12aa1b754b0658f7a9d8f66a8
+commit=fa27531b8de76c9c8ea0fb43d757093c79514b66
 authors=ajkatz


### PR DESCRIPTION
Loadout Lab 0.5.1.

Compute animations for sixty-odd bosses, groups and raids, drawn in colour from the wiki renders and shipped as a resource (the plugin's source stays under the cap); a Cancel chip mid-compute; search drops Leagues echo bosses and Nightmare Zone versions; the roster row and the sea card agree; the trip ledger collapses per profile; the bank filter carries every supply.
