### PR TITLE
clan-management: points display decimals

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=fb9be4fc048e9cb290e30792665efaf1d5c66745
+commit=e87c91fe1d7463d432ad392ec83adc972f3792b6
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Small display fix: clan points (whitelist item points, the drops points leaderboard, and per-drop points) now render decimals instead of being rounded to whole numbers. The values were already stored with decimals; the panel was truncating them to int on read.