### PR TITLE
osrs-flipper-sync: update to 5.2.28

### DIFF
--- a/plugins/osrs-flipper-sync
+++ b/plugins/osrs-flipper-sync
@@ -1,3 +1,3 @@
 repository=https://github.com/Ishmarr/osrs-flipper-runelite-sync.git
-commit=1f9fbb73dc4c8b5b612d7f879fe80805f4303b59
+commit=4b19c6a01fe45ee014e18f235fde1d1941c59038
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates OSRS Flipper Sync from 5.2.22 to 5.2.28.

Changes:
- adds buy-limit-aware quantity suggestions and live GE-slot timers;
- resets slot timers on fills and preserves the total offer duration on completion;
- reduces redundant RuneLite snapshots while keeping immediate GE updates;
- adds persistent sync-health reporting and safe automatic recovery;
- prevents stale or unavailable quantity suggestions from being applied;
- improves period-statistics handling when attribution data is incomplete.

No new dependencies were added. The existing Plugin Hub warning remains unchanged.