### PR TITLE
update clan-piano-midi

### DIFF
--- a/plugins/clan-piano-midi
+++ b/plugins/clan-piano-midi
@@ -1,2 +1,2 @@
 repository=https://github.com/TheOffSeason/clan-piano-midi.git
-commit=950250a94c7f73f2f5ff33e216f4e73eb09d6318
+commit=2729edc525b4eadf0c79963d463c8ce3c03fecc0


### PR DESCRIPTION
Updates Clan Piano MIDI to the current commit.

- Adds a `support` link to the plugin entry.
- Picks up the instrument work already on master: six instruments, level matching, and adjustable note length.