### PR TITLE
Update Kill Clog to 2.3.0: Skill Clogs

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=1a60d2b4c18aa5c596c4e61f0544be8a63dcdcd5
+commit=e29e21f291d7f4b83ef7fc84c48bdd4198af6b17
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=e29e21f291d7f4b83ef7fc84c48bdd4198af6b17
+commit=0860e91fb95a1031c1a23a4d876b6ac3f40c8f1e
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
## Summary

- adds Skill Clogs with Collection Log-style progression for all 24 skills
- adds aggregate completion, deduplicated section totals, duplicate quantities, and adaptive item sprites
- adds selectable Skill Color, 99+ Completion, or standard Kill Clog Progression color modes for skill level colors
- rebuilds comparison mode: every comparison tooltip is now the two players' regular tooltips side by side, replacing the separate comparison renderers entirely, and comparison cells pair blue over red consistently
- moves the static data tables (boss lists, skill clog sections, chat aliases, flavor text) into bundled resources; with the comparison rebuild this puts the plugin source well under the review bot's limit
- improves first-time Collection Log setup, settings organization, and clue chat commands
- expands tooltip polish, naming, personal-best display, and pinned-tooltip behavior

## Testing

- compile, tests, jar, and both checkstyle gates pass from an isolated source copy
- tested in the RuneLite 1.12.38 development client, including a full comparison-mode pass
- no new endpoints or upload paths
