### PR TITLE
Update Jam's Solo Tempoross to 1.0.13

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=4c9d7297968090a33fcd1e5c5d4457a47f230714
+commit=9cecca7e40b225961dc292cab6264a35a9dddc09


### PR DESCRIPTION
## Summary
- Bump `jams-solo-tempoross` to `9cecca7e40b225961dc292cab6264a35a9dddc09` (1.0.13). Removes in-game chat changelog announcements and the Hub README line that promised them; adds checkstyle / version-from-properties.

## Test plan
- [ ] Hub CI build passes for `jams-solo-tempoross`
- [ ] Plugin loads; login no longer dumps update notes in chat
