### PR TITLE
update drop-rate-properties

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=1cfe3808f50dbf47d814eb634b2639f65f1f82c2
+commit=857f399a9fdb3ea733cbea8e6b2b17dc06869c55


### PR DESCRIPTION
Updates `drop-rate-properties` to `857f399a9fdb3ea733cbea8e6b2b17dc06869c55`.

No code changes. This update is the plugin hub listing:

- README rewritten to lead with what the plugin does for a player, with screenshots, and the developer notes moved into a collapsed section
- Shorter `description` (461 characters of keywords down to two sentences; the keywords live in `tags`)
- New `icon.png`, still 48x72 and 3 KiB, legible at that size
- Added `version=1.0`

Fixed three inaccuracies in the old README while rewriting: a chat example that showed output from a non-default rate mode, a claim that the bundled data updates itself when the weekly job only checks it, and an ambiguous explanation of the kill counter.