### PR TITLE
Update Overheads Reworked to 1.0.2

### DIFF
--- a/plugins/overheads-reworked
+++ b/plugins/overheads-reworked
@@ -1,2 +1,2 @@
 repository=https://github.com/Swamisama/overheads-reworked.git
-commit=3557dd7562b2903afc8b7b1be9cd87595613ce31
+commit=97ec4c373e91b9cf44c46e10db4b279775be0768


### PR DESCRIPTION
Update Overheads Reworked to 1.0.2, advancing the manifest from `3557dd7` to `97ec4c3`.

The local player’s replacement prayer display now follows the visible overhead icon, preventing it from appearing ahead of the vanilla overhead when toggling prayers. This release also adds configurable outline feathering, makes character outlines the default display, and adjusts the default colors, opacity, widths, compact icon size, and height offset.

Source changes: https://github.com/Swamisama/overheads-reworked/compare/3557dd7562b2903afc8b7b1be9cd87595613ce31...97ec4c373e91b9cf44c46e10db4b279775be0768

Validation: `./gradlew test --rerun-tasks` passed.
