### PR TITLE
chat-fade: update to 1.4.1

### DIFF
--- a/plugins/chat-fade
+++ b/plugins/chat-fade
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/chat-fade.git
-commit=172fb9bc91ce6cce9389826f243637c85159d238
+commit=8f35f16f1341bea35e62cdf7515101d0cb82ab5f


### PR DESCRIPTION
Updates the chat-fade manifest to 8f35f16.

Fixes a bug introduced in 1.4 where chat commands like `!kc` displayed the raw command text instead of the resolved output. Verified in-game.

Plugin version bumped 1.4 -> 1.4.1.