### PR TITLE
Update Jam's Blast Mine to 1.1.2

### DIFF
--- a/plugins/blast-mine-improved
+++ b/plugins/blast-mine-improved
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/blast-mine-improved.git
-commit=95abf5c686c51ecf7a05c9996ef0a99df31990b1
+commit=e322ff9b4f7b1730be99f2152ac11cee11fbcd77

--- a/plugins/blast-mine-improved
+++ b/plugins/blast-mine-improved
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/blast-mine-improved.git
-commit=e322ff9b4f7b1730be99f2152ac11cee11fbcd77
+commit=f76721aafd8d0f1a93ea69a58826d7811db0d6b8


### PR DESCRIPTION
## Summary
- Bump `blast-mine-improved` to `f76721aafd8d0f1a93ea69a58826d7811db0d6b8` (1.1.2). Removes in-game chat changelog announcements; adds checkstyle / version-from-properties; strips a UTF-8 BOM from `runelite-plugin.properties` that blocked Hub validation.

## Test plan
- [ ] Hub CI build passes for `blast-mine-improved`
- [ ] Plugin loads; login no longer dumps update notes in chat