### PR TITLE
Update slayer-task-logger to 1.2.0

### DIFF
--- a/plugins/slayer-task-logger
+++ b/plugins/slayer-task-logger
@@ -1,3 +1,3 @@
 repository=https://github.com/staticvoid07/slayer-task-logger.git
-commit=2ade48ec203bbcdc913fd32c1db164e26605af9e
+commit=45315f931657f6db3e9c50d0617634722ac85f26
 warning=This plugin can send slayer event data to an external webhook URL configured by the user. The webhook is disabled by default.


### PR DESCRIPTION
Updates slayer-task-logger to version 1.2.0.

## Changes

- Fix task completions not being logged when no slayer points are awarded. The second completion message was only accepted when it contained the `and received N points, giving you a total of T` clause. Mortimer awards no points unless the task carries the points modifier, so his completions were dropped silently; the same applied to Turael and to streaks under five tasks. The points clause is now optional, and a varbit-based fallback logs the completion if the message does not match within two ticks.
- Show the task held in task storage when checking a slayer helm, slayer ring, or enchanted gem. The stored monster and amount are only sent by the server while the Slayer Rewards interface is open, so they are captured there and saved to the profile config. Prints a `Storage: N x Monster (modifier)` game message, including the Mortimer modifier when present. Controlled by a new option, enabled by default. Nothing is sent to the webhook.

Verified in-game.
