### PR TITLE
Create loot-inside

### DIFF
--- a/plugins/loot-inside
+++ b/plugins/loot-inside
@@ -1,0 +1,2 @@
+repository=https://github.com/bopsec/bop-plugins.git
+commit=6c7f5d4bcaaab6e4d197d211d69e52e813c881cc


### PR DESCRIPTION
stops you leaving tob without looting (muscle memory)
mostly for clan event stuff 