### PR TITLE
Update Lightbearer Helper to 1.0.1

### DIFF
--- a/plugins/lightbearer-helper
+++ b/plugins/lightbearer-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/1504681/LightbearerHelper.git
-commit=ca0f6671486c8dc8b8063c448626950b27d68670
+commit=780e3a462159fcea72a95769aaf821aa01843613


### PR DESCRIPTION
- Fill highlight tints the item sprite instead of the whole inventory slot
- Spec orb only lights up while a listed spec item is in the inventory or equipped (on by default, configurable)
- Spec items can be highlighted whenever spec is ready, without a Lightbearer involved (on by default)
- "Spec ready at" percentage moved to General and drives both the orb and spec item highlights
- Pulse periods default to 2000 ms, all colours default to the same translucent tan