### PR TITLE
Update Aura Tracker for Discord community button

### DIFF
--- a/plugins/aura-tracker
+++ b/plugins/aura-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Matelaa/aura-tracker.git
-commit=94b394270d9a8e344f4a2d85e927bc1f75a758b4
+commit=1df7326
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Update the Aura Tracker manifest to the latest commit containing the Discord community button.\n\nThe plugin version remains 1.4 and build=standard. No manifest fields or warning text changed.