### PR TITLE
Updated dry streak tracker to 1.3.5

### DIFF
--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
-commit=db6fd5ba0f1599b2d74a4bc2f0848b8d8d6c8006
+commit=289a360d4cef59eaf0cf3d0d0646d1cf9cf24b9f
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Fixed an oversight. When an npc dropped no loot, it wasn't being tracked. This applied to custom/original encounters that fit this edge-case