### PR TITLE
Update Essence Pouch Tracking to v1.7.0

### DIFF
--- a/plugins/essence-pouch-tracking
+++ b/plugins/essence-pouch-tracking
@@ -1,2 +1,2 @@
 repository=https://github.com/Infinitay/essence-pouch-tracking.git
-commit=a6bb8a4b1f5c6e40c2b4b580a0a3e41aaf5bd32e
+commit=b500592f5645b623af01e87c73ead1deb3d3d3a0


### PR DESCRIPTION
# Fixes

# Features

- Added support for not degrading rune essence pouches outside of the GOTR minigame with the Abyssal Lantern (Redwood) globally after 2026's Summer Sweep-up changes.

# Other Changes

- Updated debug overlay