### PR TITLE
Add material-checklist

### DIFF
--- a/plugins/material-checklist
+++ b/plugins/material-checklist
@@ -1,0 +1,2 @@
+repository=https://github.com/Dewdul/material-checklist.git
+commit=895894a6938e37c0d5e496ee703215aa1f01b8b9


### PR DESCRIPTION
Adds **Material Checklist** — plan items to craft across all production skills and track the raw materials you still need, counting your inventory and a per-profile bank snapshot.

Repository: https://github.com/Dewdul/material-checklist

**Features**
- Materials / Goods panel views with recursive drill-down into intermediate recipes (molten glass into sand + soda ash, saplings all the way down to seeds)
- Right-click "Add to Checklist" in the skill guides — client-side `MenuAction.RUNELITE` entries injected on `MenuOpened` with a mouse hit-test (most guide rows have no vanilla ops), including a submenu to pick the production method when several exist
- ~5,000 recipes generated at build time from the OSRS Wiki (recipe bucket joined with item/construction/ship-part buckets, plus Farming info templates for crop/tree/watering chains); the plugin makes no network requests at runtime, and wiki attribution (CC BY-NC-SA 3.0) is in the README
- GE cost of missing materials, level requirements, opt-in owned-product deduction and auto-removal of completed goals
- Bank snapshot persisted via RSProfile configuration (the loot tracker pattern)

Overlaps in spirit with recipe-checklist; main differences are the skill-guide right-click adding with method choice, full Farming coverage (crops, trees, watering chains), GE cost-to-complete, and level requirement display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)