### PR TITLE
Update Tile Layers

### DIFF
--- a/plugins/tile-layers
+++ b/plugins/tile-layers
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/tile-layers.git
-commit=f1b93939d2b6c33604187160c6dd484a067faa68
+commit=c546b5f37cc69678288dbd3b822359f381dcfdcf

--- a/plugins/tile-layers
+++ b/plugins/tile-layers
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/tile-layers.git
-commit=a47daf89a852aee465a59c0aec74aa7c039608f3
+commit=20649c8bd04699b9111aca53f72c9d8e793c1595

--- a/plugins/tile-layers
+++ b/plugins/tile-layers
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/tile-layers.git
-commit=cf436552f7765ea524b3f7bc0b88de932ca9dbf7
+commit=a47daf89a852aee465a59c0aec74aa7c039608f3

--- a/plugins/tile-layers
+++ b/plugins/tile-layers
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/tile-layers.git
-commit=2d4382c6303df9a668548234ca26d6b465dee840
+commit=f1b93939d2b6c33604187160c6dd484a067faa68

--- a/plugins/tile-layers
+++ b/plugins/tile-layers
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/tile-layers.git
-commit=20649c8bd04699b9111aca53f72c9d8e793c1595
+commit=f3354b05da3532af7f61d42eb493586ebb1880e0

--- a/plugins/tile-layers
+++ b/plugins/tile-layers
@@ -1,2 +1,2 @@
 repository=https://github.com/Endrit-alt/tile-layers.git
-commit=f3354b05da3532af7f61d42eb493586ebb1880e0
+commit=2d4382c6303df9a668548234ca26d6b465dee840


### PR DESCRIPTION
Fixes Loot Filters ground labels being drawn after Tile Layers had already applied its mask. The mask now runs after standard scene overlay priorities, while remaining in ABOVE_SCENE with a single mask pass. Ground text and label backgrounds respect character masking and the configured opacity.

Uses one combined crowd cutoff for other players and NPCs. With the default cutoff of 80, 40 other players plus 40 NPCs pause both crowd effects; they resume below 80 total. All loaded other players and NPCs contribute, including NPCs outside the name list and categories whose checkbox is off. The local player remains excluded and unaffected. Counting stops at the cutoff before model or height work for either crowd category.

Overlay opacity defaults to 0% instead of 10% and appears at the top of configuration, above the character checkboxes. Existing saved opacity settings are preserved.

Validation: Gradle build passes after removing the two test files.
