### PR TITLE
Update lazy-farming

### DIFF
--- a/plugins/lazy-farming
+++ b/plugins/lazy-farming
@@ -1,3 +1,3 @@
 repository=https://github.com/Speaax/Farming-Helper.git
-commit=1a61afac5c5a72b79d1931fac2f6af82fc926d85
+commit=deabfff1c9426a02be240a01400dea9cebfab34c
 authors=Speaax, JThomasDevs


### PR DESCRIPTION
- Addresses [#100](https://github.com/Speaax/Farming-Helper/issues/100)

Skip current step button now actually skips current step.
Skip current step button can now skip the item gathering phase.