### PR TITLE
add trip-eta

### DIFF
--- a/plugins/trip-eta
+++ b/plugins/trip-eta
@@ -1,0 +1,2 @@
+repository=https://github.com/mreedon/trip-eta.git
+commit=2f8b86e88792e5b0b94fe88d5578176a54631a8b


### PR DESCRIPTION
Trip ETA estimates when your inventory will fill, counting only the time you are actually gathering.

It keeps two clocks: ticks spent in the gathering animation feed the estimate, and time off the tree (walking, waiting for a respawn, being away) is shown separately but never moves it. The rate is this trip's observation blended with what earlier trips on the account taught it, so the estimate is usable from the first log and the range tightens as the trip goes on.

Woodcutting for now; mining and fishing are planned as new entries in the same activity table.

Features:
- Overlay with items this trip, chopping time left as a range, off-tree time, progress bar, and a basket line when a log basket or forestry basket is carried or worn
- Felling-axe clean cuts counted as successful rolls with the known 80% item chance, so a run of them does not inflate the estimate
- Log basket followed from the game's own messages, the Check item box, and inventory reconciliation, with no setup
- RuneLite notification a configurable number of minutes before full, optionally on full
- Optional hand-off to the Dink plugin through its external-plugin `PluginMessage` API, so the same warning can reach Discord; off by default

No network, no file I/O, no sound; the only stored value is the learned rate in the RS profile config.

Repository: https://github.com/mreedon/trip-eta
