### PR TITLE
Hop to world update

### DIFF
--- a/plugins/impling-finder
+++ b/plugins/impling-finder
@@ -1,4 +1,4 @@
 repository=https://github.com/Koopy98/ImplingFinderRT.git
-commit=bf60bdd8b7bef3c6a60588eeed050770dee9e21d
+commit=123b52e98c18712891cb0635b88deb8f4b0ec7ac
 authors=Hablapatabla,Elvonia,Koopy98
 warning=This plugin submits the location and time of found implings along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.


### PR DESCRIPTION
This update adds a right-click 'Hop to World' option to the impling list panel, using client.hopToWorld()