### PR TITLE
Update jams-solo-tempoross to 1.0.9

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=2e13fbbe96b377c91f1a8477fadb0869d51de470
+commit=222a63396f110b6f46c4d1a9667dba19cc222e87


### PR DESCRIPTION
﻿## Summary
- Rolls Jam's Solo Tempoross back from broken 1.0.8 to restored 1.0.7 behaviour as 1.0.9 (`222a633`)
- 1.0.8 caused delayed action updates, late double-spot chimes, and wrong cook/deposit overlays

## Test plan
- [ ] Plugin Hub CI builds the plugin
- [ ] Depositing shows deposit as current activity, not cook
- [ ] Double-spot / step changes feel responsive again (no ~2s lag)
