### PR TITLE
Add TOA All In 1

### DIFF
--- a/plugins/toa-all-in-1
+++ b/plugins/toa-all-in-1
@@ -1,0 +1,2 @@
+repository=https://github.com/stadtehrsoftware/toa-all-in-1.git
+commit=a3258e5235166ffd27bd64faf3d74ef18e5c199b

--- a/plugins/toa-all-in-1
+++ b/plugins/toa-all-in-1
@@ -1,2 +1,2 @@
 repository=https://github.com/stadtehrsoftware/toa-all-in-1.git
-commit=27b4bc2ab5486b740b56837149c4d561f027367c
+commit=dec8cd6fcd472e1083cbb4a6b532fc44fc5519a3

--- a/plugins/toa-all-in-1
+++ b/plugins/toa-all-in-1
@@ -1,2 +1,2 @@
 repository=https://github.com/stadtehrsoftware/toa-all-in-1.git
-commit=6a4f0eab240557210434595d7267f4dc98197d77
+commit=27b4bc2ab5486b740b56837149c4d561f027367c

--- a/plugins/toa-all-in-1
+++ b/plugins/toa-all-in-1
@@ -1,2 +1,2 @@
 repository=https://github.com/stadtehrsoftware/toa-all-in-1.git
-commit=a3258e5235166ffd27bd64faf3d74ef18e5c199b
+commit=6a4f0eab240557210434595d7267f4dc98197d77


### PR DESCRIPTION
Adds TOA All In 1, a visual-only overlay and reminder plugin for Tombs of Amascut. It does not automate gameplay: it does not click, move, or perform game actions.

- Keris partisan of the sun flashes green above 50 current Prayer and red at 50 or below; both Ambrosia doses flash green.
- Small explosive Kephri eggs receive a cycling rainbow highlight; larger hatching eggs are excluded by NPC ID.
- Shows the current spellbook above the player in the ToA lobby while the bank is closed, with an optional missing Dragon/Abyssal dagger warning while that display is enabled.
- Highlights Zebak waves in cyan, displays a tick countdown after volatile baboons start their explosion animation, and highlights Arcane Scarabs with a flashing danger outline and kill warning.
- Displays estimated personal raid points and purple chance in a movable overlay.
- Features have individual configuration checkboxes.

Includes the Plugin Hub icon, Discord support/community link, and third-party license attribution for points tracking adapted from LlemonDuck/tombs-of-amascut. The plugin is visual only and does not automate game actions. Points and purple chance are estimates.

Validation: Java 11 Gradle build and included unit tests passed. The author has tested the updated plugin in-game and reports that it works great.