### PR TITLE
Add Harrisun Mystic UI

### DIFF
--- a/plugins/harrisun-mystic-ui
+++ b/plugins/harrisun-mystic-ui
@@ -1,0 +1,2 @@
+repository=https://github.com/opaf-osrs/harrisun-mystic-ui.git
+commit=f2867450dd04f70569a2fd836d3409313b7a3101

--- a/plugins/mystic-hud
+++ b/plugins/mystic-hud
@@ -1,0 +1,2 @@
+repository=https://github.com/opaf-osrs/mystic-hud.git
+commit=63889dcd47c5410059d2154a4dd309dddda26052

--- a/plugins/mystic-hud
+++ b/plugins/mystic-hud
@@ -1,2 +1,0 @@
-repository=https://github.com/opaf-osrs/mystic-hud.git
-commit=63889dcd47c5410059d2154a4dd309dddda26052


### PR DESCRIPTION
Puts the minimap and the orbs into one rectangular block above the inventory. Square minimap instead of the round one, the four orbs as flat colour filled blocks in a row, and it works in both resizable layouts.

No external calls and no bundled art. The frame and the orb icons are read off the client's sprite table at runtime, so the block follows whatever resource pack you happen to be running and falls back to the game's own art when there is none.

Closest existing thing is compact-orbs, which repositions the orbs. This does the map and the orbs as one panel and squares the minimap off, so they are not really doing the same job.

![the block](https://github.com/opaf-osrs/harrisun-mystic-ui/raw/master/docs/screenshot.png)

Attached to the inventory so the two read as one panel:

![attached](https://github.com/opaf-osrs/harrisun-mystic-ui/raw/master/docs/attached.png)
