### PR TITLE
update bank-templates to v2.3.3

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=90157b485e40866ac398540e2456e35e56c673d3
+commit=bc2a0c7c0fe571c9700aac876ef300ab7cdfe8ca

--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=bc2a0c7c0fe571c9700aac876ef300ab7cdfe8ca
+commit=96cce1a153b7edf03b5e40c8711b02d1b2cdc79f


### PR DESCRIPTION
v2.3.3 adds three icon buttons to the panel header and removes one from the bottom.

A bell opens the changelog, a cog opens the plugin's own settings, and the third opens
our support form with the plugin and area already chosen. The Updates button that sat
along the bottom of the panel is gone; it spent a full-width row on something people
read once a release, and the bell reaches the same tab.

The cog posts an OverlayMenuClicked carrying a plain Overlay constructed with the
plugin. ConfigPlugin reads the plugin off that overlay and ignores the target string,
so the overlay exists only to hold the reference; it is never registered and never
rendered. Our two real overlays are Guice-built and take no plugin, and accepting one
would make the plugin and the overlay depend on each other.

Icons are three new 16x16 PNGs under src/main/resources. Each is null-checked at load
and falls back to a text label.

No change to what the plugin sends or stores.

Compare: https://github.com/TheSpryt/bank-templates/compare/90157b4...96cce1a