### PR TITLE
Add PathScape Sync

### DIFF
--- a/plugins/pathscape-sync
+++ b/plugins/pathscape-sync
@@ -1,0 +1,4 @@
+repository=https://github.com/Ig0rFB/pathscape-sync.git
+commit=64d2fbde003a46a3a3097dac23a1f239df13d67e
+authors=Ig0rFB
+warning=This plugin submits your IP address and uploads your account data (skills, quests, achievement diaries, combat achievements, boss KC, and worn gear) to pathscape.vercel.app, keyed by a link token you paste. Only enable it if you are comfortable with that data being uploaded.


### PR DESCRIPTION
## Summary

Adds **PathScape Sync**, a RuneLite plugin that connects the logged-in OSRS account to [pathscape.vercel.app](https://pathscape.vercel.app).

- Opt-in upload (Submit off by default) of the local player's skills, quests, diaries, combat achievements, boss KC, and worn gear
- Keyed by a link token the player generates on the site and pastes into plugin settings (BiS-style), then Pair / Sync now
- `build=standard`; no extra dependencies
- Posts only `client.getLocalPlayer()` account data to PathScape's sync API

Plugin repo: https://github.com/Ig0rFB/pathscape-sync  
Commit: `64d2fbde003a46a3a3097dac23a1f239df13d67e`

## Test plan

- [x] Hub CI build succeeds
- [x] Install from Hub (once merged), paste link token + public API key from PathScape Preferences, Pair, enable Submit, Sync now
- [x] Confirm PathScape Refresh shows plugin-ahead skills / worn gear when applicable

Made with [Cursor](https://cursor.com)