### PR TITLE
Update Overhead Scale & Color

### DIFF
--- a/plugins/overheads-scale-and-color
+++ b/plugins/overheads-scale-and-color
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/overheads-scale-and-color.git
-commit=25cc61a93edff4b66a7b249607fff1b1f08c9f16
+commit=f7ce1c70cbc09210893c360535afd40b71d2460e


### PR DESCRIPTION
Sets an explicit version so the plugin shows 1.0 rather than the commit hash, and trims the README.