### PR TITLE
Update loot-case-opening plugin

### DIFF
--- a/plugins/loot-case-opening
+++ b/plugins/loot-case-opening
@@ -1,2 +1,2 @@
 repository=https://github.com/adnapPanda/loot-case-opening.git
-commit=776f784fe7a85df52dbfd811865171c0c078e1e7
+commit=9591d5ee45f1524d47a8fb8137e45cfe6e0c4cf3


### PR DESCRIPTION
### Added
Abyssal Sire(Unsired) was added to supported content

### Fixed
Collection log popup was not being hidden when option was enabled