### PR TITLE
update ba-gamble-tracker to 1.1.1

### DIFF
--- a/plugins/ba-gamble-tracker
+++ b/plugins/ba-gamble-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/vividflash/ba-gamble-tracker.git
-commit=7a4bda569d5390dc261f75dd0148d2ea26fefd60
+commit=fb68133925ee873210d22e62a482265b3d9a6ea9


### PR DESCRIPTION
1.1.1
Readme only: removed the diagnostics table.
Client pin moved to 1.12.38.
