### PR TITLE
Add Random World Hopper++

### DIFF
--- a/plugins/random-world-hopper
+++ b/plugins/random-world-hopper
@@ -1,0 +1,2 @@
+repository=https://github.com/andrew-friedman-phd/random-world-hopper.git
+commit=aa1e23609b163d4a31bd512bc55fde017c6599a9


### PR DESCRIPTION
## What it does

Hops to a random world while keeping recently used worlds on a user-tunable cooldown, so a random hop never sends you back to one you just left. Cooldown duration is editable directly from the sidebar panel to suit whatever activity you're doing.

- Sidebar cooldown list with a live countdown, plus a "Hop to random world" button.
- Configurable ping threshold and world-type filters (Normal, Deadman, Seasonal/Tournament, Quest Speedrunning, Fresh Start, PVP, Skill Total, High Risk, Bounty Hunter, F2P).
- Skill Total worlds are filtered against the account's actual live total level, so you won't get hopped onto one you don't qualify for.
- A small "World Hops" counter shown under the minimap while the sidebar panel is open, tracking hops since the last login.

Repository: https://github.com/andrew-friedman-phd/random-world-hopper

🤖 Generated with [Claude Code](https://claude.com/claude-code)