### PR TITLE
Update gauntlet-chest-popup

### DIFF
--- a/plugins/gauntlet-chest-popup
+++ b/plugins/gauntlet-chest-popup
@@ -1,2 +1,2 @@
 repository=https://github.com/ldavid432/gauntlet-loot-popup.git
-commit=63ba8867a74894f3b0c5e413b6b1cde2f49001dd
+commit=45322f839b7a72d5793d1049f58af6510ad72e06


### PR DESCRIPTION
Fix close sprite not matching barrows therefore making it not work with resource packs