### PR TITLE
Update session-movement-tracker to 1.1

### DIFF
--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=653511124e691585c8f7129354230a868fcfa22c
+commit=e427c5a15ad34a604cccac71e973397cba03fb1f

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=640b75265fd5a045f54a339ca767c4fdc43c8651
+commit=b6362ad308dda02a43f94933efbafde8d9d19e0d

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=2f872adceb49ebb0829eb17f3258cac9d7f9f43a
+commit=5ef2f2bad8aac4b18a2708ad4c5566bde9518b52

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=b6362ad308dda02a43f94933efbafde8d9d19e0d
+commit=06446ca941796ead79a9b37ec21164c15849eda1

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=e427c5a15ad34a604cccac71e973397cba03fb1f
+commit=640b75265fd5a045f54a339ca767c4fdc43c8651

--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=06446ca941796ead79a9b37ec21164c15849eda1
+commit=2f872adceb49ebb0829eb17f3258cac9d7f9f43a


### PR DESCRIPTION
Added optional XP gain tracking (config toggle, on by default)
Added optional hitpoints change tracking (config toggle, on by default)
Local data now stored per-day within per-month folders, instead of one file per month
Added configurable local data retention (default 3 months) - automatically deletes old local files, does not affect anything already uploaded
Decoupled the GitHub upload interval from the local save interval (uploads now default to every 5 minutes instead of every save, reducing commit volume)
GitHub uploads now go into a per-account folder (route-data/<hash>/<day>.json) instead of a flat folder
Positions inside instances are now recorded as template (real-map) coordinates and flagged
Events recorded aboard a boat are flagged

(Apologies for the multiple commits)