### PR TITLE
add looting-bag-organizer plugin

### DIFF
--- a/plugins/looting-bag-organizer
+++ b/plugins/looting-bag-organizer
@@ -1,0 +1,2 @@
+repository=https://github.com/robrichardson13/looting-bag-organizer.git
+commit=b23863900dc6d59b21359118ebd861b656659dd4


### PR DESCRIPTION
Looting Bag Organizer lets you drag items around inside the looting bag's "View" window and remembers the arrangement. The game gives you no way to reorder a looting bag, so for anyone living out of one — Ultimate Ironmen most of all — the contents reshuffle every time something is added or removed.

It is entirely client-side and cosmetic. The plugin never changes what the bag contains and never fires a game action; it re-positions the dynamic children the game itself builds in interface 81, the same approach core's bank tag layouts use. The arrangement is saved per RS profile in the plugin's own config.

Repository: https://github.com/robrichardson13/looting-bag-organizer
