### PR TITLE
Add Tile Layers

### DIFF
--- a/plugins/tile-layers
+++ b/plugins/tile-layers
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/tile-layers.git
-commit=c44e03c268eb0260b88ec192ddefb22d2b6a1060
+commit=390414b865f1816bed6e184ed4273912f8935b1f

--- a/plugins/tile-layers
+++ b/plugins/tile-layers
@@ -1,0 +1,2 @@
+repository=https://github.com/Endrit-alt/tile-layers.git
+commit=c44e03c268eb0260b88ec192ddefb22d2b6a1060

--- a/plugins/tile-layers
+++ b/plugins/tile-layers
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/tile-layers.git
-commit=2426e575696d47f6ae42c32d072375dcd91601fd
+commit=cf436552f7765ea524b3f7bc0b88de932ca9dbf7

--- a/plugins/tile-layers
+++ b/plugins/tile-layers
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/tile-layers.git
-commit=390414b865f1816bed6e184ed4273912f8935b1f
+commit=2426e575696d47f6ae42c32d072375dcd91601fd


### PR DESCRIPTION
Adds Tile Layers by Endrit. The plugin draws ground markers and other overlays beneath the local player, other players, all NPCs, or NPCs selected by name.

Overlay opacity defaults to 10%. A shared crowd cutoff defaults to 80, counting other players and NPCs separately and pausing each category when its count reaches the cutoff. The local player is exempt from the crowd cutoff.

Overlay coverage checks skip characters away from overlays. A reusable silhouette mask follows characters submitted for drawing each frame, avoiding gaps caused by hidden characters in stacks.

Validation:
- Gradle build passes against RuneLite 1.12.38 with 39 tests, including opacity, crowd cutoff boundaries, child world views, and stacked character visibility.
- Development client startup verified.
