### PR TITLE
Add Stream Chat plugin

### DIFF
--- a/plugins/stream-chat
+++ b/plugins/stream-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/EAS-Andrew/runelite-stream-chat.git
-commit=7f13aa1c0cfb24f6439fa3ba47d4aa58d2873599
+commit=e99a34663c6be195456b48fe5bf1fc4173bdfa72

--- a/plugins/stream-chat
+++ b/plugins/stream-chat
@@ -1,0 +1,2 @@
+repository=https://github.com/EAS-Andrew/runelite-stream-chat.git
+commit=e62230bac9b674884cb3d28f9d390d073058abe1

--- a/plugins/stream-chat
+++ b/plugins/stream-chat
@@ -1,2 +1,2 @@
 repository=https://github.com/EAS-Andrew/runelite-stream-chat.git
-commit=e62230bac9b674884cb3d28f9d390d073058abe1
+commit=7f13aa1c0cfb24f6439fa3ba47d4aa58d2873599


### PR DESCRIPTION
Adds **Stream Chat**: shows live Twitch, YouTube and Kick chat in the game chatbox, each line prefixed with its platform's icon.

Source: https://github.com/EAS-Andrew/runelite-stream-chat

### What it does

Read-only display of external stream chat as game chat messages. It never sends anything to a stream, never writes to the chatbox input, and never reads game chat or account state.

### Notes for review

**No third-party dependencies.** OkHttp (including its WebSocket client), Gson, Guava and Guice all come from the client classpath, so nothing needs adding to the verification template.

**Credentials.** Twitch and Kick are read anonymously, so there is nothing to store. YouTube requires a Data API key because Google requires one for all Data API calls; the user supplies their own in config (marked `secret = true`), it is sent only to `googleapis.com`, and no credential ships with the plugin. OAuth is not used, as it is only needed for private broadcasts or posting, neither of which this plugin does.

**Untrusted input.** All remote text is normalised and truncated by `ChatText.clean`, then escaped with `Text.escapeJagex` before reaching the chatbox, so a chatter cannot inject `<img=n>`, `<col=...>` or `@...@`. Truncation happens before escaping so a cut cannot split a generated `<lt>`. Covered by tests in `ChatTextTest`.

**Flood control.** A bounded queue (dropping oldest) plus a per-tick print budget keeps a busy channel from pushing game messages out of view. Reconnects use exponential backoff with jitter; unrecoverable errors stop rather than retry.

**Endpoints contacted:** `irc-ws.chat.twitch.tv`, `ws-us2.pusher.com`, `kick.com`, `googleapis.com`.

### Against the rejected-features list

I checked the two entries that looked relevant:

- *Twitch/BTTV/FFZ/7TV emote plugins* — this does not fetch or distribute any emote images. Emotes are shown as their plain text name (Kick's inline `[emote:id:NAME]` markup is reduced to `NAME`), which is what Twitch already sends as text.
- *Programmatically inserting text into the chatbox input / autotyping* — this only appends messages to the chat log via `ChatMessageManager`; it never touches the chatbox input, and the plugin is read-only in both directions.

