### PR TITLE
Add Local Event Bridge

### DIFF
--- a/plugins/local-event-bridge
+++ b/plugins/local-event-bridge
@@ -1,0 +1,2 @@
+repository=https://github.com/ashy0019/runelite-local-event-bridge.git
+commit=bd93386dc47387e8b299991eba88e38b3a8ee4ad


### PR DESCRIPTION
Adds Local Event Bridge, a headless plugin that publishes a fixed allowlist of gameplay observations to local companion applications over IPv4 loopback (127.0.0.1:41713).

The protocol is one-way with respect to gameplay and provides no commands for clicks, typing, menu actions, movement, or other game control.