### PR TITLE
update better-slayer to 1.2.2

### DIFF
--- a/plugins/better-slayer
+++ b/plugins/better-slayer
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/better-slayer.git
-commit=e8b5172323483d9e0c0a02401985af6804714cad
+commit=1f6d922f7dfad601224a268db71d0e0e3520374a


### PR DESCRIPTION
1.2.2
LICENSE trimmed back to the stock BSD 2-Clause text.
Readme attribution section removed. No code was copied, just ai doing ai things.
No code change.
Client pin moved to 1.12.38.
