### PR TITLE
Add ironman-spine plugin

### DIFF
--- a/plugins/ironman-spine
+++ b/plugins/ironman-spine
@@ -1,0 +1,2 @@
+repository=https://github.com/osrstrustycontributor/ironman-spine.git
+commit=0862871a4e80c7fefa4aa10ae008c3dd65120ade


### PR DESCRIPTION
**Ironman Spine** — a read-only progression tracker for Ironman accounts. It reads quest completions, achievement-diary tiers, POH state and collection-log slots client-side and exports an account snapshot (via a "Copy snapshot JSON" / "Save snapshot to file" side panel) that the user pastes into the Ironman Unlock Spine companion app to check off unlocks. No network calls, no automation, no credentials touched; nothing leaves the client except through the two export buttons the user presses.