### PR TITLE
Update session-movement-tracker to 1.1.1

### DIFF
--- a/plugins/session-movement-tracker
+++ b/plugins/session-movement-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/lwr27/session-movement-tracker.git
-commit=5ef2f2bad8aac4b18a2708ad4c5566bde9518b52
+commit=8a2bb60cbf14490efce68dcf3e793b41f9c0e1f3


### PR DESCRIPTION
XP drops are now recorded per drop (with timestamps) and written once per save, instead of per-skill totals
Pending XP and hitpoints changes are written out before a teleport, so they stay attributed to the origin
Teleports that happen behind a loading screen (boat trips, hops) are now recorded
Uploads now merge with the existing remote file, so tracking one account from multiple computers no longer overwrites sessions
Default local data retention reduced from 3 months to 1