### PR TITLE
Add Shop Restock Alert plugin

### DIFF
--- a/plugins/shop-restock-alert
+++ b/plugins/shop-restock-alert
@@ -1,0 +1,2 @@
+repository=https://github.com/1504681/ShopRestockAlert.git
+commit=a6b7f77d75556f78299ab2814dc5001150732c41


### PR DESCRIPTION
## Summary
- Times a shop's restock tick by watching stock changes of exactly one while the shop is open, learns the interval from two observed ticks, and predicts the next one with an overlay countdown, a progress bar and an infobox
- Lists items you sold with how many are left and when they clear, with countdown dings and an optional notification before the tick
- Read-only: it only observes item containers and the shop interface, no input, no automation

## Repository
https://github.com/1504681/ShopRestockAlert