### PR TITLE
tobqol - v1.4.2

### DIFF
--- a/plugins/tobqol
+++ b/plugins/tobqol
@@ -1,3 +1,3 @@
 repository=https://github.com/damencs/tob-qol.git
-commit=59b6713e6174f8909f8f2da64f2b8cd8915e9f33
+commit=3715d6ae24547fa87dc7ed82665e37b632407ba7
 authors=damencs


### PR DESCRIPTION
- fixes: TOB Last Item "Justiciar legguards" handling, which was later corrected to reference "Justiciar leguards"