### PR TITLE
Update custom-hp-bar

### DIFF
--- a/plugins/custom-hp-bar
+++ b/plugins/custom-hp-bar
@@ -1,2 +1,2 @@
 repository=https://github.com/waitstepbro/custom-hp-bar.git
-commit=7d87af93d6523cf3a7663c9c4b1448180acc8fd5
+commit=d6f218947ab82bcfe02c6095c8f21a1b4b7a77f4


### PR DESCRIPTION
Bumps custom-hp-bar to 2.1.0.

New: shield and charge bars for Doom of Mokhaiotl, Kephri and Yama's void flares; a damage trail and a death fade-out; an elemental weakness icon; combat levels and combat-level name coloring for other players; a player blacklist and per-section text colors; ToA HP read off the game's own HUD with team-size scaling.

Fixes: one hit drawing as several hitsplats, same-tile bar and name overlap, chat text and hitsplats lost when the player's own bar wins the tile, and hiding the native health bar also hiding mechanic bars.

The config was also cut from ~150 options to 106, with a migration that carries most existing settings over.

Release notes: https://github.com/waitstepbro/custom-hp-bar/releases/tag/2.1.0