### PR TITLE
Update Brain off Aerial Fishing plugin

### DIFF
--- a/plugins/brain-off-aerial-fishing
+++ b/plugins/brain-off-aerial-fishing
@@ -1,2 +1,2 @@
 repository=https://github.com/Pvff13/brain-off-aerial-fishing.git
-commit=e78a58430102f7605eebb8131e43a669c5ceb9f8
+commit=06678a621436cbe4c60157056d227df8da1ad69e


### PR DESCRIPTION
## What's new

Adds an optional Fishing/Hunter reboost reminder feature (separate from the fishing spot highlighter):

- Independently toggled/thresholded per skill
- Gated on actually wearing the Cormorant's glove, so it never fires outside of aerial fishing
- Two display modes: an infobox (icon+margin, or a proper text panel for longer custom text) and inventory/equipment item highlighting
- Covers every real boost source for each skill from the wiki's Temporary skill boost page

Also fixes a threading bug where reading `Client` state directly from a `ConfigChanged` handler (fired on the Swing EDT) could leave item highlighting stuck off after toggling/editing a reminder, until a real client-thread event came along to recompute it.

Repo: https://github.com/Pvff13/brain-off-aerial-fishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)