### PR TITLE
Add Entourage

### DIFF
--- a/plugins/entourage
+++ b/plugins/entourage
@@ -1,0 +1,3 @@
+repository=https://github.com/MatthewMariner/entourage.git
+commit=54f500f1ff65534553d20219f266d97427ea0595
+authors=MatthewMariner


### PR DESCRIPTION
New plugin. Cosmetic followers: up to five figures of the player's choosing walk with them in one of three formations, hold an idle pose when they stop, and occasionally speak a line overhead.

A side panel picks the roster. Any NPC id can be typed in place of one of the 23 presets and starred as a favourite, and the group can be told to stay put where it stands instead of following.

**Client-side only.** The figures are `RuneLiteObject`s drawn locally — they are not players, not server-side NPCs, and nothing about them is sent anywhere.

Notes for review:

- No file or network access, no threads, no reflection, and nothing reads other players. The only `clientThread.invoke` calls are for `NPCComposition` lookups, which are marshalled back to the EDT via `SwingUtilities.invokeLater`.
- Animations and models come from each figure's own `NPCComposition` in the cache. A typed id that declares no usable stand-and-walk pair is refused rather than drawn sliding along the ground.
- `build=standard`, Java 11, and `version=` is deliberately empty so the hub falls back to the commit.
- 659 unit tests, run headless. `runelite-plugin.properties` and the `@PluginDescriptor` are pinned against each other by a test so the hub listing and the in-client panel cannot drift apart.

Source: https://github.com/MatthewMariner/entourage — BSD-2-Clause.