### PR TITLE
Add DPS Loadout Lab

### DIFF
--- a/plugins/dps-loadout-lab
+++ b/plugins/dps-loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/lynchtm/dps-loadout-lab.git
-commit=3b913aa82ced0d5d9617453b88f0b1ecb85175bf
+commit=97cb75cf2ece42c9d9d459448c2b2e77c4a56ba7

--- a/plugins/dps-loadout-lab
+++ b/plugins/dps-loadout-lab
@@ -1,0 +1,2 @@
+repository=https://github.com/lynchtm/dps-loadout-lab.git
+commit=b1556c5a41e1c5aaa96484ef1e4ece480b1f14de

--- a/plugins/dps-loadout-lab
+++ b/plugins/dps-loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/lynchtm/dps-loadout-lab.git
-commit=b1556c5a41e1c5aaa96484ef1e4ece480b1f14de
+commit=3b913aa82ced0d5d9617453b88f0b1ecb85175bf

--- a/plugins/dps-loadout-lab
+++ b/plugins/dps-loadout-lab
@@ -1,2 +1,2 @@
 repository=https://github.com/lynchtm/dps-loadout-lab.git
-commit=97cb75cf2ece42c9d9d459448c2b2e77c4a56ba7
+commit=ee6eecb56cbf959d5344fad0b1024c8c0861d50c


### PR DESCRIPTION
Adds DPS Loadout Lab, a native RuneLite sidebar for comparing editable combat loadouts against a shared target, generating target-specific suggestions from observed bank equipment, importing Wiki gear/inventory setups, and preparing Bank Tags layouts. It does not withdraw, equip, or automate game actions.

## Replacement addressing the GPL review

The submitted source now replaces the previous GPL-derived runtime with newly authored Java under BSD-2-Clause. This is a replacement of the implementation, not a retroactive license change to the old code or history.

A 377-file baseline provenance audit identified 98 GPL-derived Java files (51 runtime and 47 tests), 10 inherited calculator data/fixture files, and 59 imported images. All 167 were removed. The old engine is neither a dependency nor a fallback. The new implementation covers probability/distributions, editor models, equipment preparation, factual catalogs, combat calculations, client capture, configuration, overlay and icons. Locally authored comparison/optimizer/preparation workflows and the separately attributed BSD-2-Clause Wiki setup parser were retained and adapted.

Facts were acquired directly from public RuneLite exports and Wiki gameplay articles/Bucket APIs rather than copied calculator datasets. Tests use independently worked examples and probability invariants rather than the removed GPL calculator output fixtures. Wiki content and Jagex game assets remain separately attributed; the software license does not relicense them. Existing third-party BSD notices are preserved.

This is not a formal clean-room certification: the development session had prior exposure to the old project, and public API signatures/persisted field contracts were inspected for compatibility. PROVENANCE.md records that boundary explicitly. Known raid, phase, advanced-weapon and special-attack limitations remain documented and visible; complete Wiki calculator parity is not claimed.

## Runtime and validation

The plugin uses RuneLite events for live capture and background work for calculation. Explicit Wiki searches/imports make public read-only HTTPS requests containing page titles/search terms, not bank or character data. Bundled calculation facts require no runtime download. There is no reflection, subprocess execution, executable download, additional runtime dependency, or automated game input.

- 401 passing tests: 389 main tests and 12 isolated probability-foundation tests; zero failures, errors or skips.
- Clean Java 11 workspace and standalone export builds; source and binary migration audits passed.
- Official Plugin Hub standard build/API recorder against RuneLite 1.12.38: 354 API symbols, zero matches against the recorded disallowed-API rules snapshot.
- Exported dev client loaded the replacement engine/sidebar. The author reported the requested client smoke checks looked good on September 9, 2026.

Review records: [provenance and authoring method](https://github.com/lynchtm/dps-loadout-lab/blob/ee6eecb56cbf959d5344fad0b1024c8c0861d50c/PROVENANCE.md), [file-by-file baseline inventory](https://github.com/lynchtm/dps-loadout-lab/blob/ee6eecb56cbf959d5344fad0b1024c8c0861d50c/provenance/baseline-inventory.csv), [test/build review](https://github.com/lynchtm/dps-loadout-lab/blob/ee6eecb56cbf959d5344fad0b1024c8c0861d50c/RELEASE-REVIEW.md), [coverage limits](https://github.com/lynchtm/dps-loadout-lab/blob/ee6eecb56cbf959d5344fad0b1024c8c0861d50c/COVERAGE.md), and [third-party attribution](https://github.com/lynchtm/dps-loadout-lab/blob/ee6eecb56cbf959d5344fad0b1024c8c0861d50c/NOTICE.md).

Repository: https://github.com/lynchtm/dps-loadout-lab

Submitted release commit: `ee6eecb56cbf959d5344fad0b1024c8c0861d50c`. Source workspace provenance: `2da8f2f25da65cad844f28f3564e5631a7a84f2d`.

