### PR TITLE
Add Capstone Clan Bingo

### DIFF
--- a/plugins/capstone-clan-bingo
+++ b/plugins/capstone-clan-bingo
@@ -1,0 +1,2 @@
+repository=https://github.com/msig-prog/capstone-bingo.git
+commit=29e902ddd67c03fddd0671c975d0bac0cec5feab

--- a/plugins/capstone-clan-bingo
+++ b/plugins/capstone-clan-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/msig-prog/capstone-bingo.git
-commit=29e902ddd67c03fddd0671c975d0bac0cec5feab
+commit=883cfe1ef5984e0992fabf6ee2ab7f22fd328366

--- a/plugins/capstone-clan-bingo
+++ b/plugins/capstone-clan-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/msig-prog/capstone-bingo.git
-commit=883cfe1ef5984e0992fabf6ee2ab7f22fd328366
+commit=2cdab7aed9284ac71b6b617d952ff11f5387a2b1

--- a/plugins/capstone-clan-bingo
+++ b/plugins/capstone-clan-bingo
@@ -1,2 +1,2 @@
 repository=https://github.com/msig-prog/capstone-bingo.git
-commit=2cdab7aed9284ac71b6b617d952ff11f5387a2b1
+commit=8058df2ed58495f49b7cad4d63107d16c561308b


### PR DESCRIPTION
Adds Capstone Clan Bingo, a collaborative clan bingo board for team events. Players can claim tiles, track progress, mark completions, request aid, and join aid requests. Board state is synchronized through a third-party Cloudflare Worker/D1 service. The plugin presents a disclosure before using the service and sends the RuneScape display name, team code, and bingo-board state. It does not automate gameplay or interact with game actions.