### PR TITLE
Updated Dry Streak Tracker to 1.3.6

### DIFF
--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
-commit=289a360d4cef59eaf0cf3d0d0646d1cf9cf24b9f
+commit=13a8a0ae134f909b224749512fbadbbd692d927a
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Fixed a bug with duke/nightmare/pnm giving 2 kc per kill
- Fixed Kraken missing npcId in encounters.json so it is now being tracked

Updated plugin version to 1.3.6