### PR TITLE
update looting-bag-organizer

### DIFF
--- a/plugins/looting-bag-organizer
+++ b/plugins/looting-bag-organizer
@@ -1,2 +1,2 @@
 repository=https://github.com/robrichardson13/looting-bag-organizer.git
-commit=b23863900dc6d59b21359118ebd861b656659dd4
+commit=4bdd6f8505150078dbb4a68e3d87487cec529ccc


### PR DESCRIPTION
Bumps looting-bag-organizer to 4bdd6f8, which adds the plugin's icon.png (29x31px).