### PR TITLE
Update jams-solo-tempoross to 1.0.11

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=2184f583191b75c44e283bb05c13fabf9c1da109
+commit=4c9d7297968090a33fcd1e5c5d4457a47f230714


### PR DESCRIPTION
## Summary
- Bumps Jam's Solo Tempoross to 1.0.11 (`4c9d729`)
- First crate load is always catch 16 / deposit 16 so you can reach the ship before island fires
- At 90% storm before the first dump, the Storm bar flashes and a large HURRY overlay warns you to dump
- When a fire forces you off the crate tile during deposit, a chime plays and the screen tints until you step onto the safe tile

## Test plan
- [ ] Plugin Hub CI builds the plugin
- [ ] First batch: fish to 16 then Deposit 16 (not 19)
- [ ] Before first dump at 90%+ storm: flashing Storm bar + center HURRY
- [ ] Deposit with fire on/near crate stand: chime + tint + safe-tile highlight
