### PR TITLE
Add Maxing tracker

### DIFF
--- a/plugins/maxing-tracker
+++ b/plugins/maxing-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/OliPetri/maxing-tracker.git
+commit=a5e75515c7ddba11d085142557f6e264ef40494f


### PR DESCRIPTION
Adds a sidebar for planning the time remaining to reach level 99 in each skill using user-selected XP rates or training presets. Completed skills are hidden. It includes capped overall XP progress, a per-character tracking baseline with reset, and a manual passive option to exclude overlapping training from time estimates.

Uses the standard build and no extra runtime dependencies. Includes 21 passing automated tests against RuneLite 1.12.38. Preset assumptions and derived or provisional rates are documented in the repository.