### PR TITLE
update account-history

### DIFF
--- a/plugins/account-history
+++ b/plugins/account-history
@@ -1,3 +1,3 @@
 repository=https://github.com/josephmr/account-history.git
-commit=57844049fbc38ffc65cd8a23d8df6bfbcf4426d4
+commit=1d4e82d3c913abaf9a7291ad4286fc65562c51fd
 warning=This plugin submits your IP Address, RSN, and account progression events (level ups, collection logs, boss kc, diary completions, etc.) to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Account History to version 1.0.5.

Replaces the special-world denylist with a fail-closed allowlist of regular world types. This prevents false skill-up events when entering PvP Arena worlds, where combat levels are artificially changed.