### PR TITLE
gustav-helper: update to dedaf62

### DIFF
--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=088a9a99d0d87666220f22b643e0ea3440a7aee4
+commit=dedaf6255011a69930c0c8be4a248afb8e569682
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Data-only update: re-scrape of the bundled osiris-ironman guide to match upstream ironman.guide edits — one step gains a woodcutting auto-complete condition and a training note. No code changes, no networking changes; the opt-in reporting introduced in #14688 is untouched, and the manifest warning line is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)