### PR TITLE
update the-other-half

### DIFF
--- a/plugins/the-other-half
+++ b/plugins/the-other-half
@@ -1,3 +1,3 @@
 repository=https://github.com/NotNikolai/runelite-plugins.git
-commit=50fdd3b000b8a38ee97de46e7996b0565160c8f8
+commit=96b8982c834fd74dd800c6438354710ecb8153de
 authors=NotNikolai


### PR DESCRIPTION
Adds a bar goal setting for whether progress bars fill towards the level shown on the tile or your real next level, moves the level up message settings under the Celebration section, and reveals the real level on the tile and in the bar when you hover a skill.
