### PR TITLE
update dutch-nations-events

### DIFF
--- a/plugins/dutch-nations-events
+++ b/plugins/dutch-nations-events
@@ -1,3 +1,3 @@
 repository=https://github.com/WijheRP2023/dutch-nations-events.git
-commit=fcd61092a4e0e05ed3707b6bfc08391418b7639a
+commit=5ab9b3e3e9b75373ae64f0e6cc81ced3a15eb40b
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Dutch Nations Events to the tested commit 5ab9b3e3e9b75373ae64f0e6cc81ced3a15eb40b.\n\nThis release fixes immediate management-token recognition, lets Administrators view the roles list and revoke lower roles only, and adds the LEARNER_HOST role which is restricted server-side to learner events.