### PR TITLE
Update PoH Cosmetic Transmogs to 1.1.0

### DIFF
--- a/plugins/poh-cosmetic-transmogs
+++ b/plugins/poh-cosmetic-transmogs
@@ -1,2 +1,2 @@
 repository=https://github.com/jtclowner/poh-cosmetic-transmogs.git
-commit=7171c560907fb82a774d801bb7a2b2bc0cfed391
+commit=73386c6f7047c05c8e6368ab2995b569fb1db29f

--- a/plugins/poh-cosmetic-transmogs
+++ b/plugins/poh-cosmetic-transmogs
@@ -1,2 +1,2 @@
 repository=https://github.com/jtclowner/poh-cosmetic-transmogs.git
-commit=73386c6f7047c05c8e6368ab2995b569fb1db29f
+commit=948b43d541c09a562fd98812ceb62ec6089e8a82


### PR DESCRIPTION
Version 1.1.0 focuses on refactoring, optimisation, bug fixes and future-proofing.

**Summary**

- Consolidate targets, appearances and placements into one catalogue and shared rendering pipeline.
- Simplify catalogue definitions through inherited state/placement values, grouped placements and consistent scale fields.
- Separate fixed appearance recolours from colour channels controlled by plugin settings.
- Derive render radius from the declared replacement footprint.
- Add optional parity-based tile alignment. Existing furniture retains its manual calibrations and does not opt in.
- Fix stale replacement cleanup when bindings are removed.
- Exclude GPU Legacy, which does not support the required object-suppression callback.
- Pause replacements while no supported renderer is available, preserve the plugin's enabled setting, and resume automatically when GPU or 117 HD becomes ready. Show a one-time chat message while paused.
