### PR TITLE
Add Mouse Tab Switcher

### DIFF
--- a/plugins/mouse-tab-switcher
+++ b/plugins/mouse-tab-switcher
@@ -1,0 +1,2 @@
+repository=https://github.com/JD-Michelena/MouseTabSwitcher.git
+commit=678fe297f8f574c9cf0a77f7519a4c3ea406e55b

--- a/plugins/mouse-tab-switcher
+++ b/plugins/mouse-tab-switcher
@@ -1,2 +1,2 @@
 repository=https://github.com/JD-Michelena/MouseTabSwitcher.git
-commit=678fe297f8f574c9cf0a77f7519a4c3ea406e55b
+commit=dcc9431828a06ba001b32cccb76256af3e1d1e36


### PR DESCRIPTION
Adds Mouse Tab Switcher, a RuneLite plugin that allows users to switch OSRS interface tabs using mouse buttons 4 and 5.

The plugin provides configurable assignments for both buttons and allows each button to be disabled independently.