### PR TITLE
Update slayer-loot to v1.0.1

### DIFF
--- a/plugins/slayer-loot
+++ b/plugins/slayer-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/PapaBald/slayer-loot-plugin.git
-commit=d09ebda91188fdf01caa166a7f52147a1399fed2
+commit=9f961a8ce76cdc63dd5991bbf4d8c0d6eda33a27

--- a/plugins/slayer-loot
+++ b/plugins/slayer-loot
@@ -1,2 +1,2 @@
 repository=https://github.com/PapaBald/slayer-loot-plugin.git
-commit=9f961a8ce76cdc63dd5991bbf4d8c0d6eda33a27
+commit=148143ab0266a6b904854272df3727fd3a91ff02


### PR DESCRIPTION
Updates Slayer Loot to v1.0.1. Fixes client freezes when multiple Slayer NPCs die on the same tick by caching task resolution and coalescing persistence and panel updates.