### PR TITLE
Update Fairy Ring Map

### DIFF
--- a/plugins/fairy-ring-map
+++ b/plugins/fairy-ring-map
@@ -1,2 +1,2 @@
 repository=https://github.com/jdkrupajk/fairy-ring-map.git
-commit=b974908dffbc7fbb587bddb610d21a0482d9ecab
+commit=95a972b26fa972c3590eb0c9375327138658a420


### PR DESCRIPTION
Updates Fairy Ring Map to `95a972b`.

Two changes, no new APIs and no change to what the plugin does.

**A colour-vision fix.** The favourite marker was a rose `#FF4D6D` and the locked marker is a grey `#6A6A6A`. Under protanopia those simulate to `(98,101,110)` and `(106,106,106)` — indistinguishable — and the two states mean opposite things, so the map reported every favourite as unreachable. Favourites are now `#E92100`, the red of the travel log's own favourited-heart sprite, so the map reuses a colour the player already sees on the rows beside it. A new unit test fails the build if any two of the five marker states come within a set distance of each other under simulated deuteranopia, protanopia or tritanopia.

**A real `icon.png`**, replacing a placeholder. Custom artwork, 48x43. No wiki imagery is bundled — the map art is still `MapImageDumper` output from the local cache, as in the original submission.

Also corrects a stale figure in `DESIGN.md` that documented the map sprite's dimensions and world box incorrectly, and makes the test that guards them read the sprite's real dimensions instead of comparing against literals.

39 unit tests.
