### PR TITLE
Update commit hash for catastrophic-events plugin

### DIFF
--- a/plugins/catastrophic-events
+++ b/plugins/catastrophic-events
@@ -1,3 +1,3 @@
 repository=https://github.com/mikeyf06/cata-runelite-plugin.git
-commit=827457b41aeda8f218a49d4bd683c247bd260326
+commit=2c2b5c861be81c178a3ab277d144ed4b3a6f9235
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Fixes the event list date/time subtitle getting clipped mid-word (e.g. "Today · 7:...") by switching to a wrapping label instead of a plain JLabel, and shortens the date format. Also renames the settings gear's tooltip from "Event Setup" to "Plugin Settings" for clarity.