### PR TITLE
Add Folders for Bank Tags plugin

### DIFF
--- a/plugins/folders-for-bank-tags
+++ b/plugins/folders-for-bank-tags
@@ -1,0 +1,2 @@
+repository=https://github.com/random-cactus/folders-for-bank-tags.git
+commit=6a2d918e8c6d8fc47a7aaa15c28f278eaf14b817

--- a/plugins/folders-for-bank-tags
+++ b/plugins/folders-for-bank-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/random-cactus/folders-for-bank-tags.git
-commit=77fc3ef64ecb5143a3f7a9f33ef40dc684692fab
+commit=b5890859645cd86b4e47d09c07588686d4250a01

--- a/plugins/folders-for-bank-tags
+++ b/plugins/folders-for-bank-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/random-cactus/folders-for-bank-tags.git
-commit=6a2d918e8c6d8fc47a7aaa15c28f278eaf14b817
+commit=77fc3ef64ecb5143a3f7a9f33ef40dc684692fab


### PR DESCRIPTION
**Note: This is a new plugin as I am unable to merge with existing Bank Tag Folders plugin due to this being entirely rewritten to not have dependency on disabling the Bank Tag plugin's "Use Tag Tabs" option which should offer a significant improvement.**

Groups bank tag tabs into collapsible folders, for people who keep more tabs than fit down the side of the bank. Right-click a tab to file it into a folder, click the folder to open or close it. Works the same in the tag tab overview.

It's an add-on to the core Bank Tags plugin rather than a replacement. "Tag tabs" stays on, core draws its column as usual, and this runs afterwards and rearranges the rows. Every tab is still core's widget, so rename, delete, export, icons, layouts and dragging items onto tabs all keep working without being reimplemented. Folders live in the plugin's own config group; the only thing written to `banktags` is tab order, and that goes through core's TabManager.