### PR TITLE
Update Trouble Brewing Highlighter to 1.5.0

### DIFF
--- a/plugins/trouble-brewing-highlighter
+++ b/plugins/trouble-brewing-highlighter
@@ -1,2 +1,2 @@
 repository=https://github.com/xboxnuker-rgb/trouble-brewing-highlighter.git
-commit=4b0218b479f2736c5bb6876cb8bea3d8ee81d605
+commit=824424d69024254608f430b908cf229b475d3e6a


### PR DESCRIPTION
Updates Trouble Brewing Highlighter to version 1.5.0.

- Defaults inventory highlights to item outlines, with full-slot and off modes plus a separate fine-grained inventory outline size.
- Adds an optional AFKer Mode that keeps water, fire and repair guidance while suppressing unrelated routes.
- Stops water guidance at 100 contribution by default, restores it during fires, and provides an optional AFKer bucket-count label.
- Reduces AFKer Brew Status to the rum instruction and Polly's message while keeping contribution and expected Pieces of Eight in their separate panel.

Validation: the Gradle test suite passed, and the inventory, contribution cutoff, fire and repair behavior were confirmed in game.