### PR TITLE
chat-fade: declare version in manifest

### DIFF
--- a/plugins/chat-fade
+++ b/plugins/chat-fade
@@ -1,2 +1,2 @@
 repository=https://github.com/internetter/chat-fade.git
-commit=8f35f16f1341bea35e62cdf7515101d0cb82ab5f
+commit=a2200a83ed61ba560027cf0c78b61592cc11ae7d


### PR DESCRIPTION
Updates the chat-fade manifest to a2200a8.

Adds `version=1.4.1` to `runelite-plugin.properties`. Without it the hub falls back to the commit hash, so the plugin panel was showing "8f35f16f" instead of a version number.

No plugin code changed — this only labels the release that is already live, so the version stays 1.4.1.