### PR TITLE
Create spell-info

### DIFF
--- a/plugins/spell-info
+++ b/plugins/spell-info
@@ -1,2 +1,2 @@
 repository=https://github.com/CreeperCat1/Spell-Info.git
-commit=0c5bce02c40f2be0ab2a6af8325c4918f1e10bb7
+commit=31deabc161ad661f05d01d37ee703416213dff23

--- a/plugins/spell-info
+++ b/plugins/spell-info
@@ -1,2 +1,2 @@
 repository=https://github.com/CreeperCat1/Spell-Info.git
-commit=31deabc161ad661f05d01d37ee703416213dff23
+commit=1d0831b20d9876022d4853e8fc0fbdc4061c1539

--- a/plugins/spell-info
+++ b/plugins/spell-info
@@ -1,0 +1,2 @@
+repository=https://github.com/CreeperCat1/Spell-Info.git
+commit=0c5bce02c40f2be0ab2a6af8325c4918f1e10bb7


### PR DESCRIPTION
The plugin temporarily disables the spell tooltip in the spellbook tab and reenables it when the "Info" button is clicked. The "Info" button is added into the spellbook tab. The plugin also shifts the "Filter" button to the side to make room for the "Info" button.