### PR TITLE
Add CG Cooking Check

### DIFF
--- a/plugins/cg-cooking-check
+++ b/plugins/cg-cooking-check
@@ -1,0 +1,2 @@
+repository=https://github.com/autumn6128/CG-Cooking-Check.git
+commit=56ec94ea025df57f44bd09c5ac03f5049b623a5d


### PR DESCRIPTION
Corrupted Gauntlet / Gauntlet QoL plugin: deprioritises the boss barrier's Pass/Quick-pass left-click option while raw paddlefish are still in inventory, so a misclick doesn't walk you into Hunllef uncooked. Pass/Quick-pass remain available via right-click.

Repository: https://github.com/autumn6128/CG-Cooking-Check
