### PR TITLE
update jumpscare to 1.6.5

### DIFF
--- a/plugins/jumpscare
+++ b/plugins/jumpscare
@@ -1,3 +1,3 @@
 repository=https://github.com/vividflash/jumpscare.git
-commit=ec99fbc049914c63004b46401970bae5f3600e62
+commit=95601018c8b432a32afc06050d93908eaae9afc2
 authors=vividflash


### PR DESCRIPTION
1.6.5
had complaint of default being too loud.
Default volume lowered from 80 to 50.
Test Mode now overrides only the scare chance; the image, sound and volume are used exactly as configured.
Removes two config migrations that have finished their job.