### PR TITLE
Update Kill Clog to 2.3.3  - Setup and hardening

### DIFF
--- a/plugins/kill-clog
+++ b/plugins/kill-clog
@@ -1,3 +1,3 @@
 repository=https://github.com/420kc/kill-clog-plugin.git
-commit=c1eb9773cb730f568fd73115568afd0677635150
+commit=96dee2429ed96187e36d1451270b114f7a9dbd07
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Restores automatic Collection Log setup when opening your own log, including empty accounts, and keeps manual Search as a retry path.

Also hardens local cache saves and account-owned personal-best handling, fixes lookup timeout and comparison cancellation issues, and reduces redundant hiscore requests.

The Collection Log `client.menuAction` use follows [Riktenx's explicit approval](https://github.com/runelite/plugin-hub/pull/12380#issuecomment-4773784134), also cited by [RuneProfile's restoration](https://github.com/runelite/plugin-hub/pull/12826).

Validation: compile/checkstyle passed, 578 tests passed, and automatic setup was smoke-tested in-game on a zero-item account.
