### PR TITLE
Update Jam's Arceuus Runecrafting to 1.0.5

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=cf019f8d898bd681d3007bf3191b638099a3b7e9
+commit=5d6436260b3dfb1684a0d77d051a652453705cea


### PR DESCRIPTION
## Summary
- Bump `zeah-rc-helper` to `5d6436260b3dfb1684a0d77d051a652453705cea` (1.0.5)
- Removes the in-game chat changelog announcements; adds checkstyle / version-from-properties build hygiene

## Test plan
- [ ] Hub CI build passes for zeah-rc-helper
- [ ] Plugin loads; login no longer dumps update notes in chat
