### PR TITLE
Update AFK Crab Helper to 1.2

### DIFF
--- a/plugins/afk-crab-helper
+++ b/plugins/afk-crab-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/1504681/afk-crab-helper.git
-commit=34ec7f9967b97cd140040aba94ae1596beb12666
+commit=5ad03d11e2e886e1d1ff67185cfc204edf38a127


### PR DESCRIPTION
- Only the Gemstone Crab is detected now. Sand, Rock and Ammonite Crabs no longer trigger the overlay