### PR TITLE
Update GIM hub from 1.7.0 to 1.8.0.

### DIFF
--- a/plugins/gim-hub
+++ b/plugins/gim-hub
@@ -1,4 +1,4 @@
 repository=https://github.com/wouterrutgers/gim-hub-plugin.git
-commit=5bb190dba293025218980ceb3854f213f7cda8b6
+commit=27c7ce280106892238fd83b22863c59c01d31187
 authors=wouterrutgers,EllarBooher
 warning=This plugin sends your player data (including your items, world map location, xp values, collection log information), and IP address to a server not controlled or verified by the RuneLite developers.


### PR DESCRIPTION
This version builds on the latest improvements to collection log tracking. We now hook into RuneLite's Loot Tracker to track repeat collection log drops.

We've also added automated test coverage.

_Note: the changes are not that large if you filter out the test files._