### PR TITLE
Update Retro NPC Swapper to 1.1.0

### DIFF
--- a/plugins/retro-npc-swapper
+++ b/plugins/retro-npc-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/AJD-/RetroNPCSwapper.git
-commit=99b3f3f8092b2a39a48bfa8b21ad36f1f7d9ced7
+commit=e3b2e232dd0205b86407fcadb5280e03a6223cf2


### PR DESCRIPTION
- Added compatibility for `Interact Highlight` outlines on retro models

[retro-plugin-update-1-1-0.webm](https://github.com/user-attachments/assets/c200d047-1b55-42a5-b0e2-5d8d09f14b27)
