### PR TITLE
the-birdhouse: 1.4.2

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=f2618f89a1ff6d47ff297e6fb52e1aac6b095cf6
+commit=b55983e7518f5b829a0f0170ce7baf5cdabce457
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Kill-count tiles now keep a single running tally per player on the backend rather than one proof per kill, so only the first kill's screenshot is stored. This release stops the client capturing and uploading the rest.

The submit response carries the running count on those tiles, so the plugin learns which tiles are tallying from the server rather than inferring it. A server that sends no count keeps the previous behaviour.