### PR TITLE
coffer: bump to 3736c00 (0.1.13-beta)

### DIFF
--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=138b4123e0b22d274f3516996c307c0084da6741
+commit=b4d604b1550220e593d6f3d52be15af3d5fdfae6
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.

--- a/plugins/coffer
+++ b/plugins/coffer
@@ -1,3 +1,3 @@
 repository=https://github.com/Paul2357/coffer.git
-commit=1bc41d3feead9b2f5c2994bcfcc5e14a72047f4d
+commit=138b4123e0b22d274f3516996c307c0084da6741
 warning=This plugin requires a (free) Coffer account and submits your Grand Exchange offers to a 3rd-party server not controlled or verified by RuneLite developers, for flip suggestions and cross-account fill data.


### PR DESCRIPTION
Bumps Coffer to 0.1.12-beta.

Changes since the last accepted version: an in-panel item price chart (a small sparkline on flip/position cards, expandable per item) for Standard/Premium accounts; Discord alerts now available on all tiers; and a "Forgot password?" flow. Restricted-API note: the LinkBrowser/Desktop browser-open usages flagged in review are being removed in the next pushed revision (replaced with in-panel handling). No change to the data sent to the server.