### PR TITLE
update bank-templates to v3.0.0

### DIFF
--- a/plugins/bank-templates
+++ b/plugins/bank-templates
@@ -1,2 +1,2 @@
 repository=https://github.com/TheSpryt/bank-templates.git
-commit=96cce1a153b7edf03b5e40c8711b02d1b2cdc79f
+commit=6d2c9afa0c9e0ade75724344540bf20e2cd26935


### PR DESCRIPTION
Updates bank-templates from 2.3.3 (96cce1a) to 3.0.0.

The community repository moves to a new, static service that does not depend on the Exchange Insights website (which is being retired, see #16217). All account-linked features are removed from the plugin:

- Browse loads a static catalogue and searches, sorts and pages locally. A template's layout is fetched only when previewed or imported.
- Account linking, website sync, bank value snapshots, profile-styled cards and the "Items owned" sort are removed, along with the Exchange Insights settings section and the classes behind them. The plugin no longer sends bank contents anywhere.
- Sharing, updating and deleting shared templates work as before, keyed on the logged-in character.
- Right-click menu on every card; the help icon opens a new GitHub issue.
- The plugin talks only to two fixed hosts: a public file store for reads and one small write API.

Net: 18 files changed, 1050 insertions, 3605 deletions. That includes a GitHub Actions workflow and script that publish the catalogue; they run in this repository, not in the plugin.

