### PR TITLE
Updated Dry Streak Tracker to 1.2.2

### DIFF
--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
-commit=f8834ff538415ed517b6f3da5a3ec82bc28729bc
+commit=c6abf7d7f32185eeaa645e77292cc62a9c96edd6
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Added configurable drops on a per encounter basis.

For example, you want virtus disabled for vardorvis, you can simply right click the encounter, select Configure, and uncheck all the virtus pieces. Tracking will stop for those items. 

I've also added drops defaulting to disabled for those looking for more in-depth tracking. For example, awakener's orbs and quartz's from DT2 bosses.