### PR TITLE
update aura-tracker

### DIFF
--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Matelaa/aura-tracker.git
-commit=89ae56f24e3eb8790ef6e68fa418228f392c12db
+commit=94b394270d9a8e344f4a2d85e927bc1f75a758b4
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update Aura Tracker to version 1.4.

- Respect Retry-After on sync HTTP 429 responses and prevent overlapping submissions.
- Recover the in-flight guard after request or transport failures so later syncs can proceed.
- Report business rejection reasons and request IDs, and send the plugin version for backend diagnostics.

Local time tracking, eligibility rules, persistence, and sync cadence are unchanged. No new dependencies; build=standard is retained. The backend has already been deployed and remains compatible with version 1.3.

Validation: clean Gradle test run on Java 11, 51 tests passed, including 9 deterministic HTTP recovery tests. No manual in-game testing was performed.

This PR only updates the manifest commit. The repository and existing warning remain unchanged.
