### PR TITLE
pocketge-flip-tracker: 0.6.0 -> 0.6.1

### DIFF
--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/grant9008/pocketge-flip-tracker.git
-commit=c150453ff0b8ce6ea658a1f8856482cfee43d667
+commit=512296ade44afa1f3bde49ac71d5cbe039d2d6f4


### PR DESCRIPTION
Since 0.6.0 (c150453):

- The in-game price suggestion appears where the game's other price options are, only once the price prompt is open, and clicking it fills the price.
- Clicking the gear a second time closes the settings menu.
- Share moved to the top button bar and shares whatever is selected.
- A LINKED chip on the Favorites header when a pocketge.com tab is bridged, matching what the website already shows, plus a button there to match the website's list to the in-game one.
- Findable by what people actually search for in the plugin hub.
- The flip card reworked: target buy/sell in the website's own colours, capital needed made readable, Analyst Rating and the fill-risk meter gone.
- Three new settings: a switch for the watchlist badges and glow, a minimum profit floor for suggestions, and opt-in alerts on big price moves.


Claude-Session: https://claude.ai/code/session_01CrbbnpxzzXajkmFNwfAgTw