### PR TITLE
update drop-rate-properties

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=857f399a9fdb3ea733cbea8e6b2b17dc06869c55
+commit=97da6bf9415fdb8a694452eea59d972387405548


### PR DESCRIPTION
Updates `drop-rate-properties` to `97da6bf9415fdb8a694452eea59d972387405548`.

**Collection Log and clue reward tooltips now lead with the source you are looking at.** Reported as an issue on the plugin repo: on a hard casket's own reward screen the tooltip listed four bosses before `Hard clue`, and for a Nature rune the clue rate was past the `+91 more` cut entirely, so the one number the screen was about could not be seen. The source matching the open interface is now lifted above the rarity ordering, and above the truncation. An unrecognised context pins nothing and leaves the tooltip unchanged.

**New icon.** Still 48x72 and 2.4 KiB.

No new dependencies.