### PR TITLE
Add Healthy Stray Varrock Dogs

### DIFF
--- a/plugins/healthy-stray-varrock-dogs
+++ b/plugins/healthy-stray-varrock-dogs
@@ -1,0 +1,2 @@
+repository=https://github.com/CornyDonkeh/healthy-stray-varrock-dogs.git
+commit=ac59642eeec7a9a89a6c2ef0e7ae6dba9f213e25


### PR DESCRIPTION
Cosmetically heals Varrock’s stray dogs and Duke, with optional randomized favorite breeds, ages, and colors for unnamed strays. Manually tested in-game, including walking and interactions. Build and four regression tests pass. Clean resubmission of #16266 with only one plugin manifest added and no workflow changes.