### PR TITLE
update zeah-rc-helper

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=daa71fb343e8228b5bf305a27bd0a92b5ca9a19f
+commit=1e5d824c7a6808c37a1c4bfddf2f8ff3a57f9eca


### PR DESCRIPTION
Updates Jam's Arceuus Runecrafting to the latest commit, fixing:
- The plugin instructing "Altar" instead of "Mine second" right after the First Load's chisel run finished, before any Second Load mining had happened.
- The "Mine" instruction saying "first inventory" mid-way through mining the Second Load, inconsistent with "Venerate" correctly saying "second inventory" once the load filled.