### PR TITLE
Update Herb Run Planner to v0.33.4

### DIFF
--- a/plugins/herb-run-planner
+++ b/plugins/herb-run-planner
@@ -1,2 +1,2 @@
 repository=https://github.com/Boiss123104/herb-run-planner.git
-commit=55639e064bb6ef2aa7c5c02b9837d98be344382e
+commit=232e35af97862dfd5ec4624be045a957c269de0f


### PR DESCRIPTION
Updates Herb Run Planner from v0.30.0 to v0.33.4.

Changes:
- Adds named, per-character gear sets with item search and a default set.
- Accounts for the selected elemental staff when calculating rune requirements.
- Recognizes worn/unworn equipment variants and bottomless compost buckets.
- Adds automatic checklist progression after detected planting and composting.
- Improves bank filtering, item positioning, walking guidance, and preparation messages.
- Adds profile and bug-report buttons, a collapsible quick-start guide, and a Plugin Hub icon.

The plugin provides guidance only. Players perform all withdrawals, equipping, teleports, walking, and farming actions themselves.

Validation:
- Production sources compile targeting Java 11 against RuneLite 1.12.38.
- 1,041 standalone checks passed.
- Updated preparation, gear, navigation, and automatic progression were tested in game.