### PR TITLE
coffer: bump to 6d5a0ab (0.1.8-beta)

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=c73f59265d3edb4fe939634105d05b6d9f370496
+commit=6d5a0ab7e32807a09a3c2aab4253a811691d9f81
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Bumps Coffer to 0.1.8-beta (commit 6d5a0ab7e32807a09a3c2aab4253a811691d9f81).

Changes since 0.1.7-beta:
- P&L time-window (Session / 24h / 7d / All) and account selectors moved above the stat card as a compact account dropdown + period buttons on one row, so a wide realized-P&L value can no longer clip them.
- Beta feedback: a 'Send feedback' section in Settings (type + message + optional contact) posts to the Coffer server for bug reports / feature requests during beta.

No new permissions or dependencies. External-server behavior remains disclosed via the `warning=` line and the plugin description/README.