### PR TITLE
Add RunePerks

### DIFF
--- a/plugins/runeperks
+++ b/plugins/runeperks
@@ -1,0 +1,2 @@
+repository=https://github.com/maxisley/runeperks.git
+commit=65c8a9db7bd6c339f48b67a6cb55869cd4ecd662

--- a/plugins/runeperks
+++ b/plugins/runeperks
@@ -1,2 +1,2 @@
 repository=https://github.com/maxisley/runeperks.git
-commit=eeadec68d1fd765bd75f4b1d20291bd21798877a
+commit=f1ddf6c50a96415a4ce49f558135550d6318342a

--- a/plugins/runeperks
+++ b/plugins/runeperks
@@ -1,2 +1,2 @@
 repository=https://github.com/maxisley/runeperks.git
-commit=65c8a9db7bd6c339f48b67a6cb55869cd4ecd662
+commit=6385158c10109f0d7f98626fc4fa7616739936d1

--- a/plugins/runeperks
+++ b/plugins/runeperks
@@ -1,2 +1,2 @@
 repository=https://github.com/maxisley/runeperks.git
-commit=6385158c10109f0d7f98626fc4fa7616739936d1
+commit=eeadec68d1fd765bd75f4b1d20291bd21798877a


### PR DESCRIPTION
RunePerks adds a small, optional sponsor banner to RuneLite. Players can move and resize it (160 × 32 minimum), pause or hide it, and click through to the displayed website. The plugin enables on installation; card display and online delivery remain separately opt-in with the third-party connection warning.

### Production model and policy review

The intended product sells reviewed ad placements to businesses and shares advertising revenue with participating OSRS players through cash payouts outside the game. Sponsors supply a message, destination URL, and budget; players choose to display ads; RunePerks would verify eligible display and allocate player revenue shares. Clicks would not be required.

Please review the eligibility of paid placements, cash revenue sharing, and overlay delivery as part of this submission. The linked source implements only the banner, rotation, and links: campaign purchasing, display verification, account linking, balances, and payouts are not implemented. Approval of this commit would not be treated as approval for later tracking or payment features.

### Submitted implementation

- Fictional, explicitly labeled samples only; online destinations are restricted in code to the Google homepage.
- Fixed text-only HTTPS feed, fetched asynchronously at most every five minutes while enabled, unpaused, and logged in. Responses are bounded to 32 KB and cached in memory until expiry.
- No player data, click or impression reports, credentials, cookies, redirects, downloaded code, or gameplay automation. The feed host receives normal IP/request metadata.
- Java 11, standard build, injected OkHttp/Gson, BSD-2-Clause license, 48 × 48 icon, no additional runtime dependencies.

Validation: 22 local tests pass; [Java 11 CI](https://github.com/maxisley/runeperks/actions). The owner has exercised the plugin in-game and supplied the gameplay screenshot on the website; automated tests do not substitute for gameplay validation.

[Source and production workflow](https://github.com/maxisley/runeperks) · [Production model](https://github.com/maxisley/runeperks/blob/f1ddf6c50a96415a4ce49f558135550d6318342a/README.md#production-model) · [Privacy](https://github.com/maxisley/runeperks/blob/f1ddf6c50a96415a4ce49f558135550d6318342a/PRIVACY.md) · [Website and interactive preview](https://quiet-sponsor-review.kidlotus.chatgpt.site/)


