### PR TITLE
Slayer bank tab 1.0.3

### DIFF
--- a/plugins/slayer-bank-tab
+++ b/plugins/slayer-bank-tab
@@ -1,3 +1,3 @@
 repository=https://github.com/Maximuis94/runelite-plugins.git
-commit=fc650473fc52972bb63c1dd38d9920ee2a087408
+commit=cec503bacdb7e0d378c5c0e6e90977c1b281bb29
 authors=maximuis94


### PR DESCRIPTION
Opening the sidebar now loads the active task, if there is one
A cached snapshot will no longer be saved after the first kc is made if a setup exists for the task
Task now changes upon completing it
Added zigzag mode
Added plugin hub button