### PR TITLE
Update commit hash for catastrophic-events plugin

### DIFF
--- a/plugins/catastrophic-events
+++ b/plugins/catastrophic-events
@@ -1,3 +1,3 @@
 repository=https://github.com/mikeyf06/cata-runelite-plugin.git
-commit=3c639e3a910276e45d743203a4ed50eca888a22f
+commit=8d4ded27b4ac26eea81a599bbbdf058600494568
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.

--- a/plugins/catastrophic-events
+++ b/plugins/catastrophic-events
@@ -1,3 +1,3 @@
 repository=https://github.com/mikeyf06/cata-runelite-plugin.git
-commit=2c2b5c861be81c178a3ab277d144ed4b3a6f9235
+commit=3c639e3a910276e45d743203a4ed50eca888a22f
 warning=This plugin submits your IP address, and may submit various account data, to a 3rd-party server not controlled or verified by Runelite developers.


### PR DESCRIPTION
Bumps to version 1.0.0 (first versioned release - runelite-plugin.properties previously had an empty version field). Includes:
- $name token in the custom death message, with a one-time migration for existing custom messages
- Opt-in toggle for private event chat reminders (milestones + signed-up summary), default off
- Clan coffer Discord alerts now post text-only, no screenshot