### PR TITLE
Add PB Exporter

### DIFF
--- a/plugins/pb-exporter
+++ b/plugins/pb-exporter
@@ -1,4 +1,4 @@
 repository=https://github.com/Edison0x7/pb-exporter.git
-commit=b7a1783bdb7537b0ca019109c68f533fc354d4a2
+commit=e950ab28f0ccdc89db3847c18da20280fd1198cf
 authors=Edison0x7
 warning=This plugin submits your RuneScape name and Personal Best times to a third-party server not controlled or verified by RuneLite developers.

--- a/plugins/pb-exporter
+++ b/plugins/pb-exporter
@@ -1,0 +1,4 @@
+repository=https://github.com/Edison0x7/pb-exporter.git
+commit=b7a1783bdb7537b0ca019109c68f533fc354d4a2
+authors=Edison0x7
+warning=This plugin submits your RuneScape name and Personal Best times to a third-party server not controlled or verified by RuneLite developers.


### PR DESCRIPTION
Adds PB Exporter, a plugin for exporting RuneLite Personal Bests to the clipboard or submitting them to a configured third-party server.