### PR TITLE
update voiced-dialogue

### DIFF
--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=daabe5325140220e690fc6ead32eb492442b1036
+commit=571e720f50109b4fc1ad6bd9ac6fc2b25de22d4d
 authors=grabartley
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates voiced-dialogue to [v0.7.0](https://github.com/grabartley/runelite-voiced-dialogue/releases/tag/v0.7.0). The pinned commit is the `v0.7.0` release tag commit.

Highlights since v0.6.0:

- **Players can see what a session cost them.** The new `::voicedspend` chat command reports the cloud TTS spend for the current session, so anyone using their own provider key can keep an eye on it without leaving the client.
- The citizens of Arceuus now have their own race, accent and voice pool, so the city sounds distinct from the rest of Great Kourend instead of borrowing generic human voices.
- Both cloud providers now share a single backend and translation layer internally, which keeps their behaviour consistent and makes future provider work smaller.
