### PR TITLE
Update commit hash in discord-chatbox-broadcaster

### DIFF
--- a/plugins/discord-chatbox-broadcaster
+++ b/plugins/discord-chatbox-broadcaster
@@ -1,3 +1,3 @@
 repository=https://github.com/D4nders/discord-chatbox-broadcaster.git
-commit=f1bf7a79986fa1c9d33ce03697580723faee04bd
+commit=1d22d267dbdcacaa955251bdfb6eadd1d03a03c4
 authors=danders


### PR DESCRIPTION
Release v1.1: Comprehensive bug fixes and logic improvements

This update addresses several production bugs, improves notification accuracy,
and ensures strict compliance with RuneLite Plugin Hub guidelines.

Feature Improvements:
- Personal Bests: Now intelligently extracts and displays the boss/activity 
  name alongside the PB time by correlating with the preceding kill count message.
- Pets: Decoupled from Valuable Drops. Pet names are now accurately extracted 
  by combining the "funny feeling" message with the corresponding "Untradeable 
  drop" message on the same tick.
- Valuable Drops: No longer triggers on untradeable drops.

Bug Fixes:
- Achievement Diaries: Completely refactored from varbit tracking to chat 
  message parsing. This resolves a major bug where logging in would spam 
  Discord with all previously completed diaries.
- Combat Tasks & Quests: Fixed formatting issues where raw color tags 
  (e.g., `@ach_comp@`) were leaking into the Discord messages.
- PvP Kills: Fixed a despawn bug where PvM boss kills were incorrectly 
  triggering PvP notifications. Kills now strictly verify recent player 
  `ActorDeath` events, accounting for non-breaking spaces in API names.

Codebase & Maintenance:
- Completely removed all obsolete varbit tracking subscriptions and methods.
- Updated `DiscordChatboxBroadcasterPluginTest.java` to test the new chat 
  parsing logic and player-death logic instead of mocked varbits and NPCs.
- Removed the IP logging warning from config and disabled all notifications 
  by default to comply with Jagex/RuneLite 3rd-party client rules.
- Updated `README.md` to reflect all current behaviors and added a v1.1 changelog.
- Bumped plugin version to 1.1 in gradle and properties.