### PR TITLE
Update mystix

### DIFF
--- a/plugins/mystix
+++ b/plugins/mystix
@@ -1,4 +1,4 @@
 repository=https://github.com/Dmurph24/mystix-plugin.git
-commit=9a2004dd9e4c41ec4962c20939a0bd3e7310ceb0
+commit=8ddeb3e980a63911e395796aaeb3f6eec25f0246
 authors=Dmurph24
 warning=This plugin submits your RSN, skills, bank, equipment, loadouts, farming timers, and loot data to a 3rd-party server (Mystix) not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Mystix to the latest release.

The main change is live progress for roadmap goals. The plugin already subscribed to the events involved (StatChanged, LootReceived, ItemContainerChanged, VarbitChanged, GameTick); it now applies them to the player's goals locally so the overlay and side panel move as the player plays, with a periodic re-read of the goals from the server (every 10 minutes and shortly after the plugin's existing uploads) to reconcile. Completing a goal shows the game's own notification interface (the same one used for collection log and combat achievement popups) with a game sound effect, or optionally a .wav the user places in their .runelite/mystix folder. Goal artwork is fetched over HTTPS from the image URLs the Mystix server supplies for each goal (wiki-hosted images). No new upload types are introduced for this; the existing skills, loot-drop and bank uploads run a few seconds after a goal-relevant event, and the inventory/equipment upload also runs on logout.

The plugin also now sends the player-owned house location (a single varbit) so the app's farm-run routing can use the right house teleport. The remaining changes are fixes: local goal progress is no longer reset by region loads and world hops; quest states are also read from the game's own quest table (the row ids RuneLite's questFilter script callback hands out, then QUEST_STATUS_GET, the same script Quest.getState runs) and from the quest-complete scroll's title widget, so a quest not yet listed in RuneLite's Quest enum still syncs; and settings are grouped into data-syncing and plugin-feature sections.



This release also syncs Kingdom of Miscellania state so the app can track the player's kingdom. It reads the Managing Miscellania varbits (approval rating, coffer, subjects assigned to each labour, and the allocation choices) plus the Throne of Miscellania and Royal Trouble quest states, and posts them to the server. Nothing is sent until Throne of Miscellania is complete. Timing reuses the existing diary-sync trigger (a settle after login, a throttled resync when the state changes, and a flush on logout), and walking onto the islands also triggers a resync. A "Kingdom of Miscellania" toggle joins the Data Syncing settings section.
