### PR TITLE
coffer: bump to 1bc41d3 (0.1.10-beta)

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=30e4935ecdfc018361166b5135b6b54d87f31fbe
+commit=1bc41d3feead9b2f5c2994bcfcc5e14a72047f4d
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=6d5a0ab7e32807a09a3c2aab4253a811691d9f81
+commit=30e4935ecdfc018361166b5135b6b54d87f31fbe
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Bumps Coffer to 0.1.9-beta.

User-facing changes since 0.1.8-beta:
- Discord community link in Settings
- Clearer flip-log empty-state
- What's-new banner

No new permissions or dependencies.