### PR TITLE
trappy-chinchompa: move to AKAddons

### DIFF
--- a/plugins/trappy-chinchompa
+++ b/plugins/trappy-chinchompa
@@ -1,3 +1,3 @@
-repository=https://github.com/ajkatz/runelite-trappy-chinchompa.git
+repository=https://github.com/AKAddons/runelite-trappy-chinchompa.git
 commit=6fb6bac461e378272989a7bc6bf4059fd5192934
 authors=ajkatz


### PR DESCRIPTION
Repository move only, as asked: the plugin's home is the AKAddons organisation (https://github.com/AKAddons/runelite-trappy-chinchompa), where the 1.0.0 source is tagged v1.0.0 at the same commit this file already pins. The 2.0.0 commit bump follows in a second PR once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)