### PR TITLE
Add PoH Cosmetic Transmogs

### DIFF
--- a/plugins/poh-cosmetic-transmogs
+++ b/plugins/poh-cosmetic-transmogs
@@ -1,2 +1,2 @@
 repository=https://github.com/jtclowner/poh-cosmetic-transmogs.git
-commit=e3d6bb3e89e8e5c930f8f36dd8e8ed6f4c9a413c
+commit=2a61c58b856a25cc2a9d6540d6a569eaa50e9f59

--- a/plugins/poh-cosmetic-transmogs
+++ b/plugins/poh-cosmetic-transmogs
@@ -1,0 +1,2 @@
+repository=https://github.com/jtclowner/poh-cosmetic-transmogs.git
+commit=e3d6bb3e89e8e5c930f8f36dd8e8ed6f4c9a413c


### PR DESCRIPTION
Adds a cosmetic plugin that replaces supported PoH entrance and costume-room furniture with curated alternative appearances.

- Restricts selections to supported furniture and replacement object combinations. No arbitrary IDs.
- Preserves the original furniture clickbox and interactions.
- Supports configured recolours, animated appearances, and open/closed container states.
- Requires GPU or 117 HD for supported original-object suppression.
- Makes cosmetic changes locally without affecting game state.

Notes
- No reflection or runtime class loading.
- No networking or external services.
- No additional runtime dependencies.
- JSON parsing uses RuneLite's injected `gson` - the plugin does not create its own gson instance.
- Shutdown unregisters the render callback, removes overlays and replacement objects, and clears scene state.