### PR TITLE
Update Maxing tracker to 0.9.0

### DIFF
--- a/plugins/maxing-tracker
+++ b/plugins/maxing-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/OliPetri/maxing-tracker.git
-commit=a5e75515c7ddba11d085142557f6e264ef40494f
+commit=5a98ec0a5098e4de5b617f1ae8d15160cf4601be


### PR DESCRIPTION
Updates the displayed author to DandelyDoo and adds eight training presets: 1.5-tick and 2-tick teaks at Woodcutting levels 80/90, plus banked blessed bone shards with normal or sunfire wine at Prayer levels 70/88. Rates and assumptions follow the OSRS Wiki training tables; bone gathering and processing are excluded from the Prayer presets.

Metadata, catalogue and documentation only; no runtime Java changes or new dependencies. Java 11 compilation and all 21 existing tests pass against RuneLite 1.12.38.