### PR TITLE
Add W2

### DIFF
--- a/plugins/w2
+++ b/plugins/w2
@@ -1,0 +1,2 @@
+repository=https://github.com/Flxnts/w2-runelite.git
+commit=e129448e11f8f68e877642d5092a1a6ce2548427


### PR DESCRIPTION
Adds W2, a Grand Exchange flipping and market analysis plugin.

W2 provides live OSRS Wiki price data, post-tax flip calculations, recent market activity and liquidity information, item lookup, watchlists, and automatic local Grand Exchange trade tracking.

Trade history is stored locally through RuneLite configuration and is not uploaded to w2.gg.