### PR TITLE
Update ClanHQ plugin for tiered drop tasks

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=b590eb22efcf27993a7d53e0410254d36a72409f
+commit=4da2237d7633b47a10166277eb40862b271c03ee


### PR DESCRIPTION
## Summary

Update the ClanHQ Plugin Hub manifest to the latest standalone plugin commit.

This release adds tier-aware Drop Rush and Drip Rush task support, shared canonical item-drop matching for sidebar and overlay progress, and the associated task display updates. It also retains the accepted noted/unnoted item normalization and the standalone plugin's current RuneCrafting and dialogue compatibility fixes.

## Plugin details

- Canonicalizes noted and unnoted item drops before matching or submitting item verification.
- Uses one item-drop matcher for sidebar and overlay progress so unrelated task cards cannot be updated positionally.
- Displays Easy, Medium, and Hard drop tiers supplied by ClanHQ.
- Supports the current Drop Rush and Drip Rush claim flows without changing the API payload schema.
- Captures only the logged-in player's evidence after explicit actions.
- Ships with no endpoint or installation token.
- Disables gameplay screenshots by default.
- Never awards a rank or performs game actions.

## Verification

- Published plugin commit: `4da2237d7633b47a10166277eb40862b271c03ee`
- Clean Gradle build completed successfully against cached RuneLite dependencies.
- All 57 JUnit tests passed.
