### PR TITLE
the-birdhouse: 1.4.1

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=80edf9713493d20d2b46d0bd2ab7c84e30b78b5b
+commit=f2618f89a1ff6d47ff297e6fb52e1aac6b095cf6
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps the-birdhouse to 1.4.1.

A kill-count tile on a Birdhouse board counts kills, but the plugin submits one proof per item in a drop. A boss that hands over several things at once (Zulrah, Vorkath, Muspah) therefore read as several kills, and a stack of loot read as a stack of kills.

The backend collapsed these by ignoring repeats on the same tile within ten seconds, which is the best a timestamp alone allows and swallows genuine kills of anything that dies faster than that.

1.4.1 stamps every item of one drop with a shared random id, so the backend can collapse exactly the submissions that came out of the same kill and nothing else. An item picked up from skilling carries no id, being no kill. A kill announced in chat is one kill and carries its own id.

No new permissions, no new data collected beyond a random per-kill identifier, and no change to the existing warning text.
