### PR TITLE
Update groupscape to f3000f8

### DIFF
--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=e5a5af2ea54d08ba33c432d00e4823c1f8624169
+commit=fe563703c80f3688605643b6d07b942ee9e0ecbc
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=4209ce87d7bd2f82c0a81984aa99978441c488e7
+commit=c5c56196f5d2be2fd82357d4ab6f9c0c9025ebdf
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=c5c56196f5d2be2fd82357d4ab6f9c0c9025ebdf
+commit=f3000f8e9d41c59ef5167483fb1add813359efac
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/groupscape
+++ b/plugins/groupscape
@@ -1,3 +1,3 @@
 repository=https://github.com/MayzrDev/groupscape-plugin.git
-commit=fe563703c80f3688605643b6d07b942ee9e0ecbc
+commit=4209ce87d7bd2f82c0a81984aa99978441c488e7
 warning=This plugin submits your IP address, and may submit various account information, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Brings the deployed GroupScape plugin from v1.8.22 up to v1.8.27:

- Fixed: a finished slayer task could get stuck showing 0 kills and "In progress" in the site's History tab even after being turned in for a new task.
- Fixed: a brief stutter every time a slayer task started or finished.
- Fixed: skipping a task from a higher-level master (Vannaka, Nieve, Duradel, ...) via Turael/Aya/Spria showed up as "Superseded" instead of "Reset".
- Fixed: a task's close (finished, skipped, cancelled, or blocked) could get lost entirely on a client/plugin restart at the wrong moment, permanently stranding it as "Superseded".
- Added: Mortimer's task modifiers (bonus points, task size, clue rate, superior unique rate, Slayer XP) now show on the site's current task panel and History tab.
- Fixed: blocking or cancelling a task right after finishing its kill count, but before turning it in, showed up as a normal "Completed" task with the fee looking like the task's own reward. Now correctly labeled Blocked/Cancelled.
- Fixed: blocking a task type from the Slayer Reward Shop's list wasn't tracked at all - it now shows up as its own History entry.
- Fixed: notable drop chat notifications weren't reaching anyone due to a mismatched field name.
- Fixed: a fully-killed task could still get mislabeled Blocked/Cancelled if you blocked or cancelled a different task right afterward - completed tasks are now always recorded as Completed.
- Fixed: the Slayer Reward Shop's block-confirmation message wasn't recognized when it included the word "slayer", so some block purchases went untracked.