### PR TITLE
Update groupscape to e5a5af2

### DIFF
--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=b304a0f5538e94fe534de9ec870193bf9ede6b8d
+commit=31cb5577ed4c64c7d72164ceadfd25b0adefcc0f
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=4aa072bed544a6206d522274df1be6489c93a09f
+commit=e5a5af2ea54d08ba33c432d00e4823c1f8624169
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=31cb5577ed4c64c7d72164ceadfd25b0adefcc0f
+commit=3731b9f39d32ccc6a77d9e1777fedba247a2c288
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=3731b9f39d32ccc6a77d9e1777fedba247a2c288
+commit=4aa072bed544a6206d522274df1be6489c93a09f
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Brings the deployed groupscape plugin from v1.8.19 to v1.8.22.

- Fixed: active prayer icons no longer double up (e.g. Eagle Eye alongside Deadeye, Mystic Might alongside Mystic Vigour) in the in-game overlay, client side panel, and website side panel.
- Fixed: slayer task history and stats on the companion site were staying empty due to a wrong upload key.
- Fixed: loot from bosses with long death animations (e.g. Duke Sucellus) could fail to reach the site's loot log if the drop arrived late.
- Fixed: a completed slayer task's points reward wasn't showing up on the site - always read as 0 gained.
- Fixed: a free task skip from Turael, Aya, or Spria was showing as "Unknown" on the site instead of "Reset".