### PR TITLE
update retro-npc-swapper

### DIFF
--- a/plugins/retro-npc-swapper
+++ b/plugins/retro-npc-swapper
@@ -1,2 +1,2 @@
 repository=https://github.com/AJD-/RetroNPCSwapper.git
-commit=b08ef713a12e11a16ea8300429ab8c9aac6ba16b
+commit=bbf77a102348d27c78fe42a173f692b52c5b711e


### PR DESCRIPTION
- Add support for 2005 models/anims that are not in the live game cache
[retro-plugin-update-2-0-0.webm](https://github.com/user-attachments/assets/564e5e26-5105-4bc6-a4f5-712bb3fb2d6b)
