### PR TITLE
update osrs-fliphub

### DIFF
--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,3 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=5524ed827a77beb47e7c2e9d9c43efc1afac1bb0
+commit=6b61960fab0a863ee1f14b719ba1bdf7f3d07ca0
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/osrs-fliphub
+++ b/plugins/osrs-fliphub
@@ -1,3 +1,3 @@
 repository=https://github.com/zFallan121/OSRS-FlipHub-Plugin-Public.git
-commit=dbe8156ccc4f40f9aa75ec40c1c7843d7d8655f7
+commit=5524ed827a77beb47e7c2e9d9c43efc1afac1bb0
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps `commit=` for `osrs-fliphub`, now at `f2c7dfb`.

**On the token count.** Thanks for both notes — I had been measuring the diff, which is why the earlier "185k" was meaningless. Measured the way you describe, all of `src/main/java` with comments stripped, this commit is **194.7k** on a local cl100k count. The same measurement at `5524ed8` gives 217.6k against the 223,142 your bot reported, so scaling by that ratio puts this near 199k — under the line, but not by much. If your bot still says over, tell me the number and I will cut further rather than ask anyone to read it by hand.

The reduction is deleted code rather than reworded comments: dead methods and fields removed, the unused half of a runtime holder dropped, boilerplate replaced by Lombok, and the conversion table and its detection machinery deleted outright, which is the first item below.

**Recipes are recorded by the player, not guessed.** The conversion tracking described earlier in this PR detected recipes from a table shipped as a resource. That is gone — table, matching, the lot; nothing in this release guesses what a player made. In its place is a screen on the Profile tab. Your finished trades are listed newest first, you tick the purchases that went in and the sales the result went out through, and those trades become one activity with one profit, filed under the item the recipe was about. Assemble, disassemble, repair, set-combine and set-break are covered, a repair fee counts towards the cost, everything recorded is listed underneath with an undo beside it, and nothing is ever written without an explicit action.

**Stored trades.** One record per completed offer rather than one per fill, and the previous cap is removed, so all-time totals no longer drift as old history falls off the end. Existing files migrate on the next load. The migration conserves quantity and gp across every merge and is idempotent, so an interrupted run repeats harmlessly.

**Sale tax.** Computed in one place, floored per item and capped, with the exempt item ids. Every figure that used to carry its own copy of the formula now routes through it.

**Live prices show their age.** The sell and buy price are coloured by how long ago the trade behind them actually happened — plain under half an hour, amber to the hour, red past it — and hovering either one gives the age of both. Each side is judged on its own. The popup is kept inside the client window.

**Correctness.** The ledgers no longer treat the pieces produced by breaking something as stock available to a recipe. Those pieces carry no cost, so counting them let a recipe take one as a free ingredient and divided a bought unit's cost across units that never had any. Both overstated profit.

**Durability.** Profile writes use a temp file and an atomic move under a per-file lock, and a failed write keeps the account marked unsaved rather than reporting success. A profile file containing valid JSON of an unexpected shape is treated as unreadable instead of as an empty account. The trade flush on client shutdown no longer depends on the upload pipeline being healthy, and one account failing no longer abandons the others.

**Threading.** Background threads read a readiness flag recorded on the client thread instead of calling client methods themselves, and the decimal-amount chatbox helper performs its check on the client thread. Repeating scheduled tasks are wrapped so one exception cannot silently cancel them for the session.

**Panel.** Exactly zero is no longer coloured as a gain, a return too small to show at two decimals no longer renders as a signed zero, and the offer timer pins its digits so it cannot render in another numeral system.

**Network.** The API base URL is now `https://www.osrsfliphub.com` rather than the hosting provider's address for the deployment behind it. What is sent, and when, is unchanged; this only stops a redeploy from stranding installed copies, and it matches what the README's privacy section has always said.

Two notes for review, both long-standing in this repo rather than new here. Every source file declares `package com.osrsfliphub` even though the directories are nested, which is why the class named in `plugins=` sits at the top level. And `FlipHubHoverRestorer` dispatches a synthetic `MouseEvent` to a Swing component inside the plugin's own side panel to restore hover after the list is rebuilt; it never touches the game canvas.

One dependency change from the previously published commit: `build.gradle` gains `compileOnly` and `annotationProcessor` entries for `org.projectlombok:lombok:1.18.30`, the version in your `core` configuration and in the template plugin. No third-party dependencies. `settings.gradle` and `runelite-plugin.properties` are unchanged, apart from the stale duplicate of `runelite-plugin.properties` that was being bundled into the jar and has been deleted.

`./gradlew clean build` is green at this commit, 398 tests passing. The README and its screenshots are refreshed here too.
