### PR TITLE
Add Puppy Tracker

### DIFF
--- a/plugins/puppy-tracker
+++ b/plugins/puppy-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Parmvir/Puppy-Tracker.git
-commit=f217879dd75df31a181bbe320a5c010eff59f4e6
+commit=80c6f34aa96df9f7ce31ce224602e0c40ce51b90

--- a/plugins/puppy-tracker
+++ b/plugins/puppy-tracker
@@ -1,2 +1,2 @@
 repository=https://github.com/Parmvir/Puppy-Tracker.git
-commit=80c6f34aa96df9f7ce31ce224602e0c40ce51b90
+commit=6edc2df3a27247297c6eb87654cfe867efb65523

--- a/plugins/puppy-tracker
+++ b/plugins/puppy-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/Parmvir/Puppy-Tracker.git
+commit=f217879dd75df31a181bbe320a5c010eff59f4e6


### PR DESCRIPTION
Adds Puppy Tracker: feed and growth timers for a puppy, in the shape of the kitten tracker.

Repository: https://github.com/Parmvir/Puppy-Tracker

Puppies were added with A Ruff Situation and take about three hours of active growth to become a dog. Growth pauses twenty minutes after the last feed, so the plugin banks growth as elapsed active time rather than counting down from when the puppy was obtained — a puppy left unfed overnight is exactly as grown in the morning as when you left.

What it shows: a growth bar, time to fully grown, and time until growth stops, with a minimise button. Timings are the wiki's: 3h of active growth, hunger warning at 15m, growth stops at 20m.

The reply to "Guess age" is authoritative and overwrites what the plugin inferred, so it recovers from any stretch played without the plugin running.

Read-only — it watches the follower slot, menu clicks and chat messages, and draws an overlay. It sends no input and automates nothing. No network access.

BSD 2-Clause. Builds clean and green on 1.12.38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)