### PR TITLE
Add OSRS Lifetime Sync

### DIFF
--- a/plugins/osrs-lifetime-sync
+++ b/plugins/osrs-lifetime-sync
@@ -1,0 +1,4 @@
+repository=https://github.com/IronSetFree/osrs-lifetime-sync.git
+commit=9ec0c6362ea6599eb0cec248ca43103d4c00a02e
+authors=IronSetFree
+warning=This plugin sends your RuneScape display name, playtime, account age, Discord link code, synchronization token, and IP address to a third-party server not controlled or verified by the RuneLite Developers.

--- a/plugins/osrs-lifetime-sync
+++ b/plugins/osrs-lifetime-sync
@@ -1,4 +1,4 @@
 repository=https://github.com/IronSetFree/osrs-lifetime-sync.git
-commit=9ec0c6362ea6599eb0cec248ca43103d4c00a02e
+commit=c3e277d75528c1fe14868aa389a53c8b475e3cda
 authors=IronSetFree
 warning=This plugin sends your RuneScape display name, playtime, account age, Discord link code, synchronization token, and IP address to a third-party server not controlled or verified by the RuneLite Developers.

--- a/plugins/osrs-lifetime-sync
+++ b/plugins/osrs-lifetime-sync
@@ -1,4 +1,4 @@
 repository=https://github.com/IronSetFree/osrs-lifetime-sync.git
-commit=cd5b4fc6a7597f828a50056de82655ac1751534d
+commit=ef17797d162459ae8f0406f37ee63d9b8fd32bc3
 authors=IronSetFree
 warning=This plugin sends your RuneScape display name, playtime, account age, Discord link code, synchronization token, and IP address to a third-party server not controlled or verified by the RuneLite Developers.

--- a/plugins/osrs-lifetime-sync
+++ b/plugins/osrs-lifetime-sync
@@ -1,4 +1,4 @@
 repository=https://github.com/IronSetFree/osrs-lifetime-sync.git
-commit=c3e277d75528c1fe14868aa389a53c8b475e3cda
+commit=cd5b4fc6a7597f828a50056de82655ac1751534d
 authors=IronSetFree
 warning=This plugin sends your RuneScape display name, playtime, account age, Discord link code, synchronization token, and IP address to a third-party server not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
Adds OSRS Lifetime Sync to the Plugin Hub.

The plugin lets a player opt in to link their OSRS character to the OSRS Lifetime Discord bot, captures Hans account-age/time-played data, and periodically syncs playtime to the OSRS Lifetime service.

The plugin is disabled by default and uses a fixed HTTPS endpoint. The Plugin Hub manifest includes a warning because the third-party service receives the player's RuneScape display name, playtime, account age during initial linking, Discord link code during initial linking, synchronization token for later syncs, and IP address as part of the HTTPS connection.

The plugin uses build=standard and adds no third-party Java dependencies beyond RuneLite-provided dependencies.