### PR TITLE
b0aty-hcim-guide-v3: update to 1.3.0

### DIFF
--- a/plugins/b0aty-hcim-guide-v3
+++ b/plugins/b0aty-hcim-guide-v3
@@ -1,2 +1,2 @@
 repository=https://github.com/previns/b0aty-hcim-guide-v3.git
-commit=8e10a39baef3d0495d824955f87bb560f680c254
+commit=362f669ff6a7e8159eb2da92c16cb80655254d71

--- a/plugins/b0aty-hcim-guide-v3
+++ b/plugins/b0aty-hcim-guide-v3
@@ -1,2 +1,2 @@
 repository=https://github.com/previns/b0aty-hcim-guide-v3.git
-commit=dbba3544710d4a8bfed66fbe92805c2285c6146c
+commit=a98f9dabdba3fab4585a5440ddd4cdadb2d505ba

--- a/plugins/b0aty-hcim-guide-v3
+++ b/plugins/b0aty-hcim-guide-v3
@@ -1,2 +1,2 @@
 repository=https://github.com/previns/b0aty-hcim-guide-v3.git
-commit=a98f9dabdba3fab4585a5440ddd4cdadb2d505ba
+commit=8e10a39baef3d0495d824955f87bb560f680c254

--- a/plugins/b0aty-hcim-guide-v3
+++ b/plugins/b0aty-hcim-guide-v3
@@ -1,2 +1,2 @@
 repository=https://github.com/previns/b0aty-hcim-guide-v3.git
-commit=cf1e501fc39c6f06dff3f7c0468281cf4e660651
+commit=dbba3544710d4a8bfed66fbe92805c2285c6146c


### PR DESCRIPTION
Updates `b0aty-hcim-guide-v3` to **1.3.0**.

This PR started life as the 1.1.0 update. Neither 1.1.0 nor 1.2.0 has merged yet, so 1.3.0 rolls all three up. I've bumped `commit=` here rather than opening another PR, per the submission guidance.

### About the size

`src/main/resources/com/b0atyguide/guide.json` is the guide itself as data — about 2,900 route steps generated from the OSRS Wiki by a separate pipeline. The plugin is a renderer over that file, so changing the route never touches Java. Regenerating it rewrites the whole thing, though, which used to bury the diff under roughly 460,000 lines of machine output.

It's marked `-diff` in `.gitattributes` now, so git reports it as binary and it keeps out of the way. The bytes that ship are unchanged either way.

That leaves **9,265 insertions across 75 files, 8,859 of them Java across 64 files**. Most of it is in five:

```
path/PathTracker.java         +1164
data/QuestHelperSteps.java     +941
path/PathFinder.java           +880
overlay/SceneTracker.java      +730
B0atyGuidePlugin.java          +701
```

The guide data is reviewed in the data repository, where it stays pretty-printed and someone reads the step diff before players see it.

### 1.3.0 — Quest puzzles and routing

- Show Quest Helper's puzzle answers instead of its "turn on solutions" message: chest codes, door passwords, the stone order on Death Plateau, which guards to mark in Children of the Sun.
- Solve combination locks on screen, marking each dial's arrow with the number of clicks and the Confirm button once they're all set.
- Highlight quest scenery that Quest Helper locates by tile rather than by id, which covers about a quarter of its object steps.
- Draw the line to the nearest of several possible places — a deposit box, a statue, a captain — instead of waiting for one to come into view.
- Follow Ribbiting Tale of a Lily Pad Dispute, and stop showing one puzzle's instructions on a different puzzle.
- Board the right ship for crossings the step doesn't name a boat for, such as Entrana and Brimhaven, and stop answering island teleports with a dock.
- Send "Head to Varlamore" to Regulus Cento outside Varrock.

### 1.2.0

- Guide progress is kept separately for each RuneScape account. Existing shared progress is imported once, into the first account logged in after updating.
- Fixed progress saves stopping partway through a session, and the sidebar jumping when it shouldn't.
- Better quest dialogue, item and shop highlighting, including Tribal Totem's combination lock.
- Errands the guide asks for mid-quest are shown alongside Quest Helper instead of interrupting it.
- Travel steps name the vehicle: the right boarding point, the right direction for charter ships, and the captain actually at that dock.
- Searching several identical objects, such as the roots under the Grand Tree, stops outlining the ones already tried.
- Wider quest-branch coverage, and navigation stays on the current step.

### 1.1.0

- Quest steps highlight what Quest Helper highlights: the NPC to talk to, the object to search, the raft to board, the rope to use.
- Quest interfaces are guided too, so screens like the Dwarf Cannon repair show which part to click.
- "Start \<quest\>" steps tick when you start the quest rather than waiting for something much later, and still tick if you'd already started.
- Steps that run "until you have X" stop on the item itself.
- Training, gathering and diary steps no longer tick themselves because an unrelated quest moved.
- Better routing through closed doors, gates and fences, with the way in highlighted.
- Bank withdrawals, shop stock and ground items are highlighted again; shopkeepers and quest NPCs are marked.
- The plugin repeats far less work each frame and each tick.

### Testing

`gradlew clean build` succeeds from a fresh clone of the referenced commit and produces `b0aty-guide-1.3.0.jar`. The test suites live in the development repository rather than the published snapshot: 369 unit tests and 425 pipeline tests, all passing.

One limitation worth stating plainly: **per-account progress separation has automated coverage but hasn't been confirmed live on a second account.** It touches saved progress, so a reviewer should know. Existing progress is imported rather than discarded, and the previous save is kept.
