### PR TITLE
Add custom-stat-layout

### DIFF
--- a/plugins/custom-stat-layout
+++ b/plugins/custom-stat-layout
@@ -1,4 +1,4 @@
 repository=https://github.com/RasmonT/custom-stat-layout.git
-commit=b6ad63d7abf45cc27ae3ce373b0764ae00825f80
+commit=16e6370e929f6dd9ed7a04970f0420f6d88081af
 authors=RasmonT
 warning=This plugin opens a small HTTP server on 127.0.0.1 so a stream overlay in OBS or a browser can read your hitpoints, prayer, run energy and special attack. Nothing is uploaded and no account is involved. Be aware that any other program on your own machine can read the same values.

--- a/plugins/custom-stat-layout
+++ b/plugins/custom-stat-layout
@@ -1,4 +1,4 @@
 repository=https://github.com/RasmonT/custom-stat-layout.git
-commit=e4c258aeb3dd34cadbb5fad9d0fa9469a079e70b
+commit=b6ad63d7abf45cc27ae3ce373b0764ae00825f80
 authors=RasmonT
 warning=This plugin opens a small HTTP server on 127.0.0.1 so a stream overlay in OBS or a browser can read your hitpoints, prayer, run energy and special attack. Nothing is uploaded and no account is involved. Be aware that any other program on your own machine can read the same values.

--- a/plugins/custom-stat-layout
+++ b/plugins/custom-stat-layout
@@ -1,0 +1,4 @@
+repository=https://github.com/RasmonT/custom-stat-layout.git
+commit=e4c258aeb3dd34cadbb5fad9d0fa9469a079e70b
+authors=RasmonT
+warning=This plugin opens a small HTTP server on 127.0.0.1 so a stream overlay in OBS or a browser can read your hitpoints, prayer, run energy and special attack. Nothing is uploaded and no account is involved. Be aware that any other program on your own machine can read the same values.


### PR DESCRIPTION
Adds **Custom Stat Layout**, a plugin that serves the player's hitpoints, prayer,
run energy, and special attack as JSON on a loopback-only HTTP server, thus a
browser-source overlay in OBS can draw its own orbs instead of cropping the
client's.

It also exposes the two regeneration timers (same arithmetic as the core
Regeneration Meter plugin) and the tick clock so that an overlay can animate in step
with the game instead of with its own poll.

Notes on the local server, since that is the part worth scrutinising:

The socket is bound to localhost only.
- It has a single response, the JSON snapshot. It reads nothing from disk and
serves no files, so there is no path handling at all.
- The payload contains no account name, no world, and nothing else identifying
only things that are currently on your player screen. Intentional,
because the responses are readable cross-origin so that an overlay can be
loaded from either a local file or website.
- The manifest carries a warning line describing what is exposed.

Client state is only ever read on the client thread; the HTTP workers read a
prebuilt string.