### PR TITLE
Update Jam's Skiller Guard to 1.1.8

### DIFF
--- a/plugins/skiller-guard
+++ b/plugins/skiller-guard
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/skiller-guard.git
-commit=e87566fc8d4d0576218d096015444a9be8dcf668
+commit=b417976edf5ecbc4b49d0ba298989bc32e795fca


### PR DESCRIPTION
Two fixes since 1.1.6:

- 1.1.7: the Player Attack warning no longer fires on false positives in the Wilderness (and Bounty Hunter, fought within it) or in Last Man Standing, where the game always exposes Attack on other players regardless of the Attack Options setting.
- 1.1.8: Guard now stands down entirely on Seasonal, Deadman, and Quest Speedrunning worlds, since those run a character separate from the player's main-game account.