### PR TITLE
Slayer Prep Check

### DIFF
--- a/plugins/slayer-prep-check
+++ b/plugins/slayer-prep-check
@@ -1,0 +1,2 @@
+repository=https://github.com/billderksen/slayer-prep-check.git
+commit=aa8ee9150b9439e7f15dba10caf5624cebee436e

--- a/plugins/slayer-prep-check
+++ b/plugins/slayer-prep-check
@@ -1,2 +1,2 @@
 repository=https://github.com/billderksen/slayer-prep-check.git
-commit=aa8ee9150b9439e7f15dba10caf5624cebee436e
+commit=8f933a113329688ab1e701e9e22f500271dae06e


### PR DESCRIPTION
Slayer Prep Check shows, for the current Slayer task, which items are required (nose peg, rock hammer, boots of stone, ...) and whether they are carried, banked or missing, plus the best gear set per attack style that the player can assemble from their own bank. The gear advice follows the OSRS Wiki "Recommended equipment" tables, bundled at build time; the plugin makes no network requests.

Features: side panel with item icons, small overlay, chat message on a new task, and a bank tab (button in the bank) that shows only the items for the task, grouped per attack style.

Notes for review:
- The bank tab is built on the core Bank Tags plugin (`@PluginDependency(BankTagsPlugin.class)`). It registers a tag through `TagManager.registerTag` and opens it with `BankTagsPlugin.openTag(String, Layout, int)` so it can pass its own item order; `BankTagsService.openBankTag` only loads layouts from the user's config. Filtering and drawing are done by the core plugin. The plugin creates one button widget in the bank; clicking it only toggles the tag view, nothing is sent to the server.
- Wiki data is CC BY-NC-SA 3.0, attributed in the README and LICENSE.
- Source: https://github.com/billderksen/slayer-prep-check
