### PR TITLE
Add Better Party Defence

### DIFF
--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=38bab83b75f04927a49571983981d2d5a8d14989
+commit=bcc1c6ed2fabbe829b6965100db268bc8f8363e0

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=39e367b5b25a7304cfcd30982208d38704394f7a
+commit=38bab83b75f04927a49571983981d2d5a8d14989

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=e690c43f4bcb585096c7ecef56cddb1c3fc372b7
+commit=4c8e8cbf140aed1c90c6d60114736d477ef6e612

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=5f1ecc5ef78bda53a306d3b844d7d2b53d1450f3
+commit=39e367b5b25a7304cfcd30982208d38704394f7a

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=7a67a733925585966443b7b2033280fd9431e9cb
+commit=a298b680e4f0b6ee233014a3418c6bda051e408b

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=4c8e8cbf140aed1c90c6d60114736d477ef6e612
+commit=5e4ace89446507fb453de4c2a6336e6285f90476

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=bcc1c6ed2fabbe829b6965100db268bc8f8363e0
+commit=94b155734ac607f63989b42c2f3ab247b0997cbe

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=a298b680e4f0b6ee233014a3418c6bda051e408b
+commit=157a0bb63736a352a1f17785434706ba05bb1370

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=5e4ace89446507fb453de4c2a6336e6285f90476
+commit=9c3a446a7ccc8072becb6c32d9d671ab5625fec1

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=61c19c5a271401117295860d96ab060e9a8bdd13
+commit=9f869b423c644510a934baa3a65cdd930364aa04

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=5b683d9adf60bfe9e783ee6da539dd97d224f997
+commit=5f1ecc5ef78bda53a306d3b844d7d2b53d1450f3

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=9f869b423c644510a934baa3a65cdd930364aa04
+commit=5b683d9adf60bfe9e783ee6da539dd97d224f997

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,0 +1,2 @@
+repository=https://github.com/Falsary/better-party-defence.git
+commit=61c19c5a271401117295860d96ab060e9a8bdd13

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=9c3a446a7ccc8072becb6c32d9d671ab5625fec1
+commit=7a67a733925585966443b7b2033280fd9431e9cb

--- a/plugins/better-party-defence
+++ b/plugins/better-party-defence
@@ -1,2 +1,2 @@
 repository=https://github.com/Falsary/better-party-defence.git
-commit=94b155734ac607f63989b42c2f3ab247b0997cbe
+commit=e690c43f4bcb585096c7ecef56cddb1c3fc372b7


### PR DESCRIPTION
Adds Better Party Defence.

Better Party Defence tracks and displays the current Defence level of supported bosses after defence-draining special attacks.

It supports local special attacks and party special attacks through RuneLite's existing party and Special Counter infrastructure, including use alongside Hub Party Panel.

The plugin does not use an external server, custom backend, or custom party system.

Defence-tracking logic derived from OSParty is documented in ATTRIBUTION.md and LICENSE-OSPARTY.txt.

The plugin has been tested locally using the RuneLite development client.