### PR TITLE
afk-companion: new plugin

### DIFF
--- a/plugins/afk-companion
+++ b/plugins/afk-companion
@@ -1,0 +1,3 @@
+repository=https://github.com/K0KS13/afk-companion.git
+commit=4218dd768fe5c5d3df61e34dd6783b1dcb6bf346
+authors=K0KS13

--- a/plugins/afk-companion
+++ b/plugins/afk-companion
@@ -1,3 +1,3 @@
 repository=https://github.com/K0KS13/afk-companion.git
-commit=dd87c478b6050bbe43830b8858d5e14f4146b8d3
+commit=34a7c2e7d19d099992d50b59d6658ea00ba71f70
 authors=K0KS13

--- a/plugins/afk-companion
+++ b/plugins/afk-companion
@@ -1,3 +1,3 @@
 repository=https://github.com/K0KS13/afk-companion.git
-commit=bd35f3ef269620bc6fef0195aab00170cfafe8df
+commit=dcab326aef0529f7f6aa5933e8707ea5ab16bab9
 authors=K0KS13

--- a/plugins/afk-companion
+++ b/plugins/afk-companion
@@ -1,3 +1,3 @@
 repository=https://github.com/K0KS13/afk-companion.git
-commit=4218dd768fe5c5d3df61e34dd6783b1dcb6bf346
+commit=bd35f3ef269620bc6fef0195aab00170cfafe8df
 authors=K0KS13

--- a/plugins/afk-companion
+++ b/plugins/afk-companion
@@ -1,3 +1,3 @@
 repository=https://github.com/K0KS13/afk-companion.git
-commit=dcab326aef0529f7f6aa5933e8707ea5ab16bab9
+commit=dd87c478b6050bbe43830b8858d5e14f4146b8d3
 authors=K0KS13


### PR DESCRIPTION
Adds AFK Companion: https://github.com/K0KS13/afk-companion

Sends a notification to your phone when an AFK session is about to end, and shows the remaining time on screen.

**Gemstone Crab.** Its health bar is a ten minute countdown rather than a damage bar, so it can be read directly. The bar is coarse, so the tracker learns how long one step lasts and interpolates between steps, turning ~20 second jumps into a per-second estimate. Warns before the burrow, on the burrow (90 second shell window), and if you stop landing hits.

**General AFK warnings.** Idle animation, out of combat, inventory full, watched items running out, low ammo, special attack restored, aggression expiring, low hitpoints and prayer, poison, valuable drops, random events, level ups, death, and Grand Exchange offers completing.

**Network use, since it is the notable part of this plugin.** Delivery targets are ntfy, a Discord webhook, Pushover, Telegram, or a user-supplied webhook. Every one of them is off by default (`PushProvider.OFF`) and does nothing until the user enters their own topic or URL, so the plugin makes no requests out of the box. Screenshot attachment is a separate opt-in and is documented in the settings as showing username, chat and inventory.

There is also an optional ntfy control topic: the plugin subscribes to a topic the user names, and answers `status`, `crab`, `stats` and `help` by publishing back to their notification topic. It is strictly read-only - the commands report game state and never perform an action in the client. It is empty by default.

Nothing in the plugin automates or performs gameplay input.