### PR TITLE
Update Sixth Degree to 0.1.4

### DIFF
--- a/plugins/sixth-degree
+++ b/plugins/sixth-degree
@@ -1,4 +1,4 @@
 repository=https://github.com/ZoltanPepper/sixth-degree-runelite-plugin.git
-commit=7804182581c819d098cd6d0839b7c24ceaf90d0e
+commit=6d206c9eb01a4368e6eae8c3a51d215d9beee709
 authors=ZoltanPepper
 warning=This plugin submits your IP address, RuneScape display name, linked Discord user ID, clan-related gameplay data, loot/XP/event/LFG data, and screenshots when enabled by Sixth Degree clan settings to a third-party Sixth Degree server not controlled or verified by RuneLite developers.

--- a/plugins/sixth-degree
+++ b/plugins/sixth-degree
@@ -1,4 +1,4 @@
 repository=https://github.com/ZoltanPepper/sixth-degree-runelite-plugin.git
-commit=c7cd00a8d6d89462dc407b37c20574de3bed8891
+commit=21b281a389a9cf1c67eef35160fbec6ed5ac16e0
 authors=ZoltanPepper
 warning=This plugin submits your IP address, RuneScape display name, linked Discord user ID, clan-related gameplay data, loot/XP/event/LFG data, and screenshots when enabled by Sixth Degree clan settings to a third-party Sixth Degree server not controlled or verified by RuneLite developers.

--- a/plugins/sixth-degree
+++ b/plugins/sixth-degree
@@ -1,4 +1,4 @@
 repository=https://github.com/ZoltanPepper/sixth-degree-runelite-plugin.git
-commit=6d206c9eb01a4368e6eae8c3a51d215d9beee709
+commit=c7cd00a8d6d89462dc407b37c20574de3bed8891
 authors=ZoltanPepper
 warning=This plugin submits your IP address, RuneScape display name, linked Discord user ID, clan-related gameplay data, loot/XP/event/LFG data, and screenshots when enabled by Sixth Degree clan settings to a third-party Sixth Degree server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Updates Sixth Degree directly from 0.1.2 to 0.1.4, superseding the previously submitted 0.1.3 update.

Changes
Adds local-player death notifications.
Adds an optional per-user setting for including a RuneLite screenshot with death notifications.
Adds BOTW mobile KC reconciliation after a trusted RuneLite KC observation has been established during the same uninterrupted live competition.
Adds SOTW mobile XP reconciliation using trusted absolute XP observations.
Establishes a zero-score SOTW baseline when RuneLite first observes a live competition. This allows players to switch to mobile before gaining desktop XP and still have later mobile XP recovered safely.
Re-establishes trusted SOTW baselines following competition pause/resume so XP gained while paused is not credited.
Uses server-provided reconciliation safety state so missing progress is only recovered from a trusted observation. If a safe baseline is unavailable, the client does not guess or award lifetime KC/XP.

Adds bundled Sixth Degree notification sounds for:
Login
LFG
Quest completion
Collection log entries
Personal bests
Deaths
BOTW start
SOTW start
Competition winners
Competition winner sound only triggers after a scored BOTW/SOTW closes and does not trigger on leaderboard lead changes.
Adds a local Notification sounds configuration toggle.
Adds bright-pink Sixth Degree game-chat notifications.
Adds an in-game confirmation and notification sound when the player submits their own LFG post.
Includes all functionality previously prepared for the 0.1.3 death-notification update.
Compatibility and safety

The reconciliation API changes are additive and backwards-compatible with older Sixth Degree clients.

BOTW mobile KC reconciliation only begins once a trusted boss KC observation has been made during that competition, preventing lifetime KC from being mistaken for competition progress.

SOTW can establish its baseline immediately because RuneLite exposes the player's absolute skill XP.

Competition pause boundaries invalidate old reconciliation baselines until a new trusted observation is established.

The existing Plugin Hub third-party-data warning is unchanged.

Final plugin commit:

`21b281a389a9cf1c67eef35160fbec6ed5ac16e0`