### PR TITLE
Update material-checklist

### DIFF
--- a/plugins/material-checklist
+++ b/plugins/material-checklist
@@ -1,2 +1,2 @@
 repository=https://github.com/Dewdul/material-checklist.git
-commit=95917a39fa73cece23016eec86d7818393ffb959
+commit=92fc25a616eec925b30c06a585432c3440670450


### PR DESCRIPTION
Updates material-checklist to 92fc25a:

- Tools (saw, hammer, persistent one-offs) are no longer listed as materials; they appear only as a note in the goal tooltip
- Goods is the first and default tab; adding from the game can open the side panel (configurable)
- UI fixes: rows track the viewport width so counts and the quantity stepper no longer clip when the scrollbar appears, full-size item icons, stacked goal tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
