### PR TITLE
Update Jam's Solo Tempoross to 1.0.14

### DIFF
--- a/plugins/jams-solo-tempoross
+++ b/plugins/jams-solo-tempoross
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/jams-solo-tempoross.git
-commit=4c9d7297968090a33fcd1e5c5d4457a47f230714
+commit=f593d4ba22122805ff8e14135a7a0728bece6074


### PR DESCRIPTION
## Summary
- Bump `jams-solo-tempoross` to `f593d4ba22122805ff8e14135a7a0728bece6074` (1.0.14).
- Adds a **Require harpoon** Helper setting (default on) so barehanded / barbarian fishers can skip harpoon prep and recovery.
- Includes 1.0.13 changes already: no in-game chat changelog, Hub README cleanup, checkstyle / version-from-properties.

Supersedes https://github.com/runelite/plugin-hub/pull/16127

## Test plan
- [ ] Hub CI build passes for `jams-solo-tempoross`
- [ ] With Require harpoon off and no harpoon: dock and in-game do not nag for a harpoon
- [ ] With Require harpoon on (default): missing harpoon still prompts prep / recovery