### PR TITLE
Update Blert to 0.9.21

### DIFF
--- a/plugins/blert
+++ b/plugins/blert
@@ -1,4 +1,4 @@
 repository=https://github.com/blert-io/plugin.git
-commit=a5cff2b5c53f029ba321cb3528a9a7ef05130ae8
+commit=cbec0ee0deec9b25f2f7ac76011961813fc535be
 authors=frolv
 warning=This plugin submits your IP address, RSN, and data about your raids to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Prevents spurious Xarpus screech detection
- Only sends Maiden crab leaks once