### PR TITLE
update osrs-fliphub

### DIFF
--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,3 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=6d60cc3f12789acb656230ce7424ff7a5d394b91
+commit=19aae5368510e75415147bcd1dff1a66ad5f46a7
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps `commit=` for `osrs-fliphub`.

This is a performance fix. The plugin's Grand Exchange offer timer overlay
rebuilt its entire view state inside `render()`, which runs once per drawn
frame. On the offer slot overview that meant walking every widget root in the
client searching for offer-status text, walking the GE tree a second time for
the same markers, and then rediscovering the eight slot rectangles from
geometry heuristics plus a 300-component sweep. Each pass allocates several
strings per text widget, so the cost grew with how much interface was loaded,
and the frame rate dropped noticeably while the GE item search results were on
screen.

The offer slots and the details panel are addressable components, so the
overlay now reads them directly instead of searching for them, and the old
scanners are kept only as a fallback whose result is reused rather than
recomputed per frame. The chatbox price and quantity suggestion pass had the
same problem: it ran on every client tick and deep-scanned the chatbox widget
tree while the item search list was open. It now rules the item search out by
input type first, and respects the update interval it already defined. Item
name lookups also cache misses, so text pulled off the GE interface no longer
re-runs a full item database scan on every poll.

There is no user-visible change in behaviour: the slot timers, the price and
quantity suggestions and the panel all work as before, confirmed in a
developer-mode client.

No new dependencies. `build.gradle`, `settings.gradle` and
`runelite-plugin.properties` are unchanged from the published commit.
