### PR TITLE
Update ClanHQ plugin with Daily Drop support

### DIFF
--- a/plugins/clanhq
+++ b/plugins/clanhq
@@ -1,2 +1,2 @@
 repository=https://github.com/jewatson1994/clanhq-runelite.git
-commit=4da2237d7633b47a10166277eb40862b271c03ee
+commit=454abe79fa9b06801bc392ad49392ef5698c39c8


### PR DESCRIPTION
Updates the ClanHQ plugin manifest to the tested public plugin commit `454abe79fa9b06801bc392ad49392ef5698c39c8`.

This release adds the fourth guaranteed Daily Drop task while preserving the existing daily categories. It also removes misleading difficulty labels from normal daily tasks, adds inventory icons for Daily Drops, and keeps Daily Drop and Drop Rush item verification independent.

ClanHQ:
- captures only the logged-in player's evidence after explicit actions;
- sends complete character contents only after Character Sync or Bingo Character Submit is clicked and its disclosure is confirmed;
- ships with no endpoint or installation token;
- disables gameplay screenshots by default;
- lets the player revoke and remove the current installation from Overview;
- submits only after the player clicks the button; and
- never awards a rank or performs game actions.

Validation:
- 441 Python tests passed;
- RuneLite Gradle `clean test` passed; and
- `git diff --check` passed.