### PR TITLE
Add Inhouse Tracker

### DIFF
--- a/plugins/inhouse-tracker
+++ b/plugins/inhouse-tracker
@@ -1,0 +1,2 @@
+repository=https://github.com/AjaxIsLemons/inhouse-tracker.git
+commit=7b9b106368eca5960b0e823181254448997b6fce


### PR DESCRIPTION
Inhouse Tracker privately syncs RuneLite loot to an account paired through the Inhouse Discord bot. Syncing is opt-in and clearly warns that the player IP address, RuneScape account name, and observed loot are sent to stats.inhouseboyz.com. Events use an account-scoped token and a durable local outbox; the plugin does not automate game input. This first Plugin Hub release intentionally ships loot tracking only after a successful production pilot.