### PR TITLE
 Add Olm Melee Hand DPS Tracker

### DIFF
--- a/plugins/olm-damage-tracker
+++ b/plugins/olm-damage-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Roleiz/olm-damage-tracker.git 
-commit=6c4c86a2b63ec490c27b7d2c9f4efa372adb46d1
+commit=2531cfd62ed1d89dbffd64cfb40ef7563215a262

--- a/plugins/olm-damage-tracker
+++ b/plugins/olm-damage-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Roleiz/olm-damage-tracker.git
-commit=ac3e4e60a9763065874ff1f4b210b0c042569824
+commit=ebdbef60cd74746a8c59f691087a651dd373621b

--- a/plugins/olm-damage-tracker
+++ b/plugins/olm-damage-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Roleiz/olm-damage-tracker.git
-commit=2531cfd62ed1d89dbffd64cfb40ef7563215a262
+commit=ac3e4e60a9763065874ff1f4b210b0c042569824

--- a/plugins/olm-damage-tracker
+++ b/plugins/olm-damage-tracker
@@ -1,2 +1,2 @@
-repository=https://github.com/Roleiz/olm-damage-tracker.git 
+repository=https://github.com/Roleiz/olm-damage-tracker.git
 commit=2531cfd62ed1d89dbffd64cfb40ef7563215a262

--- a/plugins/olm-damage-tracker
+++ b/plugins/olm-damage-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Roleiz/olm-damage-tracker.git
-commit=ebdbef60cd74746a8c59f691087a651dd373621b
+commit=c58d4e2c0e1a610983d19a7e989b6bdb00778b7d

--- a/plugins/olm-damage-tracker
+++ b/plugins/olm-damage-tracker
@@ -1,0 +1,1 @@
+repository=https://github.com/Roleiz/olm-damage-tracker.git commit=6c4c86a2b63ec490c27b7d2c9f4efa372adb46d1

--- a/plugins/olm-damage-tracker
+++ b/plugins/olm-damage-tracker
@@ -1,1 +1,2 @@
-repository=https://github.com/Roleiz/olm-damage-tracker.git commit=6c4c86a2b63ec490c27b7d2c9f4efa372adb46d1
+repository=https://github.com/Roleiz/olm-damage-tracker.git 
+commit=6c4c86a2b63ec490c27b7d2c9f4efa372adb46d1

--- a/plugins/olm-damage-tracker
+++ b/plugins/olm-damage-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Roleiz/olm-damage-tracker.git
-commit=c58d4e2c0e1a610983d19a7e989b6bdb00778b7d
+commit=841e6b57c483065bf4f313ab00a321d1858a21b0


### PR DESCRIPTION
Tracks the damage done to the olm melee hand in an 8 tick cycle(cripple threshold) by all party members.