### PR TITLE
update voiced-dialogue

### DIFF
--- a/plugins/voiced-dialogue
+++ b/plugins/voiced-dialogue
@@ -1,4 +1,4 @@
 repository=https://github.com/grabartley/runelite-voiced-dialogue.git
-commit=571e720f50109b4fc1ad6bd9ac6fc2b25de22d4d
+commit=833dff5d418d457109be7f16bfdd6b2e31bbc48f
 authors=grabartley
 warning=This plugin submits your IP address to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Updates voiced-dialogue to [v0.8.0](https://github.com/grabartley/runelite-voiced-dialogue/releases/tag/v0.8.0). The pinned commit is the `v0.8.0` release tag commit.

Highlights since v0.7.0:

- **The game world narrates itself.** Objectbox and messagebox narration and examine text are spoken in a dedicated narrator voice, so the parts of the game that are not NPC dialogue get voiced too.
- Aranei, dogs, crabs and penguins each got their own race, accent and voice pool, and the casts of Blood Moon Rises, Crab Quest, and a Ruff Situation are filled in alongside them.
- Repeated dialogue lines from the same speaker are no longer spoken twice.
- Cloud provider rate limiting honours the wait the provider actually reports, and the quota notice is worded from the reported quota rather than a guess.
- The settings panel is trimmed: character voice profiles are always on, three low-value toggles are gone, and the pace labels say what they do. The disk cache size limit also applies immediately instead of after a client restart.
