### PR TITLE
Add discord-rare-drop-notifier-handoff

### DIFF
--- a/plugins/discord-rare-drop-notifier-handoff
+++ b/plugins/discord-rare-drop-notifier-handoff
@@ -1,0 +1,2 @@
+repository=https://github.com/LimJahey1337/discord-rare-drop-notificater.git
+commit=2d4ace8859fc3d379cc0a5111d65744c18b3128b


### PR DESCRIPTION
A fork of discord-rare-drop-notificater (BossHuso), whose upstream has had no commits since 2024-10-02 and unanswered pull requests since 2025-02-16.

The fork exists so the plugin can share a Discord channel with Dink without posting the same drop twice:

- "Max value (hand-off)": drops worth this much or more (GE or HA, whole stack) are not posted, whitelist and event uniques included; set it to Dink's "Min Loot value" and each drop is posted by exactly one plugin. 0 disables it.
- "Send pets" toggle, for when Dink already posts pets.
- One-time settings migration from the original plugin's config group, so users switching over keep their webhook and thresholds.
- Carries upstream PRs #107 (trim whitespace in item lists) and #109 (missing rarity tables log at debug, not warn) with their authors' commits.
- Plugin/config classes and config group renamed so it can be told apart from the original.

No gameplay, input or interface behaviour is touched; it is a Discord webhook notifier, as before. Support: https://github.com/juclor1993/discord-rare-drop-notificater