### PR TITLE
Add big-pets

### DIFF
--- a/plugins/big-pets
+++ b/plugins/big-pets
@@ -1,0 +1,2 @@
+repository=https://github.com/KihiraLove/big-pets.git
+commit=f190ba5f658078964b34d8f3bff1f8e41c5aefc8


### PR DESCRIPTION
Resize pets through the `GPU` plugin, from 0% (Which hides the pets) to 500%
Pets original clickbox and right-click menu is intact.
**Options:**
- **Resize all pets:** Apply resize to other player's pets and POH pets
- **Filter cats and dogs:** Don't apply resize to cats and dogs
- **Filter event and quest pets:** Don't apply resize to event and quest pets