### PR TITLE
grand-flip-out: update to 21e8cba

### DIFF
--- a/plugins/grand-flip-out
+++ b/plugins/grand-flip-out
@@ -1,2 +1,3 @@
 repository=https://github.com/Tunatroll/grand-flip-out.git
-commit=0a1e078002415d46aac7b7be682b43a9e88f59ba
+commit=21e8cba4cd6dc96e0fe6706b870304dbdc7c872d
+warning=This plugin submits your grand exchange offers and transactions, approximate coin total, and IP address to a 3rd party server that is not controlled or verified by the RuneLite Developers. Server features are opt-in and off by default.


### PR DESCRIPTION
Updates grand-flip-out to 21e8cba.

- Wiki prices API moved from `api/v1/osrs` to the documented `api/v2/osrs` (timeseries now uses `lookback`).
- Advisor fill-time labels read as an honest floor ("~Xm+") and the compact-row tooltip carries the measured fill-window percentages.
- GE tax exemption list corrected (civitas tab, watering can).
- Adds the `warning=` disclosure line: the plugin's optional, off-by-default server features submit GE offers/transactions, approximate coin total and IP to grandflipout.com.

Built and tested on JDK 11 (168 tests), no new outbound calls, no new permissions.
