### PR TITLE
Add Chat Regex Filter plugin

### DIFF
--- a/plugins/chat-regex-filter
+++ b/plugins/chat-regex-filter
@@ -1,0 +1,2 @@
+repository=https://github.com/1504681/ChatRegexFilter.git
+commit=0b333af64734afcd8c9b08e436f9a1adce45e6b5


### PR DESCRIPTION
## Summary
- Hides any chatbox line matching user-supplied regular expressions, for every message type (public/private/clan/friends/GIM chat, game and engine messages, broadcasts, examines, notifications) with no friend or clan-member exceptions
- Optional debug mode marks matching lines in a colour instead of hiding them, and a right-click copy of the raw or filtered text for building patterns
- Read-only: it only sets the chatbox filter flag or rewrites the drawn text, no input, no automation

## Repository
https://github.com/1504681/ChatRegexFilter