### PR TITLE
Update Jam's Arceuus Runecrafting to 1.0.10

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=f3d424c240f82c9bc6b7a98d4d9ee539e95d2627
+commit=5dd11ff98874a0bf607349aa863147757e7e6c03


### PR DESCRIPTION
## Summary
- Session and lifetime trip/rune counters on the status panel (configurable Stats section)
- Crafted runes counted on fragment deplete + blood/soul gain (ignores drop/pickup)
- Remove Dense/Dark inventory row from the status panel
- Keep chiselling until the last dark block once a chisel run has started (do not flip to Altar when the fragment stack hits Full mid-chisel)

## Test plan
- [x] Unit tests pass on https://github.com/JamsRepos/zeah-rc-helper
- [x] Only `plugins/zeah-rc-helper` commit hash changed