### PR TITLE
Update Kill Clog to 2.3.2: chat command completion and rank endpoint filter

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=020e68adf14b9c0f848570ef60711935ea9b62da
+commit=c1eb9773cb730f568fd73115568afd0677635150
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill Clog 2.3.2

- adds an optional six-endpoint account type rank filter to see how accounts are ranked on various jagex leaderboards
- extends `!kclog [page]` and `!missing [page]` across the full Collection Log, including `!kclog pets` with duplicate quantities
- fixes long chat wrapping and ambiguous aliases, including Random Events matching Venenatis
- adds Abyssal protector to Runecraft's Pets section and Phoenix to Firemaking's, without double-counting skill totals
- adds account badges to comparison headers and polishes the leaderboard footer
- fixes first-lookup badges for GIM, HCGIM, and UGIM
- refreshes the README screenshots and adds the full command, ownership, and shortcut reference

This wraps up the current Kill Clog feature sprint. Thanks for all the reviews and feedback across these updates. I really appreciate your time and tokens!
