### PR TITLE
Update Everykill

### DIFF
--- a/plugins/everykill
+++ b/plugins/everykill
@@ -1,4 +1,4 @@
 repository=https://github.com/everykill/everykill-plugin.git
-commit=e386e489d21003e65b20506f864acbb36a610a19
+commit=c6e3b1a112653641acca4627a07011c9e1c12967
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.
 authors=Delkyy


### PR DESCRIPTION
Update to c6e3b1a.
**Two accounts on one PC shared a single Everykill account.** The kill ledger is stored per RuneScape profile, but the upload identity lived in a machine-wide file, so a player running two accounts from the same computer uploaded both as the same person and their kill counts merged. sent by a user running an Ultimate Ironman alongside a main. The identity is now per-profile, with a migration that keeps existing single-account users on their current identity.

Also:

**Monster icons removed.** They mapped a monster to one of its item drops, which is a guess: two raid bosses that share a drop table would show the same icon. The panel shows the name, and the site has real monster images.
 The overlay no longer draws during cutscenes (`VarbitID.CUTSCENE_STATUS`, same check core's tile indicators use).
Awakened DT2 bosses report a variant. They reuse their npc id across quest, post-quest and Awakened, so combat level is the only signal that separates them and only the client can see it.
 Helmet and title picker on the panel. Sprites come from `ItemManager`'s existing cache, no image downloads.
 The upload toggle now states that kills counted while it was off are never sent retroactively.
