### PR TITLE
Add Clan War Board

### DIFF
--- a/plugins/clan-war-board
+++ b/plugins/clan-war-board
@@ -1,0 +1,2 @@
+repository=https://github.com/ItMeansBigMountain/clan-war-board-osrs.git
+commit=d20c533c5dc877a57d9d1adf1dc266ccb865ee32

--- a/plugins/clan-war-board
+++ b/plugins/clan-war-board
@@ -1,2 +1,2 @@
 repository=https://github.com/ItMeansBigMountain/clan-war-board-osrs.git
-commit=d20c533c5dc877a57d9d1adf1dc266ccb865ee32
+commit=53fa8e35bbd57e89520fd5fc7abd6fd4212a43fb


### PR DESCRIPTION
## Summary
- Adds Clan War Board as one isolated Plugin Hub submission
- Uses the user-approved unique 48×48 listing and toolbar icon
- Pins immutable plugin commit `d20c533c5dc877a57d9d1adf1dc266ccb865ee32`

## Verification
- Java 11: `./gradlew clean test assemble --no-daemon --console=plain`
- Result: `BUILD SUCCESSFUL`
- Root and toolbar icon SHA-256: `ff8645ea44ab2f8de003da32aaf267e9055ae430f32b4a4e58b378031421d081`
- This PR changes exactly one marker: `plugins/clan-war-board`