### PR TITLE
Disable RuneScape Coach

### DIFF
--- a/plugins/runescape-coach
+++ b/plugins/runescape-coach
@@ -1,2 +1,0 @@
-repository=https://github.com/joelbridger/runescape-coach-plugin.git
-commit=736ab5f8d093b5f08e9515cdb371e5a225109632

--- a/plugins/runescape-coach
+++ b/plugins/runescape-coach
@@ -1,0 +1,3 @@
+repository=https://github.com/joelbridger/runescape-coach-plugin.git
+commit=736ab5f8d093b5f08e9515cdb371e5a225109632
+disabled=No longer publicly distributed by the author


### PR DESCRIPTION
I am withdrawing RuneScape Coach from public distribution and have made its source repository private. I am the same GitHub account that submitted the plugin in #14146; the username changed from `joelbridger` to `jamesondaines`. This keeps the manifest and adds RuneLite’s required `disabled` reason.