### PR TITLE
Update Jam's Skiller Guard to 1.1.6

### DIFF
--- a/plugins/skiller-guard
+++ b/plugins/skiller-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/skiller-guard.git
-commit=338de5fa8ee503381ed73b5ddc0bb466c6006ba6
+commit=e87566fc8d4d0576218d096015444a9be8dcf668


### PR DESCRIPTION
## Summary
- Bump `skiller-guard` to `e87566fc8d4d0576218d096015444a9be8dcf668` (1.1.6). Removes in-game chat changelog announcements and the Hub README line that promised them; adds checkstyle / version-from-properties.

## Test plan
- [ ] Hub CI build passes for `skiller-guard`
- [ ] Plugin loads; login no longer dumps update notes in chat
