### PR TITLE
Kick Chat Side Panel: strip inline emote placeholders

### DIFF
--- a/plugins/kick-chat-side-panel
+++ b/plugins/kick-chat-side-panel
@@ -1,3 +1,3 @@
 repository=https://github.com/georgeparamore/runelite-kick-chat-side-panel.git
-commit=80ef9e8913f47cfb1b472e39594d0709fc7c8439
+commit=b67db05c2a03973ec72f01046a2f198dcd3819b9
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Follow-up to #15420 (merged) - bumps the plugin to a newer commit that fixes a real display bug found right after merge.

Kick embeds emote references directly inside the chat message text itself, e.g. "nice one [emote:5838776:odablockShalom]" - unlike Twitch, which reports emote positions in a separate tag and leaves the message body as the literal typed text. Since this plugin deliberately never renders emote images (per the emote policy applied to this plugin during the original review), those placeholders were leaking straight through to the panel as raw "[emote:id:name]" noise instead of reading as plain text.

This reduces each placeholder to just its plain name, keeping the "no emote images" behavior but making the text actually readable.

No other changes.
