### PR TITLE
Update ClanHQ plugin for noted item drop verification

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=d14c3d36d95abeef6718c89b9c221176f1fea1cf
+commit=b590eb22efcf27993a7d53e0410254d36a72409f


### PR DESCRIPTION
## Summary

Update the ClanHQ Plugin Hub manifest to the latest standalone plugin commit.

This release adds noted/unnoted item normalization for `ITEM_DROP` verification using RuneLite's `ItemManager.canonicalize`. Both submitted verification and local overlay progress now use the same canonical item ID; the payload schema and quantity handling are unchanged.

## Plugin details

- Captures only the logged-in player's evidence after explicit actions.
- Sends complete character contents only after Character Sync or Bingo Character Submit is clicked and its disclosure is confirmed.
- Ships with no endpoint or installation token.
- Disables gameplay screenshots by default.
- Lets the player revoke and remove the current installation from Overview.
- Submits only after the player clicks the button.
- Never awards a rank or performs game actions.

## Verification

- Published plugin commit: `b590eb22efcf27993a7d53e0410254d36a72409f`
- The plugin source compiles successfully against the cached RuneLite dependencies.
- 17 relevant JUnit tests pass.