### PR TITLE
Update PoH Cosmetic Transmogs

### DIFF
--- a/plugins/poh-cosmetic-transmogs
+++ b/plugins/poh-cosmetic-transmogs
@@ -1,2 +1,2 @@
 repository=https://github.com/jtclowner/poh-cosmetic-transmogs.git
-commit=f58168dfaad145f21cbb25cb31a81905282dfa1d
+commit=7171c560907fb82a774d801bb7a2b2bc0cfed391


### PR DESCRIPTION
Adds support for the deadman annihilation portal (`60789`) as an alternative exit portal object alongside the standard entrance portal (`4525`).

Both use the same entrance transmog options and behaviour.