### PR TITLE
Add dog-hider plugin

### DIFF
--- a/plugins/dog-hider
+++ b/plugins/dog-hider
@@ -1,2 +1,2 @@
 repository=https://github.com/Brightwater/runelite-dog-hider.git
-commit=1bf5014bad828f6ff56061512d1619adc4fdbd1d
+commit=23a49f6c5803398573b4ecf7b5b87a078a9b3565

--- a/plugins/dog-hider
+++ b/plugins/dog-hider
@@ -1,0 +1,2 @@
+repository=https://github.com/Brightwater/runelite-dog-hider.git
+commit=1bf5014bad828f6ff56061512d1619adc4fdbd1d


### PR DESCRIPTION
Adds the Dog Hider plugin.

Hides player-owned shelter dogs and puppies introduced in *A Ruff Situation* while preserving rare boss/clue pets and the local player's own companion.

Repository: https://github.com/Brightwater/runelite-dog-hider