### PR TITLE
RuneProfile v2.8.0

### DIFF
--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,3 +1,3 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=2da51cd7a8dcf6a5ed0e827a2df2bb985d0e0550
+commit=d80ba0f1a27477badc78023332e234a8bd5d022c
 warning=This plugin submits your player data and IP address to a server not controlled or verified by the RuneLite developers.

--- a/plugins/runeprofile
+++ b/plugins/runeprofile
@@ -1,3 +1,3 @@
 repository=https://github.com/ReinhardtR/runeprofile-plugin.git
-commit=d80ba0f1a27477badc78023332e234a8bd5d022c
+commit=703e13108b60e5a75ffeef3f428b8500091d3dc6
 warning=This plugin submits your player data and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
- Player models now export/upload as GLB instead of PLY
- Quests are tracked from the RuneProfile manifest instead of RuneLite's built-in Quest enum
-  Fetch account info on real logins/account switches, and only while the side panel is open; with API backoff
- Login card no longer flashes during loading screens
- Internal: dev client can point at a local API (`runClient` task), removed obsolete icon-generation dev tools