### PR TITLE
Add realised/banked GE tracking and item ledger

### DIFF
--- a/plugins/profit-loss-calculator
+++ b/plugins/profit-loss-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/LegitCasual/Profit-Loss-Calculator.git
-commit=c948df35b75ce7a0e951293f50b84536a2b467a3
+commit=4adf8f39886c8d6bacb58c1d24d82e9ec3ea65ce


### PR DESCRIPTION
The plugin now tracks GE sales and High Alchemy as realised income, banks as banked stock, and exposes a global per-item ledger capped by lifetime looted quantity. This also adds ambient always-on Session tracking, a History/Mobs split, and test coverage for GE tax, banking diffs, and backwards-compatible history aggregation.