### PR TITLE
Add Solo Army Bingo

### DIFF
--- a/plugins/solo-army-bingo
+++ b/plugins/solo-army-bingo
@@ -1,0 +1,4 @@
+repository=https://github.com/thesoloarmy/solo-army-runelite.git
+commit=df90c8c5539ff35080b349a42f603b568a26e3f5
+authors=thesoloarmy
+warning=This plugin sends your RuneScape username and only loot matching the active Solo Army Bingo board (item ID, quantity, source/type, timestamp, plugin version, installation identifier) to soloarmy.info, a third-party server not controlled or verified by the RuneLite Developers, for clan Bingo tracking.


### PR DESCRIPTION
Adds Solo Army Bingo, a clan Bingo integration for Solo Army.

The plugin tracks only loot items that are present on the currently active Solo Army Bingo board and submits matching drops to soloarmy.info for Bingo claim processing.

The plugin communicates with a third-party server and includes the required data-disclosure warning.