### PR TITLE
disable exchange-insights and exchange-insights-capture

### DIFF
--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,3 +1,0 @@
-repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
-commit=a7d61046f88895390c3cf849ed5981f6c1ccffc5
-warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/exchange-insights
+++ b/plugins/exchange-insights
@@ -1,0 +1,4 @@
+repository=https://github.com/TheSpryt/Exchange-Insights-Plugin.git
+commit=a7d61046f88895390c3cf849ed5981f6c1ccffc5
+warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.
+disabled=The Exchange Insights service behind this plugin has been retired

--- a/plugins/exchange-insights-capture
+++ b/plugins/exchange-insights-capture
@@ -1,0 +1,4 @@
+repository=https://github.com/TheSpryt/Exchange-Insights-Capture.git
+commit=5e0fe48b27e5df5131763863c284af370c4f8d75
+warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.
+disabled=The Exchange Insights service behind this plugin has been retired

--- a/plugins/exchange-insights-capture
+++ b/plugins/exchange-insights-capture
@@ -1,3 +1,0 @@
-repository=https://github.com/TheSpryt/Exchange-Insights-Capture.git
-commit=5e0fe48b27e5df5131763863c284af370c4f8d75
-warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Please disable both Exchange Insights plugins. The website and service behind them are being retired, so neither plugin will have anything to talk to. Both manifests keep their repository, commit and warning lines and gain a disabled flag with the reason.

- plugins/exchange-insights
- plugins/exchange-insights-capture

The open update for exchange-insights-capture (#16195) has been closed. Bank Templates is unaffected and continues; its update is #16218.