### PR TITLE
New elywatch plugin

### DIFF
--- a/plugins/elywatch
+++ b/plugins/elywatch
@@ -1,0 +1,2 @@
+repository=https://github.com/myadoran/ElyWatcher.git
+commit=3a975fc914aff9e5424edd8ed3c23f9a18f20fce

--- a/plugins/elywatch
+++ b/plugins/elywatch
@@ -1,2 +1,2 @@
 repository=https://github.com/myadoran/ElyWatcher.git
-commit=1c3e11679e3511281e8933e7d3346961396f4336
+commit=629b1e14a5fdd016f9dfeb81442b4d56e50db670

--- a/plugins/elywatch
+++ b/plugins/elywatch
@@ -1,2 +1,2 @@
 repository=https://github.com/myadoran/ElyWatcher.git
-commit=3a975fc914aff9e5424edd8ed3c23f9a18f20fce
+commit=1c3e11679e3511281e8933e7d3346961396f4336


### PR DESCRIPTION
This is a niche plugin that reads gear equip events. If the event is an elysian being equipped or unequipped, an API call is made to a user-defined host through the HttpClient java library.

The use case is connecting ely equip status to a Home Assistant instance. Equipping it turns a lamp on through one webhook, unequipping it turns it off through another.

Though I don't expect this plugin to exactly go viral, I'm happy to broaden it a bit if other people need something similar.

Cheers for making Runelite so flexible, I'm no programmer but with your documentation it was still accessible!