### PR TITLE
Update material-checklist

### DIFF
--- a/plugins/material-checklist
+++ b/plugins/material-checklist
@@ -1,2 +1,2 @@
 repository=https://github.com/Dewdul/material-checklist.git
-commit=92fc25a616eec925b30c06a585432c3440670450
+commit=9a39980418fc1ed5e499928e5813594240e0767c


### PR DESCRIPTION
Updates material-checklist to 9a39980: auto-removal of finished goods (once the wanted amount is owned, announced in chat) is now enabled by default; config key renamed so the new default applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
