### PR TITLE
Updated Dry Streak Tracker to 1.3.7

### DIFF
--- a/plugins/dry-streak-tracker
+++ b/plugins/dry-streak-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/Yomi-no-Kami/DryStreakTracker-Plugin.git
-commit=13a8a0ae134f909b224749512fbadbbd692d927a
+commit=f2fefe8c714ecd57d61e7d102dcf8e0e0416f9bc
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
- Added Dragon Axe to the Dagannoth Kings tracked drops.
- Fixed custom notifications not displaying correctly after Collection Log popups.
- Fixed Tracked Drops only showing the first 4 unique items.
- Fixed item sprites occasionally not appearing in Tracked Drops and Recent Drops.