### PR TITLE
inventory-count: v1.2.2 update

### DIFF
--- a/plugins/inventory-count
+++ b/plugins/inventory-count
@@ -1,3 +1,3 @@
 repository=https://github.com/robrichardson13/inventory-count.git
-commit=5c274cc3a15d0a038e88e1644d6c2d568f75b55c
+commit=79f58af525a90361e8e55c1023c657d95ad1ed46
 authors=robrichardson13,Zenrion

--- a/plugins/inventory-count
+++ b/plugins/inventory-count
@@ -1,3 +1,3 @@
 repository=https://github.com/robrichardson13/inventory-count.git
-commit=79f58af525a90361e8e55c1023c657d95ad1ed46
+commit=ece54f0ddd6682b84c4419b43b3c3e2f4d279d72
 authors=robrichardson13,Zenrion


### PR DESCRIPTION
Updates Inventory Count to v1.2.2.

- Fixes the free-slot count staying on the inventory tab after the plugin is disabled (robrichardson13/inventory-count#13). The add-overlay task queued on the client thread could run after `shutDown()`, re-adding the overlay with nothing left to remove it. The plugin now tracks a running flag and the queued task bails out if the plugin was shut down.
- Adds a Mockito unit test covering the ordering, and a `runClient` gradle task for local development.

Changes: https://github.com/robrichardson13/inventory-count/compare/5c274cc3a15d0a038e88e1644d6c2d568f75b55c...79f58af525a90361e8e55c1023c657d95ad1ed46