### PR TITLE
Update commit hash for catastrophic-events plugin

### DIFF
--- a/plugins/catastrophic-events
+++ b/plugins/catastrophic-events
@@ -1,3 +1,3 @@
 repository=https://github.com/mikeyf06/cata-runelite-plugin.git
-commit=2c2b5c861be81c178a3ab277d144ed4b3a6f9235
+commit=3c639e3a910276e45d743203a4ed50eca888a22f
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Adds a $name token to the death message config, substituted with the local player's name before posting to Discord, plus a one-time migration that prepends the token to any existing custom message.