### PR TITLE
Update gok-irl-xp: native bug reporting

### DIFF
--- a/plugins/gok-irl-xp
+++ b/plugins/gok-irl-xp
@@ -1,2 +1,2 @@
 repository=https://github.com/mataeo-eh/GOK-IRL-XP.git
-commit=ee96b37c80902b0f87a7fe01705f406620a5590f
+commit=5ad18a56a63789d3bbf17d1cc8915f098c313523


### PR DESCRIPTION
Adds a native **Report a bug** window to IRL XP. Players can write and review a report, explicitly confirm submission, and save local drafts without a browser or additional account.

Reports are sent over HTTPS to a Railway receiver and durably queued for a private GitHub inbox. Technical details are opt-in and previewed; no logs, screenshots, game state, account identifiers, or contact details are automatically attached. The receiver's URL is public; all GitHub credentials remain server-side. The form explains the destination, connection metadata processing, and local recovery copy. The receiver has bounded input/storage, a global intake quota, duplicate prevention, and an operational kill switch. It does not claim per-user/IP rate limiting.

The plugin uses injected OkHttpClient, Gson, and ScheduledExecutorService, stays on Java 11 with the standard build, and adds no runtime dependencies. Swing state stays on the EDT; network and local storage work run asynchronously. Disabling the plugin closes the report window and cancels only its own request.

Validation: full Gradle build passed (120 tests passed; the deliberately opt-in live test is skipped in normal builds). Native dialog lifecycle and visual checks passed. All 11 receiver tests passed on Node 24. A separately enabled test used the real Java reporting client to create one private test issue, restarted the deployed Railway receiver, and retried the same report with no duplicate issue. Security scan and git diff checks passed.
