### PR TITLE
clan-management: update (rank editor, Slayer unlocks, CA screenshots, fixes)

### DIFF
--- a/plugins/clan-management
+++ b/plugins/clan-management
@@ -1,3 +1,3 @@
 repository=https://github.com/WoodyCode23/clan-management-plugin.git
-commit=e87c91fe1d7463d432ad392ec83adc972f3792b6
+commit=f7070075e75e8f4faa6e6f6334060335dbe41e02
 warning=This plugin submits your IP address, RSN, and various other account data to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update to the Solus clan-management plugin. Highlights: server-managed rank-requirement editor (with a forward-compatible parser that safely skips unknown check kinds), Slayer Rewards unlock tracking, combat-achievement screenshots, and several fixes (collection-log posting, diary/quest sync attribution, GIM item checks by possession, UI).