### PR TITLE
Add Clog Companion

### DIFF
--- a/plugins/clog-companion
+++ b/plugins/clog-companion
@@ -1,0 +1,3 @@
+repository=https://github.com/mablack01/clog-companion.git
+commit=773486fd043c515a2e556839dc25b2df628639c4
+authors=mablack01


### PR DESCRIPTION
## Summary

Clog Companion is a plugin that helps users figure out what collection log items to go for. This syncs with a user's collection log when they open the interface and tracks incomplete tasks. You can find and track new collection log items which can be filtered through depending on difficulty, time to aquire, and requirements.

- Rates every Collection Log slot into **Easy**, **Medium**, **Long**, or **Grind** from the challenge to obtain it, the time it takes, and its requirements — so a hard clue reward is weighed higher than "loot a casket", and speed-kill drops like charged ice or coagulated venom count as hard despite a short kill.
- Side panel that filters slots by tier, category, requirements, and what you already own.
- Sort by easiest or fastest first.
- Keep a tracked list of the slots you're going for, with an All / Tracked view switch.
- Roll a random target from the filtered list.
- Syncs obtained slots from your Collection Log when you open the interface.

Repository: https://github.com/mablack01/clog-companion