### PR TITLE
Update Efficient Mortimer to 0.1.1

### DIFF
--- a/plugins/efficient-mortimer
+++ b/plugins/efficient-mortimer
@@ -1,2 +1,2 @@
 repository=https://github.com/rang-rs/Efficient-Mortimer.git
-commit=f854cd29eee1c5ac8a3a8572c0f327e41431ddd9
+commit=e04fed9dacf2e7d5cda76daf51708ad862cb5b00


### PR DESCRIPTION
Updates the Main list using revised base Slayer rates: Custodian Stalkers at 125,000 XP/hr and Dark Beasts at 43,000 XP/hr.

Version 0.1.1. Build passed with all 47 tests passing