### PR TITLE
Add Lightbearer Helper plugin

### DIFF
--- a/plugins/lightbearer-helper
+++ b/plugins/lightbearer-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/1504681/LightbearerHelper.git
+commit=ca0f6671486c8dc8b8063c448626950b27d68670


### PR DESCRIPTION
## Summary
- Highlights the Lightbearer in your inventory while special attack regenerates, then your other rings (Ultor/Bellator/Magus/Venator, configurable with wildcards) once spec is full, until one is equipped
- Optional spec weapon highlight and a pulsing aura/outline/fill on the spec orb at a configurable spec percentage
- Overlay only: no input, no automation

## Repository
https://github.com/1504681/LightbearerHelper