### PR TITLE
Update Retro NPC Swapper to 1.1.0

### DIFF
--- a/plugins/retro-npc-swapper
+++ b/plugins/retro-npc-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/AJD-/RetroNPCSwapper.git
-commit=99b3f3f8092b2a39a48bfa8b21ad36f1f7d9ced7
+commit=b08ef713a12e11a16ea8300429ab8c9aac6ba16b


### PR DESCRIPTION
- Added compatibility for `Interact Highlight` outlines on retro models

[retro-plugin-update-1-1-0.webm](https://github.com/user-attachments/assets/60d63f49-c86d-4ead-a33d-2d23fda313f9)
