### PR TITLE
add tcgg

### DIFF
--- a/plugins/tcgg
+++ b/plugins/tcgg
@@ -1,3 +1,3 @@
 repository=https://github.com/TheOffSeason/tcgg.git
-commit=e9d29ac03e023ee54e0f9a8c87d7b56f9ae3494f
+commit=418f15ad7c1ae4e948191f017816201d80745550
 authors=RoleModels

--- a/plugins/tcgg
+++ b/plugins/tcgg
@@ -1,3 +1,3 @@
 repository=https://github.com/TheOffSeason/tcgg.git
-commit=418f15ad7c1ae4e948191f017816201d80745550
+commit=11bbf54ddc69a034395b8beca035746c7b03e479
 authors=RoleModels

--- a/plugins/tcgg
+++ b/plugins/tcgg
@@ -1,0 +1,3 @@
+repository=https://github.com/TheOffSeason/tcgg.git
+commit=e9d29ac03e023ee54e0f9a8c87d7b56f9ae3494f
+authors=RoleModels


### PR DESCRIPTION
TCGG turns an OSRS TCG pack into a party race.

One player opens a five-card pack and everybody in the same RuneLite Party receives the same five objectives — obtain an item, kill a monster, or interact with an NPC. The group then races to complete any one of them from scratch, starting at Kandarin Monastery with a fixed loadout.

- Everybody presses Ready up, the host opens a pack, and the round starts on the fifth card reveal.
- Any number of racers can take part. Everyone is ranked with their completion time; the top five score 5-4-3-2-1.
- Rounds group into a match of configurable length with a running scoreboard and a winner announcement.
- Optional from-scratch rules invalidate a local run on a bank withdrawal, Grand Exchange use, a player trade, moving during the countdown, or starting with the wrong items.

It reads the live card catalogue cached by the OSRS TCG plugin to resolve card names into item and NPC ids. All state is exchanged over RuneLite Party messages; nothing is sent anywhere else.

Repository: https://github.com/TheOffSeason/tcgg