### PR TITLE
Update Jam's Arceuus Runecrafting to 1.0.8

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=1ffa3ea261f7d79efc3ad13dde9b8f6b7c6f0735
+commit=f3d424c240f82c9bc6b7a98d4d9ee539e95d2627


### PR DESCRIPTION
## Summary
- Bump `zeah-rc-helper` to `f3d424c240f82c9bc6b7a98d4d9ee539e95d2627` (1.0.8)
- Fragment count shown on the inventory stack (`?` when unknown)
- Status panel Dense/Dark as `N/N`; chisel/path fixes after the 73 hop and for unknown stacks

## Test plan
- [ ] Hub CI build passes for zeah-rc-helper
- [ ] Fragment stack overlay shows count / `?` when unknown
- [ ] After 73 west hop while chiseling, path continues to the mine
- [ ] Full inventory alone does not send GO_ALTAR until stack is known full or near altar