### PR TITLE
Add Bank Groups plugin

### DIFF
--- a/plugins/bank-groups
+++ b/plugins/bank-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/SkullTricked/bank-groups.git
-commit=9b34151b12b90b964f176a166bb6c60244291980
+commit=86eb1b5fde772024c05d314aae18abf61da09896

--- a/plugins/bank-groups
+++ b/plugins/bank-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/SkullTricked/bank-groups.git
-commit=d9fba30addebf974b732adf1f767a795b32f2d6b
+commit=9b34151b12b90b964f176a166bb6c60244291980

--- a/plugins/bank-groups
+++ b/plugins/bank-groups
@@ -1,0 +1,2 @@
+repository=https://github.com/SkullTricked/bank-groups.git
+commit=d9fba30addebf974b732adf1f767a795b32f2d6b

--- a/plugins/bank-groups
+++ b/plugins/bank-groups
@@ -1,2 +1,2 @@
 repository=https://github.com/SkullTricked/bank-groups.git
-commit=86eb1b5fde772024c05d314aae18abf61da09896
+commit=6a6137475ca68c86a0294383f13f6a329d7f84b2


### PR DESCRIPTION
Adds Bank Groups, a plugin that lets users organize bank items into up to 10 customizable groups with coloured borders and translucent fills.