### PR TITLE
Add Slayer Item Reminders

### DIFF
--- a/plugins/slayer-item-reminders
+++ b/plugins/slayer-item-reminders
@@ -1,0 +1,2 @@
+repository=https://github.com/MaeveMcT/slayer-item-reminders.git
+commit=3b932e676febac9f1fda9f8bef79b78b56ce0c25


### PR DESCRIPTION
## Summary

Adds Slayer Item Reminders, which reminds players about required and useful items for their current Slayer assignment.

- Shows required-item infoboxes for supported tasks, such as a rock hammer for Gargoyles or ice coolers for Desert lizards.
- Recommends a herb sack or seed box when the selected monster's drop table contains enough compatible drops.
- Discovers task variants from the OSRS Wiki and provides a side panel for selecting the monster being killed.
- Hides reminders while banking and reevaluates them after the bank closes.

## Network and safety

- Network access consists only of read-only requests to the public OSRS Wiki API.
- Requests run asynchronously through RuneLite's injected OkHttp client and use a descriptive User-Agent.
- No player or account information is transmitted.
- No input is automated or injected.
- No third-party dependencies are required.
- Uses the standard Plugin Hub build.

## Overlap

The existing ItemReminders plugin provides user-configured zone and item pairs. Slayer Item Reminders is assignment-aware, automatically determines relevant items from curated rules and OSRS Wiki drop tables, and does not require users to configure region or item IDs.