### PR TITLE
Update Flip Smart

### DIFF
--- a/plugins/flip-smart
+++ b/plugins/flip-smart
@@ -1,4 +1,4 @@
 repository=https://github.com/Flip-Smart/flip-smart-runelite-plugin.git
-commit=70d37a02281d1021da5eb07cb8b82ed70b71c80e
+commit=46a75d6c1f4f929134dfe6cdcac0f627aa0ed83d
 authors=mablack01
 warning=This plugin submits your IP address, account name, grand exchange transactions, and information about your account wealth to a 3rd party server that is not controlled or verified by RuneLite developers.


### PR DESCRIPTION
## Summary
- Fixed GE breakeven calculations incorrectly blending closed round trips into the current lot's cost basis, which could show an inaccurate breakeven price
- Fixed the Flip Assist hotkey intercepting keystrokes typed into the Grand Exchange item search box, so letters no longer get swallowed while searching for an item
- Fixed the Flip Assist recommendation changing while a Grand Exchange offer screen is open, so the suggested item stays locked in place instead of shifting mid-setup