### PR TITLE
Add OmniHUD

### DIFF
--- a/plugins/omnihud
+++ b/plugins/omnihud
@@ -1,0 +1,2 @@
+repository=https://github.com/glukt/OmniHUD.git
+commit=9ba91282183d98dcc6a794caca5d8fe2a1927fd2


### PR DESCRIPTION
OmniHUD is a single companion panel for OSRS: an interactive World Map guide, a vendor directory, a monster bestiary with real drop rates and weakness info, a live combat / encounter analytics HUD, loot tracking with dryness calculations, global search, and a Slayer assistant with in-panel master requirements and map indicators.

Repo: https://github.com/glukt/OmniHUD

- Java 11, `build=standard`. No reflection, no native code, no runtime class loading.
- The only network call is a GET to `oldschool.runescape.wiki` for monster portrait images (via the injected `OkHttpClient`, User-Agent identifies the plugin, results are disk-cached) - the same pattern as RuneLite's own Wiki plugin.
- Built to the third-party client rules: no chat automation (the share buttons are clipboard-only), no opponent freeze/debuff timers, no telemetry.