### PR TITLE
facette-companion: update to schema 3

### DIFF
--- a/plugins/facette-companion
+++ b/plugins/facette-companion
@@ -1,2 +1,2 @@
 repository=https://github.com/ethanmonlux/facette-osrs.git
-commit=ff5a38770b43ceaffa2dbd5c0e6abb56de73889a
+commit=4308302ad3139bb474555cd2c41e19839d0da646


### PR DESCRIPTION
Update Facette Companion to the reviewed public Schema 3 producer at [4308302](https://github.com/ethanmonlux/facette-osrs/commit/4308302ad3139bb474555cd2c41e19839d0da646).

Schema 3 adds full skill levels/lifetime XP, account mode, quest points, Slayer state, and the local player's own Grand Exchange offer slots. The existing telemetry fields are preserved in the new `state-v3.json` export. The plugin remains read-only and local-file-only, with no network requests or gameplay input.

Validated with RuneLite and Facette on Windows, including live Schema 3 selection while a stale Schema 2 file was present.

[Producer changes](https://github.com/ethanmonlux/facette-osrs/compare/ff5a38770b43ceaffa2dbd5c0e6abb56de73889a...4308302ad3139bb474555cd2c41e19839d0da646). This PR changes only the manifest commit pointer.
