### PR TITLE
Update collection-log-progress README

### DIFF
--- a/plugins/collection-log-progress
+++ b/plugins/collection-log-progress
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/Collection-log-completion-viewer.git
-commit=53334b713e4dc0f461652e4e6fdb9354f7d7f80c
+commit=c7932f310b7621f2dd6b29db7f17f1196c069ddf


### PR DESCRIPTION
Updates `collection-log-progress` from `53334b713e4dc0f461652e4e6fdb9354f7d7f80c` to `c7932f310b7621f2dd6b29db7f17f1196c069ddf`.

This is a documentation-only update. It reorganises the README around features, use cases and configuration; adds four screenshots; preserves the previous technical documentation in `DEVELOPMENT_REFERENCE.md`; and adds Patreon funding metadata.

The compared commit range contains only:

- `.github/FUNDING.yml`
- `README.md` and `DEVELOPMENT_REFERENCE.md`
- four files under `docs/images/`

There are no Java source, build, Plugin Hub metadata, runtime-resource, version or plugin-behaviour changes.

Verified the target is two commits ahead of the current Plugin Hub pin and contains only the documentation files listed above.
