### PR TITLE
Update folders-for-bank-tags to 1.1.0

### DIFF
--- a/plugins/folders-for-bank-tags
+++ b/plugins/folders-for-bank-tags
@@ -1,2 +1,2 @@
 repository=https://github.com/random-cactus/folders-for-bank-tags.git
-commit=b5890859645cd86b4e47d09c07588686d4250a01
+commit=5c548eb4e69b0fc78cd32f048422d7dbd709abd6


### PR DESCRIPTION
fix bug where folders would not redraw if a tag tab was imported.