### PR TITLE
update drop-rate-properties

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=d73d5f18e4371b794e5c67ef0ebf69c6d2ede092
+commit=1cfe3808f50dbf47d814eb634b2639f65f1f82c2


### PR DESCRIPTION
Update `drop-rate-properties` to `1cfe3808f50dbf47d814eb634b2639f65f1f82c2`.

This release is mostly user-reported bug fixes:

- **The monster's own drop rate was losing to the rare drop table.** The context-resolved lookup names (`Araxxor Legends`, `Demonic gorilla RoW`) only exist in the RDT data, so for any item on both tables the RDT rate won and the monster's own rate was never reached — Araxxor's Rune kiteshield reported 1/14720 instead of 8/115. It only affected players with a Ring of Wealth equipped or Legends' Quest completed, which is why it went unnoticed. 199 wrong rates across 72 sources, now zero.
- **Clue casket rewards printed nothing in chat.** The rates were bundled but wired only to the Collection Log tooltip. Caskets now report like any other source, and hovering an item on the reward screen shows the same tooltip.
- **Tier colours were unreadable on the standard chatbox.** The default uncommon orange sits at ~1.2:1 contrast on the parchment background. A new option darkens each colour just enough to clear 3:1 while keeping its hue; the transparent chatbox is untouched.
- **Araxxor corpse harvests showed no rate**, because the supply drops sit below the crawler's minimum-rarity floor.
- **Drop tables are now matched to the NPC that was killed**, so an Abyssal demon in the Wilderness Slayer Cave no longer reports the standard table's rate.

The bundled data is also rebuilt from the wiki's structured drop tables, which corrects 94 item names that could never match in-game loot.

No new dependencies. `LICENSE` diffs clean against this repo's own, `icon.png` is 48x72, and `build=standard` is unchanged.
