### PR TITLE
Add Better Skybox

### DIFF
--- a/plugins/better-skybox
+++ b/plugins/better-skybox
@@ -1,0 +1,2 @@
+repository=https://github.com/314159DD/better-skybox.git
+commit=09ecfa83be6b7a706571fb9d410b5d443a50f56d


### PR DESCRIPTION
Better Skybox is the standard GPU renderer with a sky pass. Out of the box it draws a procedural day/night sky
(sun, moon with its real phase, stars, clouds, aurora, lightning in storm areas). Optionally it uses 21 CC0
cubemap skies, picked per map area with dawn/day/dusk/night sets and blended across area borders. Fog colours
follow the area. It declares a conflict with the GPU plugin and imports the user's GPU settings on first start.

Notes for review:
- The renderer classes are verbatim copies of the core GPU plugin (client 1.12.38) plus a package rename.
  `python tools/sync_upstream.py --check` regenerates them from a RuneLite checkout and fails on drift; the only
  hand-written deltas are `patches/BetterSkyboxPlugin.patch` (about 25 lines of hooks) and
  `patches/BetterSkyboxConfig.patch` (config sections). Everything else lives in `SkyPass` and the sky classes.
- The jar is about 250 KB. The photographed skies and the NASA star map (about 35 MB, lossless PNG) are an
  optional pack: the "Download sky pack" setting fetches a release asset from this repository once, through the
  injected OkHttpClient on a daemon thread, into `~/.runelite/better-skybox/pack/`. Zip entries are validated
  before extraction. Without the pack the procedural sky draws with generated stars and the plugin says so once
  in the chat box.
- No reflection, no native code beyond the client's own LWJGL, no new dependencies. Cubemap PNGs are decoded on
  one daemon thread; GL uploads happen on the client thread via ClientThread.
- Licenses: BSD-2-Clause (repository), assets CC0 (Poly Haven, ambientCG, OpenGameArt) and public domain (NASA
  SVS Deep Star Maps, Gaia DR2 credit), see NOTICE.

Repository: https://github.com/314159DD/better-skybox

