### PR TITLE
Add Glass Combat Logger

### DIFF
--- a/plugins/glass-combat-logger
+++ b/plugins/glass-combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/Callum-Upton/glass-combat-logger.git
-commit=428c7a0df7c8a5017cdc34fe80e28a35c9d5e243
+commit=53bcea64a6e29e196e84b9c0c08f9cc4018f6746

--- a/plugins/glass-combat-logger
+++ b/plugins/glass-combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/Callum-Upton/glass-combat-logger.git
-commit=bb944259ef5a923e14ed00c54dc6d83c82484840
+commit=428c7a0df7c8a5017cdc34fe80e28a35c9d5e243

--- a/plugins/glass-combat-logger
+++ b/plugins/glass-combat-logger
@@ -1,0 +1,2 @@
+repository=https://github.com/Callum-Upton/glass-combat-logger.git
+commit=bb944259ef5a923e14ed00c54dc6d83c82484840

--- a/plugins/glass-combat-logger
+++ b/plugins/glass-combat-logger
@@ -1,2 +1,2 @@
 repository=https://github.com/Callum-Upton/glass-combat-logger.git
-commit=53bcea64a6e29e196e84b9c0c08f9cc4018f6746
+commit=bd07bd4ec6479b9bfaa6c9fa0d8bb76fd9275f17


### PR DESCRIPTION
Adds Glass Combat Logger for local encounter recording and optional research capture. No automatic uploads or gameplay automation. Capture scope and limitations are documented in the plugin repository's REVIEW.md. All 60 tests passed and the release build succeeded.