### PR TITLE
Add LootFinder plugin repository information

### DIFF
--- a/plugins/loot-finder
+++ b/plugins/loot-finder
@@ -1,0 +1,2 @@
+repository=https://github.com/austin-97/LootFinder.git
+commit=c2fd0e5113269074d9e8666dcdf9e2d5e80424a5


### PR DESCRIPTION
Loot Finder, a plugin that filters bank items using loot recorded by RuneLite's Loot Tracker plugin.
