### PR TITLE
Update material-checklist

### DIFF
--- a/plugins/material-checklist
+++ b/plugins/material-checklist
@@ -1,2 +1,2 @@
 repository=https://github.com/Dewdul/material-checklist.git
-commit=895894a6938e37c0d5e496ee703215aa1f01b8b9
+commit=fcbaaa8014bc22dda823e2f94ec2a98b65ee7df2

--- a/plugins/material-checklist
+++ b/plugins/material-checklist
@@ -1,2 +1,2 @@
 repository=https://github.com/Dewdul/material-checklist.git
-commit=d077a35c031fa11c97b4215905640558e016d2fe
+commit=f09323819ebde6dd9c02ec92e18ebf7c64ab2130

--- a/plugins/material-checklist
+++ b/plugins/material-checklist
@@ -1,2 +1,2 @@
 repository=https://github.com/Dewdul/material-checklist.git
-commit=f09323819ebde6dd9c02ec92e18ebf7c64ab2130
+commit=95917a39fa73cece23016eec86d7818393ffb959

--- a/plugins/material-checklist
+++ b/plugins/material-checklist
@@ -1,2 +1,2 @@
 repository=https://github.com/Dewdul/material-checklist.git
-commit=fcbaaa8014bc22dda823e2f94ec2a98b65ee7df2
+commit=d077a35c031fa11c97b4215905640558e016d2fe


### PR DESCRIPTION
Updates material-checklist to fcbaaa8:

- The Materials tab now tracks the direct ingredients of the goods on the checklist; expanding a material in the Goods view is informational and no longer rewrites the shopping list. A right-click "Add as its own goal" promotes an intermediate the user plans to craft.
- Variable-yield farming crops assume a typical harvest by default (configurable back to guaranteed minimums).
- Skill-guide fixes: rows resolve by their text before the icon item (Herblore rows show secondary-ingredient icons), pluralized tree rows resolve, and complete tree/watering chains were added to the bundled dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
