### PR TITLE
Add Fairy Ring Map

### DIFF
--- a/plugins/fairy-ring-map
+++ b/plugins/fairy-ring-map
@@ -1,0 +1,2 @@
+repository=https://github.com/jdkrupajk/fairy-ring-map.git
+commit=f3432d11e0076dbf69ed6e24aff4f5a85b245b6b

--- a/plugins/fairy-ring-map
+++ b/plugins/fairy-ring-map
@@ -1,2 +1,2 @@
 repository=https://github.com/jdkrupajk/fairy-ring-map.git
-commit=f3432d11e0076dbf69ed6e24aff4f5a85b245b6b
+commit=76ec5abe42f3e9cfe7b954a6af424dff0bb1150f

--- a/plugins/fairy-ring-map
+++ b/plugins/fairy-ring-map
@@ -1,2 +1,2 @@
 repository=https://github.com/jdkrupajk/fairy-ring-map.git
-commit=5a15e1abcc08cd9a5f5e85899fcd09e15575ae68
+commit=b974908dffbc7fbb587bddb610d21a0482d9ecab

--- a/plugins/fairy-ring-map
+++ b/plugins/fairy-ring-map
@@ -1,2 +1,2 @@
 repository=https://github.com/jdkrupajk/fairy-ring-map.git
-commit=76ec5abe42f3e9cfe7b954a6af424dff0bb1150f
+commit=5a15e1abcc08cd9a5f5e85899fcd09e15575ae68


### PR DESCRIPTION
Adds Fairy Ring Map.

Replaces the fairy ring travel log with a clickable map of Gielinor drawn over the dial interface. Clicking a destination narrows the native list to that one row; the click that travels is still the player's, on the game's own unmodified row.

Notes for review, covering the things worth knowing up front:

- **No `client.runScript`, no `client.closeInterface`, no reflection, no network or file I/O, no third-party services.** The plugin does widget work and event observation only. It never synthesises a menu action, adds a menu entry, or writes a game variable. It reads `VarClientID.FAIRYRINGS_SEARCHSTRING` but never writes it.
- **The map cannot fire a travel and does not try.** Every row of interface 381 carries the op "Use code" with no listener of any kind — it is a raw server-bound op — so the usual pattern of running a widget's own listener has nothing to run here. The map filters the list instead, and the player clicks the game's own row.
- **It draws three click-blocking panels over the dial interface while the map covers it**, using the same `setClickMask` + `setNoClickThrough(true)` pair as core's `WikiPlugin`, so the dials cannot be turned blind through the map. The interface's own close button is deliberately left clickable, and the map draws a copy of that button's own sprite over the gap so it stays visible.
- **It hides, moves and resizes travel log rows to filter the list**, and restores every change on the way out. Two existing hub plugins (`fairy-ring-organizer`, `fairy-ring-favourites`) mutate the same widgets; the interaction is documented in the README.
- **Asset provenance.** The map art is generated from the local game cache with RuneLite's own `MapImageDumper`, and the codes and destination names come from core's `FairyRing` enum. Both BSD-2. No wiki imagery is bundled.

36 unit tests. Design notes and the reasoning behind the non-obvious decisions are in `DESIGN.md` in the repository.
