### PR TITLE
Update compass-camera-control to v1.2.7

### DIFF
--- a/plugins/compass-camera-control
+++ b/plugins/compass-camera-control
@@ -1,2 +1,2 @@
 repository=https://github.com/RaazKH/CompassCameraControl.git
-commit=8c2756c41e913bc428be0bb86422c872d19f83ca
+commit=2ea21a041bbac46a9401741e5d72ad029c8d3b9f


### PR DESCRIPTION
refactoring interface check so escape key is not captured by plugin, closes https://github.com/RaazKH/CompassCameraControl/issues/38