### PR TITLE
update womclanplugin

### DIFF
--- a/plugins/womclanplugin
+++ b/plugins/womclanplugin
@@ -1,3 +1,3 @@
 repository=https://github.com/ShakyPizza/womclanplugin.git
-commit=0903d09d1da4a188370a4422146055f9160f7835
+commit=ec6791217c5c6bb43f5d8696e562cd72a636e6a0
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates `womclanplugin` from `0903d09` to `ec67912`.

This is a UI and correctness pass over the existing plugin. No new dependencies, and
`build.gradle` / `runelite-plugin.properties` are byte-identical to the currently pinned
commit — the diff is source, tests and docs only.

### API impact

Unchanged endpoints (same four `api.wiseoldman.net/v2/groups/...` paths, same request
count per sync). Load on WOM goes **down** slightly:

- The 5 minute manual cooldown is now actually enforced. Previously a successful fetch
  re-enabled the Sync button mid-cooldown, so users could click through it.
- A fetch already in flight is not duplicated by a second one.
- No `Thread.sleep` or `Thread.interrupt` anywhere; the cooldown and its countdown run on
  a `javax.swing.Timer`. (Request spacing via `Thread.sleep` was raised in earlier review
  feedback on this plugin and has not been reintroduced.)

### What changed

- **Fixed a display bug:** base-stat achievements report a `levels` measure against an
  experience threshold, so "Base 90 Stats" rendered as `128,311,968 levels`. Thresholds
  are now described with a unit that matches the number.
- **Refresh state is honest:** "Synced just now" no longer stays on screen for the whole
  hour between refreshes, and a failed refresh keeps the last good data on screen and
  marks it stale instead of replacing the member list with an error.
- **Optional history fetches** (achievements / activity / name changes) no longer collapse
  a failed request into an empty list, so "could not load" is distinguishable from "no
  recent events".
- Sidebar leads with clan identity, abbreviates large totals with exact values on hover,
  and gains a labelled search with a result count.
- Expanded window gains a shared header (clan, member count, freshness, refresh sharing
  the sidebar's cooldown), player search on every tab, and consistent numeric formatting.
- An unconfigured plugin shows a setup state instead of enabled-but-useless controls.

### Two things worth a look

1. **`LinkBrowser.browse("https://wiseoldman.net/groups")`** on the setup screen, so a new
   user can find their group ID. This opens the user's browser only — the plugin makes no
   request to that host.
2. **`ConfigManager` write outside the declared `@ConfigGroup`:** the expanded window's
   last size/position is stored as `womclan.window.expandedBounds`. It is deliberately kept
   out of the `womclan` group so that saving window geometry does not fire a `ConfigChanged`
   that reschedules an API refresh. No user-facing setting is added.

### Testing

`./gradlew build` passes against RuneLite 1.12.38. Test count goes from 5 to 54, all
passing with `java.awt.headless=true`. The UI was verified running in the development
client against a real 162-member group, and by rendering both surfaces offscreen at the
default and minimum window sizes.
