### PR TITLE
chore: disable yama attack reminder plugin

### DIFF
--- a/plugins/yama-reminder
+++ b/plugins/yama-reminder
@@ -1,0 +1,3 @@
+repository=https://github.com/jdockerty/yama-reminder.git
+commit=682887c8b1bfc7441a5723f7137b12a8ecb67a9a
+disabled=unmaintained and superseded by many other plugins

--- a/plugins/yama-reminder
+++ b/plugins/yama-reminder
@@ -1,2 +1,0 @@
-repository=https://github.com/jdockerty/yama-reminder.git
-commit=682887c8b1bfc7441a5723f7137b12a8ecb67a9a


### PR DESCRIPTION
Removing this plugin as it is not being updated/unused.

There are many Yama plugins which are much better nowadays too.
