### PR TITLE
fbclan-plugin: update to 64c62e4

### DIFF
--- a/plugins/fbclan-plugin
+++ b/plugins/fbclan-plugin
@@ -1,3 +1,3 @@
 repository=https://github.com/orgonag/fbclan-plugin.git
-commit=dbf7db880000ee2fe5d168aafd8fbed8243f7237
+commit=64c62e4067a3e2a90b0615e3e794a34e3d0a01e0
 warning=This plugin submits your IP address, RSN, drop data, and Party to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates Final Boss clan plugin from dbf7db8 to 64c62e4 (version 3.0).

- LFG is now hosted parties: hosts pick activity, size, world, roles and loot rule; clanmates apply with their kill count; full parties move into a 7-day formed-party history. `!lfg` lists open parties locally.
- Drop log qualifies drops by GE value, known rarity, a clan notable-item list, or pets, and queues submissions locally for retry on connection failures.
- PBs tab adds clan bests, collection-log and combat-achievement top-20s, weekly XP/EHB, and GP this week. Optional slayer-helmet CA badges next to clan members' names in chat.
- Backend calls consolidated into server-side RPCs with validation; anon key permissions reduced to read-only views plus those RPCs.
- No new external domains. Same Wise Old Man, Supabase, RuneLite hiscore and optional user-supplied Discord webhook as before; warning line unchanged.