### PR TITLE
Update Clan Piano MIDI

### DIFF
--- a/plugins/clan-piano-midi
+++ b/plugins/clan-piano-midi
@@ -1,2 +1,2 @@
 repository=https://github.com/TheOffSeason/clan-piano-midi.git
-commit=7071b44a44ded0b8805481042f96e8fbfff33947
+commit=950250a94c7f73f2f5ff33e216f4e73eb09d6318


### PR DESCRIPTION
Updates `clan-piano-midi`.

- Adds six instruments: Bright piano, Honky-tonk, Electric piano, Harpsichord, Music box and Marimba, alongside the existing Grand piano, Organ and RuneScape piano. All are generated at runtime, so nothing is added to the download size.
- Level-matches the instruments. The organ barely decays, so peak normalisation left it carrying far more average energy than the struck notes and it played noticeably louder; each instrument now has a level trim.
- Shortens the organ and adds a "Note length" setting so note ring-out can be adjusted without a sustain pedal.
- Updates the author field.

No change to how the plugin interacts with the game: it reads a MIDI input device, plays audio through `AudioPlayer`, and exchanges note messages with the party.