### PR TITLE
update zeah-rc-helper

### DIFF
--- a/plugins/zeah-rc-helper
+++ b/plugins/zeah-rc-helper
@@ -1,2 +1,2 @@
 repository=https://github.com/JamsRepos/zeah-rc-helper.git
-commit=1e5d824c7a6808c37a1c4bfddf2f8ff3a57f9eca
+commit=8c1e5682d4e4711161aec06911a26962e59c3924


### PR DESCRIPTION
Bumps zeah-rc-helper to JamsRepos/zeah-rc-helper@8c1e568, which fixes an issue where a reduced-capacity Second Load (fewer than 28 essence slots, due to other items in inventory) could chisel to under the plugin's Fragment-count threshold and never get routed to the altar, instead being sent back to the mine indefinitely.

Fixes JamsRepos/zeah-rc-helper#12