### PR TITLE
Submission to add hydra-timer plugin

### DIFF
--- a/plugins/hydra-timer
+++ b/plugins/hydra-timer
@@ -1,0 +1,2 @@
+repository=https://github.com/kristianmatreolsen/hydra-timer.git
+commit=98236fdc051413e816fb404a4bb433131d12e3fa


### PR DESCRIPTION
Adds Hydra Timer, a plugin that tracks normal Hydra attack cycles and predicts incoming poison attacks.

Features:
- Predicts the first poison attack after combat begins
- Resynchronizes after detecting an actual poison attack
- Follows the Hydra currently attacking the player
- Optional attack counter and acid timer overlays
- Configurable counter size and display toggles

The plugin is self-contained, uses no external dependencies, and includes a README and BSD 2-Clause license.