### PR TITLE
Add Limit Keeper

### DIFF
--- a/plugins/limit-keeper
+++ b/plugins/limit-keeper
@@ -1,0 +1,2 @@
+repository=https://github.com/CoreyUK/LimitKeeper.git
+commit=e206dc225a2cffe30e948e1883cff85e2994446c


### PR DESCRIPTION
Limit Keeper tracks how much of each item's four hour Grand Exchange buy limit you have already used.

RuneLite tells you what an item's buy limit is and when the period resets. It does not tell you the number that actually matters when you are buying: how many you have bought so far, and so how many you can still buy.

**What it does**

- On the buy offer screen it adds a line under the item text: `Bought: 8,240 / 11,000  2,760 left`, and a second line totalling the coins spent and the average paid per item this period.
- A side panel lists every item with a period running, soonest to reset first, with a progress bar and a live countdown.
- An infobox while a limit is used up, showing the item's icon and the time until it frees up, so the countdown is visible with the Grand Exchange and the panel both closed. Only maxed items get one and it clears itself when the period elapses.
- Optional notifications when a limit is used up, and when one becomes available again. Both default to off.

Counts are kept per account, so alts are tracked separately, and they survive a client restart.

**No network access**

The plugin makes no requests of its own and needs no warning in the manifest. Buy limits come from RuneLite's own item data, so there is no bundled item table to go stale. Purchases are counted from Grand Exchange offer updates, with a snapshot of each slot persisted so quantities bought during an earlier session are counted once rather than replayed as new purchases at the next login.

**Known limitations**, documented in the README: buys made on mobile or in another client are not seen, so counts can read low, and items RuneLite has no buy limit for are shown with a plain count and can be hidden.

Repository: https://github.com/CoreyUK/LimitKeeper (BSD 2-Clause, built from the example-plugin template).
