### PR TITLE
Update fixed-resizable-hybrid

### DIFF
--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=2736d5c8859e54f968bc873cf708207b9c00dc5a
+commit=2cff594f16c8fbe23ec72e9b390febc3733e80bf

--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=2cff594f16c8fbe23ec72e9b390febc3733e80bf
+commit=f5cff9f1174d8d41a094a8d26d4c009eaee7af25


### PR DESCRIPTION
Updates Fixed Resizable Hybrid to add an optional, event-driven bank expansion when the chatbox is hidden.

The bank restores its normal layout when chat, bank search, or another chatbox prompt is shown, and follows the plugin's existing transparency, viewport-centering, and wide-chatbox behavior.