### PR TITLE
Add travel-guide

### DIFF
--- a/plugins/travel-guide
+++ b/plugins/travel-guide
@@ -1,0 +1,2 @@
+repository=https://github.com/kristophbarbour/runelite-pathfinder.git
+commit=e44711c4c0f64bcca1d2346130cff60372630d3a


### PR DESCRIPTION
Travel Guide gives step-by-step travel directions to any tile, named place or NPC: walk here, use this fairy ring and dial this code, bank first and withdraw these runes, cast this teleport, take this boat. It plans with the teleports and transports the character can actually use (quests, skills, diaries, spellbook, runes in inventory/equipment/rune pouch, items in the bank) and never moves the player; it only draws the route and shows the current step in an overlay and a side panel.

The pathfinding engine, collision map and transport data are derived from Shortest Path (BSD-2, credited in THIRD_PARTY_NOTICES.md and UPSTREAM.md, vendored under a different package, config group and PluginMessage namespace so both plugins can coexist). New on top of it: the instruction compiler with bank shopping lists, a running-aware cost model with thresholds for cooldown teleports, per-account bank memory, and NPC/monster search backed by spawn data generated from the OSRS Wiki (CC BY-NC-SA 3.0, credited in the panel and README).

Repository: https://github.com/kristophbarbour/runelite-pathfinder

🤖 Generated with [Claude Code](https://claude.com/claude-code)