### PR TITLE
Update Jam's Arceuus Runecrafting to 1.0.7

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=e71fdaff6d138d6a11d81962a51778b5ea6b491c
+commit=1ffa3ea261f7d79efc3ad13dde9b8f6b7c6f0735


### PR DESCRIPTION
## Summary
- Bump `zeah-rc-helper` to `1ffa3ea261f7d79efc3ad13dde9b8f6b7c6f0735` (1.0.7)
- Guides long-range Blood Altar clicks with Stand Here / Click Here markers
- Status panel detail styling and Essence row only when blood essence reminder is on

## Test plan
- [ ] Hub CI build passes for zeah-rc-helper
- [ ] Bloods: after second Dark Altar venerate, Stand Here then Click Here on Blood Altar
- [ ] Clicking the Blood Altar clears Stand Here while walking