### PR TITLE
Update zeah-rc-helper to 1.0.11

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=5dd11ff98874a0bf607349aa863147757e7e6c03
+commit=daa71fb343e8228b5bf305a27bd0a92b5ca9a19f


### PR DESCRIPTION
Bumps Jam's Arceuus Runecrafting to daa71fb (v1.0.11), fixing:

- Fragment count going stale after a re-log with an unresolved "?" stack, which was silently sending the rotation guidance wrong
- The sticky Chisel veto skipping the second Load's mining when a Check confirmed Full during the first Load
- Finishing the second Load's Dark Blocks with nothing left going to "Mine again" instead of craft
- Blood Altar reachability detection via its tracked GameObject, for the "Stand Here" hint not showing reliably

Full details: https://github.com/JamsRepos/zeah-rc-helper/pull/10