### PR TITLE
update drop-rate-properties

### DIFF
--- a/plugins/drop-rate-properties
+++ b/plugins/drop-rate-properties
@@ -1,2 +1,2 @@
 repository=https://github.com/Pluckss/DropRatePluginFinal.git
-commit=97da6bf9415fdb8a694452eea59d972387405548
+commit=88568a7c838dd1b2774ab2f632de07ca0fd88b6d


### PR DESCRIPTION
Replaces the plugin's "Rare drops only" display mode and its numeric "Rare-only minimum rate" with a single dropdown, **Minimum rarity to show in chat** (Common / Uncommon / Rare / Ultra-rare), under Filtering.

A user reported the chat feed being cluttered by common drops printed in green. Expressing "hide the common tier" as a 1/x threshold meant keeping that number in step with the plugin's own tier boundaries by hand. The new setting shows the chosen tier and everything rarer, so that request is one choice; Common is the default and filters nothing, so existing users' chat is unchanged.

No new rarity logic: the tier comparisons that lived inline in the colour code are now a single `classifyTier`, read by both the colours and the filter, so moving a tier boundary in Appearance moves the filter with it.

Players still on the retired mode are migrated in `provideConfig` (their old threshold is classified with those same boundaries, they keep an unfiltered display mode, and the dead key is unset), because RuneLite's defaults pass rewrites unreadable stored values before `startUp` runs.

No new dependencies. Verified against a live client and with the repo's `tools/verify` harnesses.