### PR TITLE
gustav-helper: update to 23ed18d

### DIFF
--- a/plugins/gustav-helper
+++ b/plugins/gustav-helper
@@ -1,3 +1,3 @@
 repository=https://github.com/dangraagu/Gustav-s-helper.git
-commit=dedaf6255011a69930c0c8be4a248afb8e569682
+commit=23ed18db3b19b206816cb3149aa7f2cb32bc0543
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Data and tooling release — no Java changes: src/main/java is byte-identical to the currently live commit (dedaf62), so the opt-in networking surface reviewed in #14688 is untouched.

Since dedaf62:
- 117 verified step-coordinate corrections across the bundled guides (audited against Quest Helper data and the OSRS Wiki), plus removal of 5 coordinates that pointed at quest-instance or player-owned-house tiles (one sent players to the deep Wilderness on a UIM guide).
- Quest-name matching fixes: apostrophe-insensitive matching, common guide misspellings, and multi-quest steps now complete when all named quests are done — 154 previously manual steps now auto-complete, and several wrong auto-completions were removed.
- Build/tooling only: a weekly upstream-drift check runs in the repo's own CI (excluded from the build), plus new test suites (83 Java + 11 python suites, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)