### PR TITLE
rs-flipper: show flip durations, hide the risk level

### DIFF
--- a/plugins/rs-flipper
+++ b/plugins/rs-flipper
@@ -1,3 +1,3 @@
 repository=https://github.com/Ramon0205/rs-flipper.git
-commit=14b313e88d713b01d3e2ecd7a6c839ee7b19e1f6
+commit=7a6eed775abd4ae5458552a950a338fb5d2cd655
 warning=This plugin submits your IP address, Grand Exchange offers and trade history to a 3rd-party server (api.rs-flipper.com) not controlled or verified by RuneLite developers. An account is required.


### PR DESCRIPTION
- Flip feed shows buy, sell and total duration on hover
- Risk level selector hidden
- Panel timers are stopped when the plugin is disabled
- No dump alert for an item that already has an order
- A locked GE slot no longer counts as free for dump alerts

Commit: 7a6eed775abd4ae5458552a950a338fb5d2cd655