### PR TITLE
the-birdhouse: 1.4.3

### DIFF
--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=b55983e7518f5b829a0f0170ce7baf5cdabce457
+commit --trailer "Co-authored-by: Cursor <cursoragent@cursor.com>"=18605eb23346de6870aadfb09c1c0fd51363a833
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit=18605eb23346de6870aadfb09c1c0fd51363a833
+commit=7735712f7b3efb235a00c4ef6ee283f1f5c6f4ce
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/the-birdhouse
+++ b/plugins/the-birdhouse
@@ -1,3 +1,3 @@
 repository=https://github.com/birdandworm/TheBirdhouse.git
-commit --trailer "Co-authored-by: Cursor <cursoragent@cursor.com>"=18605eb23346de6870aadfb09c1c0fd51363a833
+commit=18605eb23346de6870aadfb09c1c0fd51363a833
 warning=This plugin submits your IP address, RSN, in-game screenshots, team chat messages you send, your online status and current world, and optionally loot/collection data for clan leaderboards to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Only credit a gathered item when experience actually moved.

The gathered tracker anchored on any `StatChanged` in a gathering skill, but that event also fires when a level is drained or restored, with the experience unchanged. Karil the Tainted drains Agility, so every point healing back during a Barrows trip opened the window that is meant to keep bank withdrawals, trades and Grand Exchange collections out of auto-submission.

It now compares against the experience last seen for that skill, and treats the first sighting as a baseline so the burst of stat changes at login vouches for nothing either.