### PR TITLE
update jumpscare to 1.6.3

### DIFF
--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=8c4248c4ae0abbcd9ff30c39915f37ff737c1e0a
+commit=ec99fbc049914c63004b46401970bae5f3600e62
 authors=vividflash


### PR DESCRIPTION
1.6.3
Readme only, no code change: removed a section claiming the bundled assets are original.
Client pin moved to 1.12.38.
