### PR TITLE
chat-fade: update to 1.4

### DIFF
--- a/plugins/chat-fade
+++ b/plugins/chat-fade
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/chat-fade.git
-commit=d2e1fe20917b24c00b2db857e988a0c07a9a3a43
+commit=172fb9bc91ce6cce9389826f243637c85159d238


### PR DESCRIPTION
Updates the chat-fade manifest to the latest commit (172fb9b).

Changes since 1.3.1:

**Loot value tiers** (requested in internetter/chat-fade#24) — clan drop broadcasts and the player's own "Valuable drop" notifications now colour the item and its value by GE value, mirroring the tiers the Ground Items plugin uses. The game includes the value in the message itself, so no price lookup is involved and untradeable drops tier correctly too. Defaults were picked against ~1,100 recorded broadcasts rather than copied, since clans apply their own broadcast minimum and the Ground Items thresholds put 81% of drops in a single tier.

**Collection log highlighting** — clan collection log broadcasts colour the item name. These carry no value, so they use their own colour.

Highlighting follows one rule: the game's colour wins, and only text the game left uncoloured is repainted. The single exception is messages recognised as drops, where the tier replaces the game's flat drop colour — otherwise the feature could never colour the player's own drops.

**Bug fixes**
- A typed `@` was being deleted from the overlay. The game escapes printable characters as pseudo-tags (`<at>`, `<lt>`, `<gt>`) and blind tag removal stripped them along with real markup.
- The Chat Filter plugin's "Censor Words" mode was ignored. That mode rewrites text rather than blocking it, and only on the object stack, so the overlay kept showing wording the chatbox had already starred out.

Plugin version bumped 1.3.1 -> 1.4.