### PR TITLE
Add Bingo BrazilChat

### DIFF
--- a/plugins/bingo-brazil-chat
+++ b/plugins/bingo-brazil-chat
@@ -1,0 +1,2 @@
+repository=https://github.com/SFranciscoSouza/BingoBrazilChat.git
+commit=803230b7608602f6c749bc0a57a702eb6c8f0088

--- a/plugins/bingo-brazil-chat
+++ b/plugins/bingo-brazil-chat
@@ -1,2 +1,4 @@
 repository=https://github.com/SFranciscoSouza/BingoBrazilChat.git
 commit=10f20f50f1e43a8e6755ec5d3bd2b8cb25998a6a
+authors=SFranciscoSouza
+warning=This plugin sends player data, including usernames, screenshots, and IP address to a third-party server not controlled or verified by the RuneLite Developers, to record clan drop broadcasts on an event scoreboard.

--- a/plugins/bingo-brazil-chat
+++ b/plugins/bingo-brazil-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/SFranciscoSouza/BingoBrazilChat.git
-commit=803230b7608602f6c749bc0a57a702eb6c8f0088
+commit=10f20f50f1e43a8e6755ec5d3bd2b8cb25998a6a


### PR DESCRIPTION
Records listed raid drops on a clan bingo/PvM event scoreboard automatically.

OSRS already broadcasts raid uniques to the clan channel. The plugin reads those
broadcasts, matches the item against the event's own item list, and reports it to the
event site so it scores on the team leaderboard, instead of every participant filling
in a web form with a screenshot by hand.

### Network use

This plugin sends data to a third party, so to be explicit about what and when:

- It talks only to the address in its `Site address` setting, which defaults to the
  event site `https://brazilchat.vercel.app`.
- It sends the dropped player's RSN, the item name, the raw clan broadcast text, a
  timestamp, and (unless the user turns screenshots off) a screenshot of the client.
- **It is inert until the user pastes an event token into the config.** With the token
  field empty it makes no network requests at all. The token is issued by the event
  organiser, so only people taking part in an event ever enable it.
- It only reports players who are on that event's roster, and only items on the event's
  item list. Everything else is ignored locally without any request.

The README states the same thing up front, and the config panel carries a section
explaining it before the user enters a token.

Only clan system broadcasts are read (`CLAN_MESSAGE`, `CLAN_GIM_MESSAGE`,
`CLAN_GUEST_MESSAGE`). Player-typed chat is deliberately not parsed.

### Build

`build=standard`, no third-party dependencies beyond runelite-client's own, Java 11,
BSD 2-Clause licensed. `gradlew build` is green with 53 unit tests covering broadcast
parsing and item matching.