### PR TITLE
Update Kill Clog to 2.3.1: Sync fixes and UI polish

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=0860e91fb95a1031c1a23a4d876b6ac3f40c8f1e
+commit=020e68adf14b9c0f848570ef60711935ea9b62da
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill Clog 2.3.1

* keeps automatic sync silent in the panel by default, with progress and failure messages for manual syncs and character uploads
* replaces success text with a green icon flash and reserves status-message space so the panel does not shift
* fixes unsynced RuneProfile accounts appearing synced and prevents stuck lookups
* Moves data provenance from clog summary top right hoverable icon to a Sources footer showing only synced collection-log providers
* settings cleanup and description clarity, readme edits
* shows overall rank beside total XP in Skill Summary, matching Player Summary
