### PR TITLE
update ironscape-optimal

### DIFF
--- a/plugins/ironscape-optimal
+++ b/plugins/ironscape-optimal
@@ -1,2 +1,2 @@
 repository=https://github.com/GROBBS-hash/ironscape-optimal.git
-commit=1ea909451cce09956b99c0cdb59744745f3c6eef
+commit=090a54b554fa0608bccdcb4aad3778aa9b607141


### PR DESCRIPTION
Updates the pin for ironscape-optimal. Listing metadata only, no plugin code changes.

- `author` was carrying a full credit sentence, which the hub renders as the page title, so the listing was titled "GROBBS; guide content by Oziris & the ironman.guide community (used with permission)". It is now just `GROBBS`, with the guide credit in the description and the README.
- Replaced the placeholder icon with a real one.
- Expanded the description, and rewrote the README to describe what the plugin does.
