### PR TITLE
inventory-count: v1.3.0 update

### DIFF
--- a/plugins/inventory-count
+++ b/plugins/inventory-count
@@ -1,3 +1,3 @@
 repository=https://github.com/robrichardson13/inventory-count.git
-commit=ece54f0ddd6682b84c4419b43b3c3e2f4d279d72
+commit=a8d1b19a885ff378582594575aa9d3f5ed1bbd10
 authors=robrichardson13,Zenrion


### PR DESCRIPTION
Updates Inventory Count to v1.3.0.

- Adds a Count mode setting: free, used, or both slots shown on the inventory tab.
- Adds an infobox tooltip and switches the infobox text to red when the inventory is full.

Changes: https://github.com/robrichardson13/inventory-count/pull/15