### PR TITLE
lucky-log: 1.1

### DIFF
--- a/plugins/lucky-log
+++ b/plugins/lucky-log
@@ -1,2 +1,2 @@
 repository=https://github.com/rsvaultpudgy-create/lucky-log.git
-commit=570cee4c349fb732b2e1e3700cb58e25fa35a189
+commit=e87dbef12479695bcc56bd9856e741149a90e3b2


### PR DESCRIPTION
removed sailors' amulet and boat bottle from notable drops -> spammy and cannot get duplicates of amulet so it was defaulting to 'driest' thing on card