### PR TITLE
Add Signpost

### DIFF
--- a/plugins/signpost
+++ b/plugins/signpost
@@ -1,0 +1,2 @@
+repository=https://github.com/reece-backhouse/signpost.git
+commit=0b78d4d57443f16f379b883b35fec98180ee4b39

--- a/plugins/signpost
+++ b/plugins/signpost
@@ -1,2 +1,2 @@
 repository=https://github.com/reece-backhouse/signpost.git
-commit=0b78d4d57443f16f379b883b35fec98180ee4b39
+commit=6a2072f442140a7ff688cab292abb46cb919bd4c

--- a/plugins/signpost
+++ b/plugins/signpost
@@ -1,2 +1,2 @@
 repository=https://github.com/reece-backhouse/signpost.git
-commit=6a2072f442140a7ff688cab292abb46cb919bd4c
+commit=f25af2b92fc4d4c5e96a35adf6a7fc7ebed447ae


### PR DESCRIPTION
Adds Signpost: a side panel that suggests your account's next best goal (quest, diary tier, boss or skill target), ranked for the account's stage with a Why? line for each, and a detail view that turns a skill gap into a route from the bank plus gathering plans for anything short. Ironman aware (no GE sources).

- No network calls; reads game state via the RuneLite API only and stores per-account notes under ~/.runelite/next-target/.
- Bundled knowledge base is generated from the OSRS Wiki (CC BY-NC-SA 3.0, attributed in the README) by the scripts in kb-build/.

Repository: https://github.com/reece-backhouse/signpost