### PR TITLE
update alch-blocker

### DIFF
--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,3 +1,3 @@
 repository=https://github.com/robrichardson13/alch-blocker.git
-commit=b2c10a3d99ba2334c678b1b15d28ced6f992b2d5
+commit=29ffd06fff4e56b079210471b094bd731700ca00
 authors=robrichardson13,zdunbrack

--- a/plugins/alch-blocker
+++ b/plugins/alch-blocker
@@ -1,3 +1,3 @@
 repository=https://github.com/robrichardson13/alch-blocker.git
-commit=4b89aaeb5b1819fbc3f587f08c78aadf14abb1b6
+commit=b2c10a3d99ba2334c678b1b15d28ced6f992b2d5
 authors=robrichardson13,zdunbrack


### PR DESCRIPTION
Updates Alch Blocker to 2.0 (`b2c10a3`, on `master`).

Changes in this release:
- Replaced the single item list + list-type selector with a two-list model: a blacklist and a whitelist that are both always in effect, with `unlistedItemPolicy` deciding what happens to items on neither list. Existing configs are migrated automatically; the legacy keys are left in place so a downgrade to 1.9 still works.
- Added an optional, off-by-default "Helper rules" section: block un-noted items, block untradeables, a minimum alch value, and blocking items that alch for less than their GE price after tax. With no rule enabled the hot path is unchanged.
- Added two opt-in shift-click controls: shift+right-click to add an item to a list, and shift+click to alch a blocked item anyway.
- Fixed alch detection depending on menu option/target text, which broke when other plugins rewrite that text (issue #45). Detection is now structural.

The plugin adds no new runtime dependencies (the only build.gradle addition is `org.mockito:mockito-core` under `testImplementation`, used by the unit tests and not shipped), uses no reflection, makes no network calls, and does not call `client.menuAction`.

`./gradlew build test` passes on Java 11 at this commit.
