### PR TITLE
Add skill-bank-organizer

### DIFF
--- a/plugins/skill-bank-organizer
+++ b/plugins/skill-bank-organizer
@@ -1,0 +1,2 @@
+repository=https://github.com/DonkeyXBT/skill-bank-organizer-plugin.git
+commit=f82a0a6585c3dda6df98f847d8f070965b2e8ed6


### PR DESCRIPTION
Adds **Skill Bank Organizer**.

The plugin scans the bank container and groups the stacks into one page per skill (plus a Raids kit page). Each page lists the best tools you already own and the next upgrade, training methods with the supplies they need, the matching stacks currently in the bank, and a suggested rebuild order.

Right-clicking a bank item adds a `Send to <skill>` entry, which opens that skill's page and writes a Bank Tag (`#woodcutting`, `#raids`, and so on) through the existing `banktags` config group.

The plugin is information only. It does not move, withdraw or deposit anything, and it adds no automation or input handling; rearranging the bank is left to the player.

Repository: https://github.com/DonkeyXBT/skill-bank-organizer-plugin

No third-party dependencies beyond the RuneLite client and Lombok. Builds and tests pass against runelite.version 1.12.38 on JDK 17 with release 11.