### PR TITLE
Update Jam's Arceuus Runecrafting to 1.0.6

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=cf019f8d898bd681d3007bf3191b638099a3b7e9
+commit=e71fdaff6d138d6a11d81962a51778b5ea6b491c


### PR DESCRIPTION
## Summary
- Bump `zeah-rc-helper` to `e71fdaff6d138d6a11d81962a51778b5ea6b491c` (1.0.6)
- Removes in-game chat changelog announcements and the Hub README line that promised them
- Adds checkstyle / version-from-properties build hygiene

## Test plan
- [ ] Hub CI build passes for zeah-rc-helper
- [ ] Plugin loads; login no longer dumps update notes in chat
- [ ] Hub plugin page README no longer mentions chat update notes
