### PR TITLE
Update collection-log-exporter README

### DIFF
--- a/plugins/collection-log-exporter
+++ b/plugins/collection-log-exporter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/collection-log-exporter.git
-commit=efa560ba867cfd8a078127ad5e53b7b3606fe43f
+commit=308afcfb2431431af797e891ad10a629a79fd99a


### PR DESCRIPTION
Updates `collection-log-exporter` from `efa560ba867cfd8a078127ad5e53b7b3606fe43f` to `308afcfb2431431af797e891ad10a629a79fd99a`.

This is a documentation-only update. It reorganises the README around export formats, use cases, setup and privacy; adds five product screenshots; preserves the previous technical documentation in `DEVELOPMENT_REFERENCE.md`; and adds Patreon funding metadata.

The compared commit range contains only:

- `.github/FUNDING.yml`
- `README.md` and `DEVELOPMENT_REFERENCE.md`
- five files under `docs/images/`

There are no Java source, build, Plugin Hub metadata, runtime-resource, version or plugin-behaviour changes.

Verified the target is two commits ahead of the current Plugin Hub pin and contains only the documentation files listed above.
