### PR TITLE
update osrs-fliphub

### DIFF
--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,3 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=19aae5368510e75415147bcd1dff1a66ad5f46a7
+commit=dbe8156ccc4f40f9aa75ec40c1c7843d7d8655f7
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps `commit=` for `osrs-fliphub`.

Two user-facing changes since the pinned commit.

**Decimal amounts in "enter an amount" prompts.** The game already reads a unit suffix — typing `9m` in a price box gives nine million — but it ignores the decimal point, so `9.4m` cannot be typed and the amount has to be spelled out in full. A key listener now accepts the point while the chatbox input is an amount prompt, and rewrites the text as a plain integer on Enter, before the game reads the input on its next tick. Only text carrying a point is touched, so anything the game already parses is left alone; the arithmetic runs through `BigDecimal` rather than a double, truncates rather than rounds, and clamps to the largest amount the game takes. It applies to every prompt of that input type, so bank withdraw-X and coffers get it too, and it can be turned off with the "Type decimal amounts" option.

**Discord button destination.** The panel's Discord button opened a `discord.gg` invite hardcoded in the plugin. It now opens `https://www.osrsfliphub.com/discord`, which redirects to the current invite, so that destination can change without another hash bump.

No new dependencies. `build.gradle`, `settings.gradle` and `runelite-plugin.properties` are unchanged from the previously published commit.
