### PR TITLE
Add Brain off Aerial Fishing plugin

### DIFF
--- a/plugins/brain-off-aerial-fishing
+++ b/plugins/brain-off-aerial-fishing
@@ -1,0 +1,2 @@
+repository=https://github.com/Pvff13/brain-off-aerial-fishing.git
+commit=e78a58430102f7605eebb8131e43a669c5ceb9f8


### PR DESCRIPTION
## What it does

Highlights the aerial fishing spot at Lake Molch you can catch from soonest, ranked by tick zone rather than raw tile distance, with:

- Frenzied spots always ranked as the shared 3-tick zone (their catch cycle is a flat 3 ticks once reached, regardless of distance)
- A viability check that skips a spot estimated to despawn before the round trip completes, moving the pick to the next best option instead
- Optional highlighting of the 2nd/3rd best spot too, each with its own colour
- Optional travel-ticks and estimated-time-left readouts
- Optional whole-clickbox fill instead of just an outline

Overlay-only - it never clicks, moves the mouse, or interacts with anything.

Repo: https://github.com/Pvff13/brain-off-aerial-fishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)