### PR TITLE
create bank-stack-values

### DIFF
--- a/plugins/bank-stack-values
+++ b/plugins/bank-stack-values
@@ -1,0 +1,2 @@
+repository=https://github.com/jamiegr/Bank-Stack-Values-RuneLite-Plugin.git
+commit=68bb2d7a1dcc003db9741822f808e6d65c0c5be2


### PR DESCRIPTION
Displays each bank stack's total GE value beneath its item icon, with a persistent in-bank toggle, configurable value colours and optional untradable-item filtering.

Uses RuneLite's cached ItemManager prices. Targets the personal bank item grid and skips ordinary and Bank Tags layout placeholders. The plugin makes no separate network requests and does not automate game actions.

Java 11; standard build; BSD 2-Clause; no additional runtime dependencies. Local tests cover value calculations, formatting, colour settings, placeholder handling and button cleanup.

The following testing was performed:

Compared a known stack with unit price × quantity; checked coins and mapped untradable items.
Toggled off/on, closed/reopened the bank, and restarted the client to confirm persistence.
Scrolled, searched, switched tabs, deposited, withdrew and dragged items; confirmed labels stay with their items.
Checked normal placeholders and Bank Tags layouts with missing items.
Changed each colour, enabled the single-colour option and hid untradable values.
Tried alongside my usual bank plugins (some clashes with plugins like item identification and item charges); adjusted the button offsets.
Disabled the plugin with the bank open; confirmed its button and labels disappear while other plugins' controls remain.