### PR TITLE
add shell-songs

### DIFF
--- a/plugins/shell-songs
+++ b/plugins/shell-songs
@@ -1,2 +1,2 @@
 repository=https://github.com/jimmyununu/shell-songs.git
-commit=3e50027f929612e6b7c9444314890e6d237fd05e
+commit=b4e1bc018eb28dea484d2d8824e46e3e458f909a

--- a/plugins/shell-songs
+++ b/plugins/shell-songs
@@ -1,0 +1,2 @@
+repository=https://github.com/jimmyununu/shell-songs.git
+commit=3e50027f929612e6b7c9444314890e6d237fd05e


### PR DESCRIPTION
**Shell Songs** is a song book for the seven musical shells rewarded by Crab Quest (Shell C, D, E, F, G, A and A#).

Pick a song in the sidebar and the plugin shows which shell to play next, how many times in a row to play it, and the whole song as a row of notes. It advances when the player clicks "Sound" on the correct shell. It also draws a small overlay with the upcoming notes and outlines the next shell in the inventory with the click count on it. Users can add their own songs in the settings.

The plugin only reads the user's own `MenuOptionClicked` event for the "Sound" option on a shell item. It does not play shells, send input, edit menu entries, or use the network. Shell item IDs are hard-coded. No dependencies beyond the standard build.

Repository: https://github.com/jimmyununu/shell-songs