### PR TITLE
Updated Dry Streak Tracker to 1.3.4

### DIFF
--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
-commit=740bbea9a2bed783507a9eb20c2e825fb1587136
+commit=db6fd5ba0f1599b2d74a4bc2f0848b8d8d6c8006
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Fixed a bug where non-attackable npc's with a combat level were showing custom npc tracker right click menu.

- Changed smoke lootbeams to default to off for new plugin users.