### PR TITLE
the-birdhouse: 1.4.0

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=fa04695ade4e78405441733905daae5fadae7815
+commit=80edf9713493d20d2b46d0bd2ab7c84e30b78b5b
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=f8fc3ebff49112c3740c98a092690ba3def0414d
+commit=fa04695ade4e78405441733905daae5fadae7815
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps The Birdhouse to 1.4.0.

Auto-submission runs off the loot tracker, so anything a player gathers is invisible to it and board tiles asking for a mined, fished, hunted or minigame-earned item could never complete on their own. This release adds a tracker that diffs the inventory and only credits a gain that is anchored to gathering experience in the same few ticks, which is what keeps it honest: withdrawing from a bank, buying on the Grand Exchange or from a shop, and trading all award no experience and so can never clear it. Items taken off the ground are refused, and anything the loot tracker already reported is skipped.

No new data leaves the client. Submissions carry the same item name, quantity and optional screenshot as an ordinary drop, so the existing warning is unchanged.
