### PR TITLE
Add Auto Leuy plugin

### DIFF
--- a/plugins/auto-leuy
+++ b/plugins/auto-leuy
@@ -1,2 +1,2 @@
 repository=https://github.com/nocebo808/Auto_Leuy.git
-commit=0c83f6949526f5e4c987969e2d541c7dba8e4832
+commit=2dd32613c3af08f3a09ff717f2d2e5961b6407b7

--- a/plugins/auto-leuy
+++ b/plugins/auto-leuy
@@ -1,0 +1,2 @@
+repository=https://github.com/nocebo808/Auto_Leuy.git
+commit=0c83f6949526f5e4c987969e2d541c7dba8e4832


### PR DESCRIPTION
Adds Auto Leuy, a Wilderness loot-key run tracker.

The plugin detects loot keys obtained during a PK run, tracks held and session key counts, reads the approximate value reported when checking a loot key, prevents repeated checks from double-counting value, and provides a manual run reset.