### PR TITLE
exchange-insights-capture: 1.1.0

### DIFF
--- a/plugins/exchange-insights-capture
+++ b/plugins/exchange-insights-capture
@@ -1,3 +1,3 @@
 repository=https://github.com/TheSpryt/Exchange-Insights-Capture.git
-commit=5e0fe48b27e5df5131763863c284af370c4f8d75
+commit=12decbfdc710d393810e495a42f3ac989d5fcece
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps `exchange-insights-capture` to 1.1.0.

The plugin's display name is now **Clip That**, changed in `runelite-plugin.properties` and the `@PluginDescriptor` annotation. The manifest filename and the repository URL are untouched, so existing installs are unaffected.

**In this release:**

- Combat achievements never fired. The game announces a completed task through the popup or the chatbox and never both, with `CA_TASK_POPUP` deciding which; only the chatbox was read, and the popup is the default. The chat pattern was wrong too, matching `<col=...>` where the game sends `@ach_comp@`. Both paths are handled now, gated on the varbit so they cannot double-fire.
- Collection log entries and league tasks had the same fault and are fixed with it.
- Combat achievements split into separate completed and failed triggers.
- Side panel reworked into My Clips and Quick Settings tabs, with bundled patch notes read from a local JSON resource. No new network calls.
