### PR TITLE
add bankless-bank plugin

### DIFF
--- a/plugins/bankless-bank
+++ b/plugins/bankless-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/robrichardson13/bankless-bank.git
-commit=aada01f2ebb5656c034cf701471ac41034ba596e
+commit=866a7444a58030fe5d1083326d4e3de008a3cc42

--- a/plugins/bankless-bank
+++ b/plugins/bankless-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/robrichardson13/bankless-bank.git
-commit=866a7444a58030fe5d1083326d4e3de008a3cc42
+commit=3cb10d41c79d79d3e23a402303c294e719c0426e

--- a/plugins/bankless-bank
+++ b/plugins/bankless-bank
@@ -1,0 +1,2 @@
+repository=https://github.com/robrichardson13/bankless-bank.git
+commit=aada01f2ebb5656c034cf701471ac41034ba596e

--- a/plugins/bankless-bank
+++ b/plugins/bankless-bank
@@ -1,2 +1,2 @@
 repository=https://github.com/robrichardson13/bankless-bank.git
-commit=3cb10d41c79d79d3e23a402303c294e719c0426e
+commit=179beb16fcf66f8bbfeb10ebe6a06c8ff9929e1f


### PR DESCRIPTION
Bankless Bank is a bank-style viewer overlay that shows every item a player owns (inventory, equipment, looting bag, POH, STASH units, death piles, etc.) without visiting a bank. It targets Ultimate Ironmen, who cannot use the bank. It is a viewer only — there is no withdraw or deposit functionality.

The tracking layer is ported from the BSD-2 licensed "Dude, Where's My Stuff?" plugin, with a one-time optional import of its saved data on first login. There is no runtime dependency on DWMS after import.

Repository: https://github.com/robrichardson13/bankless-bank