### PR TITLE
trappy-chinchompa: update to 2.0.0

### DIFF
--- a/plugins/trappy-chinchompa
+++ b/plugins/trappy-chinchompa
@@ -1,3 +1,3 @@
 repository=https://github.com/AKAddons/runelite-trappy-chinchompa.git
-commit=6fb6bac461e378272989a7bc6bf4059fd5192934
+commit=b2943cfb4169aed4da4127f1ff34dd992be12f1d
 authors=ajkatz


### PR DESCRIPTION
Trappy Chinchompa 2.0.0: duels, compete and a verified top-scores board.

- **Duel a friend** to the same traps on the same seed, from the dock under the game, `::duel <name> trappy`, or a right-click on a chatbox name. Best round or average, 1, 3 or 5 games. Accepting creates the duel; each player plays their games when they like inside a five-minute idle window.
- **Compete**: one game against a random opponent at your difficulty, with an Elo rating and a top-scores board per difficulty that only opponent-verified scores reach.
- **Your record**: duels won and lost, head-to-head per friend, compete record and ratings, last 20 duels.

Notes for review:
- Duels are **off by default** and connect to nothing until the player turns them on. Everything else in the plugin runs offline as before.
- With duels on, the plugin holds a WebSocket to the AKAddons relay (a Cloudflare Worker, source at https://github.com/AKAddons/akaddons-relay). It sends the display name, a SHA-256 of the RuneLite account hash made on the client (the relay keys it again; the number itself never leaves the client), and duel payloads: rules, scores and flap traces of this minigame. Nothing about the game client, the world, the bank or other players. The full list of message types and what the relay stores, and for how long, is in the relay README's "For reviewers" section; the plugin README carries the player-facing disclosure. The relay URL is a config value, so it can be pointed at a local `wrangler dev` to watch every frame.
- Fairness is server-side: the relay replays every run against the seed and forfeits a score its trace does not produce; seeds are revealed one game at a time; names are bound to accounts. Bans are operator-only shadow bans.
- No new third-party dependency: the socket is RuneLite's bundled OkHttp. The game stays EDT-only; every relay callback is handed to the EDT, and the reconnect backoff runs on RuneLite's scheduled executor.
- Commit bump only; the repository move landed in #16480.

Repository: https://github.com/AKAddons/runelite-trappy-chinchompa

🤖 Generated with [Claude Code](https://claude.com/claude-code)
