### PR TITLE
Add Sidebar Organizer

### DIFF
--- a/plugins/sidebar-organizer
+++ b/plugins/sidebar-organizer
@@ -1,0 +1,2 @@
+repository=https://github.com/Brettgod1355/runelite-sidebar-organizer.git
+commit=91f62803e6f05c0d2cccf67390b327dd7b4ac65d


### PR DESCRIPTION
Adds Sidebar Organizer: saved drag-and-drop ordering for RuneLite sidebar panel icons, with an organizer list, Up/Down controls, drag lock, reset, and remembered positions for disabled plugins.

Implementation: installs a RuneLiteTabbedPaneUI subclass through public Swing APIs and changes tab rectangles through protected layout extension points. Native logical tab indexes and plugin priorities stay intact. Production code uses no reflection, private-field access, global keyboard hooks, or networking. Test-only reflection initializes a headless ClientUI fixture and is excluded from the plugin JAR. Uses ConfigManager, standard build, and BSD 2-Clause licensing.

Validation: 15 automated tests passed; CI passed on Java 11 and 17. Windows live-client testing on RuneLite 1.12.38 confirmed reordering, correct panel selection, persistence, locking, plugin lifecycle, column resizing, and reset. Details: https://github.com/Brettgod1355/runelite-sidebar-organizer/blob/main/docs/TESTING.md

Review focus: whether UI-delegate replacement is suitable for the Hub, given the native work in runelite/runelite#19910. Profile switching and other platforms remain untested; keyboard traversal may follow logical order, and tooltip/class renames become new identities.