### PR TITLE
add the-other-half

### DIFF
--- a/plugins/the-other-half
+++ b/plugins/the-other-half
@@ -1,3 +1,3 @@
 repository=https://github.com/NotNikolai/runelite-plugins.git
-commit=f5a43d19b53edb68c9ea483dde3dc96646420fa7
+commit=50fdd3b000b8a38ee97de46e7996b0565160c8f8
 authors=NotNikolai

--- a/plugins/the-other-half
+++ b/plugins/the-other-half
@@ -1,0 +1,3 @@
+repository=https://github.com/NotNikolai/runelite-plugins.git
+commit=f5a43d19b53edb68c9ea483dde3dc96646420fa7
+authors=NotNikolai


### PR DESCRIPTION
The Other Half resets the skills tab at level 92 so you climb 1 to 92 a second time on the way to 99.

Level 92 is almost exactly the experience midpoint of 99, so the first half of the grind gives you 91 level ups and the second half gives you 7. This makes the second half feel like the first one.

Display only. It rewrites the level numbers on the skills tab, optionally tints them so you can tell a relabelled level from a real one, and can add progress bars. Hovering a skill still shows the real level. Nothing is sent to the server and no real level, experience or combat level is changed. At a real 99 it stops interfering and the tab shows 99 from then on.

One thing worth flagging up front: when a second-half level lands, it plays the game's own level up sound and level up spotanim on the local player, client side. That is the only thing the plugin does outside the skills tab, and it is there because the game will not announce these level ups itself, the real level has not moved.

No reflection, no network calls, no new dependencies, no menu entries, and it never starts, stops or reads another plugin.
