### PR TITLE
Add Offhand Ghost plugin

### DIFF
--- a/plugins/offhand-ghost
+++ b/plugins/offhand-ghost
@@ -1,2 +1,2 @@
 repository=https://github.com/jptmiranda/offhand-ghost.git
-commit=8f1770fe1cdd8c614c9f657800f0fe50f72953a1
+commit=aba49efc4633f17164721201aacd0cfb4f069732

--- a/plugins/offhand-ghost
+++ b/plugins/offhand-ghost
@@ -1,2 +1,2 @@
 repository=https://github.com/jptmiranda/offhand-ghost.git
-commit=cd3813c9caff3c789ef2655eb3c6a9cf82e1747b
+commit=b3687eb0e995dd951e5cf1a65b41c82b7ad57675

--- a/plugins/offhand-ghost
+++ b/plugins/offhand-ghost
@@ -1,2 +1,2 @@
 repository=https://github.com/jptmiranda/offhand-ghost.git
-commit=ed4c292fe8d31f85215b7a66ed6cad71023fe237
+commit=9e24978ce84bc5577ba5abb27168f978581acae8

--- a/plugins/offhand-ghost
+++ b/plugins/offhand-ghost
@@ -1,2 +1,2 @@
 repository=https://github.com/jptmiranda/offhand-ghost.git
-commit=b2d29d7c5e176c1ea89466434091aa2233379b37
+commit=8f1770fe1cdd8c614c9f657800f0fe50f72953a1

--- a/plugins/offhand-ghost
+++ b/plugins/offhand-ghost
@@ -1,0 +1,2 @@
+repository=https://github.com/jptmiranda/offhand-ghost.git
+commit=cd3813c9caff3c789ef2655eb3c6a9cf82e1747b

--- a/plugins/offhand-ghost
+++ b/plugins/offhand-ghost
@@ -1,2 +1,2 @@
 repository=https://github.com/jptmiranda/offhand-ghost.git
-commit=aba49efc4633f17164721201aacd0cfb4f069732
+commit=ed4c292fe8d31f85215b7a66ed6cad71023fe237

--- a/plugins/offhand-ghost
+++ b/plugins/offhand-ghost
@@ -1,2 +1,2 @@
 repository=https://github.com/jptmiranda/offhand-ghost.git
-commit=b3687eb0e995dd951e5cf1a65b41c82b7ad57675
+commit=b2d29d7c5e176c1ea89466434091aa2233379b37


### PR DESCRIPTION
Offhand Ghost

https://github.com/jptmiranda/offhand-ghost

When you're wielding a two-handed weapon, the shield slot sits empty. This plugin draws a faded copy of the weapon's sprite in that empty slot, so it's clear what's taking it up.

How it works

On ItemContainerChanged for the worn container, I check the weapon and shield slots. If exactly one is filled and ItemEquipmentStats.isTwoHanded() is true for it, I cache that item's sprite and draw it into the empty slot from a MANUAL-layer overlay bound with drawAfterInterface, so it only renders while the equipment interface is open. It works both ways round, so an item in the shield slot that blocks the weapon slot ghosts too.

There's an optional drop shadow, off by default.

One thing worth flagging: it hides a widget

While a ghost is showing, I set hidden = true on the empty slot's type glyph, the small sprite drawn on top of the stone plate, so the ghost sits on a bare plate instead of over the shield engraving. This is the same thing the game does with that widget when a real item is in the slot.

It only touches the glyph child, never the plate, the item widget, or the slot layer, so nothing moves or resizes and no click zones change. The glyph is restored every frame before being re-applied, and again in shutDown(), so nothing stays modified when the plugin is off.

No network calls, no menu entries, no input injection.