### PR TITLE
Add Lucky Penny Unfiltered

### DIFF
--- a/plugins/lucky-penny-unfiltered
+++ b/plugins/lucky-penny-unfiltered
@@ -1,0 +1,2 @@
+repository=https://github.com/jeopardy-brooks/lucky-penny-unfiltered.git
+commit=043082ea7365be765cf905ec49e9b2e24ea4ade8


### PR DESCRIPTION
Adds Lucky Penny Unfiltered, which keeps Ghommal's charge-saving notifications visible when OSRS Game chat is set to Filtered.

The plugin matches the specific charge-saving game message, adds its original text and timestamp as a normal game message, and removes the filtered original. The replacement does not emit a second chat event, preventing other charge trackers from counting the save twice. No configuration, network requests, or persistent data are added.

Validation: built against RuneLite 1.12.38 using Java 11; all seven unit tests passed. In-game testing confirmed the notification appears with Game chat set to Filtered.
