### PR TITLE
Update data-logger to 1.2.2

### DIFF
--- a/plugins/data-logger
+++ b/plugins/data-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/Maximuis94/runelite-plugins.git
-commit=a29b8064118b37dc9e82a0f328fef5b7739f1235
+commit=73756e4ea6b28b6689afcfbc611ff9f01fbe11b6
 authors=maximuis94

--- a/plugins/data-logger
+++ b/plugins/data-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/Maximuis94/runelite-plugins.git
-commit=73756e4ea6b28b6689afcfbc611ff9f01fbe11b6
+commit=79cdab436f11dc2ed99e373ade5d351d64237f79
 authors=maximuis94


### PR DESCRIPTION
Fixed a bug that causes an account hash related exception in the history parser
Fixed a bug that prevents the colosseum logger from recognising a wave transition