### PR TITLE
Add CG Cooking Check

### DIFF
--- a/plugins/cg-cooking-check
+++ b/plugins/cg-cooking-check
@@ -1,0 +1,2 @@
+repository=https://github.com/autumn6128/CG-Cooking-Check.git
+commit=bb8da77403a43b2c3ebbbf8dc4997c55d60c46c5


### PR DESCRIPTION
## What it does

Corrected Gauntlet / Corrupted Gauntlet QoL plugin: while the player has one or more raw paddlefish in their inventory, the left-click default on the boss room Barrier's `Pass` / `Quick-pass` option is deprioritised so a left click walks toward the barrier instead of entering the fight. `Pass` / `Quick-pass` remain available via the right-click menu, and `Escape` is untouched.

Repository: https://github.com/autumn6128/CG-Cooking-Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)