### PR TITLE
Add Portal Nexus Teleport Hider

### DIFF
--- a/plugins/portal-nexus-teleport-hider
+++ b/plugins/portal-nexus-teleport-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/friw0w/portal-nexus-teleport-hider.git
-commit=7c79402285cc0f5b50a794538a528a09acf87b41
+commit=23308ceea369a52240493601d7135462e2a50466

--- a/plugins/portal-nexus-teleport-hider
+++ b/plugins/portal-nexus-teleport-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/friw0w/portal-nexus-teleport-hider.git
+commit=7c79402285cc0f5b50a794538a528a09acf87b41


### PR DESCRIPTION
Hides chosen teleport destinations from the Portal Nexus menu in a player-owned house.

Client-side only. It hooks the list-building script, hides the rows for destinations the user has chosen, and rewinds the layout accumulators the script returns so the game's own code closes the gap, renumbers the shortcuts and resizes its own scrollbar. Hidden rows have their key listener cleared so the shortcut cannot fire.

Tested in-game on a nexus with alternate destinations: hide/unhide, shortcut recompaction on and off, click and keyboard teleports, scrollbar reflow, and persistence across restarts. Also checked against Better Teleport Menu and Nexus Map.
