### PR TITLE
Add OSRS Loadout

### DIFF
--- a/plugins/osrs-loadout
+++ b/plugins/osrs-loadout
@@ -1,0 +1,4 @@
+repository=https://github.com/nathangrooms/osrs-loadout-plugin.git
+commit=a9b1fbaf5db9bb7b82160d8f7d66e773c1769757
+authors=nathangrooms
+warning=This plugin submits your IP address and uploads your bank, worn equipment and inventory (item ids and quantities) to osrsloadout.com when you press Sync, so the site can work out the best gear you can field from what you own. Your display name is sent only if you separately opt in. Your data is stored against a random key this plugin generates, never against your character name, and the plugin makes no requests at all until you enable it. Only enable it if you are comfortable with that data being uploaded.

--- a/plugins/osrs-loadout
+++ b/plugins/osrs-loadout
@@ -1,4 +1,4 @@
 repository=https://github.com/nathangrooms/osrs-loadout-plugin.git
-commit=de1a453cd86220a280225b764d6e587f046ed861
+commit=540b4a69b34a0c9dc28204b93713868aeef0ff83
 authors=nathangrooms
 warning=This plugin submits your IP address and uploads your bank, worn equipment and inventory (item ids and quantities) to osrsloadout.com when you press Sync, so the site can work out the best gear you can field from what you own. Your display name is sent only if you separately opt in. Your data is stored against a random key this plugin generates, never against your character name, and the plugin makes no requests at all until you enable it. Only enable it if you are comfortable with that data being uploaded.

--- a/plugins/osrs-loadout
+++ b/plugins/osrs-loadout
@@ -1,4 +1,4 @@
 repository=https://github.com/nathangrooms/osrs-loadout-plugin.git
-commit=a9b1fbaf5db9bb7b82160d8f7d66e773c1769757
+commit=de1a453cd86220a280225b764d6e587f046ed861
 authors=nathangrooms
 warning=This plugin submits your IP address and uploads your bank, worn equipment and inventory (item ids and quantities) to osrsloadout.com when you press Sync, so the site can work out the best gear you can field from what you own. Your display name is sent only if you separately opt in. Your data is stored against a random key this plugin generates, never against your character name, and the plugin makes no requests at all until you enable it. Only enable it if you are comfortable with that data being uploaded.

--- a/plugins/osrs-loadout
+++ b/plugins/osrs-loadout
@@ -1,4 +1,4 @@
 repository=https://github.com/nathangrooms/osrs-loadout-plugin.git
-commit=540b4a69b34a0c9dc28204b93713868aeef0ff83
+commit=46b36dcbd518c0fb3f4386759a7fde1f4e8b7fdb
 authors=nathangrooms
-warning=This plugin submits your IP address and uploads your bank, worn equipment and inventory (item ids and quantities) to osrsloadout.com when you press Sync, so the site can work out the best gear you can field from what you own. Your display name is sent only if you separately opt in. Your data is stored against a random key this plugin generates, never against your character name, and the plugin makes no requests at all until you enable it. Only enable it if you are comfortable with that data being uploaded.
+warning=This plugin submits your IP address and uploads your bank, worn equipment and inventory (item ids and quantities) and how your bank is arranged (which item is in which slot, and your tab sizes) to osrsloadout.com when you press Sync, so the site can work out the best gear you can field from what you own. Your display name is sent only if you separately opt in. Your data is stored against a random key this plugin generates, never against your character name, and the plugin makes no requests at all until you enable it. Only enable it if you are comfortable with that data being uploaded.

--- a/plugins/osrs-loadout
+++ b/plugins/osrs-loadout
@@ -1,4 +1,4 @@
 repository=https://github.com/nathangrooms/osrs-loadout-plugin.git
-commit=46b36dcbd518c0fb3f4386759a7fde1f4e8b7fdb
+commit=78e234b357685ba30df5cee3f02d3afa74d92c59
 authors=nathangrooms
 warning=This plugin submits your IP address and uploads your bank, worn equipment and inventory (item ids and quantities) and how your bank is arranged (which item is in which slot, and your tab sizes) to osrsloadout.com when you press Sync, so the site can work out the best gear you can field from what you own. Your display name is sent only if you separately opt in. Your data is stored against a random key this plugin generates, never against your character name, and the plugin makes no requests at all until you enable it. Only enable it if you are comfortable with that data being uploaded.


### PR DESCRIPTION
Adds **OSRS Loadout**, a plugin that sends your bank, worn equipment and inventory to
[osrsloadout.com](https://www.osrsloadout.com/) when you press a button, so the site can work out the best gear
you can field from what you own.

Source: https://github.com/nathangrooms/osrs-loadout-plugin

### Third-party server disclosure

This plugin talks to a server I run, so the specifics up front:

- **Off until you turn it on.** The `sync` `@ConfigItem` is a boolean defaulting to `false` and carries the
  standard warning string. With it off the plugin makes no requests at all: every network call checks
  `config.sync()` first.
- **Only on a button press.** Opening a bank only reads it into memory. Nothing is uploaded until the player
  presses **Sync now** in the plugin's panel, with a 30-second cooldown between presses. There is no automatic
  or background upload.
- **What is sent:** item ids and quantities from the bank, worn equipment and inventory; the bank's layout
  (the id in each slot and the nine tab sizes); and a random key generated once per install with
  `UUID.randomUUID()`.
- **What is never sent:** the character name, levels, location, chat, or anything about other players.
  The bank is stored under the random key, not a character, and there is no endpoint that looks a bank up by name.
- **Get a link code** sends only the key, to pair a browser. **Reset sync key** moves the bank to a new key,
  which unlinks every browser.
- `warning=` and `authors=` are set in the manifest. Privacy page: https://www.osrsloadout.com/privacy

### Notes for review

- `build=standard`, no dependencies beyond what `runelite-client` brings in; `OkHttpClient` and `Gson` are injected.
- `build.gradle` and `settings.gradle` follow `runelite/example-plugin`.
- Placeholders are left out of the item totals via `ItemComposition#getPlaceholderTemplateId`.
- The bank is read on `BANKMAIN_FINISHBUILDING`, so the container is known to be present.
- BSD 2-Clause, `icon.png` 48x48 at the repository root, unit tests under `src/test`.
- Known limitation: the key is per install, not per character, so characters on one install share one bank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
