### PR TITLE
Add Gieligotchi

### DIFF
--- a/plugins/gieligotchi
+++ b/plugins/gieligotchi
@@ -1,0 +1,2 @@
+repository=https://github.com/wchbdotnet/gieligotchi.git
+commit=65f62a0a46b56fda22010eec7a810b551acef8a4

--- a/plugins/gieligotchi
+++ b/plugins/gieligotchi
@@ -1,2 +1,2 @@
 repository=https://github.com/wchbdotnet/gieligotchi.git
-commit=65f62a0a46b56fda22010eec7a810b551acef8a4
+commit=9896088307a9c1936083f73246a2ffb51975e0c3

--- a/plugins/gieligotchi
+++ b/plugins/gieligotchi
@@ -1,2 +1,2 @@
 repository=https://github.com/wchbdotnet/gieligotchi.git
-commit=300f230f4b7d7fbb95380e7e9cb1cc4c44ad11c6
+commit=8b90c21d39ba74ec3c5b48a4eea16f0711db6eea

--- a/plugins/gieligotchi
+++ b/plugins/gieligotchi
@@ -1,2 +1,2 @@
 repository=https://github.com/wchbdotnet/gieligotchi.git
-commit=8b90c21d39ba74ec3c5b48a4eea16f0711db6eea
+commit=0840ec1f55ccb54e5ae806b09ec1020d7b0741c9

--- a/plugins/gieligotchi
+++ b/plugins/gieligotchi
@@ -1,2 +1,2 @@
 repository=https://github.com/wchbdotnet/gieligotchi.git
-commit=9896088307a9c1936083f73246a2ffb51975e0c3
+commit=300f230f4b7d7fbb95380e7e9cb1cc4c44ad11c6


### PR DESCRIPTION
## Summary

Adds Gieligotchi, a cosmetic companion game that lives alongside ordinary Old
School RuneScape play. Players hatch and raise companions, build affection,
complete wishes, collect colour variants, toys and Gielinor-inspired backdrops,
and keep memories of the companions they have raised.

## Safety and data

- Progress is stored locally through RuneLite profile settings.
- The plugin does not automate or inject input, alter game actions, or provide a
  gameplay advantage.
- The companion is a RuneLite interface element rather than an in-world NPC.
- There are no third-party runtime services or non-RuneLite accounts.

## Verification

- Clean test and packaged-JAR build completed successfully.
- 17 automated tests pass.
- The plugin uses the standard Plugin Hub build.

Plugin repository: https://github.com/wchbdotnet/gieligotchi
