### PR TITLE
update dutch-nations-events

### DIFF
--- a/plugins/dutch-nations-events
+++ b/plugins/dutch-nations-events
@@ -1,3 +1,3 @@
 repository=https://github.com/WijheRP2023/dutch-nations-events.git
-commit=5ab9b3e3e9b75373ae64f0e6cc81ced3a15eb40b
+commit=f8a8f25b85744adee081abddb298dbdcd7b489f5
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/dutch-nations-events
+++ b/plugins/dutch-nations-events
@@ -1,3 +1,3 @@
 repository=https://github.com/WijheRP2023/dutch-nations-events.git
-commit=f8a8f25b85744adee081abddb298dbdcd7b489f5
+commit=f80259adbe27468f76e7a42f575eed8e0cd1e30e
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds authorized event editing, including safe date/time changes. Learner hosts can only edit learner events where their own RSN is the configured host. The event API enforces the same restriction server-side.