### PR TITLE
Fix config for better npc highlight

### DIFF
--- a/plugins/better-npc-highlight
+++ b/plugins/better-npc-highlight
@@ -1,3 +1,3 @@
 repository=https://github.com/riktenx/better-npc-highlight.git
-commit=9c1697feb6a757e2bc546a810b9a7bca50c7b6db
+commit=03916323b604057a88f918ffc2f35fee1c2e4a08
 authors=riktenx,SamuelDev


### PR DESCRIPTION
A recent refactor of the plugin config structure left users unable to open the config menu in runelite if they did not already have defaults loaded into their profile properties. This fix consolidates all configs back into a single monolithic config file to avoid that problem.