### PR TITLE
Add Overhead Scale & Color

### DIFF
--- a/plugins/overheads-scale-and-color
+++ b/plugins/overheads-scale-and-color
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/overheads-scale-and-color.git
-commit=db3ac58e22df76e5f91e341cbde87a74539d7d6d
+commit=231c5a3fc9bc7c645b45c730b803a7ffb43a7fb8

--- a/plugins/overheads-scale-and-color
+++ b/plugins/overheads-scale-and-color
@@ -1,0 +1,2 @@
+repository=https://github.com/internetter/overheads-scale-and-color.git
+commit=d2a6aa448db379e8130afb0802a7313b721d471d

--- a/plugins/overheads-scale-and-color
+++ b/plugins/overheads-scale-and-color
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/overheads-scale-and-color.git
-commit=d2a6aa448db379e8130afb0802a7313b721d471d
+commit=db3ac58e22df76e5f91e341cbde87a74539d7d6d

--- a/plugins/overheads-scale-and-color
+++ b/plugins/overheads-scale-and-color
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/overheads-scale-and-color.git
-commit=231c5a3fc9bc7c645b45c730b803a7ffb43a7fb8
+commit=25cc61a93edff4b66a7b249607fff1b1f08c9f16


### PR DESCRIPTION
A small cosmetic plugin. It shrinks the overhead prayer icon above your own player so it stops covering your character, and optionally draws a colored ring around it so it stays readable once it's small.