### PR TITLE
Update jams-solo-tempoross to 1.0.10

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=222a63396f110b6f46c4d1a9667dba19cc222e87
+commit=2184f583191b75c44e283bb05c13fabf9c1da109


### PR DESCRIPTION
﻿## Summary
- Bumps Jam's Solo Tempoross to 1.0.10 (`2184f58`)
- Far-side SPECIAL doubles are detected by NPC id again (without the 1.0.8 cook-hold / victory-chat regressions)
- Deposit stays sticky through leftover raw fish; regular Fish no longer stealth-routes to a double
- Doubles are no longer delayed by island-wide fire counts (other-side fires were blocking east→west)

## Test plan
- [ ] Plugin Hub CI builds the plugin
- [ ] Far east fishing when far west becomes double: yellow path + chime even while fires burn elsewhere
- [ ] Mid deposit with leftover raw: stay on Deposit until the load finishes
- [ ] Normal Fish path stays on a regular spot (not the double)
