### PR TITLE
Update Shop Restock Alert to 1.0.1

### DIFF
--- a/plugins/shop-restock-alert
+++ b/plugins/shop-restock-alert
@@ -1,2 +1,2 @@
 repository=https://github.com/1504681/ShopRestockAlert.git
-commit=a6b7f77d75556f78299ab2814dc5001150732c41
+commit=dbaabf533ee7ff04147e5572469f4978c6019de0


### PR DESCRIPTION
- Forget the timer after 30 minutes by default instead of 3