### PR TITLE
Update notification-panel to 2.1.1

### DIFF
--- a/plugins/notification-panel
+++ b/plugins/notification-panel
@@ -1,2 +1,2 @@
 repository=https://github.com/KogasaPls/notification-panel.git
-commit=b656aaf3ccc36212d36d28a3266ada5b5db244e3
+commit=deeebb0b2ffca098fe702dfce56751ecde413006


### PR DESCRIPTION
Updates Notification Panel to 2.1.1, from `b656aaf3ccc36212d36d28a3266ada5b5db244e3` to `deeebb0b2ffca098fe702dfce56751ecde413006`.

- fix an expired notification holding a panel slot against a newer one
- fix "Create rule" on a long notification producing a rule that matches nothing
- fix editing a rule silently changing a pattern that contains a line break
- fix imported ".+" rules matching more than they used to
- fix a notification from a previous session reaching the next session's list