### PR TITLE
chat-fade: pick up icon.png rename

### DIFF
--- a/plugins/chat-fade
+++ b/plugins/chat-fade
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/chat-fade.git
-commit=e213adba70bf9ebc6998469bb11bd5a0ad7ebf6c
+commit=d2e1fe20917b24c00b2db857e988a0c07a9a3a43


### PR DESCRIPTION
Updates the chat-fade manifest to d2e1fe2.

The only change since the currently referenced commit is renaming `hub-icon.png` to `icon.png`, so the hub actually finds the icon — it was never being picked up under the old name. Same image, filename only.

No plugin code changes; version stays 1.3.1.