### PR TITLE
Update abyss-rift-rune-highlighter README

### DIFF
--- a/plugins/abyss-rift-rune-highlighter
+++ b/plugins/abyss-rift-rune-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/abyss-highlighter.git
-commit=8818efa1750ac7b1e47f194b8d03547505c52b73
+commit=bdd8b7ab603489702e62053c6c6ad26b08c6bea8


### PR DESCRIPTION
Updates `abyss-rift-rune-highlighter` from `8818efa1750ac7b1e47f194b8d03547505c52b73` to `bdd8b7ab603489702e62053c6c6ad26b08c6bea8`.

This is a documentation-only update. It reorganises the README around the overlay, configuration and installation; adds two feature screenshots; preserves the previous technical documentation in `DEVELOPMENT_REFERENCE.md`; and adds Patreon funding metadata.

The compared commit range contains only:

- `.github/FUNDING.yml`
- `README.md` and `DEVELOPMENT_REFERENCE.md`
- two files under `docs/images/`

There are no Java source, build, Plugin Hub metadata, runtime-resource, version or plugin-behaviour changes.

Verified the target is two commits ahead of the current Plugin Hub pin and contains only the documentation files listed above.
