### PR TITLE
Update session-movement-tracker to 1.1

### DIFF
--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=653511124e691585c8f7129354230a868fcfa22c
+commit=e427c5a15ad34a604cccac71e973397cba03fb1f

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=f5d3d687200f64c83d8fd858d1d6f105365252f4
+commit=653511124e691585c8f7129354230a868fcfa22c

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/lwr27/session-movement-tracker
+commit=125ba56

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=83831e3f61fd85cedd6791fe2cc3efb18a1d1779
+commit=f024e85ab0f1dc977f4276bb4514e2f8d37cd32f

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=97800124e4c2c359ec5a4d18806f65c7c782ef78
+commit=504f51783515eeb3c8867b75751755187171f46b

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=9c77d5395573c8ef000f71de3ac16289847e090d
+commit=97800124e4c2c359ec5a4d18806f65c7c782ef78

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=125ba568d0cab75b8685efa177c5da237bd8a10e
+commit=83831e3f61fd85cedd6791fe2cc3efb18a1d1779

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=504f51783515eeb3c8867b75751755187171f46b
+commit=f5d3d687200f64c83d8fd858d1d6f105365252f4

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=f024e85ab0f1dc977f4276bb4514e2f8d37cd32f
+commit=9095ae8457a344e233b8df4156a30eddf30ca504

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
-repository=https://github.com/lwr27/session-movement-tracker
+repository=https://github.com/lwr27/session-movement-tracker.git
 commit=125ba56

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=125ba56
+commit=125ba568d0cab75b8685efa177c5da237bd8a10e

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=9095ae8457a344e233b8df4156a30eddf30ca504
+commit=9c77d5395573c8ef000f71de3ac16289847e090d


### PR DESCRIPTION
Added optional XP gain tracking (config toggle, on by default)
Local data now stored per-day within per-month folders, instead of one file per month
Added configurable local data retention (default 3 months) - automatically deletes old local files, does not affect anything already uploaded
Decoupled the GitHub upload interval from the local save interval (uploads now default to every 5 minutes instead of every save, reducing commit volume)