### PR TITLE
Update Bank Tag Folders to 1.1

### DIFF
--- a/plugins/bank-tag-folders
+++ b/plugins/bank-tag-folders
@@ -1,2 +1,2 @@
 repository=https://github.com/kingkj52/bank-tag-folders.git
-commit=88be739a76b29843ad8648cd424d114481ede9af
+commit=1f610b48bc189f7ceae7c80cc1962ce031453504

--- a/plugins/bank-tag-folders
+++ b/plugins/bank-tag-folders
@@ -1,2 +1,2 @@
 repository=https://github.com/kingkj52/bank-tag-folders.git
-commit=cad2380da23e4febc4e8e45485120611cf7ffeca
+commit=88be739a76b29843ad8648cd424d114481ede9af


### PR DESCRIPTION
Visual fix plus one new option. Folder membership is now shown by tinting member tabs with the folder's colour rather than indenting them, which was clipping the right edge of nested tab icons in a 39px column. Folder headers no longer use a separate row height, so their item icon is drawn at native size instead of being scaled down and looking broken. Adds a per-folder colour, settable as hex, and a config option for how strongly it tints, one for the folder row and one for the tabs inside it, and caps row height at 40 since the tab background sprite is 40 tall and tiles above that.

No dependency, behavior or permissions changes.