### PR TITLE
Add Herb Run Planner

### DIFF
--- a/plugins/herb-run-planner
+++ b/plugins/herb-run-planner
@@ -1,0 +1,2 @@
+repository=https://github.com/Boiss123104/herb-run-planner.git
+commit=55639e064bb6ef2aa7c5c02b9837d98be344382e


### PR DESCRIPTION
Adds Herb Run Planner, an account-aware helper for preparing and completing herb runs.

Features:
- Suggests patches and travel methods using account unlocks and observed supplies.
- Combines supplies for the whole route into a bank preparation checklist and bank item filter.
- Accounts for ironman item availability and tool leprechaun supplies.
- Provides teleport icons, minimap and world map guidance, and local walking paths.
- Supports manual run progress and confirmations where information cannot be detected reliably.

The plugin provides guidance only. Players perform all withdrawals, teleports, walking, and farming actions themselves.

Validation:
- Gradle check passed using Java 11.
- Full herb runs and the preparation workflow have been tested in game.