### PR TITLE
update ironscape-optimal

### DIFF
--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,0 +1,2 @@
+repository=https://github.com/GROBBS-hash/ironscape-optimal.git
+commit=53d225c20c51a77f3cfdbbd4cb46e7f72f1366a4

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=627cc6754e8bc6d3fed3129925962ba2e5e870ea
+commit=92f3c65c9b696901fd3f90ff5633126be0758ded

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=324cdf572d9d7d36e567c9be1b2b8790cbd3536a
+commit=7e03f249847a816d969e5fb2395f0ede77fa69b2

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=5ff2a2bf79d205826a476f28237a93cb2d08756b
+commit=627cc6754e8bc6d3fed3129925962ba2e5e870ea

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=53d225c20c51a77f3cfdbbd4cb46e7f72f1366a4
+commit=324cdf572d9d7d36e567c9be1b2b8790cbd3536a

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=7e03f249847a816d969e5fb2395f0ede77fa69b2
+commit=5ff2a2bf79d205826a476f28237a93cb2d08756b

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=1ea909451cce09956b99c0cdb59744745f3c6eef
+commit=090a54b554fa0608bccdcb4aad3778aa9b607141

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=1b9c4fa625198497295b874c1608e3ad1dc398a7
+commit=b094b21b6cfdb2b93a955b50ff33267b99b2fcba

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=b094b21b6cfdb2b93a955b50ff33267b99b2fcba
+commit=1ea909451cce09956b99c0cdb59744745f3c6eef

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=bc23c9b6af8151534e5f371c1ed85f7ab585fe37
+commit=1b9c4fa625198497295b874c1608e3ad1dc398a7

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,4 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=057ab9b7e48c841246af04b44801b851359c1470
-
-
+commit=bc23c9b6af8151534e5f371c1ed85f7ab585fe37

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=f2c15b4f49501b7bfc032ddb5be7bd8be2515f87
+commit=0e4dc5d6d3734d7deb07669609679f5c92da31e4

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,3 +1,4 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=1160d245fdf231b6eb2b7b54fec7a5b55697d913
+commit=ae9f062ca115c7acdf8fca24eb5f6c2907fd6f13
+
 

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=92f3c65c9b696901fd3f90ff5633126be0758ded
+commit=1c7e972256c1f398c1a04069b9997263c933b2af

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=1c7e972256c1f398c1a04069b9997263c933b2af
+commit=bd6998284fb808b80e0bf2e324754faa9231378c

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,4 +1,4 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=ae9f062ca115c7acdf8fca24eb5f6c2907fd6f13
+commit=057ab9b7e48c841246af04b44801b851359c1470
 
 

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=bd6998284fb808b80e0bf2e324754faa9231378c
+commit=f2c15b4f49501b7bfc032ddb5be7bd8be2515f87

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=3638c2fb7751a0fdafaaba42f27da196f764f62e
+commit=f634cbf93eff2cd775fe2b6d5572175b3865691b

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=0e4dc5d6d3734d7deb07669609679f5c92da31e4
+commit=cf9be08f8bd68a1abbfbf50d7efd663c746fb8f8

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=f634cbf93eff2cd775fe2b6d5572175b3865691b
+commit=bb3e11ee090ea488a4b16a7002cc8986fb7bdb6a

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,3 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=bb3e11ee090ea488a4b16a7002cc8986fb7bdb6a
+commit=1160d245fdf231b6eb2b7b54fec7a5b55697d913
+

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=a07a1ebc8464a4dd7e6da0dd3446cdb6e785090f
+commit=b8c994dea736648fe5643429f36f382179e7da89

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=cf9be08f8bd68a1abbfbf50d7efd663c746fb8f8
+commit=a07a1ebc8464a4dd7e6da0dd3446cdb6e785090f

--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=b8c994dea736648fe5643429f36f382179e7da89
+commit=3638c2fb7751a0fdafaaba42f27da196f764f62e


### PR DESCRIPTION
Updates the pin for ironscape-optimal.

Listing metadata only, no plugin code changes:

- `author` was carrying a full credit sentence, which the hub renders as the page title. It is now just `GROBBS`; the guide credit moved into the description and the README.
- Added a real icon (was a placeholder).
- Description expanded slightly, and the README rewritten with what the plugin actually does.
