### PR TITLE
pocketge-flip-tracker: 0.6.1 -> 0.6.2

### DIFF
--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/grant9008/pocketge-flip-tracker.git
-commit=0994cf52010c03037d481e0ab99f8effeb30633f
+commit=42e78b1f01fbe80909adbeb96a771889fe3b1b10

--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/grant9008/pocketge-flip-tracker.git
-commit=512296ade44afa1f3bde49ac71d5cbe039d2d6f4
+commit=bf110b76c52f59d7ee5dad6b96df42d1b5920e49

--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/grant9008/pocketge-flip-tracker.git
-commit=bf110b76c52f59d7ee5dad6b96df42d1b5920e49
+commit=e4cacb4f534ca321cd1346e7bf5db5a0e7205775

--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/grant9008/pocketge-flip-tracker.git
-commit=42e78b1f01fbe80909adbeb96a771889fe3b1b10
+commit=06f3095b578645bd8edce9aacad8db2a1039617e

--- a/plugins/pocketge-flip-tracker
+++ b/plugins/pocketge-flip-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/grant9008/pocketge-flip-tracker.git
-commit=e4cacb4f534ca321cd1346e7bf5db5a0e7205775
+commit=0994cf52010c03037d481e0ab99f8effeb30633f


### PR DESCRIPTION
Since 0.6.1 (512296a):

- Mouse wheel only scrolled while the cursor was over the scrollbar itself. PluginPanel's default constructor was wrapping the panel in a scroll pane of its own, which left the plugin's own scroll pane with a range of zero; the wheel forwarder then moved that inert bar and consumed the event. Declining the wrapper also re-pins the top button strip, which had been scrolling away with the content.
- Pause moved to that pinned strip. It acts on the advisor, not on the item, and the card it sat on is the thing it stops from changing.
- Buy ideas for stock you already hold sort last. You may have spent the 4h limit acquiring it, and adding to a position you carry is a different bet from the fresh one under it.
- Buy cards name the sell price their profit assumes. The card gave a bid price and a gp figure only true at some other price, with that price nowhere on it.
- The watchlist card prices through the trade engine. It was using the raw book alone, so an item whose insta-buy and insta-sell had both printed at 709 got "no margin after tax" while pocketge.com showed +414K over a full limit from the same data.
- A failed price request is no longer cached as "this item has no range". Any non-2xx became an all-zero result indistinguishable from "never traded", and the cache held it for the full 30-minute TTL, so one item silently lost its range badge while every item around it kept theirs.
- Chart clicks reach an open browser tab over a long-poll instead of a 5s timer that a hidden tab has throttled. Needed a real executor on the local bridge, since the JDK default runs every handler on one thread.
- Right-click a chart button to force a new browser tab, for comparing two items.
- The stats grid no longer demands twice its widest caption.
- Buy cards say where the price sits in the item's own 30-day range, when it is near an edge. A measurement, not a verdict, and it takes no part in ranking.


Claude-Session: https://claude.ai/code/session_01CrbbnpxzzXajkmFNwfAgTw