### PR TITLE
Simple Faux Bingo update to resolve a cox loot timing bug

### DIFF
--- a/plugins/faux-bingo
+++ b/plugins/faux-bingo
@@ -1,3 +1,3 @@
 repository=https://github.com/faux-bingo/faux-bingo-runelite-plugin.git
-commit=9fe67c24d5eccdf60f531e5c03c8f0ddd47e9b43
+commit=952fbf476aba53953e8d2927869099bb5e6c9cbe
 authors=ThatOhio


### PR DESCRIPTION
Simple PR to resolve a timing issue for loot tracking when a user may wait a long period of time to open the chat, after the plugin has already registered a chat message. 